### PR TITLE
fix: include repository name in worktree ID to prevent collisions

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -332,6 +332,10 @@ export function upsertWorktree(
   db: Database.Database,
   worktree: Worktree
 ): void {
+  // First, remove any existing worktree with the same path but different ID
+  // This handles cases where the ID generation scheme has changed
+  db.prepare('DELETE FROM worktrees WHERE path = ? AND id != ?').run(worktree.path, worktree.id);
+
   const stmt = db.prepare(`
     INSERT INTO worktrees (
       id, name, path, repository_path, repository_name, memo,

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -109,7 +109,7 @@ describe('Database Operations', () => {
         expect(result[0].lastMessageSummary).toBe('Updated summary');
       });
 
-      it('should maintain unique path constraint', () => {
+      it('should replace worktree when path is same but ID is different', () => {
         const worktree1: Worktree = {
           id: 'main',
           name: 'main',
@@ -119,18 +119,21 @@ describe('Database Operations', () => {
         };
 
         const worktree2: Worktree = {
-          id: 'feature-foo',
-          name: 'feature/foo',
+          id: 'repo-main', // New ID scheme with repository prefix
+          name: 'main',
           path: '/path/to/main', // Same path
           repositoryPath: '/path/to/repo',
           repositoryName: 'repo',
         };
 
         upsertWorktree(testDb, worktree1);
+        upsertWorktree(testDb, worktree2);
 
-        expect(() => {
-          upsertWorktree(testDb, worktree2);
-        }).toThrow();
+        // Should have only one worktree with the new ID
+        const result = getWorktrees(testDb);
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('repo-main');
+        expect(result[0].path).toBe('/path/to/main');
       });
     });
 

--- a/tests/unit/worktrees.test.ts
+++ b/tests/unit/worktrees.test.ts
@@ -66,6 +66,24 @@ describe('Worktree Management', () => {
     it('should handle branch name with dots', () => {
       expect(generateWorktreeId('release/v1.0.0')).toBe('release-v1-0-0');
     });
+
+    it('should include repository name in ID when provided', () => {
+      expect(generateWorktreeId('main', 'MyRepo')).toBe('myrepo-main');
+      expect(generateWorktreeId('feature/foo', 'MyRepo')).toBe('myrepo-feature-foo');
+    });
+
+    it('should handle repository name with special characters', () => {
+      expect(generateWorktreeId('main', 'My-Repo')).toBe('my-repo-main');
+      expect(generateWorktreeId('main', 'MyRepo.js')).toBe('myrepo-js-main');
+    });
+
+    it('should create unique IDs for same branch in different repos', () => {
+      const id1 = generateWorktreeId('main', 'RepoA');
+      const id2 = generateWorktreeId('main', 'RepoB');
+      expect(id1).not.toBe(id2);
+      expect(id1).toBe('repoa-main');
+      expect(id2).toBe('repob-main');
+    });
   });
 
   describe('parseWorktreeOutput', () => {


### PR DESCRIPTION
## Summary
- リポジトリ名をworktree IDに含めるよう変更（例: `main` → `myswiftagent-main`）
- 同じブランチ名を持つ複数のリポジトリを登録しても上書きされなくなる
- IDスキーム変更時のマイグレーションを自動処理

## Test plan
- [x] 単体テスト追加・更新済み
- [ ] 複数リポジトリの登録が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)