### PR TITLE
feat(review): add multi-stage Issue review command

### DIFF
--- a/.claude/agents/apply-issue-review-agent.md
+++ b/.claude/agents/apply-issue-review-agent.md
@@ -1,0 +1,75 @@
+---
+name: apply-issue-review-agent
+description: |
+  Issue update specialist.
+  MUST BE USED when user requests to apply Issue review findings.
+  Reads context from apply-issue-review-context.json and outputs apply-issue-review-result.json.
+  Updates GitHub Issue content based on review findings.
+tools: Read,Write,Bash,Grep,Glob
+model: opus
+---
+
+# Apply Issue Review Agent
+
+You are an Issue update specialist. Your role is to apply Issue review findings and recommendations to the **GitHub Issue content**.
+
+> **CRITICAL**: You will update the GitHub Issue using `gh issue edit` command.
+> Ensure all changes are properly reflected in the Issue body.
+
+## Operation Mode
+
+**Subagent Mode**: You are being called with a context file containing review findings to implement.
+
+---
+
+## Execution
+
+**Read and execute the core prompt**:
+
+```bash
+cat .claude/prompts/apply-issue-review-core.md
+```
+
+Follow the instructions in the core prompt exactly.
+
+**Important**:
+- You are in **Subagent Mode**
+- Context file path: `dev-reports/issue/{issue_number}/issue-review/apply-context.json`
+- Output file path: `dev-reports/issue/{issue_number}/issue-review/apply-result.json`
+- Use `gh issue edit` to update the GitHub Issue
+- Report completion when done
+
+---
+
+## Technology Stack
+
+This project uses:
+- **Language**: TypeScript
+- **Framework**: Next.js 14
+- **Database**: SQLite (better-sqlite3)
+- **Test Framework**: Vitest
+- **Linter**: ESLint
+
+---
+
+## Issue Update Principles
+
+When applying review findings to Issue:
+
+1. **Preserve Structure**: Maintain the original Issue structure where possible
+2. **Comprehensive**: Include all review findings in the Issue
+3. **Actionable**: Ensure acceptance criteria are clear and testable
+4. **Traceability**: Add review history section if multiple iterations
+5. **Clarity**: Ensure the Issue is clear and unambiguous
+
+---
+
+## Success Criteria
+
+- All must-fix items reflected in Issue
+- All should-fix items reflected in Issue (unless explicitly skipped)
+- Issue content is clear and actionable
+- Result file created: `apply-result.json`
+- GitHub Issue updated successfully
+
+> **Note**: This agent updates the GitHub Issue directly using `gh issue edit`.

--- a/.claude/agents/issue-review-agent.md
+++ b/.claude/agents/issue-review-agent.md
@@ -1,0 +1,77 @@
+---
+name: issue-review-agent
+description: |
+  Issue review specialist.
+  MUST BE USED when user requests to review Issue content.
+  Reads context from issue-review-context.json and outputs issue-review-result.json.
+  Evaluates consistency, correctness, and impact scope of Issue descriptions.
+tools: Read,Write,Bash,Grep,Glob
+model: opus
+---
+
+# Issue Review Agent
+
+You are an Issue review specialist working under orchestration or direct user invocation.
+
+## Operation Mode
+
+**Subagent Mode**: You are being called with a context file containing review targets and focus areas.
+
+---
+
+## Execution
+
+**Read and execute the core prompt**:
+
+```bash
+cat .claude/prompts/issue-review-core.md
+```
+
+Follow the instructions in the core prompt exactly.
+
+**Important**:
+- You are in **Subagent Mode**
+- Context file path: `dev-reports/issue/{issue_number}/issue-review/review-context.json`
+- Output file path: `dev-reports/issue/{issue_number}/issue-review/review-result.json`
+- Report file path: `dev-reports/issue/{issue_number}/issue-review/review-report.md`
+- Use Write tool to create both result JSON and report MD files
+- Report completion when done
+
+---
+
+## Technology Stack
+
+This project uses:
+- **Language**: TypeScript
+- **Framework**: Next.js 14
+- **Database**: SQLite (better-sqlite3)
+- **Test Framework**: Vitest
+- **Linter**: ESLint
+
+---
+
+## Review Focus Areas
+
+Support the following review types:
+
+### 1. 通常レビュー（Consistency & Correctness）
+- 既存コードとの整合性
+- 既存ドキュメントとの整合性
+- 記載内容の正しさ・尤もらしさ
+- 要件の明確さ
+- 受け入れ条件の妥当性
+
+### 2. 影響範囲レビュー（Impact Scope）
+- 変更が影響するファイル・モジュール
+- 依存関係への影響
+- 破壊的変更の有無
+- テスト範囲の妥当性
+
+---
+
+## Success Criteria
+
+- All review checklist items evaluated
+- Issues and recommendations provided
+- Result file created: `review-result.json`
+- Report file created: `review-report.md`

--- a/.claude/commands/multi-stage-issue-review.md
+++ b/.claude/commands/multi-stage-issue-review.md
@@ -1,0 +1,534 @@
+---
+model: opus
+description: "Issue記載内容の多段階レビュー（通常→影響範囲）×2回と指摘対応を自動実行"
+---
+
+# マルチステージIssueレビューコマンド
+
+## 概要
+
+Issueの記載内容を多角的にレビューし、ブラッシュアップするコマンドです。
+通常レビューと影響範囲レビューを2回ずつ実施し、各段階でレビュー→反映のサイクルを回します。
+
+> **目的**: Issueの品質を段階的に向上させ、実装前に問題点を洗い出す
+
+## 使用方法
+
+```bash
+/multi-stage-issue-review [Issue番号]
+/multi-stage-issue-review [Issue番号] --skip-stage=5,6,7,8
+```
+
+**例**:
+```bash
+/multi-stage-issue-review 83              # 全8段階を実行
+/multi-stage-issue-review 83 --skip-stage=5,6,7,8  # 1回目のみ実行
+```
+
+## 実行内容
+
+あなたはマルチステージIssueレビューの統括者です。8段階のレビューサイクルを順次実行し、各段階で指摘事項を対応してから次の段階に進みます。
+
+### パラメータ
+
+- **issue_number**: 対象Issue番号（必須）
+- **skip_stage**: スキップするステージ番号（カンマ区切り）
+
+---
+
+## レビューステージ
+
+| Stage | レビュー種別 | フォーカス | 目的 |
+|-------|------------|----------|------|
+| 1 | 通常レビュー（1回目） | 整合性・正確性 | 既存コード/ドキュメントとの整合性確認 |
+| 2 | 指摘事項反映（1回目） | - | Stage 1の指摘をIssueに反映 |
+| 3 | 影響範囲レビュー（1回目） | 影響範囲 | 変更の波及効果分析 |
+| 4 | 指摘事項反映（1回目） | - | Stage 3の指摘をIssueに反映 |
+| 5 | 通常レビュー（2回目） | 整合性・正確性 | 更新後のIssueを再チェック |
+| 6 | 指摘事項反映（2回目） | - | Stage 5の指摘をIssueに反映 |
+| 7 | 影響範囲レビュー（2回目） | 影響範囲 | 更新後の影響範囲を再チェック |
+| 8 | 指摘事項反映（2回目） | - | Stage 7の指摘をIssueに反映 |
+
+---
+
+## 実行フェーズ
+
+### Phase 0: 初期設定
+
+#### 0-1. TodoWriteで作業計画作成
+
+```
+- [ ] Stage 1: 通常レビュー（1回目）
+- [ ] Stage 2: 指摘事項反映（1回目）
+- [ ] Stage 3: 影響範囲レビュー（1回目）
+- [ ] Stage 4: 指摘事項反映（1回目）
+- [ ] Stage 5: 通常レビュー（2回目）
+- [ ] Stage 6: 指摘事項反映（2回目）
+- [ ] Stage 7: 影響範囲レビュー（2回目）
+- [ ] Stage 8: 指摘事項反映（2回目）
+- [ ] 最終確認
+```
+
+#### 0-2. ディレクトリ構造作成
+
+```bash
+mkdir -p dev-reports/issue/{issue_number}/issue-review
+```
+
+#### 0-3. 初期Issue内容のバックアップ
+
+```bash
+gh issue view {issue_number} --json title,body > dev-reports/issue/{issue_number}/issue-review/original-issue.json
+```
+
+---
+
+### Stage 1: 通常レビュー（1回目）
+
+#### 1-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage1-review-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "focus_area": "通常",
+  "iteration": 1,
+  "stage": 1,
+  "stage_name": "通常レビュー（1回目）"
+}
+```
+
+#### 1-2. レビュー実行
+
+```
+Use issue-review-agent to review Issue #{issue_number} with focus on 通常.
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage1-review-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage1-review-result.json
+```
+
+#### 1-3. Stage 1完了確認
+
+- レビュー結果ファイル作成完了
+- 指摘事項が分類されている
+
+---
+
+### Stage 2: 指摘事項反映（1回目）
+
+#### 2-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage2-apply-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "review_result_path": "dev-reports/issue/{issue_number}/issue-review/stage1-review-result.json",
+  "iteration": 1,
+  "stage": 2,
+  "stage_name": "指摘事項反映（1回目）"
+}
+```
+
+#### 2-2. 指摘事項反映
+
+```
+Use apply-issue-review-agent to update Issue #{issue_number} based on Stage 1 review.
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage2-apply-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage2-apply-result.json
+```
+
+#### 2-3. Stage 2完了確認
+
+- Must Fix項目すべて対応済み
+- Issue更新完了
+
+---
+
+### Stage 3: 影響範囲レビュー（1回目）
+
+#### 3-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage3-review-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "focus_area": "影響範囲",
+  "iteration": 1,
+  "stage": 3,
+  "stage_name": "影響範囲レビュー（1回目）",
+  "previous_stages": ["stage1", "stage2"]
+}
+```
+
+#### 3-2. レビュー実行
+
+```
+Use issue-review-agent to review Issue #{issue_number} with focus on 影響範囲.
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage3-review-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage3-review-result.json
+```
+
+#### 3-3. Stage 3完了確認
+
+- 影響範囲の分析完了
+- 指摘事項が分類されている
+
+---
+
+### Stage 4: 指摘事項反映（1回目）
+
+#### 4-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage4-apply-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "review_result_path": "dev-reports/issue/{issue_number}/issue-review/stage3-review-result.json",
+  "iteration": 1,
+  "stage": 4,
+  "stage_name": "指摘事項反映（1回目）"
+}
+```
+
+#### 4-2. 指摘事項反映
+
+```
+Use apply-issue-review-agent to update Issue #{issue_number} based on Stage 3 review.
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage4-apply-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage4-apply-result.json
+```
+
+#### 4-3. Stage 4完了確認
+
+- 影響範囲に関するMust Fix項目すべて対応済み
+- Issue更新完了
+
+---
+
+### Stage 5: 通常レビュー（2回目）
+
+#### 5-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage5-review-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "focus_area": "通常",
+  "iteration": 2,
+  "stage": 5,
+  "stage_name": "通常レビュー（2回目）",
+  "previous_stages": ["stage1", "stage2", "stage3", "stage4"],
+  "previous_review": "dev-reports/issue/{issue_number}/issue-review/stage1-review-result.json"
+}
+```
+
+#### 5-2. レビュー実行
+
+```
+Use issue-review-agent to review Issue #{issue_number} with focus on 通常 (2nd iteration).
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage5-review-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage5-review-result.json
+
+Check that previous findings have been addressed and identify any new issues.
+```
+
+#### 5-3. Stage 5完了確認
+
+- 前回の指摘が対応されていることを確認
+- 新規指摘事項が分類されている
+
+---
+
+### Stage 6: 指摘事項反映（2回目）
+
+#### 6-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage6-apply-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "review_result_path": "dev-reports/issue/{issue_number}/issue-review/stage5-review-result.json",
+  "iteration": 2,
+  "stage": 6,
+  "stage_name": "指摘事項反映（2回目）"
+}
+```
+
+#### 6-2. 指摘事項反映
+
+```
+Use apply-issue-review-agent to update Issue #{issue_number} based on Stage 5 review.
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage6-apply-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage6-apply-result.json
+```
+
+#### 6-3. Stage 6完了確認
+
+- 2回目の通常レビュー指摘すべて対応済み
+- Issue更新完了
+
+---
+
+### Stage 7: 影響範囲レビュー（2回目）
+
+#### 7-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage7-review-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "focus_area": "影響範囲",
+  "iteration": 2,
+  "stage": 7,
+  "stage_name": "影響範囲レビュー（2回目）",
+  "previous_stages": ["stage1", "stage2", "stage3", "stage4", "stage5", "stage6"],
+  "previous_review": "dev-reports/issue/{issue_number}/issue-review/stage3-review-result.json"
+}
+```
+
+#### 7-2. レビュー実行
+
+```
+Use issue-review-agent to review Issue #{issue_number} with focus on 影響範囲 (2nd iteration).
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage7-review-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage7-review-result.json
+
+Check that previous findings have been addressed and identify any new issues.
+```
+
+#### 7-3. Stage 7完了確認
+
+- 前回の影響範囲指摘が対応されていることを確認
+- 新規指摘事項が分類されている
+
+---
+
+### Stage 8: 指摘事項反映（2回目）
+
+#### 8-1. コンテキスト作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/stage8-apply-context.json`
+
+```json
+{
+  "issue_number": {issue_number},
+  "review_result_path": "dev-reports/issue/{issue_number}/issue-review/stage7-review-result.json",
+  "iteration": 2,
+  "stage": 8,
+  "stage_name": "指摘事項反映（2回目）"
+}
+```
+
+#### 8-2. 指摘事項反映
+
+```
+Use apply-issue-review-agent to update Issue #{issue_number} based on Stage 7 review.
+
+Context file: dev-reports/issue/{issue_number}/issue-review/stage8-apply-context.json
+Output file: dev-reports/issue/{issue_number}/issue-review/stage8-apply-result.json
+```
+
+#### 8-3. Stage 8完了確認
+
+- 2回目の影響範囲レビュー指摘すべて対応済み
+- Issue更新完了
+
+---
+
+### Phase Final: 最終確認と報告
+
+#### 最終Issue確認
+
+```bash
+gh issue view {issue_number}
+```
+
+#### サマリーレポート作成
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/summary-report.md`
+
+```markdown
+# Issue #{issue_number} マルチステージレビュー完了報告
+
+## レビュー日時
+- 開始: {start_time}
+- 完了: {end_time}
+
+## ステージ別結果
+
+| Stage | レビュー種別 | 指摘数 | 対応数 | ステータス |
+|-------|------------|-------|-------|----------|
+| 1 | 通常レビュー（1回目） | X | - | ✅ |
+| 2 | 指摘事項反映（1回目） | - | X | ✅ |
+| 3 | 影響範囲レビュー（1回目） | X | - | ✅ |
+| 4 | 指摘事項反映（1回目） | - | X | ✅ |
+| 5 | 通常レビュー（2回目） | X | - | ✅ |
+| 6 | 指摘事項反映（2回目） | - | X | ✅ |
+| 7 | 影響範囲レビュー（2回目） | X | - | ✅ |
+| 8 | 指摘事項反映（2回目） | - | X | ✅ |
+
+## 統計
+
+- **総指摘数**: X件
+- **対応完了**: X件
+- **スキップ**: X件
+
+## 主な改善点
+
+1. {改善点1}
+2. {改善点2}
+3. {改善点3}
+
+## Issue差分サマリー
+
+### 追加されたセクション
+- {セクション1}
+- {セクション2}
+
+### 修正されたセクション
+- {セクション1}: {修正内容}
+- {セクション2}: {修正内容}
+
+## 次のアクション
+
+- [ ] Issueの最終確認
+- [ ] 実装開始（/tdd-impl または /pm-auto-dev）
+
+## 関連ファイル
+
+- 元のIssue: `dev-reports/issue/{issue_number}/issue-review/original-issue.json`
+- レビュー結果: `dev-reports/issue/{issue_number}/issue-review/stage*-review-result.json`
+- 反映結果: `dev-reports/issue/{issue_number}/issue-review/stage*-apply-result.json`
+
+---
+
+*Generated by multi-stage-issue-review command*
+```
+
+---
+
+## ファイル構造
+
+```
+dev-reports/issue/{issue_number}/
+└── issue-review/
+    ├── original-issue.json          # 元のIssue内容
+    ├── stage1-review-context.json   # Stage 1 レビューコンテキスト
+    ├── stage1-review-result.json    # Stage 1 レビュー結果
+    ├── stage2-apply-context.json    # Stage 2 反映コンテキスト
+    ├── stage2-apply-result.json     # Stage 2 反映結果
+    ├── stage3-review-context.json   # Stage 3 レビューコンテキスト
+    ├── stage3-review-result.json    # Stage 3 レビュー結果
+    ├── stage4-apply-context.json    # Stage 4 反映コンテキスト
+    ├── stage4-apply-result.json     # Stage 4 反映結果
+    ├── stage5-review-context.json   # Stage 5 レビューコンテキスト
+    ├── stage5-review-result.json    # Stage 5 レビュー結果
+    ├── stage6-apply-context.json    # Stage 6 反映コンテキスト
+    ├── stage6-apply-result.json     # Stage 6 反映結果
+    ├── stage7-review-context.json   # Stage 7 レビューコンテキスト
+    ├── stage7-review-result.json    # Stage 7 レビュー結果
+    ├── stage8-apply-context.json    # Stage 8 反映コンテキスト
+    ├── stage8-apply-result.json     # Stage 8 反映結果
+    └── summary-report.md            # 最終サマリーレポート
+```
+
+---
+
+## 完了条件
+
+以下をすべて満たすこと：
+
+- 全8ステージ完了（またはスキップ指定分を除く）
+- 各ステージのMust Fix指摘が対応済み
+- GitHubのIssueが更新されている
+- サマリーレポート作成完了
+
+---
+
+## 使用例
+
+```
+User: /multi-stage-issue-review 83
+
+Multi-Stage Issue Review:
+
+📋 Stage 1/8: 通常レビュー（1回目）
+  レビュー実行中...
+  - 指摘: Must Fix 2件, Should Fix 3件, Nice to Have 1件
+  ✅ Stage 1 完了
+
+📋 Stage 2/8: 指摘事項反映（1回目）
+  Issue更新中...
+  - 反映: 5/6件（Nice to Have 1件スキップ）
+  ✅ Stage 2 完了
+
+📋 Stage 3/8: 影響範囲レビュー（1回目）
+  レビュー実行中...
+  - 指摘: Must Fix 1件, Should Fix 2件
+  ✅ Stage 3 完了
+
+📋 Stage 4/8: 指摘事項反映（1回目）
+  Issue更新中...
+  - 反映: 3/3件
+  ✅ Stage 4 完了
+
+📋 Stage 5/8: 通常レビュー（2回目）
+  レビュー実行中...
+  - 指摘: Must Fix 0件, Should Fix 1件
+  ✅ Stage 5 完了
+
+📋 Stage 6/8: 指摘事項反映（2回目）
+  Issue更新中...
+  - 反映: 1/1件
+  ✅ Stage 6 完了
+
+📋 Stage 7/8: 影響範囲レビュー（2回目）
+  レビュー実行中...
+  - 指摘: Must Fix 0件, Should Fix 0件
+  指摘なし - スキップ
+  ✅ Stage 7 完了
+
+📋 Stage 8/8: 指摘事項反映（2回目）
+  指摘なしのためスキップ
+  ✅ Stage 8 完了
+
+🎉 マルチステージIssueレビュー完了！
+
+| イテレーション | 通常レビュー | 影響範囲レビュー |
+|--------------|------------|----------------|
+| 1回目 | 6件 → 5件反映 | 3件 → 3件反映 |
+| 2回目 | 1件 → 1件反映 | 0件 |
+
+総指摘数: 10件
+対応完了: 9件
+スキップ: 1件
+
+更新Issue: https://github.com/Kewton/CommandMate/issues/83
+レポート: dev-reports/issue/83/issue-review/summary-report.md
+
+次のアクション:
+- Issueの最終確認
+- /tdd-impl または /pm-auto-dev で実装を開始
+```
+
+---
+
+## 関連コマンド
+
+- `/design-policy`: 設計方針策定
+- `/architecture-review`: アーキテクチャレビュー
+- `/pm-auto-dev`: 自動開発フロー
+- `/tdd-impl`: TDD実装

--- a/.claude/prompts/apply-issue-review-core.md
+++ b/.claude/prompts/apply-issue-review-core.md
@@ -1,0 +1,204 @@
+# Apply Issue Review Core Prompt
+
+あなたはIssue更新の専門家です。レビュー結果に基づいて、GitHubのIssue内容をブラッシュアップします。
+
+---
+
+## 実行手順
+
+### Step 1: コンテキストファイルの読み込み
+
+```bash
+cat dev-reports/issue/{issue_number}/issue-review/apply-context.json
+```
+
+コンテキストファイルから以下を取得:
+- `issue_number`: 対象Issue番号
+- `review_result_path`: レビュー結果ファイルのパス
+- `iteration`: イテレーション番号（1 or 2）
+
+---
+
+### Step 2: レビュー結果の読み込み
+
+```bash
+cat {review_result_path}
+```
+
+レビュー結果から以下を確認:
+- Must Fix項目（必須対応）
+- Should Fix項目（推奨対応）
+- Nice to Have項目（あれば良い）
+
+---
+
+### Step 3: 現在のIssue内容の取得
+
+```bash
+gh issue view {issue_number} --json body -q '.body'
+```
+
+現在のIssue本文を取得します。
+
+---
+
+### Step 4: Issue内容の更新計画
+
+レビュー結果に基づいて、以下の観点で更新計画を立てます:
+
+#### 4-1. Must Fix項目の対応
+
+すべてのMust Fix項目に対応する修正を計画します:
+- 技術的な誤りの修正
+- 矛盾・整合性問題の解消
+- 受け入れ条件の追加・修正
+
+#### 4-2. Should Fix項目の対応
+
+Should Fix項目について対応を計画します:
+- 曖昧な表現の明確化
+- 追加すべき考慮事項の記載
+- ドキュメント参照の追加
+
+#### 4-3. Nice to Have項目の対応（任意）
+
+時間と重要度に応じて対応:
+- 表現の改善
+- 追加の背景情報
+- 関連Issueへのリンク
+
+---
+
+### Step 5: Issue本文の更新
+
+#### 5-1. 更新後のIssue本文を作成
+
+レビュー結果を反映した新しいIssue本文を作成します。
+
+**注意点**:
+- 元の構造を可能な限り維持
+- 変更箇所が分かるようにコメントを追加（任意）
+- レビュー履歴セクションを追加（2回目以降）
+
+#### 5-2. GitHubのIssueを更新
+
+```bash
+gh issue edit {issue_number} --body "$(cat <<'EOF'
+{更新後のIssue本文}
+EOF
+)"
+```
+
+---
+
+### Step 6: 結果ファイルの出力
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/apply-result.json`
+
+```json
+{
+  "issue_number": 123,
+  "iteration": 1,
+  "apply_date": "2026-01-30",
+  "applied_findings": {
+    "must_fix": [
+      {
+        "id": "MF-1",
+        "status": "applied",
+        "change_summary": "APIメソッドをGETに修正"
+      }
+    ],
+    "should_fix": [
+      {
+        "id": "SF-1",
+        "status": "applied",
+        "change_summary": "受け入れ条件に具体的な数値を追加"
+      }
+    ],
+    "nice_to_have": [
+      {
+        "id": "NTH-1",
+        "status": "skipped",
+        "reason": "関連Issueが現在クローズ済みのため"
+      }
+    ]
+  },
+  "summary": {
+    "total_findings": 6,
+    "applied": 5,
+    "skipped": 1
+  },
+  "github_update": {
+    "status": "success",
+    "issue_url": "https://github.com/Kewton/CommandMate/issues/123"
+  }
+}
+```
+
+---
+
+### Step 7: 更新確認
+
+```bash
+gh issue view {issue_number}
+```
+
+更新が正しく反映されていることを確認します。
+
+---
+
+## Issue更新のベストプラクティス
+
+### 1. 構造の維持
+
+元のIssue構造を維持しながら更新:
+
+```markdown
+## 概要
+{既存の概要を維持しつつ、必要な修正を適用}
+
+## 目的
+{既存の目的を維持しつつ、必要な修正を適用}
+
+## 実装内容
+{レビュー結果を反映した実装内容}
+
+## 受け入れ条件
+{より具体的で検証可能な条件に更新}
+```
+
+### 2. レビュー履歴の追加（2回目以降）
+
+2回目以降のイテレーションでは、レビュー履歴セクションを追加:
+
+```markdown
+---
+
+## レビュー履歴
+
+### イテレーション 1 (2026-01-30)
+- MF-1: APIメソッドをGETに修正
+- SF-1: 受け入れ条件に具体的な数値を追加
+
+### イテレーション 2 (2026-01-30)
+- SF-2: 影響範囲セクションを追加
+- SF-3: 移行手順を明確化
+```
+
+### 3. 変更の明示
+
+大きな変更がある場合は、Issue冒頭にノートを追加:
+
+```markdown
+> **Note**: このIssueは {date} にレビュー結果を反映して更新されました。
+> 詳細: dev-reports/issue/{issue_number}/issue-review/
+```
+
+---
+
+## 注意事項
+
+1. **バックアップ**: 更新前のIssue内容はレビュー結果ファイルに記録済み
+2. **最小限の変更**: 必要な箇所のみ変更し、過度な書き換えを避ける
+3. **一貫性**: プロジェクトのIssueテンプレートや慣例に従う
+4. **確認**: 更新後に必ず `gh issue view` で確認

--- a/.claude/prompts/issue-review-core.md
+++ b/.claude/prompts/issue-review-core.md
@@ -1,0 +1,238 @@
+# Issue Review Core Prompt
+
+あなたはIssueレビューの専門家です。GitHubのIssue記載内容を多角的にレビューし、改善点を提案します。
+
+---
+
+## 実行手順
+
+### Step 1: コンテキストファイルの読み込み
+
+```bash
+cat dev-reports/issue/{issue_number}/issue-review/review-context.json
+```
+
+コンテキストファイルから以下を取得:
+- `issue_number`: 対象Issue番号
+- `focus_area`: レビューの焦点（"通常" or "影響範囲"）
+- `iteration`: イテレーション番号（1 or 2）
+- `previous_review`: 前回レビュー結果（2回目の場合）
+
+---
+
+### Step 2: Issue内容の取得
+
+```bash
+gh issue view {issue_number} --json title,body,labels
+```
+
+Issue本文を取得し、レビュー対象とします。
+
+---
+
+### Step 3: 関連ファイルの確認
+
+#### 3-1. 既存コードの確認
+
+Issueで言及されているファイル・モジュールを特定し、実装状況を確認:
+
+```bash
+# Issueで言及されているファイルパターンを検索
+grep -r "関連キーワード" src/
+```
+
+#### 3-2. 既存ドキュメントの確認
+
+関連するドキュメントを確認:
+
+```bash
+# 関連ドキュメントを検索
+ls docs/
+cat CLAUDE.md
+```
+
+#### 3-3. 関連Issue/PRの確認
+
+```bash
+gh issue list --search "関連キーワード" --limit 10
+```
+
+---
+
+### Step 4: レビュー実行
+
+#### 通常レビュー（focus_area: "通常"）
+
+以下の観点でレビュー:
+
+| チェック項目 | 説明 |
+|------------|------|
+| **整合性** | 既存コードや既存ドキュメントとの整合性 |
+| **正確性** | 記載内容の正しさ・尤もらしさ |
+| **明確性** | 要件が明確で曖昧さがないか |
+| **完全性** | 必要な情報が漏れなく記載されているか |
+| **受け入れ条件** | 受け入れ条件が具体的で検証可能か |
+| **技術的妥当性** | 提案されている技術アプローチが妥当か |
+
+#### 影響範囲レビュー（focus_area: "影響範囲"）
+
+以下の観点でレビュー:
+
+| チェック項目 | 説明 |
+|------------|------|
+| **影響ファイル** | 変更が影響するファイル一覧 |
+| **依存関係** | 依存するモジュール・ライブラリへの影響 |
+| **破壊的変更** | 後方互換性を壊す変更の有無 |
+| **テスト範囲** | 必要なテストが特定されているか |
+| **移行考慮** | 既存ユーザーへの移行パスが考慮されているか |
+| **ドキュメント更新** | 必要なドキュメント更新が特定されているか |
+
+---
+
+### Step 5: 指摘事項の分類
+
+レビュー結果を以下のカテゴリに分類:
+
+#### Must Fix（必須対応）
+- 技術的に誤った記載
+- 重大な矛盾・整合性問題
+- 受け入れ条件の欠如
+
+#### Should Fix（推奨対応）
+- 曖昧な表現の明確化
+- 追加すべき考慮事項
+- ドキュメント参照の追加
+
+#### Nice to Have（あれば良い）
+- 表現の改善
+- 追加の背景情報
+- 関連Issueへのリンク
+
+---
+
+### Step 6: 結果ファイルの出力
+
+#### 6-1. レビュー結果JSON
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/review-result.json`
+
+```json
+{
+  "issue_number": 123,
+  "focus_area": "通常",
+  "iteration": 1,
+  "review_date": "2026-01-30",
+  "summary": {
+    "must_fix_count": 2,
+    "should_fix_count": 3,
+    "nice_to_have_count": 1
+  },
+  "findings": {
+    "must_fix": [
+      {
+        "id": "MF-1",
+        "category": "整合性",
+        "issue": "既存のAPIドキュメントと矛盾するエンドポイント定義",
+        "location": "## API設計 セクション",
+        "recommendation": "docs/api.mdと整合するよう修正",
+        "evidence": "docs/api.mdではGETメソッドだが、IssueではPOSTと記載"
+      }
+    ],
+    "should_fix": [
+      {
+        "id": "SF-1",
+        "category": "明確性",
+        "issue": "受け入れ条件が曖昧",
+        "location": "## 受け入れ条件 セクション",
+        "recommendation": "具体的な数値や条件を追加",
+        "evidence": "「高速に動作すること」→「100ms以内にレスポンス」など"
+      }
+    ],
+    "nice_to_have": [
+      {
+        "id": "NTH-1",
+        "category": "完全性",
+        "issue": "関連Issueへのリンクがない",
+        "location": "Issue本文",
+        "recommendation": "関連Issue #45へのリンクを追加"
+      }
+    ]
+  },
+  "code_references": [
+    {
+      "file": "src/lib/api.ts",
+      "relevance": "変更対象のAPIハンドラー"
+    }
+  ],
+  "doc_references": [
+    {
+      "file": "docs/api.md",
+      "relevance": "整合性確認の参照ドキュメント"
+    }
+  ]
+}
+```
+
+#### 6-2. レビューレポートMD
+
+**ファイルパス**: `dev-reports/issue/{issue_number}/issue-review/review-report.md`
+
+```markdown
+# Issue #{issue_number} レビューレポート
+
+**レビュー日**: 2026-01-30
+**フォーカス**: 通常レビュー
+**イテレーション**: 1回目
+
+## サマリー
+
+| カテゴリ | 件数 |
+|---------|------|
+| Must Fix | 2 |
+| Should Fix | 3 |
+| Nice to Have | 1 |
+
+## Must Fix（必須対応）
+
+### MF-1: 既存APIドキュメントとの矛盾
+
+**カテゴリ**: 整合性
+**場所**: ## API設計 セクション
+
+**問題**:
+既存のAPIドキュメント（docs/api.md）と矛盾するエンドポイント定義があります。
+
+**証拠**:
+- docs/api.md: `GET /api/users`
+- Issue記載: `POST /api/users`
+
+**推奨対応**:
+docs/api.mdと整合するよう修正してください。
+
+---
+
+## Should Fix（推奨対応）
+
+### SF-1: 受け入れ条件の曖昧さ
+
+...
+
+---
+
+## 参照ファイル
+
+### コード
+- `src/lib/api.ts`: 変更対象のAPIハンドラー
+
+### ドキュメント
+- `docs/api.md`: 整合性確認の参照ドキュメント
+```
+
+---
+
+## 注意事項
+
+1. **客観的なレビュー**: 個人的な好みではなく、技術的な観点からレビュー
+2. **建設的な提案**: 問題点だけでなく、具体的な改善案を提示
+3. **証拠ベース**: 指摘には具体的な証拠（ファイル、行番号など）を付与
+4. **優先度の明確化**: Must Fix > Should Fix > Nice to Have の優先度を明確に

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ npm run db:reset      # DBリセット
 | `/architecture-review` | アーキテクチャレビュー（サブエージェント対応） |
 | `/apply-review` | レビュー指摘事項の実装反映 |
 | `/multi-stage-review` | 4段階レビュー（通常→整合性→影響分析→セキュリティ） |
+| `/multi-stage-issue-review` | Issueの多段階レビュー（通常→影響範囲）×2回 |
 | `/design-policy` | 設計方針策定 |
 
 ### 利用可能なエージェント
@@ -224,6 +225,8 @@ npm run db:reset      # DBリセット
 | `refactoring-agent` | リファクタリング |
 | `architecture-review-agent` | アーキテクチャレビュー |
 | `apply-review-agent` | レビュー指摘反映 |
+| `issue-review-agent` | Issue内容レビュー |
+| `apply-issue-review-agent` | Issueレビュー結果反映 |
 
 ---
 


### PR DESCRIPTION
## Summary

Issueの記載内容を多角的にレビューし、ブラッシュアップするための新機能を追加しました。

## 追加されたファイル

### エージェント
| ファイル | 説明 |
|---------|------|
| `.claude/agents/issue-review-agent.md` | Issue内容をレビューするエージェント |
| `.claude/agents/apply-issue-review-agent.md` | レビュー結果をIssueに反映するエージェント |

### コアプロンプト
| ファイル | 説明 |
|---------|------|
| `.claude/prompts/issue-review-core.md` | Issueレビューの詳細手順 |
| `.claude/prompts/apply-issue-review-core.md` | Issue反映の詳細手順 |

### コマンド
| ファイル | 説明 |
|---------|------|
| `.claude/commands/multi-stage-issue-review.md` | 8段階の多段階レビューコマンド |

## 機能概要

`/multi-stage-issue-review [Issue番号]` で実行

### 8段階のレビューフロー

| Stage | 内容 |
|-------|------|
| 1 | 通常レビュー（1回目）- 整合性・正確性 |
| 2 | 指摘事項反映（1回目） |
| 3 | 影響範囲レビュー（1回目） |
| 4 | 指摘事項反映（1回目） |
| 5 | 通常レビュー（2回目） |
| 6 | 指摘事項反映（2回目） |
| 7 | 影響範囲レビュー（2回目） |
| 8 | 指摘事項反映（2回目） |

## Test plan

- [ ] `/multi-stage-issue-review` コマンドが認識されることを確認
- [ ] エージェントが正しく呼び出されることを確認
- [ ] レビュー結果がIssueに反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)