### PR TITLE
feat: introduce semantic versioning v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-01-30
+
 ### Changed
 - **BREAKING**: GitHub repository renamed from `Kewton/MyCodeBranchDesk` to `Kewton/CommandMate` (Issue #80)
 - All documentation links updated to new repository URL (Issue #80)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mycodebranch-desk",
-  "version": "1.0.0",
+  "name": "commandmate",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mycodebranch-desk",
-      "version": "1.0.0",
+      "name": "commandmate",
+      "version": "0.1.0",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "scripts": {


### PR DESCRIPTION
## Summary

- package.jsonのバージョンを`1.0.0`から`0.1.0`に変更（β版リリース）
- package-lock.jsonを同期更新
- CHANGELOG.mdの`[Unreleased]`を`[0.1.0] - 2026-01-30`に更新

## 関連Issue

Closes #40

## 受け入れ条件の確認

- [x] package.json の version フィールドが `0.1.0` に設定されている
- [x] package-lock.json の version フィールドも `0.1.0` に更新されている
- [ ] Git タグ `v0.1.0` が作成されている（PRマージ後に作成）
- [x] CHANGELOG.md に `[0.1.0] - 2026-01-30` セクションが追加されている
- [ ] GitHub Releases ページにリリースが作成されている（PRマージ後に作成）

## Test plan

- [x] `npm install` が正常に完了することを確認
- [x] package.json, package-lock.json のバージョンが 0.1.0 であることを確認
- [x] CHANGELOG.md のフォーマットが Keep a Changelog 形式であることを確認

## 次のアクション（PRマージ後）

1. `git tag v0.1.0` でタグを作成
2. `git push origin v0.1.0` でタグをプッシュ
3. `gh release create v0.1.0` でGitHub Releasesを作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)