### PR TITLE
fix(cli): use package directory instead of cwd for npm run

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -11,6 +11,7 @@ import { StartOptions, ExitCode } from '../types';
 import { CLILogger } from '../utils/logger';
 import { DaemonManager } from '../utils/daemon';
 import { logSecurityEvent } from '../utils/security-logger';
+import { getPackageRoot } from '../utils/paths';
 
 const logger = new CLILogger();
 const PID_FILE = join(process.cwd(), '.commandmate.pid');
@@ -89,8 +90,11 @@ export async function startCommand(options: StartOptions): Promise<void> {
       env.CM_PORT = String(options.port);
     }
 
+    // Use package installation directory, not current working directory
+    const packageRoot = getPackageRoot();
+
     const child = spawn('npm', ['run', npmScript], {
-      cwd: process.cwd(),
+      cwd: packageRoot,
       env,
       stdio: 'inherit',
     });

--- a/src/cli/utils/daemon.ts
+++ b/src/cli/utils/daemon.ts
@@ -7,6 +7,7 @@
 import { spawn } from 'child_process';
 import { DaemonStatus, StartOptions } from '../types';
 import { PidManager } from './pid-manager';
+import { getPackageRoot } from './paths';
 
 /**
  * Daemon manager for background server process
@@ -33,7 +34,8 @@ export class DaemonManager {
     this.pidManager.removePid();
 
     const npmScript = options.dev ? 'dev' : 'start';
-    const cwd = process.cwd();
+    // Use package installation directory, not current working directory
+    const packageRoot = getPackageRoot();
 
     // Build environment
     const env: NodeJS.ProcessEnv = { ...process.env };
@@ -43,7 +45,7 @@ export class DaemonManager {
 
     // Spawn detached process
     const child = spawn('npm', ['run', npmScript], {
-      cwd,
+      cwd: packageRoot,
       env,
       detached: true,
       stdio: 'ignore',

--- a/src/cli/utils/paths.ts
+++ b/src/cli/utils/paths.ts
@@ -1,0 +1,34 @@
+/**
+ * Path Utilities for CLI
+ * Issue #96: npm install CLI support
+ *
+ * Provides utilities to resolve package installation directory
+ * regardless of where the CLI is invoked from.
+ */
+
+import { join } from 'path';
+
+/**
+ * Get the root directory of the CommandMate package installation.
+ *
+ * When installed globally via npm, the CLI runs from:
+ *   <global-modules>/commandmate/dist/cli/utils/paths.js
+ *
+ * This function returns the package root:
+ *   <global-modules>/commandmate/
+ *
+ * @returns Absolute path to the package root directory
+ */
+export function getPackageRoot(): string {
+  // __dirname points to dist/cli/utils when this file is compiled
+  // We need to go up 3 levels: utils → cli → dist → package root
+  return join(__dirname, '..', '..', '..');
+}
+
+/**
+ * Get the path to package.json
+ * @returns Absolute path to package.json
+ */
+export function getPackageJsonPath(): string {
+  return join(getPackageRoot(), 'package.json');
+}


### PR DESCRIPTION
## Summary

Fix CLI `commandmate start` failing with "package.json not found" error when run from directories outside the package installation.

## Problem

When running `commandmate start` from any directory (e.g., `/Users/user/work/git/`), the CLI was using `process.cwd()` to run `npm run start`, causing:

```
npm error code ENOENT
npm error path /Users/user/work/git/package.json
npm error enoent Could not read package.json
```

## Solution

- Add `src/cli/utils/paths.ts` utility to resolve package installation directory via `__dirname`
- Update `start.ts` and `daemon.ts` to use `getPackageRoot()` instead of `process.cwd()`

## Files Changed

- `src/cli/utils/paths.ts` (new) - Package root directory resolver
- `src/cli/commands/start.ts` - Use packageRoot for foreground mode
- `src/cli/utils/daemon.ts` - Use packageRoot for daemon mode

## Test plan

- [ ] Run `commandmate start` from a directory without package.json
- [ ] Verify server starts successfully
- [ ] Unit tests pass (2164 tests)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)