### PR TITLE
fix(ci): re-enable environment for npm Trusted Publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # environment: npm-publish  # Temporarily disabled for troubleshooting
+    environment: npm-publish  # Required: must match npm Trusted Publisher settings
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-02-01
+
+### Fixed
+- Re-enabled `environment: npm-publish` in publish workflow
+  - npm Trusted Publisher requires exact match of environment name
+
 ## [0.1.3] - 2026-02-01
 
 ### Fixed
@@ -147,7 +153,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.1.3...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/Kewton/CommandMate/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Kewton/CommandMate/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Kewton/CommandMate/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Kewton/CommandMate/compare/v0.1.0...v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "bin": {
     "commandmate": "./bin/commandmate.js"


### PR DESCRIPTION
## Summary
- Re-enable `environment: npm-publish` in publish workflow
- npm Trusted Publisher requires exact match of environment name

## Root Cause
v0.1.3 failed because environment was commented out, but npm side has it configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)