### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-02-01
+
+### Fixed
+- Added `repository` field to package.json for npm provenance verification
+
 ## [0.1.4] - 2026-02-01
 
 ### Fixed
@@ -153,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.1.4...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/Kewton/CommandMate/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Kewton/CommandMate/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Kewton/CommandMate/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Kewton/CommandMate/compare/v0.1.1...v0.1.2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "commandmate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Git worktree management with Claude CLI and tmux sessions",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kewton/CommandMate.git"
+  },
   "bin": {
     "commandmate": "./bin/commandmate.js"
   },


### PR DESCRIPTION
## Summary
- Add `repository` field to package.json
- Required for npm provenance verification

## Root Cause
v0.1.4 failed with:
```
Error verifying sigstore provenance bundle: package.json: "repository.url" is ""
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)