### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-02-02
+
+### Added
+- Documentation updated to use `npm install -g commandmate` as primary setup method (Issue #114)
+  - New CLI setup guide at `docs/user-guide/cli-setup-guide.md`
+  - README.md Quick Start uses npm global install
+  - git clone method moved to "Developer Setup" section
+  - `--port` option documented in CLI commands table
+
+### Fixed
+- iPad fullscreen mode now uses Portal to cover full viewport (Issue #104)
+- Test z-index expectations updated from 40 to 55 to match Z_INDEX.MAXIMIZED_EDITOR
+
+### Changed
+- Sidebar toggle animation uses transform instead of width for GPU acceleration (Issue #112)
+  - Improves performance on iPad
+  - Added SIDEBAR constant (30) to z-index.ts
+- Pre-built JS compilation for server.ts enables npm CLI without TypeScript compilation (Issue #113)
+
 ## [0.1.5] - 2026-02-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.1.6

### Added
- Documentation updated to use `npm install -g commandmate` as primary setup method (Issue #114)
  - New CLI setup guide at `docs/user-guide/cli-setup-guide.md`
  - README.md Quick Start uses npm global install
  - git clone method moved to "Developer Setup" section
  - `--port` option documented in CLI commands table

### Fixed
- iPad fullscreen mode now uses Portal to cover full viewport (Issue #104)
- Test z-index expectations updated from 40 to 55 to match Z_INDEX.MAXIMIZED_EDITOR

### Changed
- Sidebar toggle animation uses transform instead of width for GPU acceleration (Issue #112)
  - Improves performance on iPad
  - Added SIDEBAR constant (30) to z-index.ts
- Pre-built JS compilation for server.ts enables npm CLI without TypeScript compilation (Issue #113)

---

**After merging this PR:**
```bash
git checkout main
git pull origin main
git tag v0.1.6
git push origin v0.1.6
gh release create v0.1.6 --title "v0.1.6" --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)