### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-02-02
+
+### Fixed
+- Foreground mode (`commandmate start`) now loads .env file (Issue #125 follow-up)
+  - v0.1.8 only fixed daemon mode, foreground mode was missing .env loading
+  - Now both modes load .env from `~/.commandmate/.env` for global installs
+  - Security warnings for external access also added to foreground mode
+
 ## [0.1.8] - 2026-02-02
 
 ### Fixed
@@ -204,7 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.1.8...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/Kewton/CommandMate/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Kewton/CommandMate/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/Kewton/CommandMate/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/Kewton/CommandMate/compare/v0.1.5...v0.1.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- バージョンを0.1.9に更新
- CHANGELOG.mdにフォアグラウンドモード修正を追記

## Test plan
- [x] package.json version updated to 0.1.9
- [x] CHANGELOG.md updated with v0.1.9 section
- [x] Tag v0.1.9 pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)