### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-02-02
+
+### Added
+- Git branch visualization feature (Issue #111)
+  - Display current branch name in worktree detail header
+  - Show warning when current branch differs from session start branch
+  - Mobile support for branch information display
+  - Automatic refresh (active: 2s, idle: 5s)
+  - Migration #15: added `initial_branch` column to worktrees table
+  - New `src/lib/git-utils.ts` module with `getGitStatus()` function
+  - `BranchMismatchAlert` component for branch mismatch warnings
+
+### Fixed
+- Repository filter UI now displays even when only one repository exists (Issue #129)
+
+### Security
+- Branch visualization uses `execFile` instead of `exec` to prevent command injection
+- 1 second timeout for git commands to prevent DoS
+- React auto-escaping for XSS prevention in branch name display
+
 ## [0.1.9] - 2026-02-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.1.10

### Added
- Git branch visualization feature (Issue #111)
  - Display current branch name in worktree detail header
  - Show warning when current branch differs from session start branch
  - Mobile support for branch information display
  - Automatic refresh (active: 2s, idle: 5s)
  - Migration #15: added `initial_branch` column to worktrees table

### Fixed
- Repository filter UI now displays even when only one repository exists (Issue #129)

### Security
- Branch visualization uses `execFile` instead of `exec` to prevent command injection
- 1 second timeout for git commands to prevent DoS
- React auto-escaping for XSS prevention in branch name display

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)