### PR TITLE
fix(#163): sendTextViaBuffer shell escaping error on long strings

### DIFF
--- a/tests/unit/lib/tmux.test.ts
+++ b/tests/unit/lib/tmux.test.ts
@@ -1,13 +1,45 @@
 /**
  * Tests for sendTextViaBuffer() function
  * Issue #163: Fix multiline message sending via tmux buffer
- * TDD Approach: Write tests first (Red), then implement (Green)
+ * Uses spawn for stdin pipe to avoid shell escaping issues
  * @vitest-environment node
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { Writable } from 'stream';
 
-// Mock child_process before importing tmux module
+// Create mock spawn child process factory
+function createMockChildProcess(exitCode = 0) {
+  const cp = new EventEmitter() as EventEmitter & {
+    stdin: Writable & { writtenData: string };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+
+  const writtenChunks: string[] = [];
+  cp.stdin = {
+    writtenData: '',
+    write(data: string) {
+      writtenChunks.push(data);
+      cp.stdin.writtenData += data;
+      return true;
+    },
+    end() {
+      // Simulate async close -> emit 'close' event on process
+      setTimeout(() => cp.emit('close', exitCode), 0);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  cp.stdout = new EventEmitter();
+  cp.stderr = new EventEmitter();
+  cp.kill = vi.fn();
+
+  return cp;
+}
+
+// Mock child_process
 vi.mock('child_process', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mockExec = vi.fn((...args: any[]) => {
@@ -17,39 +49,54 @@ vi.mock('child_process', () => {
     }
     return {};
   });
-  return { exec: mockExec };
+
+  const mockSpawn = vi.fn(() => createMockChildProcess(0));
+
+  return { exec: mockExec, spawn: mockSpawn };
 });
 
 import { sendTextViaBuffer } from '@/lib/tmux';
-import { exec } from 'child_process';
+import { exec, spawn } from 'child_process';
 
 describe('sendTextViaBuffer() - Issue #163', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset spawn mock to default success behavior
+    vi.mocked(spawn).mockImplementation(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createMockChildProcess(0) as any
+    );
   });
 
   describe('Normal operations', () => {
     it('should send single-line text via buffer with Enter', async () => {
       await sendTextViaBuffer('test-session', 'Hello World');
 
-      // Should call execAsync 3 times: load-buffer, paste-buffer, send-keys (C-m)
-      expect(exec).toHaveBeenCalledTimes(3);
+      // spawn called once for load-buffer
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(spawn).toHaveBeenCalledWith(
+        'tmux',
+        ['load-buffer', '-b', 'cm-test-session', '-'],
+        expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+      );
 
-      // Verify load-buffer call
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('tmux load-buffer');
-      expect(loadBufferCall).toContain('-b "cm-test-session"');
+      // exec called twice: paste-buffer + send-keys (C-m)
+      expect(exec).toHaveBeenCalledTimes(2);
 
       // Verify paste-buffer call
-      const pasteBufferCall = vi.mocked(exec).mock.calls[1][0] as string;
+      const pasteBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
       expect(pasteBufferCall).toContain('tmux paste-buffer');
       expect(pasteBufferCall).toContain('-t "test-session"');
       expect(pasteBufferCall).toContain('-dp');
 
       // Verify Enter key
-      const enterCall = vi.mocked(exec).mock.calls[2][0] as string;
+      const enterCall = vi.mocked(exec).mock.calls[1][0] as string;
       expect(enterCall).toContain('tmux send-keys');
       expect(enterCall).toContain('C-m');
+
+      // Verify text was written to stdin
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('Hello World');
     });
 
     it('should send multiline text (50+ lines) via buffer', async () => {
@@ -58,17 +105,20 @@ describe('sendTextViaBuffer() - Issue #163', () => {
 
       await sendTextViaBuffer('test-session', multilineText);
 
-      expect(exec).toHaveBeenCalledTimes(3);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledTimes(2);
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('tmux load-buffer');
+      // Verify the full multiline text was written to stdin
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe(multilineText);
     });
 
     it('should not send Enter when sendEnter=false', async () => {
       await sendTextViaBuffer('test-session', 'Hello', false);
 
-      // Should call execAsync 2 times: load-buffer, paste-buffer (no C-m)
-      expect(exec).toHaveBeenCalledTimes(2);
+      // spawn once for load-buffer, exec once for paste-buffer (no C-m)
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledTimes(1);
 
       const calls = vi.mocked(exec).mock.calls;
       // Verify no C-m send-keys call
@@ -80,34 +130,48 @@ describe('sendTextViaBuffer() - Issue #163', () => {
     });
   });
 
-  describe('Escape processing (SEC-001)', () => {
-    it('should escape $ character (variable expansion prevention)', async () => {
+  describe('Text sent without shell escaping (stdin pipe)', () => {
+    it('should send $ character directly without escaping', async () => {
       await sendTextViaBuffer('test-session', 'echo $HOME');
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('\\$');
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('echo $HOME');
     });
 
-    it('should escape " character', async () => {
+    it('should send " character directly without escaping', async () => {
       await sendTextViaBuffer('test-session', 'say "hello"');
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('\\"');
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('say "hello"');
     });
 
-    it('should escape ` character (command substitution prevention)', async () => {
+    it('should send ` character directly without escaping', async () => {
       await sendTextViaBuffer('test-session', 'echo `id`');
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('\\`');
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('echo `id`');
     });
 
-    it('should escape \\ character (backslash first to prevent double-escape)', async () => {
+    it('should send \\ character directly without escaping', async () => {
       await sendTextViaBuffer('test-session', 'path\\to\\file');
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      // Backslash should be escaped: \ -> \\\\
-      expect(loadBufferCall).toContain('\\\\');
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('path\\to\\file');
+    });
+
+    it('should send parentheses and brackets without escaping', async () => {
+      await sendTextViaBuffer('test-session', 'func(arg) { arr[0] }');
+
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('func(arg) { arr[0] }');
+    });
+
+    it('should send JSON content without escaping issues', async () => {
+      const json = '{"key": "value", "arr": [1, 2], "nested": {"$ref": "#/defs"}}';
+      await sendTextViaBuffer('test-session', json);
+
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe(json);
     });
   });
 
@@ -115,37 +179,25 @@ describe('sendTextViaBuffer() - Issue #163', () => {
     it('should sanitize special characters in session name', async () => {
       await sendTextViaBuffer('session/with:special@chars!', 'test');
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      // Special chars replaced with _, prefix cm-
-      expect(loadBufferCall).toContain('-b "cm-session_with_special_chars_"');
+      expect(spawn).toHaveBeenCalledWith(
+        'tmux',
+        ['load-buffer', '-b', 'cm-session_with_special_chars_', '-'],
+        expect.any(Object)
+      );
     });
   });
 
   describe('Error handling', () => {
     it('should cleanup buffer on load-buffer failure', async () => {
-      // Make load-buffer fail
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(exec).mockImplementationOnce((...args: any[]) => {
-        const cb = typeof args[1] === 'function' ? args[1] : args[2];
-        if (cb) {
-          cb(new Error('load-buffer failed'), { stdout: '', stderr: '' });
-        }
-        return {} as ReturnType<typeof exec>;
-      });
-
-      // Make delete-buffer succeed (cleanup)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(exec).mockImplementationOnce((...args: any[]) => {
-        const cb = typeof args[1] === 'function' ? args[1] : args[2];
-        if (cb) {
-          cb(null, { stdout: '', stderr: '' });
-        }
-        return {} as ReturnType<typeof exec>;
-      });
+      // Make spawn return a process that exits with error
+      vi.mocked(spawn).mockImplementation(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockChildProcess(1) as any
+      );
 
       await expect(sendTextViaBuffer('test-session', 'Hello')).rejects.toThrow();
 
-      // Verify cleanup was attempted
+      // Verify cleanup was attempted via exec delete-buffer
       const calls = vi.mocked(exec).mock.calls;
       const deleteBufferCall = calls.find((call) => {
         const cmd = call[0] as string;
@@ -155,15 +207,12 @@ describe('sendTextViaBuffer() - Issue #163', () => {
     });
 
     it('should cleanup buffer on paste-buffer failure', async () => {
-      let callIndex = 0;
+      let execCallIndex = 0;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.mocked(exec).mockImplementation((...args: any[]) => {
         const cb = typeof args[1] === 'function' ? args[1] : args[2];
-        callIndex++;
-        if (callIndex === 1) {
-          // load-buffer succeeds
-          if (cb) cb(null, { stdout: '', stderr: '' });
-        } else if (callIndex === 2) {
+        execCallIndex++;
+        if (execCallIndex === 1) {
           // paste-buffer fails
           if (cb) cb(new Error('paste-buffer failed'), { stdout: '', stderr: '' });
         } else {
@@ -189,10 +238,11 @@ describe('sendTextViaBuffer() - Issue #163', () => {
     it('should handle empty string', async () => {
       await sendTextViaBuffer('test-session', '');
 
-      expect(exec).toHaveBeenCalledTimes(3);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledTimes(2);
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('tmux load-buffer');
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('');
     });
 
     it('should handle very long text (10000+ characters)', async () => {
@@ -200,7 +250,11 @@ describe('sendTextViaBuffer() - Issue #163', () => {
 
       await sendTextViaBuffer('test-session', longText);
 
-      expect(exec).toHaveBeenCalledTimes(3);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledTimes(2);
+
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe(longText);
     });
 
     it('should handle text with only special characters', async () => {
@@ -208,12 +262,12 @@ describe('sendTextViaBuffer() - Issue #163', () => {
 
       await sendTextViaBuffer('test-session', specialText);
 
-      expect(exec).toHaveBeenCalledTimes(3);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledTimes(2);
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      // All special chars should be escaped
-      expect(loadBufferCall).not.toContain('$(');
-      expect(loadBufferCall).toContain('\\$');
+      // Text should be passed through as-is (no shell escaping needed)
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe(specialText);
     });
   });
 
@@ -221,32 +275,48 @@ describe('sendTextViaBuffer() - Issue #163', () => {
     it('should remove NUL bytes from text (leading/middle/trailing/consecutive/NUL-only)', async () => {
       // Leading NUL
       await sendTextViaBuffer('test-session', '\0Hello');
-      let loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).not.toContain('\0');
+      let mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('Hello');
       vi.clearAllMocks();
+      vi.mocked(spawn).mockImplementation(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockChildProcess(0) as any
+      );
 
       // Middle NUL
       await sendTextViaBuffer('test-session', 'He\0llo');
-      loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).not.toContain('\0');
+      mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('Hello');
       vi.clearAllMocks();
+      vi.mocked(spawn).mockImplementation(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockChildProcess(0) as any
+      );
 
       // Trailing NUL
       await sendTextViaBuffer('test-session', 'Hello\0');
-      loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).not.toContain('\0');
+      mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('Hello');
       vi.clearAllMocks();
+      vi.mocked(spawn).mockImplementation(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockChildProcess(0) as any
+      );
 
       // Consecutive NULs
       await sendTextViaBuffer('test-session', 'He\0\0\0llo');
-      loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).not.toContain('\0');
+      mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('Hello');
       vi.clearAllMocks();
+      vi.mocked(spawn).mockImplementation(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockChildProcess(0) as any
+      );
 
       // NUL-only text
       await sendTextViaBuffer('test-session', '\0\0\0');
-      loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).not.toContain('\0');
+      mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('');
     });
   });
 
@@ -256,16 +326,20 @@ describe('sendTextViaBuffer() - Issue #163', () => {
       // whether it was called after a prompt detection catch block
       await sendTextViaBuffer('test-session', 'message after catch');
 
-      expect(exec).toHaveBeenCalledTimes(3);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(spawn).toHaveBeenCalledWith(
+        'tmux',
+        ['load-buffer', '-b', 'cm-test-session', '-'],
+        expect.any(Object)
+      );
 
-      const loadBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
-      expect(loadBufferCall).toContain('tmux load-buffer');
-      expect(loadBufferCall).toContain('message after catch');
+      const mockProc = vi.mocked(spawn).mock.results[0].value;
+      expect(mockProc.stdin.writtenData).toBe('message after catch');
 
-      const pasteBufferCall = vi.mocked(exec).mock.calls[1][0] as string;
+      const pasteBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
       expect(pasteBufferCall).toContain('tmux paste-buffer');
 
-      const enterCall = vi.mocked(exec).mock.calls[2][0] as string;
+      const enterCall = vi.mocked(exec).mock.calls[1][0] as string;
       expect(enterCall).toContain('C-m');
     });
   });


### PR DESCRIPTION
## Summary
- **問題**: `sendTextViaBuffer()`が`execAsync`（シェル経由）でテキストをコマンド文字列に埋め込んでいたため、長い文字列や`(`、`)`、JSON等の特殊文字を含むテキスト送信時にシェル構文エラーが発生
- **修正**: `execAsync` + `printf`パイプ → `spawn` + stdinパイプに変更し、シェル解釈を完全にバイパス
- **テスト**: spawn対応のモックに書き換え、括弧/JSON送信テストを追加（全17テストパス）

## Changes
- `src/lib/tmux.ts`: `sendTextViaBuffer()`のload-buffer処理を`spawn`のstdinパイプ方式に変更
- `tests/unit/lib/tmux.test.ts`: spawn対応のモック・アサーションに書き換え、新規テスト追加

## Test plan
- [x] TypeScript型チェックパス (`npx tsc --noEmit`)
- [x] ESLintエラーなし (`npm run lint`)
- [x] ユニットテスト全パス（140ファイル / 2,763テスト）
- [ ] 実機でのメッセージ送信確認（長文・JSON・特殊文字含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)