### PR TITLE
fix(#163): enable bracketed paste for multiline message delivery

### DIFF
--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -421,9 +421,13 @@ export async function sendTextViaBuffer(
       proc.stdin.end();
     });
 
-    // Paste buffer into session and auto-delete buffer (-d), no trailing newline (-p)
+    // Paste buffer into session with bracketed paste mode
+    // -d: delete buffer after pasting
+    // Without -p: tmux sends bracketed paste markers (\e[200~ ... \e[201~)
+    //   so the application treats the entire content as a single paste operation
+    //   and newlines are NOT interpreted as Enter keypresses
     await execAsync(
-      `tmux paste-buffer -t "${sessionName}" -b "${bufferName}" -dp`,
+      `tmux paste-buffer -t "${sessionName}" -b "${bufferName}" -d`,
       { timeout: DEFAULT_TIMEOUT }
     );
 

--- a/tests/unit/lib/tmux.test.ts
+++ b/tests/unit/lib/tmux.test.ts
@@ -87,7 +87,8 @@ describe('sendTextViaBuffer() - Issue #163', () => {
       const pasteBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
       expect(pasteBufferCall).toContain('tmux paste-buffer');
       expect(pasteBufferCall).toContain('-t "test-session"');
-      expect(pasteBufferCall).toContain('-dp');
+      expect(pasteBufferCall).toContain('-d');
+      expect(pasteBufferCall).not.toContain('-dp');
 
       // Verify Enter key
       const enterCall = vi.mocked(exec).mock.calls[1][0] as string;


### PR DESCRIPTION
## Summary
- `tmux paste-buffer` の `-p` フラグを削除し、ブラケットペーストモードを有効化
- 複数行テキスト送信時に各改行がEnterキーとして解釈され、最初の1行しか送信されない問題を修正
- ブラケットペーストマーカー（`\e[200~` ... `\e[201~`）により、Claude CLIが全テキストを1つのペースト操作として認識

## Changes
- `src/lib/tmux.ts`: `paste-buffer -dp` → `paste-buffer -d`（`-p` フラグ削除）
- `tests/unit/lib/tmux.test.ts`: `-dp` → `-d` のアサーション更新

## Test plan
- [x] TypeScript型チェックパス
- [x] ユニットテスト全17件パス
- [ ] 実機で複数行メッセージ送信確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)