### PR TITLE
fix(#163): explicit bracketed paste markers for multiline text

### DIFF
--- a/tests/unit/lib/tmux.test.ts
+++ b/tests/unit/lib/tmux.test.ts
@@ -69,7 +69,7 @@ describe('sendTextViaBuffer() - Issue #163', () => {
   });
 
   describe('Normal operations', () => {
-    it('should send single-line text via buffer with Enter', async () => {
+    it('should send single-line text via buffer with Enter (no bracketed paste)', async () => {
       await sendTextViaBuffer('test-session', 'Hello World');
 
       // spawn called once for load-buffer
@@ -80,34 +80,58 @@ describe('sendTextViaBuffer() - Issue #163', () => {
         expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
       );
 
-      // exec called twice: paste-buffer + send-keys (C-m)
+      // Single-line: exec called twice: paste-buffer + send-keys (C-m)
+      // No bracketed paste markers for single-line text
       expect(exec).toHaveBeenCalledTimes(2);
 
-      // Verify paste-buffer call
+      // Verify paste-buffer call (with -dp for single-line)
       const pasteBufferCall = vi.mocked(exec).mock.calls[0][0] as string;
       expect(pasteBufferCall).toContain('tmux paste-buffer');
       expect(pasteBufferCall).toContain('-t "test-session"');
-      expect(pasteBufferCall).toContain('-d');
-      expect(pasteBufferCall).not.toContain('-dp');
+      expect(pasteBufferCall).toContain('-dp');
 
       // Verify Enter key
       const enterCall = vi.mocked(exec).mock.calls[1][0] as string;
       expect(enterCall).toContain('tmux send-keys');
       expect(enterCall).toContain('C-m');
 
+      // Verify no bracketed paste markers were sent
+      const allCalls = vi.mocked(exec).mock.calls.map(c => c[0] as string);
+      expect(allCalls.some(c => c.includes('-H 1b 5b 32 30 30 7e'))).toBe(false);
+
       // Verify text was written to stdin
       const mockProc = vi.mocked(spawn).mock.results[0].value;
       expect(mockProc.stdin.writtenData).toBe('Hello World');
     });
 
-    it('should send multiline text (50+ lines) via buffer', async () => {
+    it('should send multiline text with explicit bracketed paste markers', async () => {
       const lines = Array.from({ length: 55 }, (_, i) => `Line ${i + 1}`);
       const multilineText = lines.join('\n');
 
       await sendTextViaBuffer('test-session', multilineText);
 
       expect(spawn).toHaveBeenCalledTimes(1);
-      expect(exec).toHaveBeenCalledTimes(2);
+      // Multiline: bracket-start + paste-buffer + bracket-end + C-m = 4 exec calls
+      expect(exec).toHaveBeenCalledTimes(4);
+
+      // Verify bracketed paste start marker (ESC [ 2 0 0 ~)
+      const startMarkerCall = vi.mocked(exec).mock.calls[0][0] as string;
+      expect(startMarkerCall).toContain('send-keys');
+      expect(startMarkerCall).toContain('-H 1b 5b 32 30 30 7e');
+
+      // Verify paste-buffer call (with -dp, markers sent explicitly)
+      const pasteBufferCall = vi.mocked(exec).mock.calls[1][0] as string;
+      expect(pasteBufferCall).toContain('tmux paste-buffer');
+      expect(pasteBufferCall).toContain('-dp');
+
+      // Verify bracketed paste end marker (ESC [ 2 0 1 ~)
+      const endMarkerCall = vi.mocked(exec).mock.calls[2][0] as string;
+      expect(endMarkerCall).toContain('send-keys');
+      expect(endMarkerCall).toContain('-H 1b 5b 32 30 31 7e');
+
+      // Verify Enter key
+      const enterCall = vi.mocked(exec).mock.calls[3][0] as string;
+      expect(enterCall).toContain('C-m');
 
       // Verify the full multiline text was written to stdin
       const mockProc = vi.mocked(spawn).mock.results[0].value;
@@ -117,7 +141,7 @@ describe('sendTextViaBuffer() - Issue #163', () => {
     it('should not send Enter when sendEnter=false', async () => {
       await sendTextViaBuffer('test-session', 'Hello', false);
 
-      // spawn once for load-buffer, exec once for paste-buffer (no C-m)
+      // Single-line, no Enter: spawn once for load-buffer, exec once for paste-buffer
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(exec).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary
- 複数行テキスト送信時、tmux任せではなく明示的にブラケットペーストマーカー（`ESC[200~` / `ESC[201~`）を`send-keys -H`で送信
- Claude CLIがブラケットペーストモードを未リクエストの場合でも、改行がEnterとして解釈されず全テキストが1つのペースト操作として認識される
- ペースト処理完了のため200ms待機後にEnter送信
- 単行テキストはマーカー不要のため従来通り

## Flow (multiline)
1. `spawn` stdin → `tmux load-buffer`（テキスト読み込み）
2. `send-keys -H 1b 5b 32 30 30 7e` → `ESC[200~`（開始マーカー）
3. `paste-buffer -dp` → テキスト貼り付け
4. `send-keys -H 1b 5b 32 30 31 7e` → `ESC[201~`（終了マーカー）
5. 200ms待機
6. `send-keys C-m` → Enter送信

## Changes
- `src/lib/tmux.ts`: 複数行判定と明示的ブラケットペーストマーカー送信
- `tests/unit/lib/tmux.test.ts`: マーカー送信のアサーション追加

## Test plan
- [x] TypeScript型チェックパス
- [x] ユニットテスト全17件パス
- [ ] 実機で複数行メッセージ送信確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)