### PR TITLE
fix(#163): use sendKeys for single-line, sendTextViaBuffer for multiline

### DIFF
--- a/src/lib/claude-session.ts
+++ b/src/lib/claude-session.ts
@@ -388,8 +388,15 @@ export async function sendMessageToClaude(
     }
   }
 
-  // Send message via buffer to avoid paste detection (Issue #163)
-  await sendTextViaBuffer(sessionName, message, true);
+  // Issue #163: Route by content type
+  // - Single-line: use sendKeys (keystroke-by-keystroke, proven to work with Claude CLI)
+  // - Multiline: use sendTextViaBuffer with bracketed paste to avoid
+  //   paste detection folding ("[Pasted text #1 +XX lines]")
+  if (message.includes('\n')) {
+    await sendTextViaBuffer(sessionName, message, true);
+  } else {
+    await sendKeys(sessionName, message, true);
+  }
 
   console.log(`Sent message to Claude session: ${sessionName}`);
 }

--- a/src/lib/cli-tools/codex.ts
+++ b/src/lib/cli-tools/codex.ts
@@ -118,8 +118,14 @@ export class CodexTool extends BaseCLITool {
     }
 
     try {
-      // Send message via buffer to avoid paste detection (Issue #163)
-      await sendTextViaBuffer(sessionName, message, true);
+      // Issue #163: Route by content type
+      // - Single-line: use sendKeys (keystroke-by-keystroke, reliable)
+      // - Multiline: use sendTextViaBuffer with bracketed paste
+      if (message.includes('\n')) {
+        await sendTextViaBuffer(sessionName, message, true);
+      } else {
+        await sendKeys(sessionName, message, true);
+      }
 
       console.log(`✓ Sent message to Codex session: ${sessionName}`);
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- 単行メッセージ: `sendKeys()` を使用（キーストローク方式、Claude CLI動作実績あり）
- 複数行メッセージ: `sendTextViaBuffer()` を使用（ブラケットペースト方式でペースト検出回避）
- `paste-buffer` はpty一括書き込みのため、Claude CLIのink製TextInputが通常のキーストロークと異なる処理をしていた問題を解決

## Root cause
`paste-buffer` はテキストをターミナルに一括write するため、Claude CLIのink製TextInputコンポーネントが個別キーストロークとは異なる処理をする。単行テキストでも `paste-buffer` 経由だと正常に送信されなかった。

## Changes
- `src/lib/claude-session.ts`: `sendMessageToClaude()` で `\n` の有無により方式を分岐
- `src/lib/cli-tools/codex.ts`: `sendMessage()` で同様の分岐

## Test plan
- [x] TypeScript型チェックパス
- [x] ユニットテスト全17件パス
- [x] ESLintエラーなし
- [ ] 実機で単行メッセージ送信確認
- [ ] 実機で複数行メッセージ送信確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)