### PR TITLE
fix(server): delete worktrees of excluded repositories from DB on startup

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -40,7 +40,8 @@ import { stopAllPolling } from './src/lib/response-poller';
 import { stopAllAutoYesPolling } from './src/lib/auto-yes-manager';
 import { runMigrations } from './src/lib/db-migrations';
 import { getEnvByKey } from './src/lib/env';
-import { registerAndFilterRepositories } from './src/lib/db-repository';
+import { registerAndFilterRepositories, resolveRepositoryPath } from './src/lib/db-repository';
+import { getWorktreeIdsByRepository, deleteWorktreesByIds } from './src/lib/db';
 
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = getEnvByKey('CM_BIND') || '127.0.0.1';
@@ -99,6 +100,17 @@ app.prepare().then(() => {
         excludedPaths.forEach(p => {
           console.log(`  [excluded] ${p}`);
         });
+
+        // Issue #202: Remove worktrees of excluded repositories from DB
+        // Without this, worktree records remain in DB and appear in the UI
+        for (const excludedPath of excludedPaths) {
+          const resolvedPath = resolveRepositoryPath(excludedPath);
+          const worktreeIds = getWorktreeIdsByRepository(db, resolvedPath);
+          if (worktreeIds.length > 0) {
+            const result = deleteWorktreesByIds(db, worktreeIds);
+            console.log(`  Removed ${result.deletedCount} worktree(s) from excluded repository: ${resolvedPath}`);
+          }
+        }
       }
 
       // Scan filtered repositories (excluded repos are skipped)


### PR DESCRIPTION
## Summary
- Excluded repositories' worktree records remained in DB after server restart, causing them to appear in the UI
- Added explicit deletion of worktree records for excluded repositories during `initializeWorktrees()`
- Uses `getWorktreeIdsByRepository()` + `deleteWorktreesByIds()` to clean up DB before scanning

## Root Cause
`syncWorktreesToDB()` only processes repositories present in scan results. Excluded repositories are never scanned, so their worktree records are never touched — they persist in the DB and appear in the UI.

## Changes
- `server.ts`: Added worktree deletion loop for excluded repositories after filtering

## Test plan
- [x] TypeScript compilation: `npx tsc --noEmit` passed
- [x] Server build: `npm run build:server` passed
- [x] ESLint: `npm run lint` 0 errors
- [x] Unit tests: `npm run test:unit` 2863 passed
- [ ] Manual verification: exclude a repository via UI, restart server, confirm it no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)