### PR TITLE
fix(prompt-detector): handle full-width question mark in isContinuationLine

### DIFF
--- a/src/lib/prompt-detector.ts
+++ b/src/lib/prompt-detector.ts
@@ -320,14 +320,15 @@ function isConsecutiveFromOne(numbers: number[]): boolean {
  */
 function isContinuationLine(rawLine: string, line: string): boolean {
   // Indented non-option line.
-  // Excludes lines ending with '?' because those are typically question lines
-  // (e.g., "  Do you want to proceed?") from Claude Bash tool output where
-  // both the question and options are 2-space indented. Without this exclusion,
+  // Excludes lines ending with '?' or '？' (U+FF1F) because those are typically question lines
+  // (e.g., "  Do you want to proceed?", "  コピーしたい対象はどれですか？") from CLI tool output
+  // where both the question and options are 2-space indented. Without this exclusion,
   // the question line would be misclassified as a continuation line, causing
   // questionEndIndex to remain -1 and Layer 5 SEC-001 to block detection.
-  const hasLeadingSpaces = rawLine.match(/^\s{2,}[^\d]/) && !rawLine.match(/^\s*\d+\./) && !line.endsWith('?');
+  const endsWithQuestion = line.endsWith('?') || line.endsWith('\uff1f');
+  const hasLeadingSpaces = rawLine.match(/^\s{2,}[^\d]/) && !rawLine.match(/^\s*\d+\./) && !endsWithQuestion;
   // Short fragment (< 5 chars, excluding question-ending lines)
-  const isShortFragment = line.length < 5 && !line.endsWith('?');
+  const isShortFragment = line.length < 5 && !endsWithQuestion;
   // Path string continuation: lines starting with / or ~, or alphanumeric-only fragments (2+ chars)
   const isPathContinuation = /^[\/~]/.test(line) || (line.length >= 2 && /^[a-zA-Z0-9_-]+$/.test(line));
   return !!hasLeadingSpaces || isShortFragment || isPathContinuation;


### PR DESCRIPTION
## Summary

- Issue #208 で追加された `isContinuationLine()` の `!line.endsWith('?')` が ASCII `?` のみ対応で、全角 `？` (U+FF1F) を考慮していなかったため、インデント付き日本語質問行がcontinuation lineとして誤分類されプロンプト検出が失敗するバグを修正
- `endsWithQuestion` 共通変数を導入し、ASCII `?` と全角 `？` の両方をチェック（DRY）
- テスト T15（インデント付き全角`？`質問）、T16（Claude Code AskUserQuestion フルフォーマット再現）を追加

## Root Cause

`isContinuationLine()` (prompt-detector.ts L328) の `hasLeadingSpaces` 判定で `!line.endsWith('?')` が ASCII `?` のみチェック。Claude Code の AskUserQuestion がインデント付き日本語質問 `コピーしたい対象はどれですか？` を表示した場合、全角 `？` が ASCII `?` と一致せず `hasLeadingSpaces = true` → 質問行がスキップ → `questionEndIndex = -1` → Layer 5 SEC-001a で検出拒否。

## Test plan

- [x] T15: インデント付き全角`？`質問の検出確認
- [x] T16: Claude Code AskUserQuestion フルフォーマット（タブ、説明行、セパレータ）再現テスト
- [x] 既存テスト 131/131 全パス（prompt-detector.test.ts）
- [x] TypeScript エラー 0件
- [x] ESLint エラー 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)