### PR TITLE
fix(tmux): send special keys individually with delay for ink-based TUI (Issue #193)

### DIFF
--- a/dev-reports/bug-fix/20260210_auto-yes-cursor-nav/progress-context.json
+++ b/dev-reports/bug-fix/20260210_auto-yes-cursor-nav/progress-context.json
@@ -1,11 +1,15 @@
 {
   "bug_id": "20260210_auto-yes-cursor-nav",
   "bug_description": "Server-side Auto-Yes poller uses sendKeys() for Claude Code multiple_choice prompts instead of cursor-based navigation",
-  "fix_summary": "Added cursor-based navigation (sendSpecialKeys) to auto-yes-manager.ts pollAutoYes(), matching the fix already applied to prompt-response/route.ts",
+  "fix_summary": "1) Added cursor-based navigation (sendSpecialKeys) to auto-yes-manager.ts and prompt-response/route.ts with multi-select/single-select detection. 2) Fixed sendSpecialKeys() to send keys one-at-a-time with 100ms delay instead of all-at-once, because Claude Code's ink-based TUI needs processing time between keystrokes.",
   "phase_results": {
     "investigation": {
       "status": "success",
-      "root_cause": "auto-yes-manager.ts L340-342 bypasses prompt-response API and sends text via sendKeys() directly"
+      "root_cause": "sendSpecialKeys() in tmux.ts sent all keys in a single tmux send-keys command (e.g., 'tmux send-keys Space Down Down Down Enter'). Claude Code's ink-based TUI cannot process multiple keystrokes arriving simultaneously - only the first key gets processed. Manual testing confirmed: individual keys with delays work correctly, all-at-once does not.",
+      "previous_root_causes": [
+        "auto-yes-manager.ts L340-342 bypasses prompt-response API and sends text via sendKeys() directly",
+        "Multi-select checkbox prompts need Space+navigate-to-Next+Enter, not just Arrow+Enter"
+      ]
     },
     "tdd_fix": {
       "status": "success",
@@ -23,7 +27,9 @@
     }
   },
   "files_modified": [
+    "src/lib/tmux.ts",
     "src/lib/auto-yes-manager.ts",
+    "src/app/api/worktrees/[id]/prompt-response/route.ts",
     "tests/unit/lib/auto-yes-manager.test.ts",
     "tests/unit/api/prompt-response-verification.test.ts"
   ]


### PR DESCRIPTION
## Summary

- **真因**: `sendSpecialKeys()` が全キーを単一の `tmux send-keys` コマンドでまとめて送信していた（例: `tmux send-keys Space Down Down Down Down Enter`）
- Claude Code の ink ベース TUI は同時到着した複数キーストロークを正しく処理できないため、キーが無視されていた
- キーを1つずつ100msの遅延を挟んで個別送信するよう修正

## 検証結果

| 送信方法 | 結果 |
|---------|------|
| 全キー一括送信 | 何も起きない |
| 個別送信（100ms遅延） | 正常に動作（チェックボックストグル→Next遷移→Submit成功） |

## 変更ファイル

- `src/lib/tmux.ts` - `sendSpecialKeys()` をキー個別送信に変更（100ms遅延付き）

## Test plan

- [x] TypeScript型チェック（エラー0件）
- [x] auto-yes-managerテスト（48/48通過）
- [x] prompt-responseテスト（5/5通過）
- [ ] 実環境でClaude Code AskUserQuestionのmulti-selectプロンプトが自動応答されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)