### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-02-10
+
+_No changes recorded._
+
 ## [0.2.0] - 2026-02-08
 
 ### Changed
@@ -331,7 +335,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Kewton/CommandMate/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Kewton/CommandMate/compare/v0.1.12...v0.2.0
 [0.1.12]: https://github.com/Kewton/CommandMate/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/Kewton/CommandMate/compare/v0.1.10...v0.1.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Patch release v0.2.1
- Updated package.json version to 0.2.1
- Updated CHANGELOG.md with v0.2.1 section

## Post-merge steps
After merging this PR:
1. Create tag: `git tag v0.2.1 && git push origin v0.2.1`
2. Create GitHub Release: `gh release create v0.2.1 --title "v0.2.1" --generate-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)