### PR TITLE
fix(#225): モバイルでモーダルコンテンツがスクロール可能に

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -92,11 +92,11 @@ export function Modal({
       <div className="flex min-h-full items-center justify-center p-2 sm:p-4">
         <div
           ref={modalRef}
-          className={`relative w-full ${sizeClasses[size]} bg-white rounded-lg shadow-xl transform transition-all`}
+          className={`relative w-full ${sizeClasses[size]} max-h-[calc(100vh-1rem)] sm:max-h-[calc(100vh-2rem)] flex flex-col bg-white rounded-lg shadow-xl transform transition-all`}
         >
           {/* Header */}
           {(title || showCloseButton) && (
-            <div className="flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200">
+            <div className="flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 flex-shrink-0">
               <h3 className="text-base sm:text-lg font-semibold text-gray-900 truncate pr-2">{title}</h3>
               {showCloseButton && (
                 <button
@@ -122,7 +122,7 @@ export function Modal({
           )}
 
           {/* Content */}
-          <div className="px-4 sm:px-6 py-3 sm:py-4">{children}</div>
+          <div className="px-4 sm:px-6 py-3 sm:py-4 overflow-y-auto flex-1 min-h-0">{children}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- モバイルでAuto-Yes確認ダイアログの「同意して有効化」ボタンが画面外に隠れて操作できない問題を修正
- Modalコンポーネントにmax-height制約とoverflow-y-autoを追加し、コンテンツが画面高を超えた場合にスクロール可能に

## Changes

- `src/components/ui/Modal.tsx`
  - モーダルカードに `max-h-[calc(100vh-1rem)]` + `flex flex-col` を追加
  - コンテンツ領域に `overflow-y-auto` + `flex-1 min-h-0` を追加
  - ヘッダーに `flex-shrink-0` を追加（常時表示を保証）

## Test plan

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] Unit tests: 2,971 passed
- [ ] モバイル実機でAuto-Yes確認ダイアログのボタンが表示されることを確認

Related: #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)