### PR TITLE
fix(#225): React Portalでモーダルを最前面に表示

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -6,6 +6,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -80,7 +81,8 @@ export function Modal({
     full: 'max-w-[calc(100vw-2rem)] sm:max-w-[95vw]',
   };
 
-  return (
+  // Use portal to render at document.body level, escaping any parent stacking context
+  return createPortal(
     <div className="fixed inset-0 z-[9999] overflow-y-auto">
       {/* Backdrop - Issue #104: skip onClick if disableClose is true */}
       <div
@@ -125,6 +127,7 @@ export function Modal({
           <div className="px-4 sm:px-6 py-3 sm:py-4 overflow-y-auto flex-1 min-h-0">{children}</div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary

- モバイルでモーダルがメッセージ入力欄の裏に隠れる問題の根本修正
- 原因: AutoYesToggleが`z-30`のfixed親要素内にあり、子要素のModalがその**stacking context**に閉じ込められていた（z-indexを上げても親のstacking contextを超えられない）
- 修正: `createPortal`で`document.body`直下にレンダリングし、親のstacking contextから脱出

## Changes

- `src/components/ui/Modal.tsx` - `createPortal(modal, document.body)`でportal化

## Test plan

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] AutoYesConfirmDialog: 全テストパス
- [x] AutoYesToggle: 全テストパス
- [ ] モバイル実機でモーダルが完全に最前面に表示されることを確認

Related: #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)