### PR TITLE
feat(#235): display instructionText in active prompt UI

### DIFF
--- a/src/components/mobile/MobilePromptSheet.tsx
+++ b/src/components/mobile/MobilePromptSheet.tsx
@@ -259,6 +259,13 @@ function PromptContent({
         Claudeからの確認
       </h3>
 
+      {/* Instruction Text (context preceding the prompt) */}
+      {promptData.instructionText && (
+        <div className="max-h-40 overflow-y-auto whitespace-pre-wrap text-sm text-gray-600 bg-gray-50 rounded p-2 border border-gray-200">
+          {promptData.instructionText}
+        </div>
+      )}
+
       {/* Question */}
       <p className="text-gray-700 leading-relaxed">{promptData.question}</p>
 

--- a/src/components/worktree/PromptPanel.tsx
+++ b/src/components/worktree/PromptPanel.tsx
@@ -142,6 +142,13 @@ function PromptPanelContent({
         )}
       </div>
 
+      {/* Instruction Text (context preceding the prompt) */}
+      {promptData.instructionText && (
+        <div className="max-h-40 overflow-y-auto whitespace-pre-wrap text-sm text-gray-600 bg-gray-50 rounded p-2 border border-gray-200">
+          {promptData.instructionText}
+        </div>
+      )}
+
       {/* Question */}
       <p className="text-gray-800 leading-relaxed">{promptData.question}</p>
 

--- a/src/lib/prompt-detector.ts
+++ b/src/lib/prompt-detector.ts
@@ -139,6 +139,7 @@ function yesNoPromptResult(
       options: ['yes', 'no'],
       status: 'pending',
       ...(defaultOption !== undefined && { defaultOption }),
+      instructionText: rawContent,
     },
     cleanContent,
     rawContent,
@@ -544,6 +545,18 @@ function detectMultipleChoicePrompt(output: string, options?: DetectPromptOption
     question = 'Please select an option:';
   }
 
+  // Extract instruction text: lines up to questionEndIndex (max 20 lines of context)
+  let instructionText: string | undefined;
+  if (questionEndIndex >= 0) {
+    const contextStart = Math.max(0, questionEndIndex - 19);
+    const contextLines = lines.slice(contextStart, questionEndIndex + 1)
+      .map(l => l.trim())
+      .filter(l => l.length > 0);
+    if (contextLines.length > 0) {
+      instructionText = contextLines.join('\n');
+    }
+  }
+
   return {
     isPrompt: true,
     promptData: {
@@ -563,6 +576,7 @@ function detectMultipleChoicePrompt(output: string, options?: DetectPromptOption
         };
       }),
       status: 'pending',
+      instructionText,
     },
     cleanContent: question.trim(),
     rawContent: truncateRawContent(output.trim()),  // Issue #235: complete prompt output (truncated) [MF-001]

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -134,6 +134,8 @@ export interface BasePromptData {
   answer?: string;
   /** Timestamp when answered (ISO 8601) */
   answeredAt?: string;
+  /** Instruction text preceding the prompt (context for the user) - Issue #235 */
+  instructionText?: string;
 }
 
 /**

--- a/tests/unit/prompt-detector.test.ts
+++ b/tests/unit/prompt-detector.test.ts
@@ -1655,6 +1655,82 @@ Are you sure you want to continue? (yes/no)
       });
     });
 
+    describe('instructionText in promptData', () => {
+      it('should set instructionText for multiple_choice prompts with context lines', () => {
+        const output = [
+          'Here is some instruction text for the user.',
+          'Please review the following changes:',
+          'Do you want to proceed?',
+          '\u276F 1. Yes',
+          '  2. No',
+          '  3. Cancel',
+        ].join('\n');
+
+        const result = detectPrompt(output);
+
+        expect(result.isPrompt).toBe(true);
+        expect(result.promptData?.type).toBe('multiple_choice');
+        expect(result.promptData?.instructionText).toBeDefined();
+        expect(result.promptData?.instructionText).toContain('Here is some instruction text');
+        expect(result.promptData?.instructionText).toContain('Do you want to proceed?');
+      });
+
+      it('should set instructionText for yes_no prompts using rawContent', () => {
+        const output = [
+          'I will execute the following command:',
+          '  rm -rf /tmp/cache',
+          'Do you want to continue? (y/n)',
+        ].join('\n');
+
+        const result = detectPrompt(output);
+
+        expect(result.isPrompt).toBe(true);
+        expect(result.promptData?.type).toBe('yes_no');
+        expect(result.promptData?.instructionText).toBeDefined();
+        expect(result.promptData?.instructionText).toContain('rm -rf /tmp/cache');
+        expect(result.promptData?.instructionText).toContain('Do you want to continue?');
+      });
+
+      it('should set instructionText for Approve? prompts', () => {
+        const output = [
+          'I will execute the following command:',
+          '  rm -rf /tmp/cache',
+          'Approve?',
+        ].join('\n');
+
+        const result = detectPrompt(output);
+
+        expect(result.isPrompt).toBe(true);
+        expect(result.promptData?.instructionText).toBeDefined();
+        expect(result.promptData?.instructionText).toContain('Approve?');
+      });
+
+      it('should not set instructionText when no prompt is detected', () => {
+        const output = 'This is just normal output without any prompt';
+        const result = detectPrompt(output);
+
+        expect(result.isPrompt).toBe(false);
+        expect(result.promptData).toBeUndefined();
+      });
+
+      it('should set instructionText for multiple_choice without cursor (requireDefaultIndicator: false)', () => {
+        const output = [
+          'Some context about the operation.',
+          'Which option would you like?',
+          '  1. Yes',
+          '  2. No',
+        ].join('\n');
+
+        const options: DetectPromptOptions = { requireDefaultIndicator: false };
+        const result = detectPrompt(output, options);
+
+        expect(result.isPrompt).toBe(true);
+        expect(result.promptData?.instructionText).toBeDefined();
+        expect(result.promptData?.instructionText).toContain('Some context about the operation.');
+        expect(result.promptData?.instructionText).toContain('Which option would you like?');
+      });
+    });
+
     describe('lastLines expansion regression [SF-S3-002]', () => {
       it('should not false-detect (y/n) pattern appearing in lines 11-20 from end', () => {
         // The (y/n) pattern should only match when it is at the END of a line


### PR DESCRIPTION
## Summary
- `BasePromptData` に `instructionText?: string` フィールドを追加し、プロンプト検出時に指示テキストを設定
- `PromptPanel`（デスクトップ）と `MobilePromptSheet`（モバイル）のQuestion表示前に instructionText を表示するUIを追加
- Yes/No・Approve・Multiple Choice 全てのプロンプトタイプで instructionText が伝搬されることをテストで検証（5件追加）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/types/models.ts` | `BasePromptData` に `instructionText?: string` 追加 |
| `src/lib/prompt-detector.ts` | `yesNoPromptResult()` / `detectMultipleChoicePrompt()` で `instructionText` を設定 |
| `src/components/worktree/PromptPanel.tsx` | instructionText 表示領域追加（max-h-40, overflow-y-auto） |
| `src/components/mobile/MobilePromptSheet.tsx` | 同上 |
| `tests/unit/prompt-detector.test.ts` | instructionText テスト5件追加 |

## Test plan
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm run lint` — ESLintエラーなし
- [x] `npm run test:unit` — 全144件パス（prompt-detector）、全体3067件パス
- [ ] 手動: デスクトップで multiple_choice プロンプト時に PromptPanel に指示テキストが表示されること
- [ ] 手動: モバイルで MobilePromptSheet に指示テキストが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)