### PR TITLE
fix(#124): correct image and document links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See the [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) for details.
 
 ### Mobile Access
 
-Enabling external access via `commandmate init` sets `CM_BIND=0.0.0.0`. Access from the same LAN at `http://<your PC's IP>:3000`. For external access, we recommend authentication via a reverse proxy. See the [Security Guide](./docs/security-guide.md) for details.
+Enabling external access via `commandmate init` sets `CM_BIND=0.0.0.0`. Access from the same LAN at `http://<your PC's IP>:3000`. For external access, we recommend authentication via a reverse proxy. See the [Security Guide](./docs/en/security-guide.md) for details.
 
 ## Developer Setup
 
@@ -121,7 +121,7 @@ A: The app, database, and sessions all run entirely locally. The only external c
 A: You can use tunneling services like Cloudflare Tunnel. Within your home, simply connect your phone to the same Wi-Fi as your PC.
 
 **Q: What about Claude Code's permissions?**
-A: Claude Code's own permission settings apply as-is. This tool does not expand permissions. See [Trust & Safety](./docs/TRUST_AND_SAFETY.md) for details.
+A: Claude Code's own permission settings apply as-is. This tool does not expand permissions. See [Trust & Safety](./docs/en/TRUST_AND_SAFETY.md) for details.
 
 **Q: Does it work on Windows?**
 A: Not currently supported. macOS / Linux is required due to the tmux dependency. WSL2 has not been tested.
@@ -139,12 +139,12 @@ A: Currently designed for individual use. Simultaneous multi-user access is not 
 | [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) | Installation and initial setup |
 | [Web App Guide](./docs/en/user-guide/webapp-guide.md) | Basic web app operations |
 | [Quick Start](./docs/en/user-guide/quick-start.md) | Using Claude Code commands |
-| [Concept](./docs/concept.md) | Vision and problems solved |
-| [Architecture](./docs/architecture.md) | System design |
-| [Deployment Guide](./docs/DEPLOYMENT.md) | Production environment setup |
-| [Migration Guide](./docs/migration-to-commandmate.md) | Migrating from MyCodeBranchDesk |
-| [UI/UX Guide](./docs/UI_UX_GUIDE.md) | UI implementation details |
-| [Trust & Safety](./docs/TRUST_AND_SAFETY.md) | Security and permissions |
+| [Concept](./docs/en/concept.md) | Vision and problems solved |
+| [Architecture](./docs/en/architecture.md) | System design |
+| [Deployment Guide](./docs/en/DEPLOYMENT.md) | Production environment setup |
+| [Migration Guide](./docs/en/migration-to-commandmate.md) | Migrating from MyCodeBranchDesk |
+| [UI/UX Guide](./docs/en/UI_UX_GUIDE.md) | UI implementation details |
+| [Trust & Safety](./docs/en/TRUST_AND_SAFETY.md) | Security and permissions |
 
 ## Contributing
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -5,7 +5,7 @@
 > 「入力待ちを見逃さない、開発の相棒。」
 > 「軽量。その場で完結。Claude Codeを、どこからでも動かす。」
 
-![PC表示](./docs/images/screenshot-desktop.png)
+![PC表示](../../docs/images/screenshot-desktop.png)
 
 ## これは何か
 
@@ -39,11 +39,11 @@ Claude Code での開発経験があり、本業の傍らで個人開発を続�
 
 | PC表示 | スマホ（History） | スマホ（Terminal） |
 |--------|-------------------|-------------------|
-| ![PC - ワークツリー詳細](./docs/images/screenshot-worktree-desktop.png) | ![スマホ - History](./docs/images/screenshot-worktree-mobile.png) | ![スマホ - Terminal](./docs/images/screenshot-worktree-mobile-terminal.png) |
+| ![PC - ワークツリー詳細](../../docs/images/screenshot-worktree-desktop.png) | ![スマホ - History](../../docs/images/screenshot-worktree-mobile.png) | ![スマホ - Terminal](../../docs/images/screenshot-worktree-mobile-terminal.png) |
 
 ### トップ画面（スマホ）
 
-![スマホ表示](./docs/images/screenshot-mobile.png)
+![スマホ表示](../../docs/images/screenshot-mobile.png)
 
 ## Quick Start
 
@@ -79,11 +79,11 @@ commandmate start --daemon    # バックグラウンドで起動
 | `commandmate stop` | サーバー停止 |
 | `commandmate status` | 状態確認 |
 
-詳しくは [CLI セットアップガイド](./docs/user-guide/cli-setup-guide.md) を参照してください。
+詳しくは [CLI セットアップガイド](../user-guide/cli-setup-guide.md) を参照してください。
 
 ### モバイルからのアクセス
 
-`commandmate init` で外部アクセスを有効にすると、`CM_BIND=0.0.0.0` が設定されます。同一LAN内から `http://<PCのIP>:3000` にアクセスします。外部公開時はリバースプロキシでの認証を推奨します。詳細は [セキュリティガイド](./docs/security-guide.md) を参照してください。
+`commandmate init` で外部アクセスを有効にすると、`CM_BIND=0.0.0.0` が設定されます。同一LAN内から `http://<PCのIP>:3000` にアクセスします。外部公開時はリバースプロキシでの認証を推奨します。詳細は [セキュリティガイド](../security-guide.md) を参照してください。
 
 ## 開発者向けセットアップ
 
@@ -121,7 +121,7 @@ A: アプリ本体・DB・セッションはすべてローカルで完結しま
 A: Cloudflare Tunnel などのトンネリングサービスを活用することで利用できます。室内であればローカル PC と同じ Wi-Fi に接続するだけでスマホから利用可能です。
 
 **Q: Claude Code の権限はどうなる？**
-A: Claude Code 自体の権限設定がそのまま適用されます。本ツールが権限を拡張することはありません。詳しくは [Trust & Safety](./docs/TRUST_AND_SAFETY.md) を参照してください。
+A: Claude Code 自体の権限設定がそのまま適用されます。本ツールが権限を拡張することはありません。詳しくは [Trust & Safety](../TRUST_AND_SAFETY.md) を参照してください。
 
 **Q: Windows で使える？**
 A: 現時点では非対応です。tmux に依存しているため macOS / Linux が必要です。WSL2 上での動作は未検証です。
@@ -136,20 +136,20 @@ A: 現時点では個人利用を想定しています。複数人での同時�
 
 | ドキュメント | 説明 |
 |-------------|------|
-| [CLI セットアップガイド](./docs/user-guide/cli-setup-guide.md) | インストールと初期設定 |
-| [Webアプリ操作ガイド](./docs/user-guide/webapp-guide.md) | Webアプリの基本操作 |
-| [クイックスタート](./docs/user-guide/quick-start.md) | Claude Codeコマンドの使い方 |
-| [コンセプト](./docs/concept.md) | ビジョンと解決する課題 |
-| [アーキテクチャ](./docs/architecture.md) | システム設計 |
-| [デプロイガイド](./docs/DEPLOYMENT.md) | 本番環境構築手順 |
-| [移行ガイド](./docs/migration-to-commandmate.md) | MyCodeBranchDesk からの移行手順 |
-| [UI/UXガイド](./docs/UI_UX_GUIDE.md) | UI実装の詳細 |
-| [Trust & Safety](./docs/TRUST_AND_SAFETY.md) | セキュリティと権限の考え方 |
+| [CLI セットアップガイド](../user-guide/cli-setup-guide.md) | インストールと初期設定 |
+| [Webアプリ操作ガイド](../user-guide/webapp-guide.md) | Webアプリの基本操作 |
+| [クイックスタート](../user-guide/quick-start.md) | Claude Codeコマンドの使い方 |
+| [コンセプト](../concept.md) | ビジョンと解決する課題 |
+| [アーキテクチャ](../architecture.md) | システム設計 |
+| [デプロイガイド](../DEPLOYMENT.md) | 本番環境構築手順 |
+| [移行ガイド](../migration-to-commandmate.md) | MyCodeBranchDesk からの移行手順 |
+| [UI/UXガイド](../UI_UX_GUIDE.md) | UI実装の詳細 |
+| [Trust & Safety](../TRUST_AND_SAFETY.md) | セキュリティと権限の考え方 |
 
 ## Contributing
 
-バグ報告・機能提案・ドキュメント改善を歓迎します。詳しくは [CONTRIBUTING.md](./CONTRIBUTING.md) を参照してください。
+バグ報告・機能提案・ドキュメント改善を歓迎します。詳しくは [CONTRIBUTING.md](../../CONTRIBUTING.md) を参照してください。
 
 ## License
 
-[MIT License](./LICENSE) - Copyright (c) 2026 Kewton
+[MIT License](../../LICENSE) - Copyright (c) 2026 Kewton


### PR DESCRIPTION
## Summary
- Fix image paths in Japanese README (`docs/ja/README.md`) to correctly load images (`../../docs/images/` instead of `./docs/images/`)
- Fix document links in English README to point to English documentation (`./docs/en/` instead of `./docs/`)
- Fix document links in Japanese README to point to Japanese documentation (relative paths from `docs/ja/`)
- Ensure language-specific READMEs link to corresponding language documentation

## Related Issue
Part of #124

## Changes
### Japanese README (`docs/ja/README.md`)
- Image paths: `./docs/images/` → `../../docs/images/` (4 locations)
- Document links: `./docs/` → `../` (Japanese docs)
- Root links: `./CONTRIBUTING.md` → `../../CONTRIBUTING.md`, `./LICENSE` → `../../LICENSE`

### English README (`README.md`)
- Document links: `./docs/concept.md` → `./docs/en/concept.md`
- All documentation links now point to `/docs/en/` directory

## Test plan
- [ ] Verify images load correctly in Japanese README
- [ ] Verify document links in English README navigate to English docs
- [ ] Verify document links in Japanese README navigate to Japanese docs
- [ ] Check both READMEs on GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)