### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-02-13
+
+### Added
+- i18n support with next-intl for English and Japanese (Issue #124)
+  - Locale-based routing (`/en`, `/ja`)
+  - Document translations and integration/e2e tests
+- Log export feature with LogViewer (Issue #11)
+  - `LogViewer` component in Info screen (desktop modal & mobile)
+  - `withLogging()` API logger middleware applied to log routes
+  - `log-config.ts` for centralized LOG_DIR constant
+  - Log-manager regression tests
+- Prompt instructionText display in active prompt UI (Issue #235)
+  - `PromptPanel` and `MobilePromptSheet` show instruction text
+  - Complete prompt output preserved with `rawContent` field
+
+### Fixed
+- Full prompt block included in instructionText for multiple_choice prompts (Issue #235)
+- Full output passed to detectPrompt in status-detector for long prompts (Issue #235)
+- next-intl middleware removed to fix redirect loop with custom server (Issue #124)
+- Image and document links corrected in README files (Issue #124)
+- Rebuild skill branch specification to prevent worktree misexecution
+
+### Removed
+- Dead code: claude-poller, terminal-websocket, WorktreeDetail legacy code, simple-terminal (Issue #237)
+
 ## [0.2.2] - 2026-02-10
 
 _No changes recorded._
@@ -339,7 +364,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.2...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/Kewton/CommandMate/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Kewton/CommandMate/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Kewton/CommandMate/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Kewton/CommandMate/compare/v0.1.12...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Release version 0.2.3 (patch)
- Update package.json, package-lock.json, CHANGELOG.md

## Changes included in this release
### Added
- i18n support with next-intl for English and Japanese (Issue #124)
- Log export feature with LogViewer (Issue #11)
- Prompt instructionText display in active prompt UI (Issue #235)

### Fixed
- Multiple prompt detection and display fixes (Issue #235)
- next-intl middleware redirect loop fix (Issue #124)
- README link corrections (Issue #124)
- Rebuild skill branch specification fix

### Removed
- Dead code cleanup: claude-poller, terminal-websocket, etc. (Issue #237)

## Post-merge steps
After merging this PR:
1. `git tag v0.2.3` on the merge commit
2. `git push origin v0.2.3`
3. `gh release create v0.2.3 --title "v0.2.3" --generate-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)