### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-02-13
+
+### Added
+- Version update notification feature (Issue #257)
+  - `UpdateNotificationBanner` component for new version alerts
+  - `VersionSection` component for Info screen
+  - `useUpdateCheck` hook and `version-checker.ts` library
+  - `/api/app/update-check` API endpoint
+
+### Fixed
+- Multiple choice prompt detection for wrapped questions (Issue #256)
+  - `isQuestionLikeLine()` now handles multi-line question wrapping (trailing `。` / `.`)
+  - Keyword-based detection for non-question prompts (model selection, etc.)
+  - Added `questionBlockScan()` for multi-line question block analysis
+- Mobile background resume error "Error loading worktree" (Issue #246)
+  - Added `visibilitychange` event listener for automatic data recovery
+  - Error state reset and data re-fetch on page visibility restore
+
 ## [0.2.3] - 2026-02-13
 
 ### Added
@@ -364,7 +382,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.3...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/Kewton/CommandMate/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Kewton/CommandMate/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Kewton/CommandMate/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Kewton/CommandMate/compare/v0.2.0...v0.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Release version 0.2.4 (patch)
- Update package.json, package-lock.json, CHANGELOG.md

## Changes included in this release

### Added
- Version update notification feature (Issue #257)

### Fixed
- Multiple choice prompt detection for wrapped questions (Issue #256)
- Mobile background resume error "Error loading worktree" (Issue #246)

## Post-merge steps
1. `git checkout main && git pull origin main`
2. `git tag v0.2.4`
3. `git push origin v0.2.4`
4. `gh release create v0.2.4 --title "v0.2.4" --generate-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)