### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-02-14
+
+### Fixed
+- Update-check API route static prerender error (Issue #270)
+  - Added `force-dynamic` export to prevent Next.js static generation at build time
+
 ## [0.2.5] - 2026-02-14
 
 ### Added
@@ -403,7 +409,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.5...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/Kewton/CommandMate/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Kewton/CommandMate/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Kewton/CommandMate/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Kewton/CommandMate/compare/v0.2.2...v0.2.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Release version 0.2.6 (patch)
- Update package.json, package-lock.json, CHANGELOG.md

## Changes included in this release

### Fixed
- Update-check API route static prerender error (Issue #270)
  - Added `force-dynamic` export to prevent Next.js static generation at build time

## Post-merge steps
1. `git checkout main && git pull origin main`
2. `git tag v0.2.6`
3. `git push origin v0.2.6`
4. `gh release create v0.2.6 --title "v0.2.6" --generate-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)