### PR TITLE
chore: release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-02-15
+
+### Added
+- File move/rename feature with `MoveDialog` component (Issue #162)
+  - Context menu "Move/Rename" option for files and directories
+  - Path validation and overwrite prevention
+- File creation date (birthtime) display in `FileViewer` header and mobile view (Issue #162)
+  - `date-utils.ts` with locale-aware formatting
+- Content copy button in `MarkdownEditor` toolbar (Issue #162)
+  - `useFileOperations` hook for file operation logic extraction
+
 ## [0.2.8] - 2026-02-14
 
 ### Fixed
@@ -432,7 +443,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.8...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.9...HEAD
+[0.2.9]: https://github.com/Kewton/CommandMate/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/Kewton/CommandMate/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/Kewton/CommandMate/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Kewton/CommandMate/compare/v0.2.5...v0.2.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump version to v0.2.9 (patch)
- Update CHANGELOG.md with Issue #162 changes

## Changes included in this release

### Added
- File move/rename feature with `MoveDialog` component (Issue #162)
- File creation date (birthtime) display in `FileViewer` header and mobile view (Issue #162)
- Content copy button in `MarkdownEditor` toolbar (Issue #162)
  - `useFileOperations` hook for file operation logic extraction

## Test plan
- [ ] Verify version is 0.2.9 in package.json
- [ ] Verify CHANGELOG.md has correct v0.2.9 entry
- [ ] After merge, create tag v0.2.9 and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)