### PR TITLE
fix(#288): resolve Enter key interception and filter text carry-over in free input mode

### DIFF
--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -138,13 +138,13 @@ export function MessageInput({ worktreeId, onMessageSent, cliToolId, isSessionRu
   };
 
   /**
-   * Handle free input mode (Issue #56)
-   * Closes selector and prefills '/' for custom command entry
+   * Handle free input mode (Issue #56, #288)
+   * Closes selector and carries over filter text as the custom command prefix
    */
-  const handleFreeInput = () => {
+  const handleFreeInput = (filterText: string) => {
     setShowCommandSelector(false);
     setIsFreeInputMode(true);
-    setMessage('/');
+    setMessage(filterText ? `/${filterText}` : '/');
     // Focus textarea with a small delay to ensure selector is closed
     setTimeout(() => {
       textareaRef.current?.focus();
@@ -211,8 +211,8 @@ export function MessageInput({ worktreeId, onMessageSent, cliToolId, isSessionRu
 
     // Submit on Enter (but not when Shift is pressed or composing with IME)
     // Shift+Enter allows line breaks
-    // Don't submit when command selector is open
-    if (e.key === 'Enter' && !isComposing && !showCommandSelector) {
+    // Don't submit when command selector is open (unless in free input mode - Issue #288)
+    if (e.key === 'Enter' && !isComposing && (!showCommandSelector || isFreeInputMode)) {
       if (isMobile) {
         // Mobile: Enter inserts newline (default behavior)
         return;

--- a/src/components/worktree/SlashCommandSelector.tsx
+++ b/src/components/worktree/SlashCommandSelector.tsx
@@ -25,8 +25,8 @@ export interface SlashCommandSelectorProps {
   isMobile?: boolean;
   /** Position for desktop dropdown */
   position?: { top: number; left: number };
-  /** Callback for free input mode (Issue #56) */
-  onFreeInput?: () => void;
+  /** Callback for free input mode (Issue #56, #288: passes current filter text) */
+  onFreeInput?: (filterText: string) => void;
 }
 
 /**
@@ -120,13 +120,15 @@ export function SlashCommandSelector({
     [isOpen, flatCommands, highlightedIndex, onClose, handleSelect]
   );
 
-  // Add keyboard listener
+  // Add keyboard listener only when selector is open (Issue #288)
+  // Prevents document-level Enter key interception when selector is closed
   useEffect(() => {
+    if (!isOpen) return;
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [handleKeyDown]);
+  }, [isOpen, handleKeyDown]);
 
   if (!isOpen) {
     return null;
@@ -185,12 +187,12 @@ export function SlashCommandSelector({
             />
           </div>
 
-          {/* Free input button (Issue #56) */}
+          {/* Free input button (Issue #56, #288) */}
           {onFreeInput && (
             <button
               type="button"
               data-testid="free-input-button"
-              onClick={onFreeInput}
+              onClick={() => onFreeInput(filter)}
               className="w-full px-4 py-3 text-left border-b border-gray-100 flex items-center gap-2 hover:bg-blue-50 transition-colors"
             >
               <span className="text-blue-600">
@@ -233,12 +235,12 @@ export function SlashCommandSelector({
         />
       </div>
 
-      {/* Free input button (Issue #56) */}
+      {/* Free input button (Issue #56, #288) */}
       {onFreeInput && (
         <button
           type="button"
           data-testid="free-input-button"
-          onClick={onFreeInput}
+          onClick={() => onFreeInput(filter)}
           className="w-full px-3 py-2 text-left border-b border-gray-100 flex items-center gap-2 hover:bg-blue-50 transition-colors text-sm"
         >
           <span className="text-blue-600">

--- a/tests/unit/components/SlashCommandSelector.test.tsx
+++ b/tests/unit/components/SlashCommandSelector.test.tsx
@@ -214,6 +214,38 @@ describe('SlashCommandSelector', () => {
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
+
+    it('should not intercept Enter key when isOpen is false (Issue #288)', () => {
+      render(
+        <SlashCommandSelector
+          isOpen={false}
+          groups={mockGroups}
+          onSelect={mockOnSelect}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'Enter' });
+
+      // onSelect should NOT be called because the listener is not registered when closed
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('should select command on Enter key when isOpen is true', () => {
+      render(
+        <SlashCommandSelector
+          isOpen={true}
+          groups={mockGroups}
+          onSelect={mockOnSelect}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'Enter' });
+
+      // First command should be selected (highlightedIndex defaults to 0)
+      expect(mockOnSelect).toHaveBeenCalledWith(mockGroups[0].commands[0]);
+    });
   });
 
   describe('Free input mode (Issue #56)', () => {

--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -406,6 +406,44 @@ describe('MessageInput', () => {
 
         expect(queryDesktopSelector()).toBeInTheDocument();
       });
+
+      it('TC-8: should submit slash command without space via Enter in free input mode (Issue #288)', async () => {
+        const { worktreeApi } = await import('@/lib/api-client');
+
+        render(<MessageInput {...defaultProps} />);
+
+        enterFreeInputMode();
+
+        // Type a command without space (e.g., /compact)
+        typeMessage('/compact');
+
+        pressEnter();
+
+        await waitFor(() => {
+          expect(worktreeApi.sendMessage).toHaveBeenCalledWith(
+            'test-worktree',
+            '/compact',
+            'claude'
+          );
+        });
+      });
+
+      it('TC-9: should not submit when selector is open in normal mode (not free input)', async () => {
+        const { worktreeApi } = await import('@/lib/api-client');
+
+        render(<MessageInput {...defaultProps} />);
+
+        // Type '/' to open selector (normal mode, not free input)
+        openSelector();
+        expect(queryDesktopSelector()).toBeInTheDocument();
+
+        // Press Enter - should select command, not submit
+        pressEnter();
+
+        await delay();
+
+        expect(worktreeApi.sendMessage).not.toHaveBeenCalled();
+      });
     });
 
     describe('Mobile', () => {


### PR DESCRIPTION
## Summary
- SlashCommandSelectorのdocument-levelキーボードリスナーを`isOpen=true`時のみ登録するよう変更し、セレクター非表示時のEnterキー横取りを防止
- フリー入力モード中は`showCommandSelector`状態に関係なくEnterキーで送信可能に（防御的修正）
- 「Enter custom command...」クリック時にフィルター入力テキストをtextareaに引き継ぐよう改善（例: フィルターに`aiueo`入力 → textareaに`/aiueo`がセット）

## Changed files
- `src/components/worktree/SlashCommandSelector.tsx` — リスナー条件付き登録、`onFreeInput`にフィルターテキスト引き渡し
- `src/components/worktree/MessageInput.tsx` — `handleFreeInput`のフィルター引き継ぎ、`isFreeInputMode`時のEnter送信許可
- `tests/unit/components/SlashCommandSelector.test.tsx` — isOpen=false時リスナー未登録テスト追加
- `tests/unit/components/worktree/MessageInput.test.tsx` — TC-8（フリー入力Enter送信）、TC-9（通常モードEnterガード）追加

## Test plan
- [ ] `/` 入力でセレクター表示 → フィルターにテキスト入力 → 「Enter custom command...」クリック → textareaに`/テキスト`が引き継がれること
- [ ] フリー入力モードでEnterキーによるメッセージ送信が動作すること
- [ ] 通常モードでセレクター表示中のEnterがコマンド選択として動作すること（送信されないこと）
- [ ] Escapeでセレクター閉じた後、再度`/`で開けること
- [ ] 単体テスト全42件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)