### PR TITLE
feat(#314): Stop条件入力に正規表現Tipsツールチップ追加

### DIFF
--- a/locales/en/autoYes.json
+++ b/locales/en/autoYes.json
@@ -22,5 +22,10 @@
   "stopPatternDescription": "Auto-Yes will be automatically stopped when terminal output matches this pattern",
   "invalidRegexPattern": "Invalid regular expression pattern",
   "patternTooLong": "Pattern must be 500 characters or less",
-  "stopPatternMatched": "Auto-Yes was automatically stopped because the stop condition was matched"
+  "stopPatternMatched": "Auto-Yes was automatically stopped because the stop condition was matched",
+  "regexTipsLabel": "Regex tips",
+  "regexTipsTitle": "Regex Tips",
+  "regexTipWordBoundary": "… match whole word only (prevents partial match)",
+  "regexTipOr": "… OR condition (matches either)",
+  "regexTipCaseNote": "… matching is case-sensitive"
 }

--- a/locales/ja/autoYes.json
+++ b/locales/ja/autoYes.json
@@ -22,5 +22,10 @@
   "stopPatternDescription": "ターミナル出力がこのパターンにマッチした場合、Auto-Yesを自動停止します",
   "invalidRegexPattern": "無効な正規表現パターンです",
   "patternTooLong": "パターンは500文字以内で入力してください",
-  "stopPatternMatched": "Stop条件にマッチしたためAuto-Yesを自動停止しました"
+  "stopPatternMatched": "Stop条件にマッチしたためAuto-Yesを自動停止しました",
+  "regexTipsLabel": "正規表現のヒント",
+  "regexTipsTitle": "正規表現Tips",
+  "regexTipWordBoundary": "… 単語単位でマッチ（部分一致を防止）",
+  "regexTipOr": "… OR条件（いずれかにマッチ）",
+  "regexTipCaseNote": "… 大文字小文字は区別されます"
 }


### PR DESCRIPTION
## Summary
- Stop条件（正規表現）入力フィールドのラベル横に `?` アイコンを追加
- クリックで正規表現のTipsをツールチップ表示（`\bcat\b` 単語境界、`error|fatal` OR条件、大文字小文字の区別について）
- `cat` が `verification` にマッチする等の部分一致問題をユーザーが自己解決できるようにする

## Test plan
- [ ] Stop条件ラベル横の `?` アイコンをクリックするとツールチップが表示される
- [ ] ツールチップ外をクリックすると閉じる
- [ ] ダイアログを再度開くとツールチップは非表示状態にリセットされる
- [ ] ja/en両方の翻訳が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)