### PR TITLE
fix: use test:unit in publish workflow and restore CI memory limits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm audit --audit-level=critical
 
       - name: Run tests
-        run: npm test
+        run: npm run test:unit
 
       - name: Build Next.js
         run: npm run build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     environment: 'node',
     env: { NODE_ENV: 'test' },
     setupFiles: ['./tests/setup.ts'],
+    // CI環境ではメモリ使用量を抑えるため同時実行を制限
+    maxConcurrency: process.env.CI === 'true' ? 1 : 10,
+    fileParallelism: process.env.CI !== 'true',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Publish workflow (`publish.yml`) の `npm test` を `npm run test:unit` に変更
- `vitest.config.ts` にCI向けメモリ制限設定を復元

## Background
v0.2.12のnpm publishが失敗した原因:
1. Issue #304で `npm test` が `NODE_ENV=test vitest` に変更され、テスト失敗時に正しくexit code 1を返すようになった
2. Publish環境にはブラウザ/tmuxがなく、E2E/integrationテストが失敗する
3. Issue #304で `vitest.config.ts` からCI向けメモリ制限設定が削除され、OOMリスクが復活

## Changes
- `publish.yml`: `npm test` → `npm run test:unit`（CIと同じくunit testのみ実行）
- `vitest.config.ts`: `maxConcurrency`/`fileParallelism` のCI設定を復元

🤖 Generated with [Claude Code](https://claude.com/claude-code)