### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-02-23
+
+### Fixed
+- False negative in `isSessionHealthy()` for recovered sessions (Issue #354)
+  - Prevent healthy sessions from being incorrectly marked as unhealthy after recovery
+
 ## [0.3.0] - 2026-02-22
 
 ### Added
@@ -538,7 +544,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Kewton/CommandMate/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Kewton/CommandMate/compare/v0.2.13...v0.3.0
 [0.2.13]: https://github.com/Kewton/CommandMate/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/Kewton/CommandMate/compare/v0.2.11...v0.2.12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Git worktree management with Claude CLI and tmux sessions",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- Patch version bump: v0.3.0 → v0.3.1
- Fix false negative in `isSessionHealthy()` for recovered sessions (#354)

## Changes
- `package.json` version updated to 0.3.1
- `package-lock.json` updated
- `CHANGELOG.md` updated with v0.3.1 release notes

## Post-merge
After merging, tag `v0.3.1` and create GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)