### PR TITLE
docs: update mobile tab bar table in webapp-guide

### DIFF
--- a/docs/en/user-guide/webapp-guide.md
+++ b/docs/en/user-guide/webapp-guide.md
@@ -330,8 +330,9 @@ On mobile, a tab bar is displayed at the bottom:
 |-----|---------|
 | **Terminal** | Real-time output + message input |
 | **History** | Chat history |
-| **Logs** | Markdown log list |
-| **Info** | Worktree information + notes |
+| **Files** | File tree view |
+| **CMATE** | Notes + execution logs |
+| **Info** | Worktree information |
 
 ![Mobile view](../../images/screenshot-mobile.png)
 *Mobile: Homepage*

--- a/docs/user-guide/webapp-guide.md
+++ b/docs/user-guide/webapp-guide.md
@@ -330,8 +330,9 @@ Cloudflare Tunnel などのトンネリングサービスを使用すること�
 |------|------|
 | **Terminal** | リアルタイム出力 + メッセージ入力 |
 | **History** | チャット履歴 |
-| **Logs** | Markdownログ一覧 |
-| **Info** | ワークツリー情報 + メモ |
+| **Files** | ファイルツリー表示 |
+| **CMATE** | メモ + 実行ログ |
+| **Info** | ワークツリー情報 |
 
 ![モバイル表示](../images/screenshot-mobile.png)
 *モバイル: トップページ*


### PR DESCRIPTION
## Summary
- モバイルUIタブ表を旧4タブ構成から現在の5タブ構成に更新（日本語・英語）
  - 旧: Terminal, History, Logs, Info
  - 新: Terminal, History, Files, CMATE, Info

## Test plan
- [ ] `docs/user-guide/webapp-guide.md` のモバイルUIセクションが正しいことを確認
- [ ] `docs/en/user-guide/webapp-guide.md` の同セクションが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)