### PR TITLE
fix(schedule): correct CLAUDE_PERMISSIONS values

### DIFF
--- a/src/config/schedule-config.ts
+++ b/src/config/schedule-config.ts
@@ -27,7 +27,7 @@ export const MAX_SCHEDULE_CRON_LENGTH = 100;
 // =============================================================================
 
 /** Allowed permission values for claude CLI (--permission-mode) */
-export const CLAUDE_PERMISSIONS = ['default', 'acceptEdits', 'full'] as const;
+export const CLAUDE_PERMISSIONS = ['default', 'acceptEdits', 'plan', 'dontAsk', 'bypassPermissions'] as const;
 export type ClaudePermission = (typeof CLAUDE_PERMISSIONS)[number];
 
 /** Allowed sandbox values for codex CLI (--sandbox) */


### PR DESCRIPTION
## Summary
- `CLAUDE_PERMISSIONS` 定数を claude CLI の `--permission-mode` 実際の有効値に修正
  - 修正前: `['default', 'acceptEdits', 'full']` (`full` は不正、3値のみ)
  - 修正後: `['default', 'acceptEdits', 'plan', 'dontAsk', 'bypassPermissions']` (正規5値)
- 影響箇所（定数参照で自動反映）: `cmate-parser.ts`, `cmate-validator.ts`, `claude-executor.ts`

## Test plan
- [x] `schedule-config.test.ts` 15テストパス
- [x] `cmate-validator.test.ts` 29テストパス
- [x] `claude-executor.test.ts` 20テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)