### PR TITLE
fix(schedule): filter disabled schedules and resolve name display on logs

### DIFF
--- a/src/app/api/worktrees/[id]/execution-logs/route.ts
+++ b/src/app/api/worktrees/[id]/execution-logs/route.ts
@@ -32,11 +32,15 @@ export async function GET(
     }
 
     // [S1-014] Exclude result column from list API for performance
+    // Return all execution logs with schedule name via LEFT JOIN
+    // (includes logs from renamed/disabled schedules)
     const logs = db.prepare(`
-      SELECT id, schedule_id, worktree_id, message, exit_code, status, started_at, completed_at, created_at
-      FROM execution_logs
-      WHERE worktree_id = ?
-      ORDER BY created_at DESC
+      SELECT el.id, el.schedule_id, el.worktree_id, el.message, el.exit_code, el.status, el.started_at, el.completed_at, el.created_at,
+             se.name AS schedule_name
+      FROM execution_logs el
+      LEFT JOIN scheduled_executions se ON el.schedule_id = se.id
+      WHERE el.worktree_id = ?
+      ORDER BY el.created_at DESC
       LIMIT 100
     `).all(params.id);
 

--- a/src/app/api/worktrees/[id]/schedules/route.ts
+++ b/src/app/api/worktrees/[id]/schedules/route.ts
@@ -39,7 +39,7 @@ export async function GET(
     }
 
     const schedules = db.prepare(
-      'SELECT * FROM scheduled_executions WHERE worktree_id = ? ORDER BY created_at DESC'
+      'SELECT * FROM scheduled_executions WHERE worktree_id = ? AND enabled = 1 ORDER BY created_at DESC'
     ).all(params.id);
 
     return NextResponse.json({ schedules }, { status: 200 });

--- a/src/components/worktree/ExecutionLogPane.tsx
+++ b/src/components/worktree/ExecutionLogPane.tsx
@@ -10,7 +10,7 @@
 
 'use client';
 
-import React, { useState, useEffect, useCallback, useMemo, memo } from 'react';
+import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
 
 // ============================================================================
@@ -31,6 +31,7 @@ interface ExecutionLog {
   started_at: number;
   completed_at: number | null;
   created_at: number;
+  schedule_name: string | null;
 }
 
 /** Execution log detail from the individual API (includes result) */
@@ -91,14 +92,6 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
   const [error, setError] = useState<string | null>(null);
   const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
   const [logDetail, setLogDetail] = useState<ExecutionLogDetail | null>(null);
-
-  const scheduleNameMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const s of schedules) {
-      map.set(s.id, s.name);
-    }
-    return map;
-  }, [schedules]);
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -229,7 +222,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                   className="w-full text-left p-3 hover:bg-gray-50 transition-colors"
                 >
                   <div className="flex items-center justify-between">
-                    <span className="text-sm truncate max-w-[60%]">{scheduleNameMap.get(log.schedule_id) || t('unknownSchedule')}</span>
+                    <span className="text-sm truncate max-w-[60%]">{log.schedule_name || t('unknownSchedule')}</span>
                     <span className={`text-xs px-2 py-0.5 rounded ${getStatusColor(log.status)}`}>
                       {t(`status.${log.status}`)}
                     </span>


### PR DESCRIPTION
## Summary
- Schedules一覧: `enabled=1`のスケジュールのみ表示（Name変更で無効化された旧エントリを非表示）
- Execution Logs一覧: 全ログを表示しつつ、`LEFT JOIN`でスケジュール名を付与（旧スケジュール名も正しく表示）
- ExecutionLogPaneのクライアント側`scheduleNameMap`を削除し、APIの`schedule_name`を直接使用

## Changes
- `src/app/api/worktrees/[id]/schedules/route.ts`: `WHERE enabled = 1`追加
- `src/app/api/worktrees/[id]/execution-logs/route.ts`: `LEFT JOIN scheduled_executions`で`schedule_name`を付与
- `src/components/worktree/ExecutionLogPane.tsx`: `useMemo`/`scheduleNameMap`削除、`log.schedule_name`を直接参照

## Test plan
- [x] `npx tsc --noEmit` — 型チェックパス
- [x] `npx vitest run tests/unit/components/worktree` — 全18ファイル387テストパス
- [x] `npm run lint` — エラー・警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)