### PR TITLE
docs: optimize README for GitHub star conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # CommandMate
 
+[![GitHub Stars](https://img.shields.io/github/stars/Kewton/CommandMate?style=social)](https://github.com/Kewton/CommandMate)
 ![npm version](https://img.shields.io/npm/v/commandmate)
 ![npm downloads](https://img.shields.io/npm/dm/commandmate)
 ![license](https://img.shields.io/github/license/Kewton/CommandMate)
@@ -16,22 +17,23 @@
 
 Not a "remote control" — a **mobile dev cockpit**.
 
-AI writes code for you. That was supposed to mean freedom.
-Instead, you're watching a terminal, afraid to walk away.
-Your friends are at dinner. Your kid needs a bath. You just want ten minutes on the couch.
-But close the lid and every session dies. So you sit there — babysitting the machine that was supposed to babysit your code.
+```bash
+npx commandmate
+```
 
-CommandMate changes that. Auto Yes keeps the agent moving. Sessions survive in the background. And a Web UI on your phone means you can check in, review diffs, edit instructions, and send screenshots — from anywhere.
+**From install to mobile monitoring in 60 seconds.** macOS / Linux · Node.js v20+ · npm · git · tmux · openssl
+
+---
+
+AI writes code for you — but you're stuck watching a terminal, afraid to walk away.
+Close the lid and every session dies.
+**CommandMate keeps it alive, and puts the controls on your phone.**
 
 Of course, it works great on desktop too — the two-column layout gives you a full overview of all sessions and worktrees at a glance.
 
 <p align="center">
   <img src="./docs/images/demo-desktop.gif" alt="CommandMate desktop demo" width="600">
 </p>
-
-```bash
-npx commandmate
-```
 
 ---
 
@@ -48,23 +50,15 @@ npx commandmate
 
 ---
 
-## Quick Start
+## Use Cases
 
-**Prerequisites:** macOS / Linux, Node.js v20+, npm, git, tmux, openssl
-
-```bash
-# Install & start in one command
-npx commandmate
-
-# Or install globally
-npm install -g commandmate
-commandmate init
-commandmate start --daemon
-```
-
-Open http://localhost:3000 in your browser.
-
-See the [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) for details.
+| Scenario | How CommandMate helps |
+|----------|----------------------|
+| **Couch coding** | Start a task on your PC, then monitor and steer from the sofa |
+| **Commute review** | Review AI-generated code changes on the train |
+| **Overnight runs** | Let Claude Code work all night — check progress from bed |
+| **Visual bug fix** | Snap a UI bug on your phone, send it with "Fix this" |
+| **Parallel tasks** | Run multiple worktree sessions, manage them all from one dashboard |
 
 ---
 
@@ -83,29 +77,21 @@ See the [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) for details.
 
 ---
 
-## Workflow
+## Screenshots
 
-```
-1. Start tasks on your PC
-   $ commandmate start --daemon
-   → Claude Code begins working with Auto Yes
+### Desktop
 
-2. Close your laptop and go
+![Desktop view](./docs/images/screenshot-desktop.png)
 
-3. Check in from your phone
-   → Web UI shows all sessions at a glance
+### Mobile
 
-4. Review code changes
-   → File Viewer lets you read diffs on mobile
+| Top Page | Worktree (History) | Worktree (Terminal) |
+|----------|-------------------|-------------------|
+| ![Mobile view](./docs/images/screenshot-mobile.png) | ![Mobile - History](./docs/images/screenshot-worktree-mobile.png) | ![Mobile - Terminal](./docs/images/screenshot-worktree-mobile-terminal.png) |
 
-5. Adjust direction
-   → Edit a Markdown instruction file, or type a new prompt
+### Worktree Detail (Desktop)
 
-6. Snap a bug
-   → Screenshot Instructions: attach a photo and say "Fix this"
-
-7. Claude Code sees the image and starts fixing
-```
+![Desktop - Worktree detail](./docs/images/screenshot-worktree-desktop.png)
 
 ---
 
@@ -115,7 +101,7 @@ Runs **100% locally**. No external server, no cloud relay, no account required. 
 
 - Fully open-source ([MIT License](./LICENSE))
 - Local database, local sessions
-- For remote access, use a VPN or authenticated reverse proxy
+- For remote access, use a tunneling service ([Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), [ngrok](https://ngrok.com/), [Pinggy](https://pinggy.io/)), a VPN, or an authenticated reverse proxy
 
 See the [Security Guide](./docs/security-guide.md) and [Trust & Safety](./docs/en/TRUST_AND_SAFETY.md) for details.
 
@@ -135,6 +121,25 @@ flowchart LR
 Each Git worktree gets its own tmux session, so multiple tasks run in parallel without interference.
 
 ---
+
+<details>
+<summary><strong>Quick Start (detailed)</strong></summary>
+
+```bash
+# Install & start in one command
+npx commandmate
+
+# Or install globally
+npm install -g commandmate
+commandmate init
+commandmate start --daemon
+```
+
+Open http://localhost:3000 in your browser.
+
+See the [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) for details.
+
+</details>
 
 <details>
 <summary><strong>CLI Commands</strong></summary>
@@ -197,25 +202,6 @@ See `commandmate --help` for all options.
 </details>
 
 <details>
-<summary><strong>Screenshots</strong></summary>
-
-### Desktop
-
-![Desktop view](./docs/images/screenshot-desktop.png)
-
-### Worktree Detail View (Message / Console / History)
-
-| Desktop | Mobile (History) | Mobile (Terminal) |
-|---------|-----------------|-------------------|
-| ![Desktop - Worktree detail](./docs/images/screenshot-worktree-desktop.png) | ![Mobile - History](./docs/images/screenshot-worktree-mobile.png) | ![Mobile - Terminal](./docs/images/screenshot-worktree-mobile-terminal.png) |
-
-### Top Page (Mobile)
-
-![Mobile view](./docs/images/screenshot-mobile.png)
-
-</details>
-
-<details>
 <summary><strong>Troubleshooting & FAQ</strong></summary>
 
 ### Claude CLI not found / path changed?
@@ -258,7 +244,13 @@ Claude Code sets `CLAUDECODE=1` to prevent nesting. CommandMate removes this aut
 A: CommandMate runs a web server on your PC. To access it from your phone, your phone and PC must be on the same network (Wi-Fi). Run `commandmate init` and enable external access — this sets `CM_BIND=0.0.0.0`. Then open `http://<your-PC-IP>:3000` in your phone's browser.
 
 **Q: Can I access it from outside my home network?**
-A: Yes. Use a tunneling service like [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) to securely expose your local server without opening router ports. Alternatively, a VPN or an authenticated reverse proxy (Basic Auth, OIDC, etc.) also works. **Do not** expose the server directly to the internet without authentication.
+A: Yes. Use a tunneling service to securely expose your local server without opening router ports:
+
+- [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — free, requires Cloudflare account
+- [ngrok](https://ngrok.com/) — free tier available, easy setup
+- [Pinggy](https://pinggy.io/) — no sign-up required, simple SSH-based tunnel
+
+Alternatively, a VPN or an authenticated reverse proxy (Basic Auth, OIDC, etc.) also works. **Do not** expose the server directly to the internet without authentication.
 
 **Q: Does it work on iPhone / Android?**
 A: Yes. CommandMate's Web UI is responsive and works on any modern mobile browser (Safari, Chrome, etc.). No app install required.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,5 +1,6 @@
 # CommandMate
 
+[![GitHub Stars](https://img.shields.io/github/stars/Kewton/CommandMate?style=social)](https://github.com/Kewton/CommandMate)
 ![npm version](https://img.shields.io/npm/v/commandmate)
 ![npm downloads](https://img.shields.io/npm/dm/commandmate)
 ![license](https://img.shields.io/github/license/Kewton/CommandMate)
@@ -16,22 +17,23 @@
 
 「リモコン」ではなく、**モバイル開発コックピット**。
 
-AI がコードを書いてくれる。それは自由を意味するはずだった。
-なのに、ターミナルを見つめている。画面の前から離れられない。
-友達はご飯を食べている。子どもはお風呂を待っている。ソファで10分だけ休みたい。
-でも蓋を閉じたら全セッションが死ぬ。だから座り続ける — コードの面倒を見るはずだったマシンの、面倒を見るために。
+```bash
+npx commandmate
+```
 
-CommandMate がそれを変える。Auto Yes でエージェントは止まらない。セッションはバックグラウンドで生き続ける。スマホの Web UI があれば、進捗確認、差分レビュー、指示の編集、スクリーンショット送信 — どこからでも。
+**インストールからモバイル監視まで 60 秒。** macOS / Linux · Node.js v20+ · npm · git · tmux · openssl
+
+---
+
+AI がコードを書いてくれる — なのに、ターミナルを見つめたまま離れられない。
+蓋を閉じたら全セッションが死ぬ。
+**CommandMate がセッションを生かし続け、操縦桿をスマホに渡す。**
 
 もちろんデスクトップでも快適に使えます。2カラムレイアウトで全セッション・全ワークツリーを一望できます。
 
 <p align="center">
   <img src="../../docs/images/demo-desktop.gif" alt="CommandMate デスクトップデモ" width="600">
 </p>
-
-```bash
-npx commandmate
-```
 
 ---
 
@@ -48,23 +50,15 @@ npx commandmate
 
 ---
 
-## Quick Start
+## ユースケース
 
-**前提条件：** macOS / Linux、Node.js v20+、npm、git、tmux、openssl
-
-```bash
-# インストール & 起動をワンコマンドで
-npx commandmate
-
-# またはグローバルインストール
-npm install -g commandmate
-commandmate init
-commandmate start --daemon
-```
-
-ブラウザで http://localhost:3000 にアクセスしてください。
-
-詳しくは [CLI セットアップガイド](../user-guide/cli-setup-guide.md) を参照してください。
+| シナリオ | CommandMate でできること |
+|----------|------------------------|
+| **ソファで開発** | PC でタスクを開始し、ソファからスマホで監視・指示 |
+| **通勤中レビュー** | 電車の中で AI が生成したコード変更をレビュー |
+| **夜間自律実行** | Claude Code を一晩稼働させ、寝室から進捗確認 |
+| **ビジュアルバグ修正** | スマホで UI バグを撮影 →「これ直して」で送信 |
+| **並列タスク管理** | 複数の worktree セッションを 1 つのダッシュボードで管理 |
 
 ---
 
@@ -83,29 +77,21 @@ commandmate start --daemon
 
 ---
 
-## ワークフロー
+## スクリーンショット
 
-```
-1. PC でタスクを開始
-   $ commandmate start --daemon
-   → Claude Code が Auto Yes で自律稼働開始
+### デスクトップ
 
-2. PC を閉じて外出
+![PC表示](../../docs/images/screenshot-desktop.png)
 
-3. スマホから Web UI で確認
-   → 全セッションの状態を一目で把握
+### モバイル
 
-4. コード変更をレビュー
-   → ファイルビューワでモバイルから差分を確認
+| トップ画面 | ワークツリー（History） | ワークツリー（Terminal） |
+|-----------|----------------------|------------------------|
+| ![スマホ表示](../../docs/images/screenshot-mobile.png) | ![スマホ - History](../../docs/images/screenshot-worktree-mobile.png) | ![スマホ - Terminal](../../docs/images/screenshot-worktree-mobile-terminal.png) |
 
-5. 方向を修正
-   → Markdown の指示ファイルを編集、または新しいプロンプトを入力
+### ワークツリー詳細（デスクトップ）
 
-6. バグを発見
-   → スクリーンショット指示: 画面を撮影して「これ直して」
-
-7. Claude Code が画像を認識して修正開始
-```
+![PC - ワークツリー詳細](../../docs/images/screenshot-worktree-desktop.png)
 
 ---
 
@@ -115,7 +101,7 @@ commandmate start --daemon
 
 - フルオープンソース（[MIT License](../../LICENSE)）
 - ローカルデータベース、ローカルセッション
-- リモートアクセスは VPN または認証付きリバースプロキシを推奨
+- リモートアクセスはトンネリングサービス（[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)、[ngrok](https://ngrok.com/)、[Pinggy](https://pinggy.io/)）、VPN、または認証付きリバースプロキシを推奨
 
 詳細は[セキュリティガイド](../security-guide.md)と [Trust & Safety](../TRUST_AND_SAFETY.md) を参照してください。
 
@@ -135,6 +121,25 @@ flowchart LR
 Git worktree ごとに専用の tmux セッションが割り当てられるため、複数タスクを干渉なく並列実行できます。
 
 ---
+
+<details>
+<summary><strong>Quick Start（詳細）</strong></summary>
+
+```bash
+# インストール & 起動をワンコマンドで
+npx commandmate
+
+# またはグローバルインストール
+npm install -g commandmate
+commandmate init
+commandmate start --daemon
+```
+
+ブラウザで http://localhost:3000 にアクセスしてください。
+
+詳しくは [CLI セットアップガイド](../user-guide/cli-setup-guide.md) を参照してください。
+
+</details>
 
 <details>
 <summary><strong>CLI コマンド</strong></summary>
@@ -197,25 +202,6 @@ Issue/worktree ごとにサーバーを分離起動し、自動ポート割当�
 </details>
 
 <details>
-<summary><strong>スクリーンショット</strong></summary>
-
-### デスクトップ
-
-![PC表示](../../docs/images/screenshot-desktop.png)
-
-### ワークツリー詳細画面（Message / Console / History）
-
-| PC表示 | スマホ（History） | スマホ（Terminal） |
-|--------|-------------------|-------------------|
-| ![PC - ワークツリー詳細](../../docs/images/screenshot-worktree-desktop.png) | ![スマホ - History](../../docs/images/screenshot-worktree-mobile.png) | ![スマホ - Terminal](../../docs/images/screenshot-worktree-mobile-terminal.png) |
-
-### トップ画面（スマホ）
-
-![スマホ表示](../../docs/images/screenshot-mobile.png)
-
-</details>
-
-<details>
 <summary><strong>トラブルシューティング & FAQ</strong></summary>
 
 ### Claude CLI が見つからない / パスが変わった？
@@ -258,7 +244,13 @@ Claude Code は `CLAUDECODE=1` を設定してネストを防止しています�
 A: CommandMate は PC 上で Web サーバーを起動します。スマホと PC が同じネットワーク（Wi-Fi）にいる状態で、`commandmate init` で外部アクセスを有効にすると `CM_BIND=0.0.0.0` が設定されます。スマホのブラウザで `http://<PCのIPアドレス>:3000` を開いてください。
 
 **Q: 外出先からアクセスできる？**
-A: はい。[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) などのトンネリングサービスを使えば、ルーターのポート開放なしにローカルサーバーを安全に公開できます。VPN や認証付きリバースプロキシ（Basic 認証、OIDC 等）も利用可能です。**認証なしでインターネットに直接公開しないでください。**
+A: はい。トンネリングサービスを使えば、ルーターのポート開放なしにローカルサーバーを安全に公開できます：
+
+- [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — 無料、Cloudflare アカウントが必要
+- [ngrok](https://ngrok.com/) — 無料枠あり、セットアップが簡単
+- [Pinggy](https://pinggy.io/) — サインアップ不要、SSH ベースのシンプルなトンネル
+
+VPN や認証付きリバースプロキシ（Basic 認証、OIDC 等）も利用可能です。**認証なしでインターネットに直接公開しないでください。**
 
 **Q: iPhone / Android で使える？**
 A: はい。CommandMate の Web UI はレスポンシブ対応で、Safari・Chrome などのモバイルブラウザで動作します。アプリのインストールは不要です。


### PR DESCRIPTION
## Summary

- **Quick Start を above the fold に移動**: `npx commandmate` をタグライン直後に配置。訪問者がスクロールせずに「1コマンドで試せる」と分かるように
- **Star CTA バッジ追加**: バッジ行の先頭に GitHub Stars バッジを追加し、Star アクションを自然に促進
- **ナラティブ短縮**: 6文 → 3文に凝縮。離脱率を下げつつメッセージを維持
- **Use Cases セクション追加**: Workflow（手順書的）→ Use Cases（共感ベース）に置換。ソファ開発・通勤レビュー・夜間実行など具体シナリオ
- **Screenshots 展開表示**: `<details>` 内に隠れていたスクリーンショットを直接表示（スクリーンショット付き README は +42% Star というリサーチに基づく）
- **トンネリングサービス追加**: Security セクション・FAQ に Cloudflare Tunnel / ngrok / Pinggy の3サービスを記載
- **日本語 README も同一構造で更新**

## Background

GitHub README のベストプラクティス調査（Liam の 0→3000 Star ケーススタディ等）に基づき、Star 獲得に直結する S/A ランク改善を実施。

## Test plan

- [ ] GitHub 上で README のレンダリングを確認（EN/JA 両方）
- [ ] バッジが正しく表示されるか確認
- [ ] スクリーンショット画像が正しく表示されるか確認
- [ ] Mermaid 図が正しくレンダリングされるか確認
- [ ] 各リンク（docs, security guide 等）が正しく動作するか確認
- [ ] モバイルブラウザでの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)