### PR TITLE
feat(ui): Dark Modern UI - comprehensive dark mode (Issue #424)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,8 +19,10 @@ export default function Home() {
       <div className="container-custom py-8 overflow-auto h-full">
         <div className="mb-8">
           <h1 className="mb-2">CommandMate</h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400">
-            Git worktree management with Claude CLI and tmux sessions
+          <p className="text-base text-gray-600 dark:text-gray-400">
+            Stop managing terminal tabs. Start running issue-driven development.
+            <br />
+            CommandMate helps you refine issues, run them in parallel, switch agents when needed, and keep work moving wherever you are.
           </p>
         </div>
 

--- a/src/components/external-apps/ExternalAppCard.tsx
+++ b/src/components/external-apps/ExternalAppCard.tsx
@@ -80,10 +80,10 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">
-          <h4 className="text-base font-semibold text-gray-900 truncate">
+          <h4 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
             {app.displayName}
           </h4>
-          <p className="text-xs text-gray-500 mt-0.5 font-mono truncate">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 font-mono truncate">
             {app.name}
           </p>
         </div>
@@ -95,27 +95,27 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Info */}
       <div className="space-y-2 mb-4">
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600">Status</span>
+          <span className="text-sm text-gray-600 dark:text-gray-300">Status</span>
           <ExternalAppStatus appId={app.id} pollInterval={30000} />
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600">Port</span>
-          <span className="text-sm font-mono text-gray-900">:{app.targetPort}</span>
+          <span className="text-sm text-gray-600 dark:text-gray-300">Port</span>
+          <span className="text-sm font-mono text-gray-900 dark:text-gray-100">:{app.targetPort}</span>
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600">Path</span>
-          <span className="text-sm font-mono text-gray-900 truncate max-w-[150px]">
+          <span className="text-sm text-gray-600 dark:text-gray-300">Path</span>
+          <span className="text-sm font-mono text-gray-900 dark:text-gray-100 truncate max-w-[150px]">
             /proxy/{app.pathPrefix}/
           </span>
         </div>
         {app.websocketEnabled && (
           <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-600">WebSocket</span>
+            <span className="text-sm text-gray-600 dark:text-gray-300">WebSocket</span>
             <Badge variant="info">Enabled</Badge>
           </div>
         )}
         {!app.enabled && (
-          <div className="mt-2 py-1 px-2 bg-yellow-50 border border-yellow-200 rounded text-xs text-yellow-700">
+          <div className="mt-2 py-1 px-2 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-700 rounded text-xs text-yellow-700 dark:text-yellow-300">
             This app is disabled
           </div>
         )}
@@ -124,7 +124,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Actions */}
       {showDeleteConfirm ? (
         <div className="space-y-2">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
             Delete &quot;{app.displayName}&quot;?
           </p>
           <div className="flex gap-2">
@@ -168,7 +168,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
             variant="ghost"
             size="sm"
             onClick={() => setShowDeleteConfirm(true)}
-            className="text-red-600 hover:bg-red-50"
+            className="text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
           >
             Delete
           </Button>

--- a/src/components/external-apps/ExternalAppForm.tsx
+++ b/src/components/external-apps/ExternalAppForm.tsx
@@ -201,8 +201,8 @@ export function ExternalAppForm({
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Issue #395: Security warning about same-origin proxy risks */}
-        <div className="rounded-md bg-amber-50 p-3 mb-4 border border-amber-200">
-          <p className="text-sm text-amber-800">
+        <div className="rounded-md bg-amber-50 dark:bg-amber-900/30 p-3 mb-4 border border-amber-200 dark:border-amber-700">
+          <p className="text-sm text-amber-800 dark:text-amber-300">
             Proxied apps run under the CommandMate origin and can access CommandMate APIs. Only register trusted applications.
           </p>
         </div>
@@ -211,7 +211,7 @@ export function ExternalAppForm({
         <div>
           <label
             htmlFor="displayName"
-            className="block text-sm font-medium text-gray-700 mb-1"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
           >
             Display Name <span className="text-red-500">*</span>
           </label>
@@ -234,7 +234,7 @@ export function ExternalAppForm({
           <div>
             <label
               htmlFor="name"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
             >
               Identifier Name <span className="text-red-500">*</span>
             </label>
@@ -247,7 +247,7 @@ export function ExternalAppForm({
               placeholder="my-app"
               disabled={isSubmitting}
             />
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
               Alphanumeric and hyphens only. Cannot be changed later.
             </p>
             {errors.name && (
@@ -261,12 +261,12 @@ export function ExternalAppForm({
           <div>
             <label
               htmlFor="pathPrefix"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
             >
               Path Prefix <span className="text-red-500">*</span>
             </label>
             <div className="flex items-center">
-              <span className="text-sm text-gray-500 mr-1">/proxy/</span>
+              <span className="text-sm text-gray-500 dark:text-gray-400 mr-1">/proxy/</span>
               <input
                 id="pathPrefix"
                 type="text"
@@ -276,9 +276,9 @@ export function ExternalAppForm({
                 placeholder="app-name"
                 disabled={isSubmitting}
               />
-              <span className="text-sm text-gray-500 ml-1">/</span>
+              <span className="text-sm text-gray-500 dark:text-gray-400 ml-1">/</span>
             </div>
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
               URL path for accessing this app. Cannot be changed later.
             </p>
             {errors.pathPrefix && (
@@ -291,7 +291,7 @@ export function ExternalAppForm({
         <div>
           <label
             htmlFor="targetPort"
-            className="block text-sm font-medium text-gray-700 mb-1"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
           >
             Port Number <span className="text-red-500">*</span>
           </label>
@@ -321,7 +321,7 @@ export function ExternalAppForm({
           <div>
             <label
               htmlFor="appType"
-              className="block text-sm font-medium text-gray-700 mb-1"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
             >
               App Type <span className="text-red-500">*</span>
             </label>
@@ -349,7 +349,7 @@ export function ExternalAppForm({
         <div>
           <label
             htmlFor="description"
-            className="block text-sm font-medium text-gray-700 mb-1"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
           >
             Description
           </label>
@@ -376,7 +376,7 @@ export function ExternalAppForm({
           />
           <label
             htmlFor="websocketEnabled"
-            className="ml-2 text-sm text-gray-700"
+            className="ml-2 text-sm text-gray-700 dark:text-gray-200"
           >
             Enable WebSocket support
           </label>
@@ -393,7 +393,7 @@ export function ExternalAppForm({
               className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               disabled={isSubmitting}
             />
-            <label htmlFor="enabled" className="ml-2 text-sm text-gray-700">
+            <label htmlFor="enabled" className="ml-2 text-sm text-gray-700 dark:text-gray-200">
               App is enabled
             </label>
           </div>
@@ -401,13 +401,13 @@ export function ExternalAppForm({
 
         {/* Submit Error */}
         {submitError && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+          <div className="p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded text-sm text-red-700 dark:text-red-300">
             {submitError}
           </div>
         )}
 
         {/* Actions */}
-        <div className="flex justify-end gap-2 pt-4 border-t border-gray-200">
+        <div className="flex justify-end gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
           <Button
             type="button"
             variant="ghost"

--- a/src/components/external-apps/ExternalAppStatus.tsx
+++ b/src/components/external-apps/ExternalAppStatus.tsx
@@ -77,8 +77,8 @@ export function ExternalAppStatus({
   if (isLoading) {
     return (
       <div className="flex items-center gap-1.5">
-        <span className="inline-block h-2.5 w-2.5 rounded-full bg-gray-300 animate-pulse" />
-        {!compact && <span className="text-xs text-gray-400">Checking...</span>}
+        <span className="inline-block h-2.5 w-2.5 rounded-full bg-gray-300 dark:bg-gray-600 animate-pulse" />
+        {!compact && <span className="text-xs text-gray-400 dark:text-gray-500">Checking...</span>}
       </div>
     );
   }
@@ -99,7 +99,7 @@ export function ExternalAppStatus({
   return (
     <div className="flex items-center gap-1.5">
       <span className={`inline-block h-2.5 w-2.5 rounded-full ${statusColor}`} />
-      <span className={`text-xs ${isHealthy ? 'text-green-600' : 'text-gray-500'}`}>
+      <span className={`text-xs ${isHealthy ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}>
         {statusText}
       </span>
       {showResponseTime && health?.responseTime !== undefined && (

--- a/src/components/external-apps/ExternalAppsManager.tsx
+++ b/src/components/external-apps/ExternalAppsManager.tsx
@@ -107,7 +107,7 @@ export function ExternalAppsManager() {
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-gray-900">External Apps</h2>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">External Apps</h2>
         <Button variant="primary" size="sm" onClick={handleAdd}>
           + Add App
         </Button>
@@ -117,14 +117,14 @@ export function ExternalAppsManager() {
       {isLoading ? (
         <Card padding="lg">
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
-            <span className="ml-3 text-gray-600">Loading apps...</span>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyan-600" />
+            <span className="ml-3 text-gray-600 dark:text-gray-300">Loading apps...</span>
           </div>
         </Card>
       ) : error ? (
         <Card padding="lg">
           <div className="text-center py-8">
-            <p className="text-red-600 mb-4">Failed to load external apps</p>
+            <p className="text-red-600 dark:text-red-400 mb-4">Failed to load external apps</p>
             <Button variant="secondary" size="sm" onClick={fetchApps}>
               Retry
             </Button>
@@ -133,10 +133,10 @@ export function ExternalAppsManager() {
       ) : apps.length === 0 ? (
         <Card padding="lg">
           <div className="text-center py-8">
-            <p className="text-gray-500 mb-4">
+            <p className="text-gray-500 dark:text-gray-400 mb-4">
               No external apps registered yet.
             </p>
-            <p className="text-sm text-gray-400 mb-4">
+            <p className="text-sm text-gray-400 dark:text-gray-500 mb-4">
               Add an external app to proxy requests to other frontend
               applications.
             </p>

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -69,7 +69,7 @@ const Icon = memo(function Icon({ path, className = 'w-6 h-6' }: IconProps) {
 
 /** Icon path definitions */
 const ICON_PATHS = {
-  back: 'M15 19l-7-7 7-7',
+  back: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z',
   menu: 'M4 6h16M4 12h16M4 18h16',
 } as const;
 

--- a/src/components/repository/RepositoryManager.tsx
+++ b/src/components/repository/RepositoryManager.tsx
@@ -212,19 +212,19 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
         <Card padding="lg">
           <div className="space-y-4">
             <div>
-              <h3 className="text-lg font-semibold mb-2">Add New Repository</h3>
+              <h3 className="text-lg font-semibold mb-2 dark:text-gray-100">Add New Repository</h3>
             </div>
 
             {/* Mode Toggle Tabs */}
-            <div className="flex border-b border-gray-200" role="tablist">
+            <div className="flex border-b border-gray-200 dark:border-gray-700" role="tablist">
               <button
                 role="tab"
                 aria-selected={inputMode === 'local'}
                 onClick={() => setInputMode('local')}
                 className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
                   inputMode === 'local'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                    ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
                 }`}
               >
                 Local Path
@@ -235,8 +235,8 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
                 onClick={() => setInputMode('url')}
                 className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
                   inputMode === 'url'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                    ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
                 }`}
               >
                 Clone URL
@@ -247,10 +247,10 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
             {inputMode === 'local' && (
               <form onSubmit={handleAddRepository} className="space-y-4">
                 <div>
-                  <p className="text-sm text-gray-600 mb-4">
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
                     Enter the absolute path to a git repository containing worktrees.
                   </p>
-                  <label htmlFor="repositoryPath" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="repositoryPath" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                     Repository Path
                   </label>
                   <input
@@ -262,7 +262,7 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
                     className="input w-full font-mono text-sm"
                     disabled={isScanning}
                   />
-                  <p className="text-xs text-gray-500 mt-1">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Example: /Users/username/projects/my-repo
                   </p>
                 </div>
@@ -291,10 +291,10 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
             {inputMode === 'url' && (
               <form onSubmit={handleCloneRepository} className="space-y-4">
                 <div>
-                  <p className="text-sm text-gray-600 mb-4">
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
                     Enter a git clone URL to clone a remote repository.
                   </p>
-                  <label htmlFor="cloneUrl" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="cloneUrl" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                     Clone URL
                   </label>
                   <input
@@ -306,7 +306,7 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
                     className="input w-full font-mono text-sm"
                     disabled={isCloning}
                   />
-                  <p className="text-xs text-gray-500 mt-1">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Supports HTTPS and SSH URLs
                   </p>
                 </div>
@@ -336,15 +336,15 @@ export function RepositoryManager({ onRepositoryAdded }: RepositoryManagerProps)
 
       {/* Success Message */}
       {success && (
-        <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
-          <p className="text-sm text-green-800">{success}</p>
+        <div className="p-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg">
+          <p className="text-sm text-green-800 dark:text-green-300">{success}</p>
         </div>
       )}
 
       {/* Error Message */}
       {error && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-          <p className="text-sm text-red-800">{error}</p>
+        <div className="p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
+          <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
         </div>
       )}
     </div>

--- a/src/components/worktree/AgentSettingsPane.tsx
+++ b/src/components/worktree/AgentSettingsPane.tsx
@@ -252,10 +252,10 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
 
   return (
     <div className="p-4">
-      <h3 className="text-sm font-semibold text-gray-700 mb-1">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">
         {t('agentSettings')}
       </h3>
-      <p className="text-xs text-gray-500 mb-4">
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
         {t('selectAgents')}
       </p>
 
@@ -269,10 +269,10 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
               key={toolId}
               className={`flex items-center gap-3 p-2 rounded-lg border transition-colors ${
                 isChecked
-                  ? 'border-blue-200 bg-blue-50'
+                  ? 'border-cyan-200 dark:border-cyan-700 bg-cyan-50 dark:bg-cyan-900/30'
                   : isDisabled
-                    ? 'border-gray-100 bg-gray-50 opacity-50'
-                    : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                    ? 'border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-800 opacity-50'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800'
               }`}
             >
               <input
@@ -282,9 +282,9 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
                 checked={isChecked}
                 disabled={isDisabled || saving}
                 onChange={(e) => handleCheckboxChange(toolId, e.target.checked)}
-                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-cyan-600 focus:ring-cyan-500"
               />
-              <span className="text-sm font-medium text-gray-700">
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
                 {getCliToolDisplayName(toolId)}
               </span>
             </label>
@@ -295,27 +295,27 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
       {saving && (
         <div
           data-testid="agent-settings-loading"
-          className="mt-3 flex items-center gap-2 text-xs text-gray-500"
+          className="mt-3 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400"
         >
-          <span className="w-3 h-3 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+          <span className="w-3 h-3 border-2 border-cyan-500 border-t-transparent rounded-full animate-spin" />
           {t('loading')}
         </div>
       )}
 
       {/* Ollama model selector */}
       {isVibeLocalChecked && (
-        <div className="mt-4 pt-4 border-t border-gray-200">
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">
+        <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
             {t('vibeLocalModel')}
           </h4>
 
           {loadingModels ? (
-            <div className="flex items-center gap-2 text-xs text-gray-500">
-              <span className="w-3 h-3 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+            <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+              <span className="w-3 h-3 border-2 border-cyan-500 border-t-transparent rounded-full animate-spin" />
               {t('loading')}
             </div>
           ) : ollamaError && ollamaModels.length === 0 ? (
-            <p className="text-xs text-amber-600">
+            <p className="text-xs text-amber-600 dark:text-amber-400">
               {t('ollamaNotAvailable')}
             </p>
           ) : (
@@ -324,7 +324,7 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
               value={vibeLocalModel ?? ''}
               onChange={handleModelChange}
               disabled={savingModel}
-              className="w-full text-sm border border-gray-300 rounded-md px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50"
+              className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 disabled:opacity-50"
             >
               <option value="">{t('vibeLocalModelDefault')}</option>
               {ollamaModels.map((model) => (
@@ -337,7 +337,7 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
 
           {/* Context window input */}
           <div className="mt-3">
-            <h4 className="text-sm font-semibold text-gray-700 mb-2">
+            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
               {t('vibeLocalContextWindow')}
             </h4>
             <input
@@ -351,7 +351,7 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
               onBlur={handleContextWindowBlur}
               placeholder={t('vibeLocalContextWindowDefault')}
               disabled={savingContextWindow}
-              className="w-full text-sm border border-gray-300 rounded-md px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50"
+              className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 disabled:opacity-50"
             />
           </div>
         </div>

--- a/src/components/worktree/ExecutionLogPane.tsx
+++ b/src/components/worktree/ExecutionLogPane.tsx
@@ -69,11 +69,11 @@ function formatTimestamp(ts: number): string {
 /** Map execution log status to Tailwind CSS color classes */
 function getStatusColor(status: ExecutionLogStatus): string {
   switch (status) {
-    case 'completed': return 'text-green-600 bg-green-50';
-    case 'failed': return 'text-red-600 bg-red-50';
-    case 'timeout': return 'text-yellow-600 bg-yellow-50';
-    case 'running': return 'text-blue-600 bg-blue-50';
-    case 'cancelled': return 'text-gray-600 bg-gray-50';
+    case 'completed': return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/30';
+    case 'failed': return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30';
+    case 'timeout': return 'text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/30';
+    case 'running': return 'text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-900/30';
+    case 'cancelled': return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800';
   }
 }
 
@@ -146,8 +146,8 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
     return (
       <div className={`flex items-center justify-center h-full p-4 ${className}`}>
         <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-4 border-gray-200 border-t-blue-500 rounded-full animate-spin" />
-          <span className="text-sm text-gray-500">{t('loading')}</span>
+          <div className="w-8 h-8 border-4 border-gray-200 dark:border-gray-700 border-t-cyan-500 rounded-full animate-spin" />
+          <span className="text-sm text-gray-500 dark:text-gray-400">{t('loading')}</span>
         </div>
       </div>
     );
@@ -157,11 +157,11 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
     return (
       <div className={`flex items-center justify-center h-full p-4 ${className}`}>
         <div className="text-center">
-          <span className="text-sm text-red-600">{error}</span>
+          <span className="text-sm text-red-600 dark:text-red-400">{error}</span>
           <button
             type="button"
             onClick={() => void fetchData()}
-            className="ml-2 px-3 py-1 text-sm text-white bg-blue-500 rounded hover:bg-blue-600"
+            className="ml-2 px-3 py-1 text-sm text-white bg-cyan-500 rounded hover:bg-cyan-600"
           >
             {t('retry')}
           </button>
@@ -174,10 +174,10 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
     <div className={`flex flex-col gap-4 p-4 overflow-y-auto ${className}`}>
       {/* Schedules Section */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">{t('title')} ({schedules.length})</h3>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">{t('title')} ({schedules.length})</h3>
         {schedules.length === 0 ? (
-          <div className="text-center py-8 text-gray-500">
-            <p className="font-medium text-gray-600 mb-3">{t('noSchedulesTitle')}</p>
+          <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+            <p className="font-medium text-gray-600 dark:text-gray-300 mb-3">{t('noSchedulesTitle')}</p>
             <ol className="text-sm text-left inline-block space-y-1.5 list-decimal list-inside">
               <li>{t('noSchedulesStep1')}</li>
               <li>{t('noSchedulesStep2')}</li>
@@ -188,14 +188,14 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
         ) : (
           <div className="space-y-2">
             {schedules.map((schedule) => (
-              <div key={schedule.id} className="border border-gray-200 rounded p-3 bg-white">
+              <div key={schedule.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-900">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-sm">{schedule.name}</span>
-                  <span className={`text-xs px-2 py-0.5 rounded ${schedule.enabled ? 'bg-green-50 text-green-600' : 'bg-gray-50 text-gray-500'}`}>
+                  <span className={`text-xs px-2 py-0.5 rounded ${schedule.enabled ? 'bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400' : 'bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400'}`}>
                     {schedule.enabled ? t('enabled') : t('disabled')}
                   </span>
                 </div>
-                <div className="text-xs text-gray-500 mt-1">
+                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   <span>{t('cron')}: {schedule.cron_expression || 'N/A'}</span>
                   {schedule.last_executed_at && (
                     <span className="ml-3">{t('lastRun')}: {formatTimestamp(schedule.last_executed_at)}</span>
@@ -209,17 +209,17 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
 
       {/* Execution Logs Section */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">{t('executionLogs')} ({logs.length})</h3>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">{t('executionLogs')} ({logs.length})</h3>
         {logs.length === 0 ? (
-          <p className="text-sm text-gray-500">{t('noLogs')}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{t('noLogs')}</p>
         ) : (
           <div className="space-y-2">
             {logs.map((log) => (
-              <div key={log.id} className="border border-gray-200 rounded bg-white">
+              <div key={log.id} className="border border-gray-200 dark:border-gray-700 rounded bg-white dark:bg-gray-900">
                 <button
                   type="button"
                   onClick={() => void handleExpandLog(log.id)}
-                  className="w-full text-left p-3 hover:bg-gray-50 transition-colors"
+                  className="w-full text-left p-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
                 >
                   <div className="flex items-center justify-between">
                     <span className="text-sm truncate max-w-[60%]">{log.schedule_name || t('unknownSchedule')}</span>
@@ -227,23 +227,23 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                       {t(`status.${log.status}`)}
                     </span>
                   </div>
-                  <div className="text-xs text-gray-500 mt-1">
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     {formatTimestamp(log.started_at)}
                     {log.exit_code !== null && <span className="ml-2">{t('exitCode')}: {log.exit_code}</span>}
                   </div>
                 </button>
 
                 {expandedLogId === log.id && logDetail && (
-                  <div className="border-t border-gray-200 p-3 bg-gray-50 space-y-3">
+                  <div className="border-t border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-gray-800 space-y-3">
                     <div>
-                      <div className="text-xs font-semibold text-gray-600 mb-1">{t('message')}</div>
-                      <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700">
+                      <div className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1">{t('message')}</div>
+                      <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200">
                         {logDetail.message}
                       </pre>
                     </div>
                     <div>
-                      <div className="text-xs font-semibold text-gray-600 mb-1">{t('response')}</div>
-                      <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 max-h-60 overflow-y-auto">
+                      <div className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1">{t('response')}</div>
+                      <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200 max-h-60 overflow-y-auto">
                         {logDetail.result || t('noOutput')}
                       </pre>
                     </div>

--- a/src/components/worktree/MemoAddButton.tsx
+++ b/src/components/worktree/MemoAddButton.tsx
@@ -78,17 +78,17 @@ export const MemoAddButton = memo(function MemoAddButton({
         aria-disabled={isDisabled}
         className={`
           flex items-center gap-2 px-4 py-2 rounded-lg border-2 border-dashed
-          transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500
+          transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500
           ${isDisabled
-            ? 'border-gray-200 text-gray-400 cursor-not-allowed opacity-50'
-            : 'border-gray-300 text-gray-600 hover:border-blue-400 hover:text-blue-600 hover:bg-blue-50'
+            ? 'border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed opacity-50'
+            : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:border-cyan-400 dark:hover:border-cyan-500 hover:text-cyan-600 dark:hover:text-cyan-400 hover:bg-cyan-50 dark:hover:bg-cyan-900/30'
           }
         `}
       >
         {isLoading ? (
           <span
             data-testid="loading-indicator"
-            className="w-5 h-5 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin"
+            className="w-5 h-5 border-2 border-gray-300 dark:border-gray-600 border-t-cyan-500 rounded-full animate-spin"
           />
         ) : (
           <svg
@@ -108,7 +108,7 @@ export const MemoAddButton = memo(function MemoAddButton({
         )}
         <span className="text-sm font-medium">Add Memo</span>
       </button>
-      <span className="text-xs text-gray-500">
+      <span className="text-xs text-gray-500 dark:text-gray-400">
         {remaining} remaining
       </span>
     </div>

--- a/src/components/worktree/MemoCard.tsx
+++ b/src/components/worktree/MemoCard.tsx
@@ -171,7 +171,7 @@ export const MemoCard = memo(function MemoCard({
   return (
     <div
       data-testid="memo-card"
-      className={`bg-white border border-gray-200 rounded-lg p-4 space-y-3 ${className}`}
+      className={`bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3 ${className}`}
     >
       {/* Header: Title and Delete button */}
       <div className="flex items-center gap-2">
@@ -181,12 +181,12 @@ export const MemoCard = memo(function MemoCard({
           onChange={handleTitleChange}
           onBlur={handleTitleBlur}
           placeholder="Memo title"
-          className="flex-1 text-sm font-medium text-gray-900 bg-transparent border-none focus:outline-none focus:ring-0 p-0"
+          className="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100 bg-transparent border-none focus:outline-none focus:ring-0 p-0"
         />
         {isSaving && (
           <span
             data-testid="saving-indicator"
-            className="text-xs text-gray-400"
+            className="text-xs text-gray-400 dark:text-gray-500"
           >
             Saving...
           </span>
@@ -196,7 +196,7 @@ export const MemoCard = memo(function MemoCard({
           type="button"
           onClick={handleCopy}
           aria-label="Copy memo content"
-          className="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded"
+          className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded"
         >
           {copied ? (
             <Check className="w-4 h-4 text-green-600" />
@@ -208,7 +208,7 @@ export const MemoCard = memo(function MemoCard({
           type="button"
           onClick={handleDelete}
           aria-label="Delete memo"
-          className="p-1 text-gray-400 hover:text-red-500 transition-colors rounded"
+          className="p-1 text-gray-400 dark:text-gray-500 hover:text-red-500 transition-colors rounded"
         >
           <svg
             className="w-4 h-4"
@@ -234,7 +234,7 @@ export const MemoCard = memo(function MemoCard({
         onBlur={handleContentBlur}
         placeholder="Enter memo content..."
         rows={4}
-        className="w-full text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-md p-2 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        className="w-full text-sm text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md p-2 resize-y focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
       />
 
       {/* Error message */}

--- a/src/components/worktree/MemoPane.tsx
+++ b/src/components/worktree/MemoPane.tsx
@@ -148,8 +148,8 @@ export const MemoPane = memo(function MemoPane({
           data-testid="memo-loading"
           className="flex flex-col items-center gap-3"
         >
-          <div className="w-8 h-8 border-4 border-gray-200 border-t-blue-500 rounded-full animate-spin" />
-          <span className="text-sm text-gray-500">Loading memos...</span>
+          <div className="w-8 h-8 border-4 border-gray-200 dark:border-gray-700 border-t-cyan-500 rounded-full animate-spin" />
+          <span className="text-sm text-gray-500 dark:text-gray-400">Loading memos...</span>
         </div>
       </div>
     );
@@ -176,12 +176,12 @@ export const MemoPane = memo(function MemoPane({
               d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
-          <span className="text-sm text-red-600">{error}</span>
+          <span className="text-sm text-red-600 dark:text-red-400">{error}</span>
           <button
             type="button"
             onClick={handleRetry}
             aria-label="Retry"
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded-lg hover:bg-blue-600 transition-colors"
+            className="px-4 py-2 text-sm font-medium text-white bg-cyan-500 rounded-lg hover:bg-cyan-600 transition-colors"
           >
             Retry
           </button>
@@ -197,7 +197,7 @@ export const MemoPane = memo(function MemoPane({
     >
       {/* Empty state */}
       {memos.length === 0 && !createError && (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <p>No memos yet.</p>
           <p className="text-sm">Click the button below to add one.</p>
         </div>

--- a/src/components/worktree/NotesAndLogsPane.tsx
+++ b/src/components/worktree/NotesAndLogsPane.tsx
@@ -61,9 +61,9 @@ const SUB_TABS: readonly SubTabConfig[] = [
 ] as const;
 
 /** CSS class for the active sub-tab button */
-const ACTIVE_TAB_CLASS = 'text-blue-600 border-b-2 border-blue-600 bg-blue-50';
+const ACTIVE_TAB_CLASS = 'text-cyan-600 dark:text-cyan-400 border-b-2 border-cyan-600 dark:border-cyan-400 bg-cyan-50 dark:bg-cyan-900/30';
 /** CSS class for inactive sub-tab buttons */
-const INACTIVE_TAB_CLASS = 'text-gray-500 hover:text-gray-700 hover:bg-gray-50';
+const INACTIVE_TAB_CLASS = 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800';
 
 // ============================================================================
 // Component

--- a/src/components/worktree/PromptPanel.tsx
+++ b/src/components/worktree/PromptPanel.tsx
@@ -25,7 +25,7 @@ const BUTTON_BASE_STYLES = `
 `.trim();
 
 /** Primary button styles */
-const BUTTON_PRIMARY_STYLES = 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500';
+const BUTTON_PRIMARY_STYLES = 'bg-cyan-600 text-white hover:bg-cyan-700 focus:ring-cyan-500';
 
 /** Secondary button styles */
 const BUTTON_SECONDARY_STYLES = 'bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 focus:ring-gray-500';
@@ -130,7 +130,7 @@ function PromptPanelContent({
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h3 id={labelId} className="text-lg font-semibold text-yellow-800 flex items-center gap-2">
+        <h3 id={labelId} className="text-lg font-semibold text-yellow-800 dark:text-yellow-300 flex items-center gap-2">
           <span className="text-xl" aria-hidden="true">?</span>
           {cliToolName ? t('confirmationFrom', { toolName: cliToolName }) : t('confirmationFromClaude')}
         </h3>
@@ -139,9 +139,9 @@ function PromptPanelContent({
             type="button"
             onClick={onDismiss}
             aria-label="close"
-            className="p-1 rounded hover:bg-yellow-200 transition-colors"
+            className="p-1 rounded hover:bg-yellow-200 dark:hover:bg-gray-700 transition-colors"
           >
-            <svg className="w-5 h-5 text-yellow-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <svg className="w-5 h-5 text-yellow-700 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -160,7 +160,7 @@ function PromptPanelContent({
 
       {/* Answering indicator */}
       {isDisabled && (
-        <div data-testid="answering-indicator" className="flex items-center gap-2 text-sm text-gray-500" role="status" aria-live="polite">
+        <div data-testid="answering-indicator" className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400" role="status" aria-live="polite">
           <div className="animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-blue-600" aria-hidden="true" />
           <span>{t('sending')}</span>
         </div>
@@ -300,7 +300,7 @@ function MultipleChoicePromptActions({
               <div className="flex-1">
                 <span className="font-medium">{option.number}. {option.label}</span>
                 {option.isDefault && (
-                  <span id={`default-${option.number}`} className="ml-2 text-xs text-blue-600 bg-blue-100 px-2 py-0.5 rounded">
+                  <span id={`default-${option.number}`} className="ml-2 text-xs text-cyan-600 dark:text-cyan-400 bg-cyan-100 dark:bg-cyan-900/30 px-2 py-0.5 rounded">
                     {t('default')}
                   </span>
                 )}
@@ -343,7 +343,7 @@ function MultipleChoicePromptActions({
  * Generates container class names based on animation state
  */
 function getContainerClasses(animationClass: string): string {
-  const baseClasses = 'bg-yellow-50 border-2 border-yellow-300 rounded-lg p-4 shadow-lg transition-all duration-200 ease-in-out';
+  const baseClasses = 'bg-yellow-50 dark:bg-gray-800 border-2 border-yellow-300 dark:border-yellow-600 rounded-lg p-4 shadow-lg transition-all duration-200 ease-in-out';
 
   let animationStyles = 'opacity-100';
   if (animationClass === 'animate-fade-in') {

--- a/src/components/worktree/SlashCommandList.tsx
+++ b/src/components/worktree/SlashCommandList.tsx
@@ -56,7 +56,7 @@ export function SlashCommandList({
       {groups.map((group) => (
         <div key={group.category} className="mb-2">
           {/* Category label */}
-          <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50">
+          <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider bg-gray-50 dark:bg-gray-800">
             {group.label}
           </div>
 
@@ -74,14 +74,14 @@ export function SlashCommandList({
                   data-command-item
                   data-highlighted={isHighlighted}
                   onClick={() => onSelect(command)}
-                  className={`w-full px-3 py-2 text-left flex items-start gap-2 hover:bg-blue-50 transition-colors ${
-                    isHighlighted ? 'bg-blue-100' : ''
+                  className={`w-full px-3 py-2 text-left flex items-start gap-2 hover:bg-cyan-50 dark:hover:bg-cyan-900/30 transition-colors ${
+                    isHighlighted ? 'bg-cyan-100 dark:bg-cyan-900/40' : ''
                   }`}
                 >
-                  <span className="text-blue-600 font-mono text-sm flex-shrink-0">
+                  <span className="text-cyan-600 dark:text-cyan-400 font-mono text-sm flex-shrink-0">
                     /{command.name}
                   </span>
-                  <span className="text-gray-600 text-sm truncate">
+                  <span className="text-gray-600 dark:text-gray-300 text-sm truncate">
                     {command.description}
                   </span>
                 </button>

--- a/src/components/worktree/SlashCommandSelector.tsx
+++ b/src/components/worktree/SlashCommandSelector.tsx
@@ -152,7 +152,7 @@ export const SlashCommandSelector = memo(function SlashCommandSelector({
         >
           {/* Header */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-            <h2 className="text-lg font-semibold">Commands</h2>
+            <h2 className="text-lg font-semibold dark:text-gray-100">Commands</h2>
             <button
               type="button"
               onClick={onClose}
@@ -176,7 +176,7 @@ export const SlashCommandSelector = memo(function SlashCommandSelector({
           </div>
 
           {/* Search */}
-          <div className="px-4 py-2 border-b border-gray-100">
+          <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
             <input
               ref={inputRef}
               type="text"
@@ -193,9 +193,9 @@ export const SlashCommandSelector = memo(function SlashCommandSelector({
               type="button"
               data-testid="free-input-button"
               onClick={() => onFreeInput(filter)}
-              className="w-full px-4 py-3 text-left border-b border-gray-100 flex items-center gap-2 hover:bg-blue-50 transition-colors"
+              className="w-full px-4 py-3 text-left border-b border-gray-100 dark:border-gray-700 flex items-center gap-2 hover:bg-cyan-50 dark:hover:bg-cyan-900/30 transition-colors"
             >
-              <span className="text-blue-600">
+              <span className="text-cyan-600 dark:text-cyan-400">
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                 </svg>
@@ -224,7 +224,7 @@ export const SlashCommandSelector = memo(function SlashCommandSelector({
       style={position ? { top: position.top, left: position.left } : { bottom: '100%', left: 0, marginBottom: '4px' }}
     >
       {/* Search */}
-      <div className="px-3 py-2 border-b border-gray-100">
+      <div className="px-3 py-2 border-b border-gray-100 dark:border-gray-700">
         <input
           ref={inputRef}
           type="text"
@@ -241,9 +241,9 @@ export const SlashCommandSelector = memo(function SlashCommandSelector({
           type="button"
           data-testid="free-input-button"
           onClick={() => onFreeInput(filter)}
-          className="w-full px-3 py-2 text-left border-b border-gray-100 flex items-center gap-2 hover:bg-blue-50 transition-colors text-sm"
+          className="w-full px-3 py-2 text-left border-b border-gray-100 dark:border-gray-700 flex items-center gap-2 hover:bg-cyan-50 dark:hover:bg-cyan-900/30 transition-colors text-sm"
         >
-          <span className="text-blue-600">
+          <span className="text-cyan-600 dark:text-cyan-400">
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
             </svg>
@@ -261,7 +261,7 @@ export const SlashCommandSelector = memo(function SlashCommandSelector({
       />
 
       {/* Keyboard hints */}
-      <div className="px-3 py-1.5 border-t border-gray-100 text-xs text-gray-400 flex gap-3">
+      <div className="px-3 py-1.5 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400 dark:text-gray-500 flex gap-3">
         <span>
           <kbd className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">Enter</kbd> select
         </span>

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -515,10 +515,10 @@ const DesktopHeader = memo(function DesktopHeader({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M15 19l-7-7 7-7"
+              d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z"
             />
           </svg>
-          <span className="text-sm font-medium">Back</span>
+          <span className="text-sm font-medium">Home</span>
         </button>
         <div className="w-px h-6 bg-gray-300 dark:bg-gray-600" aria-hidden="true" />
         {/* Status indicator */}


### PR DESCRIPTION
## Summary
- Comprehensive dark mode support across all remaining components (home page, CMATE tabs, slash commands, external apps, memos, execution logs, agent settings, prompt panel)
- Unified accent color migration from blue to cyan throughout the app
- Updated homepage tagline and navigation (Back → Home with house icon)

## Changes
- **Home page**: RepositoryManager, ExternalApps (Card/Form/Status/Manager) dark mode
- **CMATE tabs**: NotesAndLogsPane tab classes with dark variants, MemoPane/MemoCard/MemoAddButton, ExecutionLogPane, AgentSettingsPane
- **Slash commands**: SlashCommandSelector and SlashCommandList dark mode + blue→cyan
- **Navigation**: Back button → Home button with house icon (desktop + mobile)
- **PromptPanel**: Confirmation dialog dark mode
- **Homepage tagline**: Updated text and unified font sizing

## Test plan
- [ ] Verify dark mode appearance on desktop (all pages)
- [ ] Verify dark mode appearance on mobile (all pages)
- [ ] Verify slash command dropdown in dark mode
- [ ] Verify CMATE tabs (Notes/Logs/Agent) color consistency
- [ ] Verify Home button with house icon on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)