### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-06
+
+### Added
+- Tabbed split file panel replacing desktop file viewer modal (Issue #438)
+  - Code highlighting, MARP slide rendering, fullscreen mode, path copy
+  - Line numbers in code viewers and markdown editor
+  - File tab persistence to localStorage per worktree
+  - Content copy buttons for file panels
+- Show description next to branch name in PC header
+- Persist draft message input across worktree switches
+- Allow up to 4 agents on PC, keep 2 on mobile
+
+### Fixed
+- File panel XSS, sandbox escape, and edge case hardening (Issue #438)
+- Encode file paths and reset MARP slide state
+- Center placeholder text vertically in message input
+
+### Changed
+- Move CLI tool tabs into terminal pane header (Issue #438)
+- Move AutoYesToggle to CLI tool tab bar (Issue #438)
+- Narrow left pane initial width for 1:2:2 layout ratio (Issue #438)
+- Add --port option and stop guidance to rebuild skill
+
 ## [0.4.0] - 2026-03-05
 
 ### Added
@@ -679,7 +702,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/Kewton/CommandMate/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Kewton/CommandMate/compare/v0.3.6...v0.4.0
 [0.3.6]: https://github.com/Kewton/CommandMate/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Kewton/CommandMate/compare/v0.3.4...v0.3.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "IDE for issue-driven AI development — define, plan, and let coding agents execute across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- Patch release v0.4.1
- Version bump in package.json / package-lock.json
- CHANGELOG.md updated with changes since v0.4.0

## Changes included
### Added
- Tabbed split file panel with code highlighting, MARP, fullscreen, tab persistence (Issue #438)
- Branch description in PC header, draft message persistence, up to 4 agents on PC

### Fixed
- File panel XSS/sandbox escape hardening (Issue #438)
- File path encoding, MARP slide state reset, message input placeholder centering

### Changed
- CLI tool tabs moved to terminal pane header, AutoYesToggle to tab bar
- Left pane narrowed for 1:2:2 layout ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)