### PR TITLE
fix(ui): align sidebar branch names regardless of agent count

### DIFF
--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -91,7 +91,7 @@ export const BranchListItem = memo(function BranchListItem({
       <div className="flex items-center gap-3 w-full">
         {/* CLI tool status dots (Issue #368: dynamic from selectedAgents) */}
         {branch.cliStatus && Object.keys(branch.cliStatus).length > 0 && (
-          <div className="flex items-center gap-1 flex-shrink-0" aria-label="CLI tool status">
+          <div className="flex items-center gap-1 flex-shrink-0 w-11" aria-label="CLI tool status">
             {Object.entries(branch.cliStatus).map(([tool, status]) => (
               <CliStatusDot
                 key={tool}


### PR DESCRIPTION
## Summary

- サイドバーのCLIステータスドットコンテナに固定幅(`w-11`)を設定し、エージェント2個と4個でブランチ名の表示位置がずれる問題を修正

## Changes

- `c7a0a08` fix(ui): align sidebar branch names regardless of agent count

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes
- [x] All 4597 unit tests pass
- [ ] Manual: エージェント2個のブランチと4個のブランチでサイドバー表示位置が揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)