### PR TITLE
feat(git): add commit history & diff viewer (Issue #447)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,8 @@ tests/
 | `src/lib/file-search.ts` | ファイル内容検索 |
 | `src/lib/terminal-highlight.ts` | CSS Custom Highlight API ラッパー（Issue #47）XSS安全なターミナルハイライト |
 | `src/lib/file-tree.ts` | ディレクトリツリー構造生成 |
-| `src/lib/git-utils.ts` | Git情報取得 |
+| `src/lib/git-utils.ts` | Git情報取得・コミット履歴/diff取得（Issue #447） |
+| `src/types/git.ts` | Git関連型定義（CommitInfo, ChangedFile, GitLogResponse等）（Issue #447） |
 | `src/lib/utils.ts` | 汎用ユーティリティ |
 | `src/lib/date-utils.ts` | 相対時刻フォーマット |
 | `src/lib/clipboard-utils.ts` | クリップボードコピー |
@@ -198,6 +199,7 @@ tests/
 | `src/components/worktree/FilePanelContent.tsx` | ファイルコンテンツ表示 |
 | `src/components/worktree/FileViewer.tsx` | ファイルビューア |
 | `src/components/worktree/FileTreeView.tsx` | ファイルツリー表示 |
+| `src/components/worktree/GitPane.tsx` | Gitタブ（コミット履歴・diff表示）（Issue #447） |
 | `src/hooks/useFileTabs.ts` | タブ状態管理フック |
 | `src/hooks/useAutoYes.ts` | Auto-Yesクライアント側フック |
 | `src/hooks/useFileSearch.ts` | 検索状態管理フック |
@@ -206,6 +208,9 @@ tests/
 | `src/app/api/worktrees/[id]/terminal/route.ts` | ターミナルコマンド送信API |
 | `src/app/api/worktrees/[id]/capture/route.ts` | ターミナル出力キャプチャAPI |
 | `src/app/api/worktrees/[id]/marp-render/route.ts` | MARPスライドレンダリングAPI |
+| `src/app/api/worktrees/[id]/git/log/route.ts` | Gitコミット履歴取得API（Issue #447） |
+| `src/app/api/worktrees/[id]/git/show/[commitHash]/route.ts` | Gitコミット変更ファイル一覧API（Issue #447） |
+| `src/app/api/worktrees/[id]/git/diff/route.ts` | Gitファイルdiff取得API（Issue #447） |
 
 ### CLIモジュール
 

--- a/src/app/api/worktrees/[id]/git/diff/route.ts
+++ b/src/app/api/worktrees/[id]/git/diff/route.ts
@@ -9,10 +9,8 @@ import { getDbInstance } from '@/lib/db-instance';
 import { getWorktreeById } from '@/lib/db';
 import { isValidWorktreeId } from '@/lib/auto-yes-manager';
 import { isPathSafe } from '@/lib/path-validator';
-import { getGitDiff, GitTimeoutError, GitNotRepoError } from '@/lib/git-utils';
-
-/** Commit hash validation pattern: 7-40 hex characters */
-const COMMIT_HASH_PATTERN = /^[0-9a-f]{7,40}$/;
+import { getGitDiff, handleGitApiError } from '@/lib/git-utils';
+import { COMMIT_HASH_PATTERN } from '@/types/git';
 
 export async function GET(
   request: NextRequest,
@@ -76,22 +74,6 @@ export async function GET(
 
     return NextResponse.json({ diff }, { status: 200 });
   } catch (error) {
-    if (error instanceof GitNotRepoError) {
-      return NextResponse.json(
-        { error: 'Not a git repository' },
-        { status: 400 }
-      );
-    }
-    if (error instanceof GitTimeoutError) {
-      return NextResponse.json(
-        { error: 'Git command timed out' },
-        { status: 504 }
-      );
-    }
-    console.error('[GET /api/worktrees/:id/git/diff] Error:', error);
-    return NextResponse.json(
-      { error: 'Failed to execute git command' },
-      { status: 500 }
-    );
+    return handleGitApiError(error, 'GET /api/worktrees/:id/git/diff');
   }
 }

--- a/src/app/api/worktrees/[id]/git/log/route.ts
+++ b/src/app/api/worktrees/[id]/git/log/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDbInstance } from '@/lib/db-instance';
 import { getWorktreeById } from '@/lib/db';
 import { isValidWorktreeId } from '@/lib/auto-yes-manager';
-import { getGitLog, GitTimeoutError, GitNotRepoError } from '@/lib/git-utils';
+import { getGitLog, handleGitApiError } from '@/lib/git-utils';
 
 export async function GET(
   request: NextRequest,
@@ -65,22 +65,6 @@ export async function GET(
 
     return NextResponse.json({ commits }, { status: 200 });
   } catch (error) {
-    if (error instanceof GitNotRepoError) {
-      return NextResponse.json(
-        { error: 'Not a git repository' },
-        { status: 400 }
-      );
-    }
-    if (error instanceof GitTimeoutError) {
-      return NextResponse.json(
-        { error: 'Git command timed out' },
-        { status: 504 }
-      );
-    }
-    console.error('[GET /api/worktrees/:id/git/log] Error:', error);
-    return NextResponse.json(
-      { error: 'Failed to execute git command' },
-      { status: 500 }
-    );
+    return handleGitApiError(error, 'GET /api/worktrees/:id/git/log');
   }
 }

--- a/src/app/api/worktrees/[id]/git/show/[commitHash]/route.ts
+++ b/src/app/api/worktrees/[id]/git/show/[commitHash]/route.ts
@@ -4,17 +4,15 @@
  * Issue #447: Git tab feature
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getDbInstance } from '@/lib/db-instance';
 import { getWorktreeById } from '@/lib/db';
 import { isValidWorktreeId } from '@/lib/auto-yes-manager';
-import { getGitShow, GitTimeoutError, GitNotRepoError } from '@/lib/git-utils';
-
-/** Commit hash validation pattern: 7-40 hex characters */
-const COMMIT_HASH_PATTERN = /^[0-9a-f]{7,40}$/;
+import { getGitShow, handleGitApiError } from '@/lib/git-utils';
+import { COMMIT_HASH_PATTERN } from '@/types/git';
 
 export async function GET(
-  request: NextRequest,
+  _request: Request,
   { params }: { params: { id: string; commitHash: string } }
 ) {
   try {
@@ -55,22 +53,6 @@ export async function GET(
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    if (error instanceof GitNotRepoError) {
-      return NextResponse.json(
-        { error: 'Not a git repository' },
-        { status: 400 }
-      );
-    }
-    if (error instanceof GitTimeoutError) {
-      return NextResponse.json(
-        { error: 'Git command timed out' },
-        { status: 504 }
-      );
-    }
-    console.error('[GET /api/worktrees/:id/git/show/:hash] Error:', error);
-    return NextResponse.json(
-      { error: 'Failed to execute git command' },
-      { status: 500 }
-    );
+    return handleGitApiError(error, 'GET /api/worktrees/:id/git/show/:hash');
   }
 }

--- a/src/components/worktree/DiffViewer.tsx
+++ b/src/components/worktree/DiffViewer.tsx
@@ -1,0 +1,95 @@
+/**
+ * DiffViewer Component
+ * Issue #447: Displays git diff content in the right pane file panel area.
+ *
+ * Renders unified diff with color-coded lines (green for additions,
+ * red for deletions, blue for hunk headers).
+ */
+
+'use client';
+
+import React, { memo } from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DiffViewerProps {
+  /** The diff content to display */
+  diff: string;
+  /** File path being diffed */
+  filePath: string;
+  /** Callback to close the diff view */
+  onClose: () => void;
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+const DiffLine = memo(function DiffLine({ line }: { line: string }) {
+  let className = 'whitespace-pre font-mono text-xs leading-5';
+
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    className += ' text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-900/20';
+  } else if (line.startsWith('-') && !line.startsWith('---')) {
+    className += ' text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20';
+  } else if (line.startsWith('@@')) {
+    className += ' text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/10';
+  } else if (line.startsWith('diff --git') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++')) {
+    className += ' text-gray-500 dark:text-gray-400';
+  } else {
+    className += ' text-gray-700 dark:text-gray-300';
+  }
+
+  return <div className={className}>{line}</div>;
+});
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export const DiffViewer = memo(function DiffViewer({
+  diff,
+  filePath,
+  onClose,
+}: DiffViewerProps) {
+  return (
+    <div className="h-full flex flex-col bg-white dark:bg-gray-900">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-xs font-medium text-cyan-600 dark:text-cyan-400 shrink-0">
+            DIFF
+          </span>
+          <span className="text-xs font-mono text-gray-600 dark:text-gray-300 truncate">
+            {filePath}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded shrink-0"
+          aria-label="Close diff view"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Diff content */}
+      <div className="flex-1 overflow-auto p-2">
+        <pre className="text-xs">
+          <code>
+            {diff.split('\n').map((line, index) => (
+              <DiffLine key={index} line={line} />
+            ))}
+          </code>
+        </pre>
+      </div>
+    </div>
+  );
+});
+
+export default DiffViewer;

--- a/src/components/worktree/FilePanelSplit.tsx
+++ b/src/components/worktree/FilePanelSplit.tsx
@@ -12,6 +12,7 @@
 import React, { memo, useState, useCallback, useRef, useMemo } from 'react';
 import { PaneResizer } from './PaneResizer';
 import { FilePanelTabs } from './FilePanelTabs';
+import { DiffViewer } from './DiffViewer';
 import type { FileTabsState } from '@/hooks/useFileTabs';
 import type { FileContent } from '@/types/models';
 
@@ -40,6 +41,12 @@ export interface FilePanelSplitProps {
   onSetLoading: (path: string, loading: boolean) => void;
   /** Callback when file is saved (refresh tree) */
   onFileSaved?: (path: string) => void;
+  /** Diff content to display in the file panel area (Issue #447) */
+  diffContent?: string | null;
+  /** File path of the diff being displayed (Issue #447) */
+  diffFilePath?: string | null;
+  /** Callback to close the diff view (Issue #447) */
+  onCloseDiff?: () => void;
 }
 
 // ============================================================================
@@ -76,6 +83,9 @@ export const FilePanelSplit = memo(function FilePanelSplit({
   onLoadError,
   onSetLoading,
   onFileSaved,
+  diffContent,
+  diffFilePath,
+  onCloseDiff,
 }: FilePanelSplitProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [terminalWidth, setTerminalWidth] = useState(INITIAL_TERMINAL_WIDTH);
@@ -107,8 +117,11 @@ export const FilePanelSplit = memo(function FilePanelSplit({
     </div>
   );
 
-  // No tabs: terminal at full width
-  if (fileTabs.tabs.length === 0) {
+  // Determine if the right panel should show (file tabs or diff)
+  const hasRightPanel = fileTabs.tabs.length > 0 || (diffContent && diffFilePath);
+
+  // No tabs and no diff: terminal at full width
+  if (!hasRightPanel) {
     return (
       <div className="h-full">
         {terminalWithHeader}
@@ -140,17 +153,26 @@ export const FilePanelSplit = memo(function FilePanelSplit({
         style={filePanelStyle}
         className="flex-grow overflow-hidden"
       >
-        <FilePanelTabs
-          tabs={fileTabs.tabs}
-          activeIndex={fileTabs.activeIndex}
-          worktreeId={worktreeId}
-          onClose={onCloseTab}
-          onActivate={onActivateTab}
-          onLoadContent={onLoadContent}
-          onLoadError={onLoadError}
-          onSetLoading={onSetLoading}
-          onFileSaved={onFileSaved}
-        />
+        {/* Diff view takes priority when active (Issue #447) */}
+        {diffContent && diffFilePath && onCloseDiff ? (
+          <DiffViewer
+            diff={diffContent}
+            filePath={diffFilePath}
+            onClose={onCloseDiff}
+          />
+        ) : (
+          <FilePanelTabs
+            tabs={fileTabs.tabs}
+            activeIndex={fileTabs.activeIndex}
+            worktreeId={worktreeId}
+            onClose={onCloseTab}
+            onActivate={onActivateTab}
+            onLoadContent={onLoadContent}
+            onLoadError={onLoadError}
+            onSetLoading={onSetLoading}
+            onFileSaved={onFileSaved}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/worktree/GitPane.tsx
+++ b/src/components/worktree/GitPane.tsx
@@ -4,6 +4,9 @@
  *
  * Displays commit history, changed files per commit, and file diffs.
  * Uses execFile-based API endpoints for security.
+ *
+ * PC: Clicking a file triggers onDiffSelect to show diff in the right pane.
+ * Mobile: Diff is displayed inline within this component.
  */
 
 'use client';
@@ -17,7 +20,10 @@ import type { CommitInfo, ChangedFile } from '@/types/git';
 
 interface GitPaneProps {
   worktreeId: string;
-  onDiffSelect: (diff: string) => void;
+  /** Called when a diff is selected (PC: displays in right pane) */
+  onDiffSelect: (diff: string, filePath: string) => void;
+  /** When true, shows diff inline instead of calling onDiffSelect */
+  isMobile?: boolean;
   className?: string;
 }
 
@@ -63,6 +69,17 @@ const DiffLine = memo(function DiffLine({ line }: { line: string }) {
   return <div className={className}>{line}</div>;
 });
 
+/**
+ * Inline error display for sub-section errors
+ */
+const InlineError = memo(function InlineError({ message }: { message: string }) {
+  return (
+    <div className="px-3 py-2 text-xs text-red-600 dark:text-red-400" role="alert">
+      {message}
+    </div>
+  );
+});
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -70,6 +87,7 @@ const DiffLine = memo(function DiffLine({ line }: { line: string }) {
 export const GitPane = memo(function GitPane({
   worktreeId,
   onDiffSelect,
+  isMobile = false,
   className = '',
 }: GitPaneProps) {
   const [commits, setCommits] = useState<CommitInfo[]>([]);
@@ -80,25 +98,26 @@ export const GitPane = memo(function GitPane({
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingFiles, setIsLoadingFiles] = useState(false);
   const [isLoadingDiff, setIsLoadingDiff] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [commitError, setCommitError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
 
   /**
    * Fetch commit history
    */
   const fetchCommits = useCallback(async () => {
     setIsLoading(true);
-    setError(null);
+    setCommitError(null);
     try {
       const response = await fetch(`/api/worktrees/${worktreeId}/git/log`);
       if (!response.ok) {
         const data = await response.json();
-        setError(data.error || 'Failed to fetch commit history');
+        setCommitError(data.error || 'Failed to fetch commit history');
         return;
       }
       const data = await response.json();
       setCommits(data.commits);
     } catch {
-      setError('Failed to fetch commit history');
+      setCommitError('Failed to fetch commit history');
     } finally {
       setIsLoading(false);
     }
@@ -112,17 +131,18 @@ export const GitPane = memo(function GitPane({
     setChangedFiles([]);
     setSelectedFile(null);
     setDiffContent(null);
+    setDetailError(null);
     try {
       const response = await fetch(`/api/worktrees/${worktreeId}/git/show/${commitHash}`);
       if (!response.ok) {
         const data = await response.json();
-        setError(data.error || 'Failed to fetch commit details');
+        setDetailError(data.error || 'Failed to fetch commit details');
         return;
       }
       const data = await response.json();
       setChangedFiles(data.files);
     } catch {
-      setError('Failed to fetch commit details');
+      setDetailError('Failed to fetch commit details');
     } finally {
       setIsLoadingFiles(false);
     }
@@ -133,20 +153,22 @@ export const GitPane = memo(function GitPane({
    */
   const fetchDiff = useCallback(async (commitHash: string, filePath: string) => {
     setIsLoadingDiff(true);
+    setDiffContent(null);
+    setDetailError(null);
     try {
       const response = await fetch(
         `/api/worktrees/${worktreeId}/git/diff?commit=${commitHash}&file=${encodeURIComponent(filePath)}`
       );
       if (!response.ok) {
         const data = await response.json();
-        setError(data.error || 'Failed to fetch diff');
+        setDetailError(data.error || 'Failed to fetch diff');
         return;
       }
       const data = await response.json();
       setDiffContent(data.diff);
-      onDiffSelect(data.diff);
+      onDiffSelect(data.diff, filePath);
     } catch {
-      setError('Failed to fetch diff');
+      setDetailError('Failed to fetch diff');
     } finally {
       setIsLoadingDiff(false);
     }
@@ -182,6 +204,7 @@ export const GitPane = memo(function GitPane({
     setChangedFiles([]);
     setSelectedFile(null);
     setDiffContent(null);
+    setDetailError(null);
     fetchCommits();
   }, [fetchCommits]);
 
@@ -214,66 +237,73 @@ export const GitPane = memo(function GitPane({
         </div>
       )}
 
-      {/* Error state */}
-      {error && !isLoading && (
+      {/* Commit-level error state */}
+      {commitError && !isLoading && (
         <div className="px-3 py-4 text-sm text-red-600 dark:text-red-400" role="alert">
-          {error}
+          {commitError}
         </div>
       )}
 
       {/* Empty state */}
-      {!isLoading && !error && commits.length === 0 && (
+      {!isLoading && !commitError && commits.length === 0 && (
         <div className="px-3 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
           No commits found
         </div>
       )}
 
-      {/* Commit list */}
-      {!isLoading && !error && commits.length > 0 && (
-        <div className="flex-1 overflow-y-auto min-h-0">
-          {/* Commits */}
-          <ul className="divide-y divide-gray-100 dark:divide-gray-800">
-            {commits.map((commit) => (
-              <li key={commit.hash}>
-                <button
-                  type="button"
-                  onClick={() => handleCommitSelect(commit.hash)}
-                  className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${
-                    selectedCommit === commit.hash
-                      ? 'bg-cyan-50 dark:bg-cyan-900/30'
-                      : ''
-                  }`}
-                >
-                  <div className="flex items-baseline gap-2">
-                    <span className="font-mono text-xs text-cyan-600 dark:text-cyan-400 shrink-0">
-                      {commit.shortHash}
-                    </span>
-                    <span className="truncate text-gray-800 dark:text-gray-200">
-                      {commit.message}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                    <span>{commit.author}</span>
-                    <span>{new Date(commit.date).toLocaleDateString()}</span>
-                  </div>
-                </button>
-              </li>
-            ))}
-          </ul>
+      {/* Commit list + detail split layout */}
+      {!isLoading && !commitError && commits.length > 0 && (
+        <div className="flex-1 flex flex-col overflow-hidden min-h-0">
+          {/* Upper: Commit list (scrollable, max 40%) */}
+          <div className={`overflow-y-auto ${selectedCommit ? 'max-h-[40%] shrink-0' : 'flex-1'}`}>
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+              {commits.map((commit) => (
+                <li key={commit.hash}>
+                  <button
+                    type="button"
+                    onClick={() => handleCommitSelect(commit.hash)}
+                    className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${
+                      selectedCommit === commit.hash
+                        ? 'bg-cyan-50 dark:bg-cyan-900/30'
+                        : ''
+                    }`}
+                  >
+                    <div className="flex items-baseline gap-2">
+                      <span className="font-mono text-xs text-cyan-600 dark:text-cyan-400 shrink-0">
+                        {commit.shortHash}
+                      </span>
+                      <span className="truncate text-gray-800 dark:text-gray-200">
+                        {commit.message}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                      <span>{commit.author}</span>
+                      <span>{new Date(commit.date).toLocaleDateString()}</span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
 
-          {/* Changed files for selected commit */}
+          {/* Lower: Changed files + Diff (scrollable) */}
           {selectedCommit && (
-            <div className="border-t border-gray-200 dark:border-gray-700">
-              <div className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50">
+            <div className="flex-1 overflow-y-auto min-h-0 border-t border-gray-200 dark:border-gray-700">
+              {/* Changed files header */}
+              <div className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 sticky top-0 z-10">
                 Changed Files
               </div>
+
+              {/* Detail-level error (files/diff) - shown inline */}
+              {detailError && <InlineError message={detailError} />}
+
               {isLoadingFiles && (
                 <div className="flex items-center justify-center py-4" role="status">
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-cyan-500" />
                   <span className="sr-only">Loading changed files...</span>
                 </div>
               )}
-              {!isLoadingFiles && changedFiles.length === 0 && (
+              {!isLoadingFiles && !detailError && changedFiles.length === 0 && (
                 <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
                   No changed files
                 </div>
@@ -307,30 +337,42 @@ export const GitPane = memo(function GitPane({
                   ))}
                 </ul>
               )}
-            </div>
-          )}
 
-          {/* Diff viewer */}
-          {selectedFile && diffContent && (
-            <div className="border-t border-gray-200 dark:border-gray-700">
-              <div className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50">
-                Diff: {selectedFile}
-              </div>
-              {isLoadingDiff && (
-                <div className="flex items-center justify-center py-4" role="status">
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-cyan-500" />
-                  <span className="sr-only">Loading diff...</span>
+              {/* Inline diff viewer (mobile only) */}
+              {isMobile && selectedFile && (
+                <div className="border-t border-gray-200 dark:border-gray-700">
+                  <div className="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 sticky top-0 z-10">
+                    Diff: {selectedFile}
+                  </div>
+                  {isLoadingDiff && (
+                    <div className="flex items-center justify-center py-4" role="status">
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-cyan-500" />
+                      <span className="sr-only">Loading diff...</span>
+                    </div>
+                  )}
+                  {!isLoadingDiff && diffContent && (
+                    <div className="overflow-x-auto p-2">
+                      <pre className="text-xs">
+                        <code>
+                          {diffContent.split('\n').map((line, index) => (
+                            <DiffLine key={index} line={line} />
+                          ))}
+                        </code>
+                      </pre>
+                    </div>
+                  )}
+                  {!isLoadingDiff && !diffContent && !detailError && (
+                    <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                      No diff available
+                    </div>
+                  )}
                 </div>
               )}
-              {!isLoadingDiff && (
-                <div className="overflow-x-auto p-2">
-                  <pre className="text-xs">
-                    <code>
-                      {diffContent.split('\n').map((line, index) => (
-                        <DiffLine key={index} line={line} />
-                      ))}
-                    </code>
-                  </pre>
+
+              {/* PC: show selected file indicator */}
+              {!isMobile && selectedFile && !detailError && (
+                <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700">
+                  {isLoadingDiff ? 'Loading diff...' : `Diff displayed in file panel: ${selectedFile}`}
                 </div>
               )}
             </div>

--- a/src/components/worktree/LeftPaneTabSwitcher.tsx
+++ b/src/components/worktree/LeftPaneTabSwitcher.tsx
@@ -16,7 +16,7 @@ import React, { useCallback, memo } from 'react';
 /**
  * Available tabs for the left pane
  */
-export type LeftPaneTab = 'history' | 'files' | 'memo' | 'git';
+export type LeftPaneTab = 'history' | 'files' | 'memo';
 
 export interface LeftPaneTabSwitcherProps {
   /** Currently active tab */
@@ -94,25 +94,6 @@ const MemoIcon = memo(function MemoIcon() {
   );
 });
 
-const GitIcon = memo(function GitIcon() {
-  return (
-    <svg
-      className="w-4 h-4"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M13 10V3L4 14h7v7l9-11h-7z"
-      />
-    </svg>
-  );
-});
-
 // ============================================================================
 // Tab Configuration
 // ============================================================================
@@ -121,7 +102,6 @@ const TABS: TabConfig[] = [
   { id: 'history', label: 'History', icon: <HistoryIcon /> },
   { id: 'files', label: 'Files', icon: <FilesIcon /> },
   { id: 'memo', label: 'CMATE', icon: <MemoIcon /> },
-  { id: 'git', label: 'Git', icon: <GitIcon /> },
 ];
 
 // ============================================================================

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -841,6 +841,12 @@ interface MobileContentProps {
   onScrollChange?: (enabled: boolean) => void;
   /** [Issue #379] Disable auto-follow for TUI tools (OpenCode) */
   disableAutoFollow?: boolean;
+  /** [Issue #447] History sub-tab state */
+  historySubTab: 'message' | 'git';
+  /** [Issue #447] History sub-tab change handler */
+  onHistorySubTabChange: (tab: 'message' | 'git') => void;
+  /** [Issue #447] Diff select handler for GitPane */
+  onDiffSelect: (diff: string, filePath: string) => void;
 }
 
 /** [Issue #21] Type for file search hook return */
@@ -877,6 +883,9 @@ const MobileContent = memo(function MobileContent({
   autoScroll,
   onScrollChange,
   disableAutoFollow,
+  historySubTab,
+  onHistorySubTabChange,
+  onDiffSelect,
 }: MobileContentProps) {
   switch (activeTab) {
     case 'terminal':
@@ -895,15 +904,53 @@ const MobileContent = memo(function MobileContent({
       );
     case 'history':
       return (
-        <ErrorBoundary componentName="HistoryPane">
-          <HistoryPane
-            messages={messages}
-            worktreeId={worktreeId}
-            onFilePathClick={onFilePathClick}
-            className="h-full"
-            showToast={showToast}
-          />
-        </ErrorBoundary>
+        <div className="h-full flex flex-col">
+          {/* History sub-tab switcher: Message | Git (Issue #447) */}
+          <div className="flex border-b border-gray-200 dark:border-gray-700 shrink-0">
+            <button
+              type="button"
+              onClick={() => onHistorySubTabChange('message')}
+              className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
+                historySubTab === 'message'
+                  ? 'text-cyan-600 dark:text-cyan-400 border-b-2 border-cyan-600 dark:border-cyan-400 bg-cyan-50 dark:bg-cyan-900/30'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              Message
+            </button>
+            <button
+              type="button"
+              onClick={() => onHistorySubTabChange('git')}
+              className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
+                historySubTab === 'git'
+                  ? 'text-cyan-600 dark:text-cyan-400 border-b-2 border-cyan-600 dark:border-cyan-400 bg-cyan-50 dark:bg-cyan-900/30'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              Git
+            </button>
+          </div>
+          {historySubTab === 'message' ? (
+            <ErrorBoundary componentName="HistoryPane">
+              <HistoryPane
+                messages={messages}
+                worktreeId={worktreeId}
+                onFilePathClick={onFilePathClick}
+                className="flex-1 min-h-0"
+                showToast={showToast}
+              />
+            </ErrorBoundary>
+          ) : (
+            <ErrorBoundary componentName="GitPane">
+              <GitPane
+                worktreeId={worktreeId}
+                onDiffSelect={onDiffSelect}
+                isMobile={true}
+                className="flex-1 min-h-0"
+              />
+            </ErrorBoundary>
+          )}
+        </div>
       );
     case 'files':
       return (
@@ -1025,6 +1072,13 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   activeCliTabRef.current = activeCliTab;
   // Trigger to refresh FileTreeView after file operations
   const [fileTreeRefresh, setFileTreeRefresh] = useState(0);
+
+  // [Issue #447] History sub-tab: 'message' (default) or 'git'
+  const [historySubTab, setHistorySubTab] = useState<'message' | 'git'>('message');
+
+  // [Issue #447] Diff content for right pane display (PC only)
+  const [diffContent, setDiffContent] = useState<string | null>(null);
+  const [diffFilePath, setDiffFilePath] = useState<string | null>(null);
 
   // [Issue #21] File search state
   const fileSearch = useFileSearch({ worktreeId });
@@ -1272,10 +1326,19 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   }, [router]);
 
   /** Handle diff selection from GitPane (Issue #447) */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleDiffSelect = useCallback((diff: string) => {
-    // Diff content is displayed within GitPane itself
-    // This callback can be extended for right-pane integration in the future
+  const handleDiffSelect = useCallback((diff: string, filePath: string) => {
+    if (!isMobile) {
+      // PC: show diff in right pane file panel area
+      setDiffContent(diff);
+      setDiffFilePath(filePath);
+    }
+    // Mobile: diff is shown inline within GitPane
+  }, [isMobile]);
+
+  /** Close diff view in right pane (Issue #447) */
+  const handleCloseDiff = useCallback(() => {
+    setDiffContent(null);
+    setDiffFilePath(null);
   }, []);
 
   /** Handle info button click - open info modal */
@@ -2025,9 +2088,12 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         onLoadError={handleLoadError}
         onSetLoading={handleSetLoading}
         onFileSaved={handleFilePanelSave}
+        diffContent={diffContent}
+        diffFilePath={diffFilePath}
+        onCloseDiff={handleCloseDiff}
       />
     ),
-    [state.terminal.output, state.terminal.isActive, state.terminal.isThinking, state.terminal.autoScroll, handleAutoScrollChange, disableAutoFollow, terminalHeaderMemo, fileTabs.state, fileTabs.closeTab, fileTabs.activateTab, worktreeId, handleLoadContent, handleLoadError, handleSetLoading, handleFilePanelSave]
+    [state.terminal.output, state.terminal.isActive, state.terminal.isThinking, state.terminal.autoScroll, handleAutoScrollChange, disableAutoFollow, terminalHeaderMemo, fileTabs.state, fileTabs.closeTab, fileTabs.activateTab, worktreeId, handleLoadContent, handleLoadError, handleSetLoading, handleFilePanelSave, diffContent, diffFilePath, handleCloseDiff]
   );
 
   /**
@@ -2048,13 +2114,52 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         />
         <div className="flex-1 min-h-0 overflow-hidden">
           {leftPaneTab === 'history' && (
-            <HistoryPane
-              messages={state.messages}
-              worktreeId={worktreeId}
-              onFilePathClick={handleFilePathClick}
-              className="h-full"
-              showToast={showToast}
-            />
+            <div className="h-full flex flex-col">
+              {/* History sub-tab switcher: Message | Git (Issue #447) */}
+              <div className="flex border-b border-gray-200 dark:border-gray-700 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => setHistorySubTab('message')}
+                  className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
+                    historySubTab === 'message'
+                      ? 'text-cyan-600 dark:text-cyan-400 border-b-2 border-cyan-600 dark:border-cyan-400 bg-cyan-50 dark:bg-cyan-900/30'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  }`}
+                >
+                  Message
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setHistorySubTab('git')}
+                  className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
+                    historySubTab === 'git'
+                      ? 'text-cyan-600 dark:text-cyan-400 border-b-2 border-cyan-600 dark:border-cyan-400 bg-cyan-50 dark:bg-cyan-900/30'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  }`}
+                >
+                  Git
+                </button>
+              </div>
+              {historySubTab === 'message' && (
+                <HistoryPane
+                  messages={state.messages}
+                  worktreeId={worktreeId}
+                  onFilePathClick={handleFilePathClick}
+                  className="flex-1 min-h-0"
+                  showToast={showToast}
+                />
+              )}
+              {historySubTab === 'git' && (
+                <ErrorBoundary componentName="GitPane">
+                  <GitPane
+                    worktreeId={worktreeId}
+                    onDiffSelect={handleDiffSelect}
+                    isMobile={false}
+                    className="flex-1 min-h-0"
+                  />
+                </ErrorBoundary>
+              )}
+            </div>
           )}
           {leftPaneTab === 'files' && (
             <ErrorBoundary componentName="FileTreeView">
@@ -2103,19 +2208,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               />
             </ErrorBoundary>
           )}
-          {leftPaneTab === 'git' && (
-            <ErrorBoundary componentName="GitPane">
-              <GitPane
-                worktreeId={worktreeId}
-                onDiffSelect={handleDiffSelect}
-                className="h-full"
-              />
-            </ErrorBoundary>
-          )}
         </div>
       </div>
     ),
-    [leftPaneTab, handleLeftPaneTabChange, state.messages, worktreeId, handleFilePathClick, showToast, fileSearch.query, fileSearch.mode, fileSearch.isSearching, fileSearch.error, fileSearch.setQuery, fileSearch.setMode, fileSearch.clearSearch, fileSearch.results?.results, handleFileSelect, handleNewFile, handleNewDirectory, handleRename, handleDelete, handleUpload, handleMove, handleCmateSetup, fileTreeRefresh, selectedAgents, handleSelectedAgentsChange, vibeLocalModel, handleVibeLocalModelChange, vibeLocalContextWindow, handleVibeLocalContextWindowChange, handleDiffSelect]
+    [leftPaneTab, handleLeftPaneTabChange, historySubTab, state.messages, worktreeId, handleFilePathClick, showToast, fileSearch.query, fileSearch.mode, fileSearch.isSearching, fileSearch.error, fileSearch.setQuery, fileSearch.setMode, fileSearch.clearSearch, fileSearch.results?.results, handleFileSelect, handleNewFile, handleNewDirectory, handleRename, handleDelete, handleUpload, handleMove, handleCmateSetup, fileTreeRefresh, selectedAgents, handleSelectedAgentsChange, vibeLocalModel, handleVibeLocalModelChange, vibeLocalContextWindow, handleVibeLocalContextWindowChange, handleDiffSelect]
   );
 
   // ========================================================================
@@ -2407,6 +2503,9 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
             autoScroll={state.terminal.autoScroll}
             onScrollChange={handleAutoScrollChange}
             disableAutoFollow={disableAutoFollow}
+            historySubTab={historySubTab}
+            onHistorySubTabChange={setHistorySubTab}
+            onDiffSelect={handleDiffSelect}
           />
         </main>
 

--- a/src/lib/git-utils.ts
+++ b/src/lib/git-utils.ts
@@ -10,6 +10,7 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { NextResponse } from 'next/server';
 import type { GitStatus } from '@/types/models';
 import type { CommitInfo, ChangedFile } from '@/types/git';
 
@@ -237,39 +238,31 @@ export async function getGitLog(
 }
 
 /**
- * Parse git show --stat output to extract changed files
+ * Parse git diff-tree --name-status output to extract changed files.
+ * Format: "STATUS\tpath" (e.g., "M\tsrc/lib/foo.ts", "A\tnew-file.ts")
+ * For renames: "RXXX\told-path\tnew-path"
+ *
+ * Uses diff-tree instead of show --stat to avoid path truncation with long paths.
  */
-function parseGitShowStatOutput(statSection: string): ChangedFile[] {
+function parseDiffTreeOutput(output: string): ChangedFile[] {
   const files: ChangedFile[] = [];
-  const lines = statSection.trim().split('\n');
+  const lines = output.trim().split('\n');
 
   for (const line of lines) {
-    // git show --stat format: " path/to/file | N +++---"
-    // Last line is summary: " N files changed, N insertions(+), N deletions(-)"
-    const statMatch = line.match(/^\s*(.+?)\s+\|\s+\d+/);
-    if (!statMatch) continue;
+    if (!line.trim()) continue;
 
-    const filePath = statMatch[1].trim();
+    const parts = line.split('\t');
+    if (parts.length < 2) continue;
 
-    // Detect renamed files: "old => new" or "{old => new}/path"
-    if (filePath.includes('=>')) {
+    const statusCode = parts[0].trim();
+    const filePath = parts[parts.length - 1].trim(); // Use last part (new path for renames)
+
+    if (statusCode.startsWith('R')) {
       files.push({ path: filePath, status: 'renamed' });
-      continue;
-    }
-
-    // Determine status from the +/- indicators
-    const plusMinus = line.match(/\|\s+\d+\s+([+-]+)/);
-    if (plusMinus) {
-      const indicators = plusMinus[1];
-      const hasPlus = indicators.includes('+');
-      const hasMinus = indicators.includes('-');
-      if (hasPlus && !hasMinus) {
-        files.push({ path: filePath, status: 'added' });
-      } else if (!hasPlus && hasMinus) {
-        files.push({ path: filePath, status: 'deleted' });
-      } else {
-        files.push({ path: filePath, status: 'modified' });
-      }
+    } else if (statusCode === 'A') {
+      files.push({ path: filePath, status: 'added' });
+    } else if (statusCode === 'D') {
+      files.push({ path: filePath, status: 'deleted' });
     } else {
       files.push({ path: filePath, status: 'modified' });
     }
@@ -293,13 +286,14 @@ export async function getGitShow(
   commitHash: string
 ): Promise<{ commit: CommitInfo; files: ChangedFile[] } | null> {
   try {
-    const stdout = await execGitCommandTyped(
-      ['show', '--stat', '--format=%H%n%h%n%s%n%an%n%aI', commitHash, '--'],
+    // Get commit info using git log (1 commit)
+    const logStdout = await execGitCommandTyped(
+      ['log', '-1', '--format=%H%n%h%n%s%n%an%n%aI', commitHash, '--'],
       worktreePath,
       GIT_LOG_TIMEOUT_MS
     );
 
-    const lines = stdout.trim().split('\n');
+    const lines = logStdout.trim().split('\n');
     if (lines.length < 5) return null;
 
     const commit: CommitInfo = {
@@ -310,9 +304,14 @@ export async function getGitShow(
       date: lines[4],
     };
 
-    // Lines after the 5 commit info lines (and an empty line) are the --stat output
-    const statSection = lines.slice(5).join('\n');
-    const files = parseGitShowStatOutput(statSection);
+    // Get changed files using diff-tree (outputs full paths, no truncation)
+    const diffTreeStdout = await execGitCommandTyped(
+      ['diff-tree', '--no-commit-id', '-r', '--name-status', commitHash, '--'],
+      worktreePath,
+      GIT_LOG_TIMEOUT_MS
+    );
+
+    const files = parseDiffTreeOutput(diffTreeStdout);
 
     return { commit, files };
   } catch (error) {
@@ -358,4 +357,33 @@ export async function getGitDiff(
     }
     return null;
   }
+}
+
+/**
+ * Handle git-related errors in API routes and return appropriate NextResponse.
+ * Centralizes the error-to-HTTP-status mapping for GitNotRepoError, GitTimeoutError,
+ * and generic errors.
+ *
+ * @param error - The caught error
+ * @param logPrefix - Prefix for the console.error log message
+ * @returns NextResponse with the appropriate status code and error message
+ */
+export function handleGitApiError(error: unknown, logPrefix: string): NextResponse {
+  if (error instanceof GitNotRepoError) {
+    return NextResponse.json(
+      { error: 'Not a git repository' },
+      { status: 400 }
+    );
+  }
+  if (error instanceof GitTimeoutError) {
+    return NextResponse.json(
+      { error: 'Git command timed out' },
+      { status: 504 }
+    );
+  }
+  console.error(`[${logPrefix}] Error:`, error);
+  return NextResponse.json(
+    { error: 'Failed to execute git command' },
+    { status: 500 }
+  );
 }

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -51,3 +51,9 @@ export interface GitDiffResponse {
   /** Unified diff format */
   diff: string;
 }
+
+/**
+ * Commit hash validation pattern: 7-40 lowercase hex characters
+ * Used by API routes to validate commit hash parameters before passing to git commands.
+ */
+export const COMMIT_HASH_PATTERN = /^[0-9a-f]{7,40}$/;

--- a/src/types/ui-state.ts
+++ b/src/types/ui-state.ts
@@ -59,7 +59,12 @@ export type MobileActivePane = 'history' | 'terminal' | 'files' | 'memo' | 'info
 /**
  * Left pane tab type for desktop view
  */
-export type LeftPaneTab = 'history' | 'files' | 'memo' | 'git';
+export type LeftPaneTab = 'history' | 'files' | 'memo';
+
+/**
+ * Sub-tab type within the History tab (Issue #447)
+ */
+export type HistorySubTab = 'message' | 'git';
 
 /**
  * Layout State

--- a/tests/unit/api/git-diff.test.ts
+++ b/tests/unit/api/git-diff.test.ts
@@ -23,15 +23,32 @@ vi.mock('@/lib/path-validator', () => ({
   isPathSafe: vi.fn(),
 }));
 
-vi.mock('@/lib/git-utils', () => ({
-  getGitDiff: vi.fn(),
-  GitTimeoutError: class GitTimeoutError extends Error {
+vi.mock('@/lib/git-utils', async () => {
+  const { NextResponse } = await import('next/server');
+
+  class GitTimeoutError extends Error {
     constructor(msg: string) { super(msg); this.name = 'GitTimeoutError'; }
-  },
-  GitNotRepoError: class GitNotRepoError extends Error {
+  }
+  class GitNotRepoError extends Error {
     constructor(msg: string) { super(msg); this.name = 'GitNotRepoError'; }
-  },
-}));
+  }
+
+  return {
+    getGitDiff: vi.fn(),
+    GitTimeoutError,
+    GitNotRepoError,
+    handleGitApiError: (error: unknown, logPrefix: string) => {
+      if (error instanceof GitNotRepoError) {
+        return NextResponse.json({ error: 'Not a git repository' }, { status: 400 });
+      }
+      if (error instanceof GitTimeoutError) {
+        return NextResponse.json({ error: 'Git command timed out' }, { status: 504 });
+      }
+      console.error(`[${logPrefix}] Error:`, error);
+      return NextResponse.json({ error: 'Failed to execute git command' }, { status: 500 });
+    },
+  };
+});
 
 import { GET } from '@/app/api/worktrees/[id]/git/diff/route';
 import { getWorktreeById } from '@/lib/db';

--- a/tests/unit/api/git-log.test.ts
+++ b/tests/unit/api/git-log.test.ts
@@ -19,15 +19,32 @@ vi.mock('@/lib/auto-yes-manager', () => ({
   isValidWorktreeId: vi.fn(),
 }));
 
-vi.mock('@/lib/git-utils', () => ({
-  getGitLog: vi.fn(),
-  GitTimeoutError: class GitTimeoutError extends Error {
+vi.mock('@/lib/git-utils', async () => {
+  const { NextResponse } = await import('next/server');
+
+  class GitTimeoutError extends Error {
     constructor(msg: string) { super(msg); this.name = 'GitTimeoutError'; }
-  },
-  GitNotRepoError: class GitNotRepoError extends Error {
+  }
+  class GitNotRepoError extends Error {
     constructor(msg: string) { super(msg); this.name = 'GitNotRepoError'; }
-  },
-}));
+  }
+
+  return {
+    getGitLog: vi.fn(),
+    GitTimeoutError,
+    GitNotRepoError,
+    handleGitApiError: (error: unknown, logPrefix: string) => {
+      if (error instanceof GitNotRepoError) {
+        return NextResponse.json({ error: 'Not a git repository' }, { status: 400 });
+      }
+      if (error instanceof GitTimeoutError) {
+        return NextResponse.json({ error: 'Git command timed out' }, { status: 504 });
+      }
+      console.error(`[${logPrefix}] Error:`, error);
+      return NextResponse.json({ error: 'Failed to execute git command' }, { status: 500 });
+    },
+  };
+});
 
 import { GET } from '@/app/api/worktrees/[id]/git/log/route';
 import { getWorktreeById } from '@/lib/db';

--- a/tests/unit/api/git-show.test.ts
+++ b/tests/unit/api/git-show.test.ts
@@ -19,15 +19,32 @@ vi.mock('@/lib/auto-yes-manager', () => ({
   isValidWorktreeId: vi.fn(),
 }));
 
-vi.mock('@/lib/git-utils', () => ({
-  getGitShow: vi.fn(),
-  GitTimeoutError: class GitTimeoutError extends Error {
+vi.mock('@/lib/git-utils', async () => {
+  const { NextResponse } = await import('next/server');
+
+  class GitTimeoutError extends Error {
     constructor(msg: string) { super(msg); this.name = 'GitTimeoutError'; }
-  },
-  GitNotRepoError: class GitNotRepoError extends Error {
+  }
+  class GitNotRepoError extends Error {
     constructor(msg: string) { super(msg); this.name = 'GitNotRepoError'; }
-  },
-}));
+  }
+
+  return {
+    getGitShow: vi.fn(),
+    GitTimeoutError,
+    GitNotRepoError,
+    handleGitApiError: (error: unknown, logPrefix: string) => {
+      if (error instanceof GitNotRepoError) {
+        return NextResponse.json({ error: 'Not a git repository' }, { status: 400 });
+      }
+      if (error instanceof GitTimeoutError) {
+        return NextResponse.json({ error: 'Git command timed out' }, { status: 504 });
+      }
+      console.error(`[${logPrefix}] Error:`, error);
+      return NextResponse.json({ error: 'Failed to execute git command' }, { status: 500 });
+    },
+  };
+});
 
 import { GET } from '@/app/api/worktrees/[id]/git/show/[commitHash]/route';
 import { getWorktreeById } from '@/lib/db';

--- a/tests/unit/components/GitPane.test.tsx
+++ b/tests/unit/components/GitPane.test.tsx
@@ -15,7 +15,7 @@ global.fetch = mockFetch;
 describe('GitPane', () => {
   const defaultProps = {
     worktreeId: 'test-worktree-id',
-    onDiffSelect: vi.fn(),
+    onDiffSelect: vi.fn() as (diff: string, filePath: string) => void,
   };
 
   beforeEach(() => {

--- a/tests/unit/components/worktree/LeftPaneTabSwitcher.test.tsx
+++ b/tests/unit/components/worktree/LeftPaneTabSwitcher.test.tsx
@@ -19,14 +19,13 @@ describe('LeftPaneTabSwitcher', () => {
   });
 
   describe('Basic rendering', () => {
-    it('should render tab buttons for history, files, memo, and git', () => {
+    it('should render tab buttons for history, files, and memo', () => {
       const onTabChange = vi.fn();
       render(<LeftPaneTabSwitcher activeTab="history" onTabChange={onTabChange} />);
 
       expect(screen.getByRole('tab', { name: /history/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /files/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /cmate/i })).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: /git/i })).toBeInTheDocument();
     });
 
     it('should render with tablist role', () => {
@@ -192,7 +191,6 @@ describe('LeftPaneTabSwitcher', () => {
       expect(screen.getByRole('tab', { name: /history/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /files/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /cmate/i })).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: /git/i })).toBeInTheDocument();
     });
   });
 
@@ -224,31 +222,13 @@ describe('LeftPaneTabSwitcher', () => {
     });
   });
 
-  describe('Git tab', () => {
-    it('should indicate git tab as active when activeTab is git', () => {
-      const onTabChange = vi.fn();
-      render(<LeftPaneTabSwitcher activeTab="git" onTabChange={onTabChange} />);
-
-      const gitTab = screen.getByRole('tab', { name: /git/i });
-      expect(gitTab).toHaveAttribute('aria-selected', 'true');
-    });
-
-    it('should call onTabChange with "git" when git tab is clicked', () => {
+  describe('Tab count', () => {
+    it('should render 3 tabs (history, files, cmate) without standalone git tab', () => {
       const onTabChange = vi.fn();
       render(<LeftPaneTabSwitcher activeTab="history" onTabChange={onTabChange} />);
 
-      const gitTab = screen.getByRole('tab', { name: /git/i });
-      fireEvent.click(gitTab);
-
-      expect(onTabChange).toHaveBeenCalledWith('git');
-    });
-
-    it('should show git icon', () => {
-      const onTabChange = vi.fn();
-      render(<LeftPaneTabSwitcher activeTab="history" onTabChange={onTabChange} />);
-
-      const gitTab = screen.getByRole('tab', { name: /git/i });
-      expect(gitTab.querySelector('svg')).toBeInTheDocument();
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs).toHaveLength(3);
     });
   });
 

--- a/tests/unit/git-utils-447.test.ts
+++ b/tests/unit/git-utils-447.test.ts
@@ -136,20 +136,24 @@ describe('git-utils Issue #447', () => {
   });
 
   describe('getGitShow', () => {
-    it('should parse commit info and changed files', async () => {
-      const mockOutput = [
+    it('should parse commit info and changed files using diff-tree', async () => {
+      const mockLogOutput = [
         'abc123def456abc123def456abc123def456abc12345',
         'abc123d',
         'feat: add new feature',
         'John Doe',
         '2026-03-08T10:00:00+09:00',
-        '',
-        ' src/lib/new-file.ts | 50 ++++++++++++++++++++++++++++++++++++++++++++++++++',
-        ' src/lib/old-file.ts | 10 +++-------',
-        ' 2 files changed, 53 insertions(+), 7 deletions(-)',
       ].join('\n');
 
-      execFileMock.mockResolvedValue({ stdout: mockOutput, stderr: '' });
+      const mockDiffTreeOutput = [
+        'A\tsrc/lib/new-file.ts',
+        'M\tsrc/lib/old-file.ts',
+      ].join('\n');
+
+      // First call: git log, Second call: git diff-tree
+      execFileMock
+        .mockResolvedValueOnce({ stdout: mockLogOutput, stderr: '' })
+        .mockResolvedValueOnce({ stdout: mockDiffTreeOutput, stderr: '' });
 
       const { getGitShow } = await import('@/lib/git-utils');
       const result = await getGitShow('/path/to/worktree', 'abc123d');
@@ -162,6 +166,35 @@ describe('git-utils Issue #447', () => {
       expect(result!.files[0].status).toBe('added');
       expect(result!.files[1].path).toBe('src/lib/old-file.ts');
       expect(result!.files[1].status).toBe('modified');
+    });
+
+    it('should handle renamed and deleted files', async () => {
+      const mockLogOutput = [
+        'abc123def456abc123def456abc123def456abc12345',
+        'abc123d',
+        'refactor: rename files',
+        'John Doe',
+        '2026-03-08T10:00:00+09:00',
+      ].join('\n');
+
+      const mockDiffTreeOutput = [
+        'R100\tsrc/old-name.ts\tsrc/new-name.ts',
+        'D\tsrc/removed.ts',
+      ].join('\n');
+
+      execFileMock
+        .mockResolvedValueOnce({ stdout: mockLogOutput, stderr: '' })
+        .mockResolvedValueOnce({ stdout: mockDiffTreeOutput, stderr: '' });
+
+      const { getGitShow } = await import('@/lib/git-utils');
+      const result = await getGitShow('/path/to/worktree', 'abc123d');
+
+      expect(result).not.toBeNull();
+      expect(result!.files).toHaveLength(2);
+      expect(result!.files[0].status).toBe('renamed');
+      expect(result!.files[0].path).toBe('src/new-name.ts');
+      expect(result!.files[1].status).toBe('deleted');
+      expect(result!.files[1].path).toBe('src/removed.ts');
     });
 
     it('should return null for unknown commit', async () => {

--- a/tests/unit/types/left-pane-tab.test.ts
+++ b/tests/unit/types/left-pane-tab.test.ts
@@ -17,7 +17,7 @@ describe('LeftPaneTab type consistency', () => {
     const assertTypesEqual = <T extends UIStateLeftPaneTab & SwitcherLeftPaneTab>(_val: T): void => {};
 
     // Runtime validation: test all known values
-    const allTabs: UIStateLeftPaneTab[] = ['history', 'files', 'memo', 'git'];
+    const allTabs: UIStateLeftPaneTab[] = ['history', 'files', 'memo'];
 
     // Verify each value is assignable to both types
     for (const tab of allTabs) {
@@ -26,20 +26,18 @@ describe('LeftPaneTab type consistency', () => {
       expect(uiStateTab).toBe(switcherTab);
     }
 
-    // Ensure we're testing 4 tabs (prevents silent removal)
-    expect(allTabs).toHaveLength(4);
+    // Ensure we're testing 3 tabs
+    expect(allTabs).toHaveLength(3);
 
     // Use the assertion function to prevent unused variable warnings
     assertTypesEqual('history');
     assertTypesEqual('files');
     assertTypesEqual('memo');
-    assertTypesEqual('git');
   });
 
-  it('should include git tab in both type definitions', () => {
-    const gitTab: UIStateLeftPaneTab = 'git';
-    const gitTabSwitcher: SwitcherLeftPaneTab = 'git';
-    expect(gitTab).toBe('git');
-    expect(gitTabSwitcher).toBe('git');
+  it('should not include git as a standalone tab (moved to history sub-tab)', () => {
+    // Git is now a sub-tab within History, not a standalone LeftPaneTab
+    const allTabs: UIStateLeftPaneTab[] = ['history', 'files', 'memo'];
+    expect(allTabs).not.toContain('git');
   });
 });


### PR DESCRIPTION
## Summary

- Historyタブ内にMessage/Gitサブタブ切り替えを追加し、コミット履歴とdiff表示を実装
- PC版: 右ペインのファイルパネルエリアにDiffViewerコンポーネントでdiffを表示
- モバイル版: GitPane内にインラインでdiffを表示
- `git show --stat`のパス切り詰め問題を`git diff-tree`で解決
- エラー状態を分離し、サブコンポーネントのエラーがUI全体を隠す問題を修正

## Changes

- **New**: `DiffViewer` component for right pane diff display
- **New**: Git API endpoints (`git/log`, `git/show`, `git/diff`)
- **Modified**: `LeftPaneTabSwitcher` - removed standalone Git tab (now 3 tabs)
- **Modified**: `WorktreeDetailRefactored` - added History sub-tab switcher (Message | Git)
- **Modified**: `FilePanelSplit` - added diff display support with priority over file tabs
- **Modified**: `GitPane` - added `isMobile` prop, split error states
- **Modified**: `git-utils.ts` - replaced `parseGitShowStatOutput` with `parseDiffTreeOutput`
- **Modified**: `ui-state.ts` - added `HistorySubTab` type, removed `'git'` from `LeftPaneTab`

## Test plan

- [x] Unit tests: 230 files, 4715 tests all passing
- [x] TypeScript compilation: no errors
- [ ] PC版: Historyタブ内でMessage/Git切り替え確認
- [ ] PC版: コミット選択→ファイル選択→右ペインにdiff表示確認
- [ ] モバイル版: Historyタブ内でMessage/Git切り替え確認
- [ ] モバイル版: コミット選択→ファイル選択→インラインdiff表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)