### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-03-08
+
+### Fixed
+- Reset hljs padding in CodeViewer to fix line height issue
+
 ## [0.4.2] - 2026-03-08
 
 ### Added
@@ -727,7 +732,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.2...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/Kewton/CommandMate/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Kewton/CommandMate/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Kewton/CommandMate/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Kewton/CommandMate/compare/v0.3.6...v0.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "IDE for issue-driven AI development — define, plan, and let coding agents execute across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- Patch release v0.4.3
- Version bump in package.json / package-lock.json
- CHANGELOG.md updated with changes since v0.4.2

## Changes included
### Fixed
- Reset hljs padding in CodeViewer to fix line height issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)