### PR TITLE
fix: Gemini model selection dialog and multi-tool prompt detection

### DIFF
--- a/src/lib/prompt-detector.ts
+++ b/src/lib/prompt-detector.ts
@@ -773,6 +773,23 @@ function detectMultipleChoicePrompt(output: string, options?: DetectPromptOption
 
     // Non-option line handling
     if (collectedOptions.length > 0 && line && !SEPARATOR_LINE_PATTERN.test(line)) {
+      const rawLine = lines[i]; // Original line with indentation preserved
+
+      // [Issue #460] For deeply indented lines (4+ leading spaces), check
+      // continuation BEFORE question keywords. These are option description
+      // lines (e.g., "     Let Gemini CLI decide the best model...") that may
+      // contain keywords like "decide" or "select" but are NOT question lines.
+      // The 2-space "  Select model" case (Issue #256) is excluded by the 4+ threshold.
+      const isDeepIndent = /^\s{4,}/.test(rawLine);
+      if (isDeepIndent && isContinuationLine(rawLine, line)) {
+        continuationLineCount++;
+        if (continuationLineCount > MAX_CONTINUATION_LINES) {
+          questionEndIndex = i;
+          break;
+        }
+        continue;
+      }
+
       // [MF-001 / Issue #256] Check if line is a question-like line BEFORE
       // continuation check. This preserves isContinuationLine()'s SRP by not
       // mixing question detection into it. Without this pre-check, indented
@@ -790,7 +807,6 @@ function detectMultipleChoicePrompt(output: string, options?: DetectPromptOption
 
       // Check if this is a continuation line (indented line between options,
       // or path/filename fragments from terminal width wrapping - Issue #181)
-      const rawLine = lines[i]; // Original line with indentation preserved
       if (isContinuationLine(rawLine, line)) {
         continuationLineCount++;
         // Issue #372: Codex TUI indents all output with 2 spaces, causing

--- a/tests/unit/prompt-detector.test.ts
+++ b/tests/unit/prompt-detector.test.ts
@@ -2213,6 +2213,48 @@ Are you sure you want to continue? (yes/no)
         expect(result.promptData.options[2].label).toBe('No, suggest changes (esc)');
       }
     });
+
+    it('should detect Gemini model selection dialog with description lines below options', () => {
+      // Issue #460: Gemini CLI /model command shows options with multi-line descriptions.
+      // Description lines (e.g., "     Let Gemini CLI decide...") are deeply indented (5+ spaces)
+      // and may contain keywords like "decide" that trigger isQuestionLikeLine().
+      // These must be treated as continuation lines, not question lines.
+      const output = [
+        '> /model',
+        '',
+        '',
+        'Select Model',
+        '',
+        '\u25CF 1. Auto (Gemini 3)',
+        '     Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash',
+        '  2. Auto (Gemini 2.5)',
+        '     Let Gemini CLI decide the best model for the task: gemini-2.5-pro, gemini-2.5-flash',
+        '  3. Manual',
+        '     Manually select a model',
+        '',
+        'Remember model for future sessions: false',
+        '(Press Tab to toggle)',
+        '',
+        '> To use a specific Gemini model on startup, use the --model flag.',
+        '',
+        '(Press Esc to close)',
+        '',
+        '',
+      ].join('\n');
+
+      const result = detectPrompt(output);
+
+      expect(result.isPrompt).toBe(true);
+      expect(result.promptData?.type).toBe('multiple_choice');
+      if (isMultipleChoicePrompt(result.promptData)) {
+        expect(result.promptData.options.length).toBe(3);
+        expect(result.promptData.options[0].isDefault).toBe(true);
+        expect(result.promptData.options[0].label).toBe('Auto (Gemini 3)');
+        expect(result.promptData.options[1].label).toBe('Auto (Gemini 2.5)');
+        expect(result.promptData.options[2].label).toBe('Manual');
+        expect(result.promptData.question).toContain('Select Model');
+      }
+    });
   });
 
   // ========================================================================


### PR DESCRIPTION
## Summary
- **Gemini model selection dialog**: Fix prompt detection for `/model` command where option description lines (deeply indented, containing keywords like "decide") were falsely detected as question lines, preventing option collection
- **Gemini CLI**: Strip ANSI codes and wait for prompt before sending messages
- **OpenCode**: Strip `█` scrollbar character; use full output for long prompt detection
- **Codex**: Skip unreasonably large option numbers (>20) in prompt detection
- **Prompt detector**: Tolerate garbage prefix chars, missing periods, and single-gap in option sequences
- **Issue #460**: Add tmux control mode transport for terminal page
- **Issue #457**: Reposition CommandMate as "agent CLI control plane" in README

## Test plan
- [x] 4802 unit tests passing (187 prompt detector tests)
- [x] TypeScript type check passing
- [x] Gemini tab: model selection dialog displays selection window
- [x] Gemini tab: first message sent successfully
- [x] OpenCode tab: status indicator and selection window working
- [x] Codex tab: selection/prompt window displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)