### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-03-10
+
+### Added
+- Persist active CLI tool tab selection via localStorage
+
+### Fixed
+- Codex: detect approval prompts by expanding detection window and skipping collapsed lines
+- Codex: skip update notification instead of triggering npm install
+- Codex: polling-based init with trust dialog and update notification handling
+
+### Performance
+- Parallelize CLI tool status detection, git commands, and initial data fetch
+
 ## [0.4.4] - 2026-03-10
 
 ### Added
@@ -761,7 +774,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.4...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.5...HEAD
+[0.4.5]: https://github.com/Kewton/CommandMate/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/Kewton/CommandMate/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/Kewton/CommandMate/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Kewton/CommandMate/compare/v0.4.1...v0.4.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

- Release v0.4.5 (patch)
- Version bump: 0.4.4 → 0.4.5
- CHANGELOG.md updated

### Changes included

**Added:**
- Persist active CLI tool tab selection via localStorage

**Fixed:**
- Codex approval prompt detection (expanded window, skip collapsed lines)
- Codex update notification handling (skip instead of npm install)
- Codex polling-based init with trust dialog handling

**Performance:**
- Parallelize CLI tool status detection, git commands, and initial data fetch

## Post-merge steps

```bash
git checkout main && git pull
git tag v0.4.5
git push origin v0.4.5
gh release create v0.4.5 --title "v0.4.5" --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)