### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-03-11
+
+### Added
+- File auto-update polling for external change detection (Issue #469)
+  - `useFilePolling` hook with visibility-change lifecycle management
+  - `useFileContentPolling` hook with If-Modified-Since/304 support
+  - `useFileContentSearch` shared search hook
+  - `FileSearchBar` shared component
+  - `file-polling-config.ts` for polling interval constants
+  - File tree and content auto-refresh when agent modifies files
+
+### Fixed
+- Auto-Yes: add retry expiry to prevent permanent duplicate prompt blocking
+- Codex: detect approval prompts with wrapped preview lines
+- Codex: handle long wrapped approval options
+- Sidebar: add fallback navigation when Next.js router.push silently fails
+
+### Refactored
+- File panel: extract duplicated search logic into shared hook and component
+
 ## [0.4.5] - 2026-03-10
 
 ### Added
@@ -774,7 +794,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.5...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.6...HEAD
+[0.4.6]: https://github.com/Kewton/CommandMate/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/Kewton/CommandMate/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/Kewton/CommandMate/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/Kewton/CommandMate/compare/v0.4.2...v0.4.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

- Release v0.4.6 (patch)
- Version bump: 0.4.5 → 0.4.6
- CHANGELOG.md updated

### Changes included

**Added:**
- File auto-update polling for external change detection (Issue #469)
  - File tree and content auto-refresh when agent modifies files

**Fixed:**
- Auto-Yes retry expiry to prevent permanent duplicate prompt blocking
- Codex approval prompt detection with wrapped preview/long options
- Sidebar fallback navigation when router.push silently fails

**Refactored:**
- File panel search logic extracted into shared hook and component

## Post-merge steps

```bash
git checkout main && git pull
git tag v0.4.6
git push origin v0.4.6
gh release create v0.4.6 --title "v0.4.6" --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)