### PR TITLE
chore: release v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-03-13
+
+### Added
+- OpenCode TUI selection list navigation support (Issue #473)
+  - Detect prompt state in OpenCode TUI content area
+  - NavigationButtons for TUI selection lists
+- Image file attachment for message input (Issue #474)
+  - Image attachment UI integrated into MessageInput
+  - Mobile: split message input into two rows
+- Claude CLI selection list prompt detection with NavigationButtons
+
+### Fixed
+- OpenCode: selection list pattern, mobile layout overlap, and button responsiveness
+- Build: remove logger imports from auth.ts and selected-agents-validator (client bundle compatibility)
+- Logger: fix remaining console.error in conversation-logger
+
+### Refactored
+- Logger: migrate console.log/warn/error to structured logger (#480)
+- TODO/FIXME markers cleanup (#482)
+- Large file splitting into smaller modules (Issue #479)
+  - Phase 1: split schedule-manager, FileTreeView, MarkdownEditor
+  - Phase 2: split 5 large files into smaller modules
+  - Phase 3: split db.ts and response-poller.ts
+- lib/ directory restructuring (Issue #481)
+  - Phase 1-7: reorganize into db/, tmux/, security/, detection/, session/, polling/, git/ groups
+  - Add @deprecated compatibility layer for old import paths
+
 ## [0.4.6] - 2026-03-11
 
 ### Added
@@ -794,7 +821,8 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.6...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.7...HEAD
+[0.4.7]: https://github.com/Kewton/CommandMate/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/Kewton/CommandMate/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/Kewton/CommandMate/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/Kewton/CommandMate/compare/v0.4.3...v0.4.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

- Release v0.4.7 (patch)
- Version bump: 0.4.6 → 0.4.7
- CHANGELOG.md updated

### Changes included

**Added:**
- OpenCode TUI selection list navigation support (Issue #473)
- Image file attachment for message input (Issue #474)
- Claude CLI selection list prompt detection with NavigationButtons

**Fixed:**
- OpenCode selection list pattern and mobile layout
- Build compatibility: logger imports in client bundles
- Logger: remaining console.error in conversation-logger

**Refactored:**
- console.log/warn/error → structured logger (#480)
- TODO/FIXME cleanup (#482)
- Large file splitting into smaller modules (Issue #479)
- lib/ directory restructuring into domain groups (Issue #481)

## Post-merge steps

```bash
git checkout main && git pull
git tag v0.4.7
git push origin v0.4.7
gh release create v0.4.7 --title "v0.4.7" --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)