### PR TITLE
fix: force iframe re-mount on sandbox level change (#490)

### DIFF
--- a/src/components/worktree/HtmlPreview.tsx
+++ b/src/components/worktree/HtmlPreview.tsx
@@ -96,6 +96,7 @@ function HtmlIframePreview({
 }) {
   return (
     <iframe
+      key={`${filePath}-${sandboxLevel}`}
       srcDoc={htmlContent}
       sandbox={SANDBOX_ATTRIBUTES[sandboxLevel]}
       title={`HTML Preview: ${filePath}`}


### PR DESCRIPTION
## Summary

- Safe/Interactiveサンドボックスレベル切り替え時にiframeが再レンダリングされない不具合を修正
- iframeに`key`プロパティを追加し、sandbox属性変更時にiframeを再マウントさせる

## Changes

- `src/components/worktree/HtmlPreview.tsx`: iframeに`key={filePath}-${sandboxLevel}`を追加

## Root cause

ブラウザはiframeの`sandbox`属性を動的に変更しても、既に読み込まれたコンテンツには新しい制約を再適用しない。Reactの`key`プロパティを利用してiframe要素を再マウントさせることで解決。

## Test plan

- [x] TypeScript: 0 errors
- [x] Unit Tests: 4956 passed
- [x] 手動確認: Safe/Interactive切り替えでiframeが再読み込みされる

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)