### PR TITLE
fix: force iframe re-mount on sandbox change in mobile view (#490)

### DIFF
--- a/src/components/worktree/FileViewer.tsx
+++ b/src/components/worktree/FileViewer.tsx
@@ -144,6 +144,7 @@ function HtmlPreviewMobile({
           </table>
         ) : (
           <iframe
+            key={`${filePath}-${sandboxLevel}`}
             srcDoc={htmlContent}
             sandbox={SANDBOX_ATTRIBUTES[sandboxLevel]}
             title={`HTML Preview: ${filePath}`}


### PR DESCRIPTION
## Summary

- モバイル版（FileViewer.tsx）でSafe/Interactiveサンドボックス切り替えが反映されない不具合を修正
- PC版と同様にiframeに`key`プロパティを追加し、sandbox変更時にiframeを再マウント

## Changes

- `src/components/worktree/FileViewer.tsx`: モバイル版iframeに`key={filePath}-${sandboxLevel}`を追加

## Test plan

- [x] TypeScript: 0 errors
- [x] Unit Tests: 4956 passed
- [x] 手動確認: モバイル版でSafe/Interactive切り替えが即座に反映される

Related: #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)