### PR TITLE
fix(auto-yes): prevent client-side duplicate response when server poller is active #501

### DIFF
--- a/src/app/api/worktrees/[id]/current-output/route.ts
+++ b/src/app/api/worktrees/[id]/current-output/route.ts
@@ -10,7 +10,7 @@ import { CLIToolManager } from '@/lib/cli-tools/manager';
 import { CLI_TOOL_IDS, type CLIToolType } from '@/lib/cli-tools/types';
 import { captureSessionOutput } from '@/lib/session/cli-session';
 import { detectSessionStatus, STATUS_REASON } from '@/lib/detection/status-detector';
-import { getAutoYesState, getLastServerResponseTimestamp } from '@/lib/polling/auto-yes-manager';
+import { getAutoYesState, getLastServerResponseTimestamp, isPollerActive } from '@/lib/polling/auto-yes-manager';
 import { isValidWorktreeId } from '@/lib/security/path-validator';
 import { createLogger } from '@/lib/logger';
 
@@ -139,6 +139,8 @@ export async function GET(
       isSelectionListActive,
       // Issue #138: Server-side response timestamp for duplicate prevention
       lastServerResponseTimestamp,
+      // Issue #501: Whether server-side auto-yes poller is active for this worktree
+      serverPollerActive: isPollerActive(params.id),
     });
   } catch (error: unknown) {
     logger.error('error-getting-current-output:', { error: error instanceof Error ? error.message : String(error) });

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -131,6 +131,8 @@ interface CurrentOutputResponse {
   };
   /** Issue #501: Server-side auto-yes response timestamp for client duplicate prevention */
   lastServerResponseTimestamp?: number | null;
+  /** Issue #501: Whether server-side auto-yes poller is active */
+  serverPollerActive?: boolean;
 }
 
 // ============================================================================
@@ -198,6 +200,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   const [autoYesExpiresAt, setAutoYesExpiresAt] = useState<number | null>(null);
   // Issue #501: Track last server-side auto-yes response timestamp for duplicate prevention
   const [lastServerResponseTimestamp, setLastServerResponseTimestamp] = useState<number | null>(null);
+  // Issue #501: Track whether server-side auto-yes poller is active
+  const [serverPollerActive, setServerPollerActive] = useState(false);
   // Issue #473: Track OpenCode TUI selection list state
   const [isSelectionListActive, setIsSelectionListActive] = useState(false);
   // Issue #314: Track previous auto-yes enabled state for stop reason toast
@@ -387,6 +391,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
 
       // Issue #501: Update last server response timestamp for useAutoYes duplicate prevention
       setLastServerResponseTimestamp(data.lastServerResponseTimestamp ?? null);
+      setServerPollerActive(data.serverPollerActive ?? false);
 
       // Update auto-yes state from server (Issue #314: stopReason tracking)
       if (data.autoYes) {
@@ -977,6 +982,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     promptData: state.prompt.data,
     autoYesEnabled,
     lastServerResponseTimestamp,
+    serverPollerActive,
   });
 
   /** Retry loading all data after error */

--- a/src/hooks/useAutoYes.ts
+++ b/src/hooks/useAutoYes.ts
@@ -34,6 +34,8 @@ export interface UseAutoYesParams {
   autoYesEnabled: boolean;
   /** Last server-side response timestamp (Issue #138) */
   lastServerResponseTimestamp?: number | null;
+  /** Whether server-side auto-yes poller is active (Issue #501) */
+  serverPollerActive?: boolean;
 }
 
 /** Return value of useAutoYes hook */
@@ -58,6 +60,7 @@ export function useAutoYes({
   promptData,
   autoYesEnabled,
   lastServerResponseTimestamp,
+  serverPollerActive,
 }: UseAutoYesParams): UseAutoYesReturn {
   const lastAutoRespondedRef = useRef<string | null>(null);
   const [lastAutoResponse, setLastAutoResponse] = useState<string | null>(null);
@@ -71,11 +74,16 @@ export function useAutoYes({
 
     if (!promptData || !autoYesEnabled) return;
 
-    // Issue #138: Skip if server has responded recently (duplicate prevention)
+    // Issue #501: Skip client-side response entirely when server-side poller is active.
+    // The server poller handles all prompt responses; client responding would cause duplicates.
+    if (serverPollerActive) {
+      return;
+    }
+
+    // Issue #138: Skip if server has responded recently (duplicate prevention fallback)
     if (lastServerResponseTimestamp) {
       const timeSinceServerResponse = Date.now() - lastServerResponseTimestamp;
       if (timeSinceServerResponse < DUPLICATE_PREVENTION_WINDOW_MS) {
-        // Server responded within the last 3 seconds, skip client-side response
         return;
       }
     }
@@ -102,7 +110,7 @@ export function useAutoYes({
     }).catch((err) => {
       console.error('[useAutoYes] Failed to send auto-response:', err);
     });
-  }, [isPromptWaiting, promptData, autoYesEnabled, worktreeId, cliTool, lastServerResponseTimestamp]);
+  }, [isPromptWaiting, promptData, autoYesEnabled, worktreeId, cliTool, lastServerResponseTimestamp, serverPollerActive]);
 
   return { lastAutoResponse };
 }

--- a/src/lib/auto-yes-poller.ts
+++ b/src/lib/auto-yes-poller.ts
@@ -134,6 +134,17 @@ export function getLastServerResponseTimestamp(worktreeId: string): number | nul
 }
 
 /**
+ * Check if a server-side auto-yes poller is active for a worktree.
+ * Used by the client to skip client-side auto-response when the server is handling it.
+ *
+ * @param worktreeId - Worktree identifier
+ * @returns true if a poller is actively running for this worktree
+ */
+export function isPollerActive(worktreeId: string): boolean {
+  return autoYesPollerStates.has(worktreeId);
+}
+
+/**
  * Update the last server response timestamp.
  *
  * @param worktreeId - Worktree identifier

--- a/src/lib/polling/auto-yes-manager.ts
+++ b/src/lib/polling/auto-yes-manager.ts
@@ -45,6 +45,7 @@ export {
   getActivePollerCount,
   clearAllPollerStates,
   getLastServerResponseTimestamp,
+  isPollerActive,
   validatePollingContext,
   captureAndCleanOutput,
   processStopConditionDelta,


### PR DESCRIPTION
## Summary

- サーバー側ポーラーがアクティブな場合、クライアント側 `useAutoYes` の応答を完全にスキップするよう修正
- コンポーネントリマウント（worktreeクリック）時の二重応答問題を根本解決

## Root Cause

前回のPR (#502) で3秒タイムスタンプウィンドウによる重複防止を実装したが、以下のケースで不十分だった：
- worktree切り替え時にコンポーネントがリマウント → `lastAutoRespondedRef` がリセット
- 3秒ウィンドウ経過後はクライアントがサーバーと同じプロンプトに再応答

## Fix

`serverPollerActive` フラグを導入し、サーバー側ポーラー稼働中はクライアント側応答を完全に無効化：

- `auto-yes-poller.ts`: `isPollerActive()` 関数追加
- `auto-yes-manager.ts`: バレルエクスポート追加
- `current-output/route.ts`: レスポンスに `serverPollerActive` 追加
- `WorktreeDetailRefactored.tsx`: 型・state・fetch・useAutoYes引数追加
- `useAutoYes.ts`: `serverPollerActive=true` 時に応答を完全スキップ

## Test plan

- [x] `npx tsc --noEmit` パス (0 errors)
- [x] `npm run lint` パス (0 warnings)
- [x] `npm run test:unit` パス (5019 passed)
- [ ] 手動確認: Auto-Yes有効時にworktreeクリックしても二重応答が発生しないこと
- [ ] 手動確認: サイドバーステータスがorangeのまま固まらないこと

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)