### PR TITLE
fix: リポジトリアイコンを色付きフォルダに変更 (#504)

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -289,12 +289,7 @@ function GroupHeader({
       "
     >
       <ChevronIcon isExpanded={isExpanded} />
-      <span
-        className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-        style={{ backgroundColor: generateRepositoryColor(repositoryName) }}
-        aria-hidden="true"
-      />
-      <GroupIcon />
+      <GroupIcon color={generateRepositoryColor(repositoryName)} />
       <span className="flex-1 text-left truncate">{repositoryName}</span>
       <span className="text-gray-500 font-normal">{branchCount}</span>
     </button>
@@ -350,15 +345,16 @@ function ChevronIcon({ isExpanded }: { isExpanded: boolean }) {
   );
 }
 
-/** Folder/group icon */
-function GroupIcon({ className = 'w-3 h-3' }: { className?: string }) {
+/** Folder/group icon with optional repository color */
+function GroupIcon({ className = 'w-3.5 h-3.5', color }: { className?: string; color?: string }) {
   return (
     <svg
-      className={className}
-      fill="none"
+      className={`${className} flex-shrink-0`}
       viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
+      fill={color ?? 'none'}
+      stroke={color ? 'none' : 'currentColor'}
+      strokeWidth={color ? 0 : 2}
+      aria-hidden="true"
     >
       <path
         strokeLinecap="round"


### PR DESCRIPTION
## Summary

- 色付き丸ドットをやめて、**フォルダアイコン自体にリポジトリ色を塗る**方式に変更
- フォルダ形状でリポジトリであることが一目でわかり、CLIステータスドット（丸）と完全に差別化

## 変更内容

- `GroupHeader`: 丸ドット要素を削除し、`GroupIcon`にcolor propを渡す
- `GroupIcon`: `color` propを追加。指定時はfillで塗りつぶし、未指定時は既存のstroke表示
- アイコンサイズを `w-3 h-3` → `w-3.5 h-3.5` に微増し視認性向上

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` エラー0件
- [x] `npm run test:unit` パス（1件の既存環境依存テスト除く）

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)