### PR TITLE
fix: ファイルタブUI・リンクナビゲーション不具合修正 (#505)

### DIFF
--- a/src/components/worktree/FilePanelTabs.tsx
+++ b/src/components/worktree/FilePanelTabs.tsx
@@ -11,7 +11,7 @@
 
 'use client';
 
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useState, useEffect, useRef } from 'react';
 import { X, ChevronDown } from 'lucide-react';
 import { FilePanelContent } from './FilePanelContent';
 import type { FileTab } from '@/hooks/useFileTabs';
@@ -144,6 +144,7 @@ export const FilePanelTabs = memo(function FilePanelTabs({
   onOpenFile,
 }: FilePanelTabsProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const activeTab = activeIndex !== null && activeIndex >= 0 && activeIndex < tabs.length
     ? tabs[activeIndex]
@@ -151,6 +152,18 @@ export const FilePanelTabs = memo(function FilePanelTabs({
 
   const visibleTabs = tabs.length > VISIBLE_TAB_COUNT ? tabs.slice(0, VISIBLE_TAB_COUNT) : tabs;
   const overflowTabs = tabs.length > VISIBLE_TAB_COUNT ? tabs.slice(VISIBLE_TAB_COUNT) : [];
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [dropdownOpen]);
 
   const handleDropdownSelect = useCallback((path: string) => {
     setDropdownOpen(false);
@@ -164,30 +177,32 @@ export const FilePanelTabs = memo(function FilePanelTabs({
   return (
     <div className="flex flex-col h-full">
       {/* Tab bar */}
-      <div className="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-x-auto">
-        {visibleTabs.map((tab, index) => (
-          <TabButton
-            key={tab.path}
-            tab={tab}
-            isActive={index === activeIndex}
-            onActivate={onActivate}
-            onClose={onClose}
-          />
-        ))}
+      <div className="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 min-w-0">
+        <div className="flex min-w-0 overflow-hidden flex-1">
+          {visibleTabs.map((tab, index) => (
+            <TabButton
+              key={tab.path}
+              tab={tab}
+              isActive={index === activeIndex}
+              onActivate={onActivate}
+              onClose={onClose}
+            />
+          ))}
+        </div>
         {/* Dropdown button for overflow tabs [DR1-008] */}
         {overflowTabs.length > 0 && (
-          <div className="relative flex-shrink-0">
+          <div className="relative flex-shrink-0" ref={dropdownRef}>
             <button
               type="button"
               data-testid="tab-dropdown-button"
               onClick={handleDropdownToggle}
-              className="flex items-center gap-0.5 px-2 py-2 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 border-b-2 border-transparent"
+              className="flex items-center gap-0.5 px-2 py-2 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 border-b-2 border-transparent transition-colors"
             >
-              <ChevronDown className="w-3 h-3" />
+              <ChevronDown className={`w-3 h-3 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`} />
               <span>+{overflowTabs.length}</span>
             </button>
             {dropdownOpen && (
-              <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50 min-w-[160px] max-h-[300px] overflow-y-auto">
+              <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50 min-w-[200px] max-h-[300px] overflow-y-auto">
                 {overflowTabs.map(tab => (
                   <button
                     key={tab.path}

--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -136,20 +136,13 @@ export const MarkdownPreview = memo(function MarkdownPreview({
     [handleLinkClick],
   );
 
-  // rehype plugins with custom sanitize schema [DR4-001]
-  const rehypePlugins = useMemo(
-    () => [
-      [rehypeSanitize, REHYPE_SANITIZE_SCHEMA] as const,
-      rehypeHighlight,
-    ],
-    [],
-  );
-
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      rehypePlugins={rehypePlugins as any}
+      rehypePlugins={[
+        [rehypeSanitize, REHYPE_SANITIZE_SCHEMA],
+        rehypeHighlight,
+      ]}
       components={markdownComponents}
     >
       {content}

--- a/src/lib/link-utils.ts
+++ b/src/lib/link-utils.ts
@@ -35,7 +35,14 @@ export type LinkType = 'anchor' | 'external' | 'relative';
  */
 export function classifyLink(href: string): LinkType {
   if (href.startsWith('#')) return 'anchor';
-  if (href.startsWith('http://') || href.startsWith('https://')) return 'external';
+  if (
+    href.startsWith('http://') ||
+    href.startsWith('https://') ||
+    href.startsWith('mailto:') ||
+    href.startsWith('tel:')
+  ) {
+    return 'external';
+  }
   return 'relative';
 }
 
@@ -106,7 +113,11 @@ export const REHYPE_SANITIZE_SCHEMA = {
   attributes: {
     ...defaultSchema.attributes,
     a: [
-      ...(defaultSchema.attributes?.a ?? []),
+      // Keep all default 'a' attributes except bare 'href' (which allows any value)
+      ...(defaultSchema.attributes?.a ?? []).filter(
+        (attr) => attr !== 'href',
+      ),
+      // Replace with allowlist-filtered href [DR4-001]
       ['href', /^(?:#|mailto:|tel:|https?:\/\/|(?![a-zA-Z][a-zA-Z0-9+.-]*:))/],
     ],
   },

--- a/tests/unit/lib/link-utils.test.ts
+++ b/tests/unit/lib/link-utils.test.ts
@@ -46,11 +46,9 @@ describe('classifyLink', () => {
     expect(classifyLink('/docs/guide.md')).toBe('relative');
   });
 
-  it('should return "relative" for mailto: and tel: (not external)', () => {
-    // mailto: and tel: are not http/https, so classifyLink treats them as relative
-    // This is fine because sanitizeHref handles the protocol validation
-    expect(classifyLink('mailto:test@example.com')).toBe('relative');
-    expect(classifyLink('tel:+1234567890')).toBe('relative');
+  it('should return "external" for mailto: and tel: links', () => {
+    expect(classifyLink('mailto:test@example.com')).toBe('external');
+    expect(classifyLink('tel:+1234567890')).toBe('external');
   });
 });
 


### PR DESCRIPTION
## Summary

- ファイルタブが表示幅を超えて選択不能になる問題を修正
- +Nドロップダウンメニューのクリック動作・クリック外閉じを修正
- Markdownプレビュー内リンクからファイルタブが開かない問題を修正

## Changes

### FilePanelTabs.tsx
- タブバーを `overflow-hidden` に変更し、表示幅内に収める
- タブ表示領域とドロップダウンボタンをレイアウト分離
- ドロップダウンのクリック外閉じ（`mousedown` ハンドラ）を追加
- ホバー効果・ChevronDown回転アニメーション追加

### MarkdownPreview.tsx
- `rehypePlugins` を `useMemo` ラッパーからインライン定義に変更

### link-utils.ts
- `REHYPE_SANITIZE_SCHEMA` のデフォルト `"href"` 全許可を除去し、正規表現アローリストのみに統一
- `classifyLink` で `mailto:` / `tel:` を `external` に正しく分類

## Test plan

- [x] `npx tsc --noEmit` - 0 errors
- [x] `npm run lint` - 0 errors
- [x] `npm run test:unit` - 5075 passed
- [ ] ファイルタブ6個以上でタブバーが幅内に収まること
- [ ] +Nボタンクリックでドロップダウンが開くこと
- [ ] ドロップダウン外クリックで閉じること
- [ ] Markdownプレビュー内の相対パスリンクでファイルタブが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)