### PR TITLE
fix: Markdownプレビューのリンクがクリックできない問題を修正 (#505)

### DIFF
--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -20,7 +20,7 @@
 
 'use client';
 
-import React, { memo, useMemo, useCallback } from 'react';
+import React, { memo, useMemo, useCallback, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
@@ -77,11 +77,17 @@ export const MarkdownPreview = memo(function MarkdownPreview({
   onOpenFile,
   currentFilePath,
 }: MarkdownPreviewProps) {
+  // Use refs to avoid re-creating handleLinkClick when props change.
+  // This prevents ReactMarkdown from rebuilding the entire DOM tree
+  // (which makes links unclickable due to constant element detach/reattach).
+  const onOpenFileRef = useRef(onOpenFile);
+  onOpenFileRef.current = onOpenFile;
+  const currentFilePathRef = useRef(currentFilePath);
+  currentFilePathRef.current = currentFilePath;
+
   /**
    * Handle link click based on link type. [DR1-002]
-   * - relative: resolve path and call onOpenFile
-   * - external: open in new window
-   * - anchor: default browser scroll behavior
+   * Uses refs for onOpenFile/currentFilePath so the callback identity is stable.
    */
   const handleLinkClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
@@ -100,20 +106,23 @@ export const MarkdownPreview = memo(function MarkdownPreview({
           break;
         case 'relative': {
           e.preventDefault();
-          if (currentFilePath && onOpenFile) {
-            const resolvedPath = resolveRelativePath(currentFilePath, sanitized);
+          const filePath = currentFilePathRef.current;
+          const openFile = onOpenFileRef.current;
+          if (filePath && openFile) {
+            const resolvedPath = resolveRelativePath(filePath, sanitized);
             if (resolvedPath) {
-              onOpenFile(resolvedPath);
+              openFile(resolvedPath);
             }
           }
           break;
         }
       }
     },
-    [onOpenFile, currentFilePath],
+    [],
   );
 
   // Memoized ReactMarkdown components configuration (DRY principle)
+  // Empty deps: handleLinkClick identity is stable via refs above.
   const markdownComponents: Partial<Components> = useMemo(
     () => ({
       code: MermaidCodeBlock, // [Issue #100] mermaid diagram support
@@ -136,13 +145,20 @@ export const MarkdownPreview = memo(function MarkdownPreview({
     [handleLinkClick],
   );
 
+  // Memoize plugin arrays to prevent ReactMarkdown from re-rendering on every parent render.
+  // New array references cause ReactMarkdown to fully rebuild the DOM tree,
+  // which detaches link elements and makes them unclickable.
+  const remarkPlugins = useMemo(() => [remarkGfm], []);
+  const rehypePlugins = useMemo(
+    () => [[rehypeSanitize, REHYPE_SANITIZE_SCHEMA], rehypeHighlight],
+    [],
+  );
+
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      rehypePlugins={[
-        [rehypeSanitize, REHYPE_SANITIZE_SCHEMA],
-        rehypeHighlight,
-      ]}
+      remarkPlugins={remarkPlugins}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      rehypePlugins={rehypePlugins as any}
       components={markdownComponents}
     >
       {content}


### PR DESCRIPTION
## Summary

- Markdownプレビュー内のリンク要素がDOMの連続再構築によりクリック不能になっていた問題を修正
- DOMミューテーションが3秒で2,288回→0回に改善

## Root Cause

ReactMarkdownのカスタム`a`コンポーネントが親のリレンダリングごとに再生成され、ReactMarkdownがDOM全体を毎回再構築していた。リンク要素が約100msごとにdetach/reattachされるため、ユーザーのクリックが空振りしていた。

## Changes

### MarkdownPreview.tsx
- `onOpenFile`/`currentFilePath`を`useRef`で保持し、`handleLinkClick`の`useCallback`依存配列を空に変更
- `remarkPlugins`/`rehypePlugins`配列を`useMemo`でメモ化
- コールバック参照が安定化し、ReactMarkdownのカスタムコンポーネント再生成を防止

## Test plan

- [x] `npx tsc --noEmit` - 0 errors
- [x] `npm run lint` - 0 errors
- [x] `npm run test:unit` - 5076 passed (全パス)
- [x] Playwright: DOMミューテーション 3秒で0回を確認
- [x] Playwright: リンククリックでファイルタブが正常に追加されることを確認
- [ ] ブラウザで `workspace/anvil-memory-policy.md` の test リンクをクリック → 新しいタブで開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)