### PR TITLE
fix: MessageListのReactMarkdownプラグイン配列・コールバック安定化

### DIFF
--- a/src/components/worktree/MessageList.tsx
+++ b/src/components/worktree/MessageList.tsx
@@ -20,6 +20,10 @@ import { PromptMessage } from './PromptMessage';
 import AnsiToHtml from 'ansi-to-html';
 import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
 
+// Module-level constants to prevent ReactMarkdown DOM rebuilds on re-render
+const REMARK_PLUGINS = [remarkGfm];
+const REHYPE_PLUGINS = [rehypeHighlight];
+
 export interface MessageListProps {
   messages: ChatMessage[];
   worktreeId: string;
@@ -81,8 +85,14 @@ const MessageBubble = React.memo(function MessageBubble({
     return convert.toHtml(text);
   };
 
+  // Use ref to stabilize onFilePathClick reference for markdownComponents.
+  // This prevents ReactMarkdown from rebuilding DOM when parent re-renders.
+  const onFilePathClickRef = useRef(onFilePathClick);
+  onFilePathClickRef.current = onFilePathClick;
+
   /**
-   * Memoized markdown components to prevent re-renders
+   * Memoized markdown components to prevent re-renders.
+   * Uses ref for onFilePathClick so deps are stable ([isUser] only).
    */
   const markdownComponents = useMemo<Components>(() => {
     /**
@@ -114,7 +124,7 @@ const MessageBubble = React.memo(function MessageBubble({
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onFilePathClick(filePath);
+              onFilePathClickRef.current(filePath);
             }}
             className={`underline hover:no-underline font-mono transition-colors break-all inline ${
               isUser ? 'text-blue-100 hover:text-white' : 'text-blue-600 hover:text-blue-800'
@@ -163,7 +173,7 @@ const MessageBubble = React.memo(function MessageBubble({
     };
 
     return components;
-  }, [isUser, onFilePathClick]);
+  }, [isUser]);
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
@@ -200,8 +210,8 @@ const MessageBubble = React.memo(function MessageBubble({
                 />
               ) : (
                 <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeHighlight]}
+                  remarkPlugins={REMARK_PLUGINS}
+                  rehypePlugins={REHYPE_PLUGINS}
                   components={markdownComponents}
                 >
                   {message.content}


### PR DESCRIPTION
## Summary

- MessageList内ReactMarkdownのプラグイン配列とコールバック参照を安定化し、MarkdownPreviewと同様のDOM再構築問題を予防

## Changes

### MessageList.tsx
- `remarkPlugins`/`rehypePlugins`をモジュールレベル定数に抽出（インライン配列による毎レンダリング再生成を防止）
- `onFilePathClick`を`useRef`で保持し、`markdownComponents`の`useMemo`依存配列から除去
- MarkdownPreviewの修正（532aaff）と同じパターンを適用

## Context

現在はMessageBubbleの`React.memo`でリレンダリングが抑制されているため実害はないが、将来的にmemo条件が変わった場合にリンク・ファイルパスがクリック不能になるリスクがあるため予防修正。

## Test plan

- [x] `npx tsc --noEmit` - 0 errors
- [x] `npm run lint` - 0 errors
- [x] `npm run test:unit` - 5075 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)