### PR TITLE
fix: Auto-YesのUI状態をエージェント毎に分離 (#525)

### DIFF
--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -196,8 +196,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   const [editorFilePath, setEditorFilePath] = useState<string | null>(null);
   // Issue #104: Track editor maximized state to disable Modal close handlers
   const [isEditorMaximized, setIsEditorMaximized] = useState(false);
-  const [autoYesEnabled, setAutoYesEnabled] = useState(false);
-  const [autoYesExpiresAt, setAutoYesExpiresAt] = useState<number | null>(null);
+  // Issue #525: Per-agent auto-yes state management
+  const [autoYesStateMap, setAutoYesStateMap] = useState<Map<string, { enabled: boolean; expiresAt: number | null }>>(new Map());
   // Issue #501: Track last server-side auto-yes response timestamp for duplicate prevention
   const [lastServerResponseTimestamp, setLastServerResponseTimestamp] = useState<number | null>(null);
   // Issue #501: Track whether server-side auto-yes poller is active
@@ -238,6 +238,9 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   // Issue #4: Ref to avoid polling callback recreation on tab switch
   const activeCliTabRef = useRef<CLIToolType>(activeCliTab);
   activeCliTabRef.current = activeCliTab;
+  // Issue #525: Derive active agent's auto-yes state from per-agent map
+  const autoYesEnabled = autoYesStateMap.get(activeCliTab)?.enabled ?? false;
+  const autoYesExpiresAt = autoYesStateMap.get(activeCliTab)?.expiresAt ?? null;
   // Trigger to refresh FileTreeView after file operations
   const [fileTreeRefresh, setFileTreeRefresh] = useState(0);
 
@@ -393,12 +396,17 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
       setLastServerResponseTimestamp(data.lastServerResponseTimestamp ?? null);
       setServerPollerActive(data.serverPollerActive ?? false);
 
-      // Update auto-yes state from server (Issue #314: stopReason tracking)
+      // Update auto-yes state from server (Issue #314: stopReason tracking, Issue #525: per-agent)
       if (data.autoYes) {
+        const currentCliTool = activeCliTabRef.current;
         const wasEnabled = prevAutoYesEnabledRef.current;
-        setAutoYesEnabled(data.autoYes.enabled);
-        setAutoYesExpiresAt(data.autoYes.expiresAt);
-        prevAutoYesEnabledRef.current = data.autoYes.enabled;
+        const autoYes = data.autoYes;
+        setAutoYesStateMap(prev => {
+          const next = new Map(prev);
+          next.set(currentCliTool, { enabled: autoYes.enabled, expiresAt: autoYes.expiresAt });
+          return next;
+        });
+        prevAutoYesEnabledRef.current = autoYes.enabled;
 
         // Issue #314 / #499 Item 5: Detect stop condition match or consecutive error (enabled -> disabled transition)
         if (wasEnabled && !data.autoYes.enabled &&
@@ -652,8 +660,12 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
       });
       if (response.ok) {
         const data = await response.json();
-        setAutoYesEnabled(data.enabled);
-        setAutoYesExpiresAt(data.expiresAt);
+        // Issue #525: Store per-agent state
+        setAutoYesStateMap(prev => {
+          const next = new Map(prev);
+          next.set(activeCliTab, { enabled: data.enabled, expiresAt: data.expiresAt });
+          return next;
+        });
         prevAutoYesEnabledRef.current = data.enabled;
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

- `WorktreeDetailRefactored.tsx` の `autoYesEnabled` / `autoYesExpiresAt` を単一値から `Map<CLIToolType, {enabled, expiresAt}>` に変更
- エージェントタブ切り替え時に即座に正しいauto-yes状態を表示（ポーリング待ち不要）

## Problem

PR #527 マージ後、UIのauto-yes状態がエージェント毎に分離されていなかった。
- Claudeタブで Auto-Yes ON → Codexタブに切り替え → 一瞬ONのまま表示される問題
- `autoYesEnabled` / `autoYesExpiresAt` がworktree単位の単一stateのままだった

## Fix

- `autoYesStateMap: Map<string, {enabled, expiresAt}>` でエージェント毎に独立管理
- `activeCliTab` から即座に導出（`autoYesStateMap.get(activeCliTab)`）
- ポーリング更新時・トグル操作時にエージェント別にMap更新

## Test plan

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] Unit Tests: 5253/5253 passed (1件は既知のgit-utils環境依存)

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)