### PR TITLE
chore: release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-03-21
+
+### Added
+- Auto-Yes: per-agent composite key support for independent Auto-Yes control per agent (Issue #525)
+- Auto-Yes: per-agent UI controls with agent name display in AutoYesToggle
+- Session history: retain message history after session clear with archived toggle (Issue #168)
+  - Logical deletion (archived column) instead of physical DELETE
+  - `showArchived` toggle in HistoryPane with localStorage persistence
+- CLI: `/orchestrate` command for parallel issue development lifecycle
+- CLI: `/pr-merge-pipeline` command for PR creation through merge automation
+- CLI: `/uat-fix-loop` command for UAT failure repair cycle automation
+
+### Fixed
+- Sync: clean up orphaned tmux sessions when worktrees are deleted during sync (Issue #526)
+- Auto-Yes: separate per-agent auto-yes state in UI to avoid stale display on tab switch
+- Auto-Yes: fix disable-all to properly disable all agents (not just default claude)
+- Test: make session-cleanup tests resilient to mock reset timing in CI
+- bin/commandmate.js: add execute permission
+
+### Refactored
+- Logging: standardize logger action strings to `module:action` format
+- Auto-Yes: extract `filterCompositeKeysByWorktree` shared utility for DRY compliance
+- Auto-Yes: rename state/poller ID functions to `CompositeKeys` for naming clarity
+- Release skill: use git worktree + commandmatedev delegation
+
 ## [0.4.10] - 2026-03-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- Release v0.4.11 (patch)
- Updated package.json version to 0.4.11
- Updated CHANGELOG.md with v0.4.11 entries
- All quality checks passed (lint, tsc, test:unit, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)