### PR TITLE
feat(wsl2): WSL2環境でのWindows対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CommandMate is a local control plane for agent CLIs.
 npx commandmate
 ```
 
-**From install to your first session in 60 seconds.** macOS / Linux · Node.js v20+ · npm · git · tmux
+**From install to your first session in 60 seconds.** macOS / Linux / Windows (WSL2) · Node.js v20+ · npm · git · tmux
 
 ---
 
@@ -108,6 +108,7 @@ commandmate start --daemon
 Open http://localhost:3000 in your browser.
 
 See the [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) for details.
+For Windows users, see the [WSL2 Setup Guide](./docs/user-guide/wsl2-setup.md).
 
 </details>
 

--- a/docs/user-guide/wsl2-setup.md
+++ b/docs/user-guide/wsl2-setup.md
@@ -1,0 +1,190 @@
+# WSL2 Setup Guide (Windows)
+
+CommandMate runs on Windows via WSL2 (Windows Subsystem for Linux).
+Since CommandMate depends on tmux, WSL2 is required — native Windows is not supported.
+
+---
+
+## Prerequisites
+
+- Windows 10 (version 2004+) or Windows 11
+- WSL2 enabled with Ubuntu 22.04 or later
+- Windows Terminal (recommended)
+
+---
+
+## 1. WSL2 Setup
+
+If WSL2 is not yet installed, open **PowerShell as Administrator** and run:
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Restart your PC when prompted, then launch Ubuntu from the Start menu to complete the initial setup (username/password).
+
+Verify WSL2 is active:
+
+```powershell
+wsl --list --verbose
+```
+
+The `VERSION` column should show `2`.
+
+---
+
+## 2. Install Dependencies
+
+Open your WSL2 terminal (Ubuntu) and run:
+
+```bash
+# Update packages
+sudo apt update && sudo apt upgrade -y
+
+# Install required packages
+sudo apt install -y git tmux build-essential
+```
+
+### Install Node.js (v20+)
+
+We recommend using [nvm](https://github.com/nvm-sh/nvm) for Node.js version management:
+
+```bash
+# Install nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# Reload shell
+source ~/.bashrc
+
+# Install Node.js 20
+nvm install 20
+nvm use 20
+
+# Verify
+node -v   # v20.x.x
+npm -v
+```
+
+---
+
+## 3. Clone & Build
+
+```bash
+# Clone the repository
+git clone https://github.com/Kewton/CommandMate.git
+cd CommandMate
+
+# Install dependencies
+npm install
+
+# Build
+npm run build:all
+```
+
+---
+
+## 4. Initialize & Start
+
+```bash
+# Initialize (interactive setup)
+npx commandmate init
+
+# Start the server
+npx commandmate start --daemon
+```
+
+The server starts at `http://localhost:3000` by default.
+
+---
+
+## 5. Access from Windows Browser
+
+### localhost access (default)
+
+In most WSL2 configurations, `localhost` is automatically forwarded to WSL2.
+Open your Windows browser and navigate to:
+
+```
+http://localhost:3000
+```
+
+### If localhost does not work
+
+If `localhost` forwarding is not working, find the WSL2 IP address:
+
+```bash
+# Run inside WSL2
+hostname -I
+```
+
+Then access `http://<WSL2_IP>:3000` from your Windows browser.
+
+To bind CommandMate to all interfaces (required if using the WSL2 IP):
+
+```bash
+CM_BIND=0.0.0.0 npx commandmate start --daemon
+```
+
+---
+
+## 6. Development Mode
+
+For development with hot-reload:
+
+```bash
+cd CommandMate
+
+# Start dev server
+npm run dev
+```
+
+Open `http://localhost:3000` in your Windows browser.
+
+---
+
+## Troubleshooting
+
+### tmux not found
+
+```bash
+sudo apt install -y tmux
+tmux -V
+```
+
+### Node.js version too old
+
+```bash
+nvm install 20
+nvm use 20
+node -v
+```
+
+### Port already in use
+
+```bash
+# Check what is using the port
+ss -tlnp | grep :3000
+
+# Stop the existing server
+npx commandmate stop
+```
+
+### Cannot access from Windows browser
+
+1. Check the server is running: `npx commandmate status`
+2. Try the WSL2 IP address: `hostname -I`
+3. Start with `CM_BIND=0.0.0.0` to bind to all interfaces
+4. Check Windows Firewall is not blocking the port
+
+### File permission issues
+
+WSL2 mounts Windows drives under `/mnt/c/`, `/mnt/d/`, etc. For best performance and compatibility, **keep the repository inside the WSL2 filesystem** (e.g., `~/CommandMate`), not on a Windows-mounted path.
+
+```bash
+# Good - WSL2 native filesystem
+cd ~
+git clone https://github.com/Kewton/CommandMate.git
+
+# Avoid - Windows mounted path (slower, permission issues)
+# cd /mnt/c/Users/YourName/CommandMate
+```

--- a/scripts/stop-server.sh
+++ b/scripts/stop-server.sh
@@ -21,9 +21,21 @@ echo "=== Stopping server ==="
 
 stopped=false
 
+# Cross-platform PID lookup: lsof (macOS/Linux) -> ss+fuser fallback (WSL2/Linux)
+find_pids_by_port() {
+    local port=$1
+    if command -v lsof &>/dev/null; then
+        lsof -ti:"$port" 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true
+    elif command -v ss &>/dev/null && command -v fuser &>/dev/null; then
+        fuser "$port"/tcp 2>/dev/null | tr -s ' ' '\n' | grep -E '^[0-9]+$' | sort -u || true
+    else
+        echo "WARNING: Neither lsof nor ss+fuser available. Cannot find processes by port." >&2
+    fi
+}
+
 # Step 1: Port-based stop - kill all processes using the port (most reliable)
 # Safe PID pipeline: validate numeric + deduplicate [D1-002]
-PIDS=$(lsof -ti:$PORT 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true)
+PIDS=$(find_pids_by_port $PORT)
 
 if [ -n "$PIDS" ]; then
     echo "Stopping process(es) on port $PORT: $(echo $PIDS | tr '\n' ' ')"
@@ -31,7 +43,7 @@ if [ -n "$PIDS" ]; then
     sleep 2
 
     # SIGKILL fallback [D1-002: || true for REMAINING]
-    REMAINING=$(lsof -ti:$PORT 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true)
+    REMAINING=$(find_pids_by_port $PORT)
     if [ -n "$REMAINING" ]; then
         echo "Force killing remaining: $(echo $REMAINING | tr '\n' ' ')"
         echo "$REMAINING" | xargs kill -9 2>/dev/null
@@ -68,7 +80,7 @@ sleep 1
 
 # Step 3: Final check - make sure port is free [C2-003]
 # At this point SIGTERM->SIGKILL stages already attempted, SIGKILL is justified
-REMAINING=$(lsof -ti:$PORT 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true)
+REMAINING=$(find_pids_by_port $PORT)
 if [ -n "$REMAINING" ]; then
     echo "Cleaning up remaining processes: $(echo $REMAINING | tr '\n' ' ')"
     echo "$REMAINING" | xargs kill -9 2>/dev/null  # Final check: SIGKILL as last resort

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -26,8 +26,20 @@ else
     exit 1
   fi
 
+  # Cross-platform PID lookup: lsof (macOS/Linux) -> ss+fuser fallback (WSL2/Linux)
+  find_pids_by_port() {
+      local port=$1
+      if command -v lsof &>/dev/null; then
+          lsof -ti:"$port" 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true
+      elif command -v ss &>/dev/null && command -v fuser &>/dev/null; then
+          fuser "$port"/tcp 2>/dev/null | tr -s ' ' '\n' | grep -E '^[0-9]+$' | sort -u || true
+      else
+          echo "WARNING: Neither lsof nor ss+fuser available. Cannot find processes by port." >&2
+      fi
+  }
+
   # Safe PID pipeline: validate numeric + deduplicate [D1-002]
-  PIDS=$(lsof -ti:$PORT 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true)
+  PIDS=$(find_pids_by_port $PORT)
 
   if [ -n "$PIDS" ]; then
     echo "Stopping process(es) on port $PORT: $(echo $PIDS | tr '\n' ' ')"
@@ -35,7 +47,7 @@ else
 
     # SIGTERM -> SIGKILL fallback [D1-002: || true for REMAINING]
     sleep 2
-    REMAINING=$(lsof -ti:$PORT 2>/dev/null | grep -E '^[0-9]+$' | sort -u || true)
+    REMAINING=$(find_pids_by_port $PORT)
     if [ -n "$REMAINING" ]; then
       echo "Force killing remaining processes: $(echo $REMAINING | tr '\n' ' ')"
       echo "$REMAINING" | xargs kill -9 2>/dev/null


### PR DESCRIPTION
## Summary
- シェルスクリプト（stop-server.sh, stop.sh）の `lsof` 依存を解消し、WSL2環境で動作する `fuser` へのフォールバックを追加
- WSL2セットアップガイド（docs/user-guide/wsl2-setup.md）を新規作成（GitHub clone→ビルド→起動→ブラウザアクセス）
- README.mdの対応プラットフォームに Windows (WSL2) を追加

Closes #551

## Test plan
- [ ] macOS環境で `scripts/stop-server.sh` が従来通り動作すること（lsofパス）
- [ ] WSL2 (Ubuntu) 環境でガイドに従いclone→ビルド→起動ができること
- [ ] WSL2環境で `scripts/stop-server.sh` が動作すること（fuserフォールバック）
- [ ] Windows側ブラウザから `localhost:3000` でアクセスできること
- [ ] 既存のunit test / lint / tscが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)