### PR TITLE
fix(copilot): COPILOT_SKIP_PATTERNSにTUI装飾パターン追加 (#565)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -287,6 +287,22 @@ export const COPILOT_SKIP_PATTERNS: readonly RegExp[] = [
   COPILOT_SEPARATOR_PATTERN,
   COPILOT_THINKING_PATTERN,
   COPILOT_SELECTION_LIST_PATTERN,
+  // Logo/banner lines
+  /^GitHub Copilot\s+v/,
+  /[█▘▝▖▗▔▄▌▐]/,
+  /[╭╮╰╯│]/,
+  // Status bar (branch + model display)
+  /\[⎇\s+\w[^\]]*\]/,
+  // Operation guide lines
+  /^shift\+tab\s/,
+  /^\?\s+for\s+shortcuts/,
+  /^ctrl\+[a-z]\s+\w/,
+  // Prompt lines
+  /^[❯>]\s*(Type\s+@|$)/,
+  // Tip/hint lines
+  /^Tip:\s+\//,
+  // Initial display text
+  /^Describe a task to get started/,
 ] as const;
 
 /**

--- a/tests/unit/lib/response-cleaner-copilot.test.ts
+++ b/tests/unit/lib/response-cleaner-copilot.test.ts
@@ -72,4 +72,89 @@ describe('cleanCopilotResponse', () => {
     const input = '  \nContent line\n  ';
     expect(cleanCopilotResponse(input)).toBe('Content line');
   });
+
+  // Issue #565 追加: TUI装飾パターンのフィルタリング
+  describe('Copilot TUI decoration filtering', () => {
+    it('should skip logo/banner lines', () => {
+      const input = [
+        'GitHub Copilot v1.0.12',
+        '█ ▘▝ █',
+        '▔▔▔▔',
+        '╭─╮╭─╮',
+        '╰─╯╰─╯',
+        'Actual response content',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe('Actual response content');
+    });
+
+    it('should skip status bar lines with branch and model info', () => {
+      const input = [
+        '~/share/work/github/Anvil-develop [⎇ develop] GPT-5 mini (medium)',
+        'The analysis result is:',
+        'Bug is in line 42',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe('The analysis result is:\nBug is in line 42');
+    });
+
+    it('should skip operation guide lines', () => {
+      const input = [
+        'shift+tab switch mode',
+        '? for shortcuts',
+        'ctrl+q enqueue',
+        'Actual content here',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe('Actual content here');
+    });
+
+    it('should skip prompt lines', () => {
+      const input = [
+        '❯ Type @ to mention files...',
+        '❯',
+        'Response text here',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe('Response text here');
+    });
+
+    it('should skip tip/hint lines', () => {
+      const input = [
+        'Tip: /share Share session or research report...',
+        'Tip: /model Switch between available models',
+        'Here is the actual response',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe('Here is the actual response');
+    });
+
+    it('should skip initial display text', () => {
+      const input = [
+        'Describe a task to get started.',
+        'The result of the analysis:',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe('The result of the analysis:');
+    });
+
+    it('should handle complex real-world Copilot TUI output', () => {
+      const input = [
+        'GitHub Copilot v1.0.12',
+        '█ ▘▝ █',
+        '──────────────────',
+        'Describe a task to get started.',
+        'Tip: /share Share session or research report...',
+        '~/share/work/github/Anvil-develop [⎇ develop] GPT-5 mini (medium)',
+        '❯ Type @ to mention files...',
+        'shift+tab switch mode',
+        '? for shortcuts',
+        '──────────────────',
+        'Here is my analysis of the issue:',
+        '',
+        'The bug is caused by a null pointer.',
+        'I recommend fixing line 42.',
+        '',
+        '❯',
+        'shift+tab switch mode',
+      ].join('\n');
+      expect(cleanCopilotResponse(input)).toBe(
+        'Here is my analysis of the issue:\nThe bug is caused by a null pointer.\nI recommend fixing line 42.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Message HistoryにCopilot TUI装飾（ロゴ、ステータスバー、操作ガイド等）が残る問題を修正
- `COPILOT_SKIP_PATTERNS`に12パターンを追加し、`cleanCopilotResponse()`/`extractCopilotContentLines()`でフィルタリング

## 追加パターン

| カテゴリ | パターン例 |
|---------|-----------|
| ロゴ/バナー | `GitHub Copilot v`, `█▘▝`, `╭╮╰╯` |
| ステータスバー | `[⎇ develop] GPT-5 mini` |
| 操作ガイド | `shift+tab switch mode`, `? for shortcuts`, `ctrl+q enqueue` |
| プロンプト | `❯ Type @ to mention files...`, `❯`（空プロンプト） |
| ヒント | `Tip: /share ...` |
| 初期表示 | `Describe a task to get started.` |

## 変更ファイル

- `src/lib/detection/cli-patterns.ts` — COPILOT_SKIP_PATTERNSに12パターン追加
- `tests/unit/lib/response-cleaner-copilot.test.ts` — 7テストケース追加（11→18件）

## Test plan

- [x] `npx tsc --noEmit` — エラー0件
- [x] `npm run lint` — エラー0件
- [x] `npm run test:unit` — 5479パス, 0失敗
- [ ] 実機でCopilot応答のMessage Historyに装飾が残らないことを確認

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)