### PR TITLE
release: v0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.15] - 2026-03-31
+
+### Added
+- Schedule: allow Copilot model selection in CMATE schedule CLI Tool column (Issue #588)
+- Schedule: add Copilot CLI permission flag support for CMATE schedules (Issue #584)
+- Schedule: expose active schedule state
+- Commands: add current-situation, cause-analysis commands and update orchestrate for bug workflow
+- Commands: add Codex cross-review to multi-stage review commands
+
+### Fixed
+- Slash commands: prevent Copilot builtins from overriding Claude standard commands (Issue #586)
+- Schedule: recover inactive schedule cron jobs
+- Schedule: stop cron job when schedule is disabled via Enabled=false
+- Commands: correct agent assignment rules in orchestrate command
+- Scripts: add .env auto-loading to all shell scripts
+- Schedule: add missing new files for Copilot model selection (Issue #588)
+
+### Docs
+- Add Copilot model selection syntax to CMATE schedules guide (ja/en)
+
 ## [0.4.14] - 2026-03-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- chore: release v0.4.15
- package.json version bump to 0.4.15
- CHANGELOG.md updated with v0.4.15 entries

## Changes
- **Added**: Copilot model selection (Schedule), permission flag, current-situation/cause-analysis commands
- **Fixed**: slash command overwrite prevention, cron job recovery, agent assignment fixes
- **Docs**: CMATE schedules guide updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)