### PR TITLE
release: v0.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.16] - 2026-04-01
+
+### Added
+- Navigation: add Left/Right keys to NavigationButtons for Copilot TUI (Issue #592)
+
 ## [0.4.15] - 2026-03-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- chore: release v0.4.16
- package.json version bump to 0.4.16
- CHANGELOG.md updated with v0.4.16 entries

## Changes
- **Added**: Navigation Left/Right keys to NavigationButtons for Copilot TUI (Issue #592)

🤖 Generated with [Claude Code](https://claude.com/claude-code)