### PR TITLE
fix(status): unify capture line count to fix spinner stuck on ready (#604)

### DIFF
--- a/src/app/api/worktrees/[id]/current-output/route.ts
+++ b/src/app/api/worktrees/[id]/current-output/route.ts
@@ -12,6 +12,7 @@ import { captureSessionOutput } from '@/lib/session/cli-session';
 import { detectSessionStatus, STATUS_REASON, SELECTION_LIST_REASONS } from '@/lib/detection/status-detector';
 import { getAutoYesState, getLastServerResponseTimestamp, isPollerActive, buildCompositeKey } from '@/lib/polling/auto-yes-manager';
 import { isValidWorktreeId } from '@/lib/security/path-validator';
+import { STATUS_CAPTURE_LINES } from '@/config/status-capture-config';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('api/current-output');
@@ -74,7 +75,7 @@ export async function GET(
     const lastCapturedLine = sessionState?.lastCapturedLine || 0;
 
     // Capture current output
-    const output = await captureSessionOutput(params.id, cliToolId, 10000);
+    const output = await captureSessionOutput(params.id, cliToolId, STATUS_CAPTURE_LINES);
     const lines = output.split('\n');
     const totalLines = lines.length;
 

--- a/src/config/status-capture-config.ts
+++ b/src/config/status-capture-config.ts
@@ -1,0 +1,10 @@
+/**
+ * Default capture line count for session status detection.
+ * Used by both worktree-status-helper.ts and current-output/route.ts
+ * to ensure consistent status detection across APIs.
+ *
+ * Issue #604: Previously, worktree-status-helper used 100 lines while
+ * current-output used 10000, causing status inconsistency when tmux
+ * buffer had 150+ trailing blank lines after a prompt.
+ */
+export const STATUS_CAPTURE_LINES = 10000;

--- a/src/lib/session/worktree-status-helper.ts
+++ b/src/lib/session/worktree-status-helper.ts
@@ -18,6 +18,7 @@ import { captureSessionOutput } from './cli-session';
 import { detectSessionStatus } from '@/lib/detection/status-detector';
 import { OPENCODE_PANE_HEIGHT } from '@/lib/cli-tools/opencode';
 import { GEMINI_PANE_HEIGHT } from '@/lib/cli-tools/gemini';
+import { STATUS_CAPTURE_LINES } from '@/config/status-capture-config';
 import { isSessionHealthy } from './claude-session';
 import { getLastServerResponseTimestamp, buildCompositeKey } from '@/lib/polling/auto-yes-manager';
 import type { getMessages as GetMessagesFn, markPendingPromptsAsAnswered as MarkPendingFn } from '@/lib/db';
@@ -31,7 +32,7 @@ function getStatusCaptureLines(cliToolId: CLIToolType): number {
     return GEMINI_PANE_HEIGHT;
   }
 
-  return 100;
+  return STATUS_CAPTURE_LINES;
 }
 
 /** Per-CLI-tool session status */

--- a/tests/unit/config/status-capture-config.test.ts
+++ b/tests/unit/config/status-capture-config.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Tests for status-capture-config.ts
+ *
+ * Issue #604: Shared capture line count constant for consistent
+ * status detection across worktree-status-helper and current-output API.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect } from 'vitest';
+import { STATUS_CAPTURE_LINES } from '@/config/status-capture-config';
+
+describe('status-capture-config', () => {
+  describe('STATUS_CAPTURE_LINES', () => {
+    it('should be 10000', () => {
+      expect(STATUS_CAPTURE_LINES).toBe(10000);
+    });
+
+    it('should be a positive number', () => {
+      expect(STATUS_CAPTURE_LINES).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/unit/lib/status-detector.test.ts
+++ b/tests/unit/lib/status-detector.test.ts
@@ -448,4 +448,61 @@ describe('status-detector', () => {
       expect(result.reason).toBe('thinking_indicator');
     });
   });
+
+  // ==========================================================================
+  // Issue #604: Trailing blank lines after prompt
+  // ==========================================================================
+  describe('Issue #604: trailing blank lines after prompt', () => {
+    it('should detect input_prompt when 150+ blank lines follow the prompt', () => {
+      // Simulate tmux buffer: Claude prompt followed by 200 empty lines
+      // (tmux terminal padding). The status detector strips trailing empty
+      // lines before windowing, so the prompt should still be detected.
+      const promptLine = `${PROMPT} `;
+      const blankLines = Array(200).fill('').join('\n');
+      const output = [
+        'Some response content',
+        SEPARATOR,
+        promptLine,
+        blankLines,
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'claude');
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+    });
+
+    it('should detect input_prompt when 500 blank lines follow the prompt', () => {
+      // Even with a very large number of trailing blank lines, the prompt
+      // should be correctly detected after stripping empty lines.
+      const promptLine = `${PROMPT} `;
+      const blankLines = Array(500).fill('').join('\n');
+      const output = [
+        SEPARATOR,
+        'Response content here',
+        SEPARATOR,
+        promptLine,
+        blankLines,
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'claude');
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+    });
+
+    it('should detect input_prompt with recommended command after blank lines', () => {
+      // Claude prompt with a suggested command, followed by blank lines
+      const promptLine = `${PROMPT} /work-plan`;
+      const blankLines = Array(200).fill('').join('\n');
+      const output = [
+        'Response content',
+        SEPARATOR,
+        promptLine,
+        blankLines,
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'claude');
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `STATUS_CAPTURE_LINES` 定数を `status-capture-config.ts` に新規作成し、capture行数を統一
- `worktree-status-helper.ts` と `current-output/route.ts` の両方で同一定数を使用
- prompt後に大量空行がある場合でもステータス判定が一致するように修正

Closes #604

## Root Cause

`/api/worktrees/:id` は100行、`/api/worktrees/:id/current-output` は10000行でcaptureしていたため、同じ `detectSessionStatus()` に異なる範囲の出力が渡され、ステータス判定が不一致になっていた。

## Test plan

- [x] STATUS_CAPTURE_LINES定数テスト追加
- [x] prompt後に大量空行がある場合のdetectSessionStatus回帰テスト追加
- [x] lint / tsc / test:unit / build 全パス（5906 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)