### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-04-04
+
+### Added
+- Review: レポートテンプレート機能を追加し、CRUD API と 3 モード生成UIを実装 (Issue #618)
+- Report: レポート本文のコピーボタンを追加
+
+### Fixed
+- Codex: `/model` Step 1 のモデル選択UIを selection list として検出 (Issue #622)
+- Codex: `/model` 選択UIを waiting status として検出 (Issue #619)
+- Detection: Codex Reasoning Level UI を `multiple_choice` prompt と `submitMode` 対応で処理
+
+### Refactored
+- Template API: 共有ヘルパーを抽出して重複を削減 (Issue #618)
+- Prompt handling: `SubmitMode` バリデーションヘルパーを抽出して重複を削減 (Issue #616)
+
 ## [0.5.1] - 2026-04-02
 
 ### Added
@@ -1052,7 +1067,17 @@ _No changes recorded._
   - `MCBD_DB_PATH` -> `CM_DB_PATH`
 - `NEXT_PUBLIC_MCBD_AUTH_TOKEN` -> `NEXT_PUBLIC_CM_AUTH_TOKEN`
 
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.4.9...HEAD
+[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/Kewton/CommandMate/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/Kewton/CommandMate/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/Kewton/CommandMate/compare/v0.4.16...v0.5.0
+[0.4.16]: https://github.com/Kewton/CommandMate/compare/v0.4.15...v0.4.16
+[0.4.15]: https://github.com/Kewton/CommandMate/compare/v0.4.14...v0.4.15
+[0.4.14]: https://github.com/Kewton/CommandMate/compare/v0.4.13...v0.4.14
+[0.4.13]: https://github.com/Kewton/CommandMate/compare/v0.4.12...v0.4.13
+[0.4.12]: https://github.com/Kewton/CommandMate/compare/v0.4.11...v0.4.12
+[0.4.11]: https://github.com/Kewton/CommandMate/compare/v0.4.10...v0.4.11
+[0.4.10]: https://github.com/Kewton/CommandMate/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/Kewton/CommandMate/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/Kewton/CommandMate/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/Kewton/CommandMate/compare/v0.4.6...v0.4.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## What changed
- bump version from `0.5.1` to `0.5.2`
- update `CHANGELOG.md` for changes merged since `v0.5.1`
- sync `package-lock.json`

## Why
- prepare the next patch release from the current `main` state
- direct pushes to `main` are blocked, so this release is proposed via PR

## How it was validated
- `npm install --package-lock-only`

## Known risks / follow-up
- release tag `v0.5.2` exists locally only and should be pushed after this PR is merged
- repository has existing untracked local docs files not included in this PR