### PR TITLE
fix(report): use tool-specific permission for daily summary generation (#626)

### DIFF
--- a/src/lib/daily-summary-generator.ts
+++ b/src/lib/daily-summary-generator.ts
@@ -16,6 +16,7 @@ import type Database from 'better-sqlite3';
 import { createLogger } from '@/lib/logger';
 import { executeClaudeCommand, MAX_MESSAGE_LENGTH } from '@/lib/session/claude-executor';
 import { buildSummaryPrompt } from '@/lib/summary-prompt-builder';
+import { DEFAULT_PERMISSIONS } from '@/config/schedule-config';
 import { getMessagesByDateRange } from '@/lib/db/chat-db';
 import { saveDailyReport } from '@/lib/db/daily-report-db';
 import { getWorktrees } from '@/lib/db/worktree-db';
@@ -158,11 +159,13 @@ export async function generateDailySummary(
     const prompt = buildSummaryPrompt(messages, worktreeMap, userInstruction);
 
     // 4. Execute AI command
+    // Issue #626: Use tool-specific default permission (e.g. codex: 'workspace-write')
+    const permission = DEFAULT_PERMISSIONS[tool] || 'default';
     const result = await executeClaudeCommand(
       prompt,
       process.cwd(),
       tool,
-      'default',
+      permission,
       { timeoutMs: SUMMARY_GENERATION_TIMEOUT_MS, model }
     );
 

--- a/tests/unit/lib/daily-summary-generator.test.ts
+++ b/tests/unit/lib/daily-summary-generator.test.ts
@@ -46,6 +46,17 @@ vi.mock('@/config/review-config', () => ({
   SUMMARY_GENERATION_TIMEOUT_MS: 60000,
 }));
 
+// Mock schedule-config (DEFAULT_PERMISSIONS)
+vi.mock('@/config/schedule-config', () => ({
+  DEFAULT_PERMISSIONS: {
+    claude: 'acceptEdits',
+    codex: 'workspace-write',
+    gemini: '',
+    'vibe-local': '',
+    copilot: 'allow-all-tools',
+  },
+}));
+
 // Mock summary-prompt-builder
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockBuildSummaryPrompt = vi.fn((..._args: any[]) => 'mock prompt');
@@ -227,8 +238,74 @@ describe('daily-summary-generator', () => {
         expect.any(String),
         expect.any(String),
         'copilot',
-        'default',
+        'allow-all-tools',
         { timeoutMs: 60000, model: 'gpt-4o' }
+      );
+    });
+
+    it('should pass workspace-write permission for codex (Issue #626)', async () => {
+      const validOutput = 'x'.repeat(MIN_SUMMARY_OUTPUT_LENGTH + 10);
+      mockGetMessagesByDateRange.mockReturnValue([
+        { id: 'msg-1', worktreeId: 'wt-1', role: 'user', content: 'hello', timestamp: new Date() },
+      ]);
+      mockExecuteClaudeCommand.mockResolvedValue({
+        output: validOutput,
+        exitCode: 0,
+        status: 'completed',
+      });
+      mockSaveDailyReport.mockReturnValue({
+        date: '2026-04-02',
+        content: validOutput,
+        generatedByTool: 'codex',
+        model: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await generateDailySummary(mockDb, {
+        date: '2026-04-02',
+        tool: 'codex',
+      });
+
+      expect(mockExecuteClaudeCommand).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        'codex',
+        'workspace-write',
+        { timeoutMs: 60000, model: undefined }
+      );
+    });
+
+    it('should pass acceptEdits permission for claude (Issue #626)', async () => {
+      const validOutput = 'x'.repeat(MIN_SUMMARY_OUTPUT_LENGTH + 10);
+      mockGetMessagesByDateRange.mockReturnValue([
+        { id: 'msg-1', worktreeId: 'wt-1', role: 'user', content: 'hello', timestamp: new Date() },
+      ]);
+      mockExecuteClaudeCommand.mockResolvedValue({
+        output: validOutput,
+        exitCode: 0,
+        status: 'completed',
+      });
+      mockSaveDailyReport.mockReturnValue({
+        date: '2026-04-02',
+        content: validOutput,
+        generatedByTool: 'claude',
+        model: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await generateDailySummary(mockDb, {
+        date: '2026-04-02',
+        tool: 'claude',
+      });
+
+      expect(mockExecuteClaudeCommand).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        'claude',
+        'acceptEdits',
+        { timeoutMs: 60000, model: undefined }
       );
     });
 


### PR DESCRIPTION
## Summary

- `daily-summary-generator.ts` のハードコード `'default'` permission を `DEFAULT_PERMISSIONS[tool]` に変更
- 既存の `schedule-config.ts` の `DEFAULT_PERMISSIONS` マップを再利用
- Codex: `workspace-write`, Claude: `acceptEdits`, Copilot: `allow-all-tools`

Closes #626

## Test plan

- [x] `npm run lint` — PASS
- [x] `npx tsc --noEmit` — PASS
- [x] `npm run test:unit` — 6108 passed
- [x] `npm run build` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)