### PR TITLE
fix(report): filter invalid repositories before commit log collection (#632)

### DIFF
--- a/src/lib/daily-summary-generator.ts
+++ b/src/lib/daily-summary-generator.ts
@@ -12,6 +12,8 @@
  * - Output sanitization (control character removal)
  */
 
+import { existsSync } from 'fs';
+import { join } from 'path';
 import type Database from 'better-sqlite3';
 import { createLogger } from '@/lib/logger';
 import { executeClaudeCommand, MAX_MESSAGE_LENGTH } from '@/lib/session/claude-executor';
@@ -159,8 +161,22 @@ export async function generateDailySummary(
       worktreeMap.set(wt.id, wt.name);
     }
 
-    // 3. Collect commit logs from all repositories (Issue #627)
-    const repositories = getAllRepositories(db);
+    // 3. Collect commit logs from valid repositories (Issue #627, #632)
+    const allRepositories = getAllRepositories(db);
+    const repositories = allRepositories.filter(repo => {
+      if (!repo.enabled) return false;
+      if (!existsSync(repo.path)) return false;
+      if (!existsSync(join(repo.path, '.git'))) return false;
+      return true;
+    });
+
+    if (repositories.length < allRepositories.length) {
+      logger.info('repositories-filtered', {
+        total: allRepositories.length,
+        valid: repositories.length,
+        skipped: allRepositories.length - repositories.length,
+      });
+    }
     const since = dayStart.toISOString();
     const until = dayEnd.toISOString();
     const commitLogs = await withTimeout(

--- a/tests/unit/lib/daily-summary-generator.test.ts
+++ b/tests/unit/lib/daily-summary-generator.test.ts
@@ -1,9 +1,21 @@
 /**
  * Tests for daily-summary-generator.ts
  * Issue #607: AI summary generation with concurrent execution control
+ * Issue #632: Filter invalid repositories before commit log collection
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fs (for existsSync) - Issue #632
+const mockExistsSync = vi.fn();
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+}));
+
+// Mock path (for join) - Issue #632
+vi.mock('path', () => ({
+  join: (...args: string[]) => args.join('/'),
+}));
 
 // Mock logger
 vi.mock('@/lib/logger', () => ({
@@ -120,10 +132,12 @@ describe('daily-summary-generator', () => {
       { id: 'wt-1', name: 'feature/test' },
     ]);
     mockGetAllRepositories.mockReturnValue([
-      { id: 'repo-1', name: 'MyRepo', path: '/repos/myrepo' },
+      { id: 'repo-1', name: 'MyRepo', path: '/repos/myrepo', enabled: true },
     ]);
     mockCollectRepositoryCommitLogs.mockResolvedValue(new Map());
     mockCollectIssueInfos.mockResolvedValue([]);
+    // Default: all paths exist (Issue #632)
+    mockExistsSync.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -569,6 +583,119 @@ describe('daily-summary-generator', () => {
         expect.any(Map),
         [] // graceful degradation: empty array
       );
+    });
+  });
+
+  describe('repository filtering (Issue #632)', () => {
+    const validOutput = 'x'.repeat(MIN_SUMMARY_OUTPUT_LENGTH + 10);
+
+    /** Helper to set up mocks for a successful generation flow */
+    function setupSuccessfulGeneration() {
+      mockGetMessagesByDateRange.mockReturnValue([
+        { id: 'msg-1', worktreeId: 'wt-1', role: 'user', content: 'hello', timestamp: new Date() },
+      ]);
+      mockExecuteClaudeCommand.mockResolvedValue({
+        output: validOutput,
+        exitCode: 0,
+        status: 'completed',
+      });
+      mockSaveDailyReport.mockReturnValue({
+        date: '2026-04-02',
+        content: validOutput,
+        generatedByTool: 'claude',
+        model: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+
+    it('should exclude disabled repositories (enabled=false)', async () => {
+      setupSuccessfulGeneration();
+      mockGetAllRepositories.mockReturnValue([
+        { id: 'repo-1', name: 'EnabledRepo', path: '/repos/enabled', enabled: true },
+        { id: 'repo-2', name: 'DisabledRepo', path: '/repos/disabled', enabled: false },
+      ]);
+      mockExistsSync.mockReturnValue(true);
+
+      await generateDailySummary(mockDb, { date: '2026-04-02', tool: 'claude' });
+
+      const passedRepos = mockCollectRepositoryCommitLogs.mock.calls[0][0];
+      expect(passedRepos).toHaveLength(1);
+      expect(passedRepos[0].name).toBe('EnabledRepo');
+    });
+
+    it('should exclude repositories with non-existent paths', async () => {
+      setupSuccessfulGeneration();
+      mockGetAllRepositories.mockReturnValue([
+        { id: 'repo-1', name: 'ExistsRepo', path: '/repos/exists', enabled: true },
+        { id: 'repo-2', name: 'MissingRepo', path: '/repos/missing', enabled: true },
+      ]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === '/repos/missing') return false;
+        return true;
+      });
+
+      await generateDailySummary(mockDb, { date: '2026-04-02', tool: 'claude' });
+
+      const passedRepos = mockCollectRepositoryCommitLogs.mock.calls[0][0];
+      expect(passedRepos).toHaveLength(1);
+      expect(passedRepos[0].name).toBe('ExistsRepo');
+    });
+
+    it('should exclude repositories without .git directory', async () => {
+      setupSuccessfulGeneration();
+      mockGetAllRepositories.mockReturnValue([
+        { id: 'repo-1', name: 'GitRepo', path: '/repos/gitrepo', enabled: true },
+        { id: 'repo-2', name: 'NoGitRepo', path: '/repos/nogit', enabled: true },
+      ]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === '/repos/nogit/.git') return false;
+        return true;
+      });
+
+      await generateDailySummary(mockDb, { date: '2026-04-02', tool: 'claude' });
+
+      const passedRepos = mockCollectRepositoryCommitLogs.mock.calls[0][0];
+      expect(passedRepos).toHaveLength(1);
+      expect(passedRepos[0].name).toBe('GitRepo');
+    });
+
+    it('should pass only valid repositories to collectRepositoryCommitLogs', async () => {
+      setupSuccessfulGeneration();
+      mockGetAllRepositories.mockReturnValue([
+        { id: 'repo-1', name: 'ValidRepo', path: '/repos/valid', enabled: true },
+        { id: 'repo-2', name: 'DisabledRepo', path: '/repos/disabled', enabled: false },
+        { id: 'repo-3', name: 'MissingPathRepo', path: '/repos/missing', enabled: true },
+        { id: 'repo-4', name: 'NoGitRepo', path: '/repos/nogit', enabled: true },
+      ]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === '/repos/missing') return false;
+        if (p === '/repos/nogit/.git') return false;
+        return true;
+      });
+
+      await generateDailySummary(mockDb, { date: '2026-04-02', tool: 'claude' });
+
+      const passedRepos = mockCollectRepositoryCommitLogs.mock.calls[0][0];
+      expect(passedRepos).toHaveLength(1);
+      expect(passedRepos[0].name).toBe('ValidRepo');
+    });
+
+    it('should handle all repositories being invalid without error', async () => {
+      setupSuccessfulGeneration();
+      mockGetAllRepositories.mockReturnValue([
+        { id: 'repo-1', name: 'DisabledRepo', path: '/repos/disabled', enabled: false },
+        { id: 'repo-2', name: 'MissingRepo', path: '/repos/missing', enabled: true },
+      ]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === '/repos/missing') return false;
+        return true;
+      });
+
+      await generateDailySummary(mockDb, { date: '2026-04-02', tool: 'claude' });
+
+      const passedRepos = mockCollectRepositoryCommitLogs.mock.calls[0][0];
+      expect(passedRepos).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `daily-summary-generator.ts` でリポジトリ取得後に3段階フィルタを追加
  - `enabled === true` のリポジトリのみ
  - `path` が存在するディレクトリであること
  - `path` 配下に `.git` が存在すること（gitリポジトリ確認）
- 無効リポジトリ（親ディレクトリ、存在しないパス、disabled）がコミットログ収集から除外される
- 5テストケース追加（フィルタリングの各条件）

Closes #632

## Test plan

- [x] `npx tsc --noEmit` — PASS
- [x] `npm run lint` — PASS
- [x] `npm run test:unit` — PASS
- [x] `npm run build` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)