### PR TITLE
fix(sidebar): resolve post-compaction UX issues — resize, tooltip, overflow

### DIFF
--- a/dev-reports/issue/651/pm-auto-dev/iteration-1/progress-context.json
+++ b/dev-reports/issue/651/pm-auto-dev/iteration-1/progress-context.json
@@ -1,0 +1,38 @@
+{
+  "issue_number": 651,
+  "iteration": 1,
+  "phase_results": {
+    "tdd": {
+      "status": "success",
+      "tests_passing": 6293,
+      "lint_errors": 0,
+      "ts_errors": 0,
+      "files_changed": 6,
+      "test_files_changed": 5
+    },
+    "acceptance": {
+      "status": "passed",
+      "scenarios_total": 15,
+      "scenarios_passed": 15
+    },
+    "refactor": {
+      "status": "success",
+      "improvements": ["BranchTooltipサブコンポーネント抽出", "AppShell.tsxにコメント追加（定数同期の明示）", "useSidebar.tsのJSDoc改善"]
+    },
+    "uat": {
+      "status": "passed",
+      "total": 15,
+      "passed": 15,
+      "failed": 0,
+      "pass_rate": "100%"
+    }
+  },
+  "key_changes": [
+    "src/types/sidebar.ts: SidebarBranchItem型にworktreePath追加、toBranchItem()マッピング",
+    "src/contexts/SidebarContext.tsx: DEFAULT_SIDEBAR_WIDTH 288→224",
+    "src/hooks/useSidebar.ts: LocalStorageマイグレーション（旧値288→224）",
+    "src/components/layout/AppShell.tsx: w-72→w-56, pl-72→pl-56（デスクトップのみ）",
+    "src/components/sidebar/BranchListItem.tsx: showRepositoryName props、BranchTooltipサブコンポーネント（WAI-ARIA対応）",
+    "src/components/layout/Sidebar.tsx: grouped表示にshowRepositoryName={false}"
+  ]
+}

--- a/dev-reports/issue/651/pm-auto-dev/iteration-1/progress-report.md
+++ b/dev-reports/issue/651/pm-auto-dev/iteration-1/progress-report.md
@@ -1,0 +1,155 @@
+# Issue #651 開発進捗レポート
+
+## イテレーション 1 完了
+
+**Issue**: #651 - PC版サイドバーをコンパクト化し、ツールチップで詳細表示
+**ブランチ**: feature/651-worktree
+**報告日時**: 2026-04-14
+**ステータス**: 全フェーズ成功
+
+---
+
+## 実施内容
+
+PC版サイドバーの幅を288px(w-72)から224px(w-56)に縮小し、省略された情報をWAI-ARIAツールチップで補完する機能を実装した。既存ユーザー向けのlocalStorageマイグレーションも実装済み。
+
+---
+
+## フェーズ別結果
+
+### Phase 1: TDD実装
+
+**ステータス**: 成功
+
+- **テスト結果**: 6293/6293 passed (7 skipped)
+- **テストファイル**: 331ファイル全パス
+- **静的解析**: ESLint 0 errors, TypeScript 0 errors
+
+**コミット**:
+- `270db0c7`: feat(sidebar): compact PC sidebar to w-56 with tooltip details (#651)
+
+### Phase 2: 受入テスト
+
+**ステータス**: 成功 (15/15 PASS)
+
+**受入条件検証**:
+
+| # | 受入条件 | 結果 |
+|---|---------|------|
+| 1 | サイドバー幅が224px(w-56)に縮小されている | 合格 |
+| 2 | DEFAULT_SIDEBAR_WIDTH定数とAppShell.tsxのレイアウト幅が一致 | 合格 |
+| 3 | localStorage互換性対応(旧値288->224マイグレーション) | 合格 |
+| 4 | ツリー表示モード時、ツリー配下の項目にリポジトリ名が非表示 | 合格 |
+| 5 | フラット表示モード時、リポジトリ名(別名)が従来通り表示 | 合格 |
+| 6 | ツールチップに詳細情報(ブランチ名、リポジトリ名、ステータス、worktreeパス)表示 | 合格 |
+| 7 | WAI-ARIA tooltipパターン(role='tooltip', aria-describedby)準拠 | 合格 |
+| 8 | キーボードフォーカス時にもツールチップ表示 | 合格 |
+| 9 | 既存サイドバー機能(ソート、フィルタ、グループ化)が正常動作 | 合格 |
+| 10 | lint / tsc / test:unit がパス | 合格 |
+
+### Phase 3: リファクタリング
+
+**ステータス**: 成功
+
+**改善内容**:
+- BranchTooltipサブコンポーネントの抽出(Single Responsibility改善)
+- セクションヘッダー名を 'CLI Status Dot' から 'Sub-components' に改名
+- AppShell.tsxにTailwind幅クラスとDEFAULT_SIDEBAR_WIDTH定数の対応コメント追加
+- LEGACY_SIDEBAR_WIDTHのJSDocにTailwindクラス参照(w-72=288px, w-56=224px)を追加
+- worktreePathのJSDoc簡略化
+
+**コミット**:
+- `59c8e3f3`: refactor(sidebar): extract BranchTooltip sub-component and improve maintainability comments
+
+| 指標 | Before | After | 変化 |
+|------|--------|-------|------|
+| Coverage | 80.0% | 80.0% | 維持 |
+| ESLint errors | 0 | 0 | 維持 |
+| TypeScript errors | 0 | 0 | 維持 |
+| テスト数 | 6293 | 6293 | 維持 |
+
+### Phase 4: UAT (実機受入テスト)
+
+**ステータス**: 成功 (15/15 PASS, 100%)
+
+静的コード解析 + ユニットテストによる検証を実施。全テストケース(TC-001 - TC-015)が合格。
+
+---
+
+## 総合品質メトリクス
+
+| 指標 | 値 | 基準 | 判定 |
+|------|-----|------|------|
+| ユニットテスト | 6293 passed / 0 failed | 全パス | 合格 |
+| テストファイル | 331 passed | 全パス | 合格 |
+| ESLint | 0 errors | 0 errors | 合格 |
+| TypeScript | 0 errors | 0 errors | 合格 |
+| 受入テスト | 15/15 | 全パス | 合格 |
+| UAT | 15/15 (100%) | 全パス | 合格 |
+| アクセシビリティ | WAI-ARIA tooltip準拠 | - | 合格 |
+
+---
+
+## 変更ファイル一覧
+
+### ソースコード (6ファイル)
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/types/sidebar.ts` | SidebarBranchItem型にworktreePathフィールド追加、toBranchItem()マッピング |
+| `src/contexts/SidebarContext.tsx` | DEFAULT_SIDEBAR_WIDTH 288 -> 224 |
+| `src/hooks/useSidebar.ts` | LocalStorageマイグレーション(旧値288 -> 224)、LEGACY_SIDEBAR_WIDTH定数追加 |
+| `src/components/layout/AppShell.tsx` | w-72 -> w-56, pl-72 -> pl-56(デスクトップのみ)、定数同期コメント |
+| `src/components/sidebar/BranchListItem.tsx` | showRepositoryName props、BranchTooltipサブコンポーネント(WAI-ARIA対応) |
+| `src/components/layout/Sidebar.tsx` | grouped表示にshowRepositoryName={false}を渡す |
+
+### テストコード (5ファイル)
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `tests/unit/types/sidebar.test.ts` | worktreePathマッピングテスト追加 |
+| `tests/unit/contexts/SidebarContext.test.tsx` | DEFAULT_SIDEBAR_WIDTH=224のテスト更新 |
+| `tests/unit/hooks/useSidebar.test.ts` | LocalStorageマイグレーションテスト追加 |
+| `tests/unit/components/sidebar/BranchListItem.test.tsx` | ツールチップ・showRepositoryNameテスト追加 |
+| `tests/unit/components/layout/Sidebar.test.tsx` | grouped表示のshowRepositoryNameテスト更新 |
+
+### ドキュメント (2ファイル)
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `CLAUDE.md` | SidebarContext.tsxのDEFAULT_SIDEBAR_WIDTH=224記載 |
+| `docs/implementation-history.md` | Issue #651の実装履歴追加 |
+
+### コミット履歴
+
+| ハッシュ | メッセージ | 日時 |
+|---------|-----------|------|
+| `270db0c7` | feat(sidebar): compact PC sidebar to w-56 with tooltip details (#651) | 2026-04-13 23:56 |
+| `59c8e3f3` | refactor(sidebar): extract BranchTooltip sub-component and improve maintainability comments | 2026-04-14 00:03 |
+| `272d9b46` | chore(issue-651): add dev-reports, update CLAUDE.md and implementation-history | 2026-04-14 00:15 |
+
+---
+
+## ブロッカー / 課題
+
+なし。全フェーズが成功し、品質基準を満たしている。
+
+---
+
+## 次のアクション
+
+1. **PR作成** - feature/651-worktree -> develop へのPRを作成
+2. **レビュー依頼** - 実装内容のコードレビューを依頼
+3. **実機動作確認** - develop環境でのブラウザ動作確認(サイドバー幅、ツールチップ表示、キーボードアクセシビリティ)
+4. **マージ** - レビュー承認後、developブランチへマージ
+
+---
+
+## 備考
+
+- 全4フェーズ(TDD、受入テスト、リファクタリング、UAT)が成功
+- 既存テスト6293件の回帰なし
+- WAI-ARIAアクセシビリティパターンに準拠
+- 既存ユーザー向けlocalStorageマイグレーション実装済み
+
+**Issue #651の実装が完了しました。**

--- a/dev-reports/issue/651/uat/acceptance-test-report.html
+++ b/dev-reports/issue/651/uat/acceptance-test-report.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Issue #651 実機受入テスト報告書</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 24px; background: #f5f5f5; color: #333; }
+  .container { max-width: 960px; margin: 0 auto; }
+  h1 { font-size: 1.5rem; border-bottom: 3px solid #4f46e5; padding-bottom: 8px; color: #1e1b4b; }
+  h2 { font-size: 1.1rem; color: #374151; margin-top: 28px; }
+  .meta { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 16px 0; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .meta dt { font-weight: 600; color: #6b7280; font-size: 0.85rem; }
+  .meta dd { margin: 0; font-size: 0.9rem; }
+  .summary { display: flex; gap: 16px; margin: 16px 0; }
+  .stat { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px 24px; text-align: center; flex: 1; }
+  .stat .num { font-size: 2.2rem; font-weight: 700; }
+  .stat .label { font-size: 0.8rem; color: #6b7280; margin-top: 4px; }
+  .stat.total .num { color: #374151; }
+  .stat.passed .num { color: #059669; }
+  .stat.failed .num { color: #dc2626; }
+  .stat.rate .num { color: #4f46e5; }
+  .pass-banner { background: #d1fae5; border: 1px solid #6ee7b7; border-radius: 8px; padding: 12px 16px; color: #065f46; font-weight: 600; text-align: center; margin: 16px 0; font-size: 1rem; }
+  table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; border: 1px solid #e5e7eb; margin: 16px 0; }
+  th { background: #f3f4f6; padding: 10px 14px; text-align: left; font-size: 0.82rem; color: #374151; font-weight: 600; }
+  td { padding: 10px 14px; font-size: 0.85rem; border-top: 1px solid #f3f4f6; vertical-align: top; }
+  tr:hover td { background: #f9fafb; }
+  .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 0.75rem; font-weight: 700; }
+  .badge.pass { background: #d1fae5; color: #065f46; }
+  .badge.fail { background: #fee2e2; color: #991b1b; }
+  .tc-id { font-family: monospace; font-weight: 600; color: #4f46e5; }
+  .cmd { font-family: monospace; font-size: 0.8rem; background: #f3f4f6; padding: 4px 8px; border-radius: 4px; word-break: break-all; }
+  .evidence { font-family: monospace; font-size: 0.78rem; background: #1e1b4b; color: #a5f3fc; padding: 8px 12px; border-radius: 4px; white-space: pre-wrap; word-break: break-all; margin-top: 4px; }
+  .footer { text-align: center; color: #9ca3af; font-size: 0.8rem; margin-top: 32px; padding-top: 16px; border-top: 1px solid #e5e7eb; }
+  .ac-table { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; margin: 16px 0; }
+  .ac-table th { background: #ede9fe; color: #4c1d95; }
+  .ac-row td { border-top: 1px solid #f3f4f6; }
+  .check { color: #059669; font-size: 1.1rem; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>Issue #651 実機受入テスト報告書</h1>
+
+  <dl class="meta">
+    <dt>Issue</dt><dd>#651 feat(sidebar): PC版サイドバーをコンパクト化し、ツールチップで詳細表示</dd>
+    <dt>テスト日</dt><dd>2026-04-13</dd>
+    <dt>ブランチ</dt><dd>feature/651-worktree</dd>
+    <dt>テスト種別</dt><dd>静的コード解析 + ユニットテスト</dd>
+  </dl>
+
+  <div class="pass-banner">✅ 全テスト PASS（15 / 15）</div>
+
+  <div class="summary">
+    <div class="stat total"><div class="num">15</div><div class="label">総テスト数</div></div>
+    <div class="stat passed"><div class="num">15</div><div class="label">PASS</div></div>
+    <div class="stat failed"><div class="num">0</div><div class="label">FAIL</div></div>
+    <div class="stat rate"><div class="num">100%</div><div class="label">合格率</div></div>
+  </div>
+
+  <h2>受入条件カバレッジ</h2>
+  <table class="ac-table">
+    <thead><tr><th>#</th><th>受入条件</th><th>対応TC</th><th>結果</th></tr></thead>
+    <tbody class="ac-row">
+      <tr><td>1</td><td>サイドバー幅が224px（w-56）に縮小</td><td>TC-001</td><td><span class="check">✅</span></td></tr>
+      <tr><td>2</td><td>DEFAULT_SIDEBAR_WIDTH定数とAppShell.tsxのレイアウト幅が一致</td><td>TC-002, TC-003</td><td><span class="check">✅</span></td></tr>
+      <tr><td>3</td><td>localStorage互換性対応（width:288→224マイグレーション）</td><td>TC-004</td><td><span class="check">✅</span></td></tr>
+      <tr><td>4</td><td>ツリー表示モード時、リポジトリ名が非表示</td><td>TC-007, TC-010</td><td><span class="check">✅</span></td></tr>
+      <tr><td>5</td><td>フラット表示モード時、リポジトリ名が従来通り表示</td><td>TC-010</td><td><span class="check">✅</span></td></tr>
+      <tr><td>6</td><td>ツールチップに詳細情報（ブランチ名、リポジトリ名、ステータス、worktreeパス）</td><td>TC-008, TC-009</td><td><span class="check">✅</span></td></tr>
+      <tr><td>7</td><td>ツールチップのworktreeパスがSidebarBranchItem.worktreePathから取得</td><td>TC-005, TC-006, TC-009</td><td><span class="check">✅</span></td></tr>
+      <tr><td>8</td><td>ツールチップがキーボードフォーカス時にも表示</td><td>TC-008</td><td><span class="check">✅</span></td></tr>
+      <tr><td>9</td><td>WAI-ARIA tooltipパターン準拠（role="tooltip", aria-describedby）</td><td>TC-008</td><td><span class="check">✅</span></td></tr>
+      <tr><td>10</td><td>リポジトリ名省略時にaria-labelにリポジトリ名が含まれる</td><td>TC-007</td><td><span class="check">✅</span></td></tr>
+      <tr><td>11</td><td>既存のサイドバー機能が正常動作</td><td>TC-011, TC-015</td><td><span class="check">✅</span></td></tr>
+      <tr><td>12</td><td>既存テストが更新されパスしている</td><td>TC-011</td><td><span class="check">✅</span></td></tr>
+      <tr><td>13</td><td>npm run lint がパス</td><td>TC-013</td><td><span class="check">✅</span></td></tr>
+      <tr><td>14</td><td>npx tsc --noEmit / npm run test:unit がパス</td><td>TC-011, TC-012</td><td><span class="check">✅</span></td></tr>
+    </tbody>
+  </table>
+
+  <h2>テストケース詳細</h2>
+  <table>
+    <thead><tr><th>ID</th><th>テスト内容</th><th>実行コマンド / エビデンス</th><th>判定</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><span class="tc-id">TC-001</span></td>
+        <td>AppShell.tsxにw-56クラスが適用</td>
+        <td>
+          <div class="cmd">grep -n 'w-56' src/components/layout/AppShell.tsx</div>
+          <div class="evidence">118: {/* w-56 = 224px = DEFAULT_SIDEBAR_WIDTH */}
+123:   fixed left-0 top-0 h-full w-56</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-002</span></td>
+        <td>メインコンテンツにmd:pl-56が適用</td>
+        <td>
+          <div class="cmd">grep -n 'pl-56' src/components/layout/AppShell.tsx</div>
+          <div class="evidence">141: ${showSidebar && isOpen ? 'md:pl-56' : 'md:pl-0'}</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-003</span></td>
+        <td>DEFAULT_SIDEBAR_WIDTH = 224</td>
+        <td>
+          <div class="cmd">grep -n 'DEFAULT_SIDEBAR_WIDTH' src/contexts/SidebarContext.tsx</div>
+          <div class="evidence">30: export const DEFAULT_SIDEBAR_WIDTH = 224;</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-004</span></td>
+        <td>LocalStorageマイグレーション実装（288→224）</td>
+        <td>
+          <div class="cmd">grep -n 'LEGACY_SIDEBAR_WIDTH' src/hooks/useSidebar.ts</div>
+          <div class="evidence">21: const LEGACY_SIDEBAR_WIDTH = 288;
+94: // Issue #651: Migrate old default width (288) to new default (224)
+95: if (parsed.width === LEGACY_SIDEBAR_WIDTH) {</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-005</span></td>
+        <td>SidebarBranchItem型にworktreePathフィールド存在</td>
+        <td>
+          <div class="cmd">grep -n 'worktreePath' src/types/sidebar.ts</div>
+          <div class="evidence">64:   worktreePath?: string;</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-006</span></td>
+        <td>toBranchItem()でworktreePathをマッピング</td>
+        <td>
+          <div class="cmd">grep -n 'worktreePath' src/types/sidebar.ts</div>
+          <div class="evidence">131:     worktreePath: worktree.path,</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-007</span></td>
+        <td>showRepositoryName propsとaria-label実装</td>
+        <td>
+          <div class="cmd">grep -n 'showRepositoryName\|aria-label' src/components/sidebar/BranchListItem.tsx</div>
+          <div class="evidence">28:   showRepositoryName?: boolean;
+115:   aria-label={!showRepositoryName ? `${branch.name} - ${branch.repositoryName}` : undefined}
+143:   {showRepositoryName && (</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-008</span></td>
+        <td>WAI-ARIA tooltipパターン実装（role="tooltip", aria-describedby）</td>
+        <td>
+          <div class="cmd">grep -n 'role="tooltip"\|aria-describedby' src/components/sidebar/BranchListItem.tsx</div>
+          <div class="evidence">64:       role="tooltip"
+114:       aria-describedby={tooltipId}</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-009</span></td>
+        <td>BranchTooltipでworktreePathを表示</td>
+        <td>
+          <div class="cmd">grep -n 'worktreePath\|BranchTooltip' src/components/sidebar/BranchListItem.tsx</div>
+          <div class="evidence">60: function BranchTooltip({ id, branch }: { id: string; branch: SidebarBranchItem }) {
+78:       {branch.worktreePath && (
+79:         &lt;p&gt;{branch.worktreePath}&lt;/p&gt;</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-010</span></td>
+        <td>Sidebar.tsxのgrouped表示でshowRepositoryName={false}</td>
+        <td>
+          <div class="cmd">grep -n 'showRepositoryName' src/components/layout/Sidebar.tsx</div>
+          <div class="evidence">194:                       showRepositoryName={false}</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-011</span></td>
+        <td>npm run test:unit 全件パス（6293テスト）</td>
+        <td>
+          <div class="cmd">npm run test:unit</div>
+          <div class="evidence">Test Files  331 passed (331)
+Tests  6293 passed | 7 skipped (6300)
+Duration  14.41s</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-012</span></td>
+        <td>npx tsc --noEmit 0エラー</td>
+        <td>
+          <div class="cmd">npx tsc --noEmit</div>
+          <div class="evidence">(出力なし — エラー0件)
+Exit code: 0</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-013</span></td>
+        <td>npm run lint 0エラー</td>
+        <td>
+          <div class="cmd">npm run lint</div>
+          <div class="evidence">✔ No ESLint warnings or errors
+Exit code: 0</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-014</span></td>
+        <td>ビルド品質確認（静的解析で代替）</td>
+        <td>
+          <div class="cmd">npx tsc --noEmit &amp;&amp; npm run lint</div>
+          <div class="evidence">TypeScript: 0 errors
+ESLint: 0 errors/warnings</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+      <tr>
+        <td><span class="tc-id">TC-015</span></td>
+        <td>既存サイドバー機能の回帰確認</td>
+        <td>
+          <div class="cmd">npm run test:unit (SidebarContext.test.tsx含む)</div>
+          <div class="evidence">331 test files passed — SidebarContext含む既存テスト全件パス</div>
+        </td>
+        <td><span class="badge pass">PASS</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="footer">
+    Generated by CommandMate pm-auto-issue2dev | Issue #651 | 2026-04-13
+  </div>
+</div>
+</body>
+</html>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -10,7 +10,7 @@
 
 'use client';
 
-import React, { memo, type ReactNode } from 'react';
+import React, { memo, useCallback, type ReactNode } from 'react';
 import { useSidebarContext } from '@/contexts/SidebarContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useLayoutConfig } from '@/hooks/useLayoutConfig';
@@ -28,6 +28,12 @@ import { Z_INDEX } from '@/config/z-index';
  * Used by both mobile drawer and desktop sidebar (Issue #112).
  */
 const SIDEBAR_TRANSITION = 'transform transition-transform duration-300 ease-out';
+
+/** Minimum sidebar width when drag-resizing */
+const MIN_SIDEBAR_WIDTH = 160;
+
+/** Maximum sidebar width when drag-resizing */
+const MAX_SIDEBAR_WIDTH = 480;
 
 // ============================================================================
 // Types
@@ -62,9 +68,13 @@ export interface AppShellProps {
  * ```
  */
 export const AppShell = memo(function AppShell({ children }: AppShellProps) {
-  const { isOpen, isMobileDrawerOpen, closeMobileDrawer } = useSidebarContext();
+  const { isOpen, isMobileDrawerOpen, closeMobileDrawer, width, setWidth } = useSidebarContext();
   const isMobile = useIsMobile();
   const { showSidebar, showGlobalNav } = useLayoutConfig();
+
+  const handleWidthChange = useCallback((newWidth: number) => {
+    setWidth(Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, newWidth)));
+  }, [setWidth]);
 
   // Mobile layout with drawer
   if (isMobile) {
@@ -115,31 +125,29 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
 
       <div className="flex flex-1 min-h-0">
         {/* Desktop sidebar - fixed position with transform animation (Issue #112) */}
-        {/* w-56 = 224px = DEFAULT_SIDEBAR_WIDTH; keep in sync with pl-56 below */}
+        {/* Width is dynamic (drag-resizable); stored in SidebarContext + localStorage */}
         {showSidebar && (
           <aside
             data-testid="sidebar-container"
             className={`
-              fixed left-0 top-0 h-full w-56
+              fixed left-0 top-0 h-full
               border-r border-gray-200 dark:border-gray-600
               ${SIDEBAR_TRANSITION}
               ${isOpen ? 'translate-x-0' : '-translate-x-full'}
             `}
-            style={{ zIndex: Z_INDEX.SIDEBAR }}
+            style={{ width: `${width}px`, zIndex: Z_INDEX.SIDEBAR }}
             role="complementary"
             aria-hidden={!isOpen}
           >
             <Sidebar />
+            <ResizeHandle currentWidth={width} onWidthChange={handleWidthChange} />
           </aside>
         )}
 
-        {/* Main content - pl-56 matches sidebar w-56 = DEFAULT_SIDEBAR_WIDTH */}
+        {/* Main content - paddingLeft matches sidebar width */}
         <main
-          className={`
-            flex-1 min-w-0 h-full overflow-hidden
-            transition-[padding] duration-300 ease-out
-            ${showSidebar && isOpen ? 'md:pl-56' : 'md:pl-0'}
-          `}
+          className="flex-1 min-w-0 h-full overflow-hidden transition-[padding] duration-300 ease-out"
+          style={{ paddingLeft: showSidebar && isOpen ? `${width}px` : 0 }}
           role="main"
         >
           {children}
@@ -148,3 +156,50 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
     </div>
   );
 });
+
+// ============================================================================
+// ResizeHandle
+// ============================================================================
+
+/**
+ * Thin drag handle on the right edge of the sidebar for resizing.
+ * Emits the new absolute width (not a delta) via onWidthChange.
+ */
+function ResizeHandle({
+  currentWidth,
+  onWidthChange,
+}: {
+  currentWidth: number;
+  onWidthChange: (width: number) => void;
+}) {
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = currentWidth;
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      onWidthChange(startWidth + (moveEvent.clientX - startX));
+    };
+
+    const handleMouseUp = () => {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
+  return (
+    <div
+      data-testid="sidebar-resize-handle"
+      aria-hidden="true"
+      onMouseDown={handleMouseDown}
+      className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-cyan-500/40 transition-colors"
+    />
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -283,7 +283,6 @@ function GroupHeader({
       className="
         w-full flex items-center gap-2 px-4 py-2
         text-xs font-semibold text-gray-300 uppercase tracking-wider
-        bg-gray-800/50 hover:bg-gray-800
         border-b border-gray-700
         focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500
         transition-colors

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -7,7 +7,8 @@
 
 'use client';
 
-import React, { memo } from 'react';
+import React, { memo, useRef, useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
 import type { SidebarBranchItem, BranchStatus } from '@/types/sidebar';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import { getCliToolDisplayName, type CLIToolType } from '@/lib/cli-tools/types';
@@ -56,21 +57,53 @@ function CliStatusDot({ status, label }: { status: BranchStatus; label: string }
   );
 }
 
-/** Tooltip shown on hover/focus with branch details (Issue #651) */
-function BranchTooltip({ id, branch }: { id: string; branch: SidebarBranchItem }) {
-  return (
+/**
+ * Tooltip shown on hover/focus with branch details (Issue #651).
+ * Rendered via React portal to escape the sidebar's overflow-y:auto clipping.
+ * Always present in DOM (CSS-controlled visibility) so aria-describedby works.
+ */
+function BranchTooltip({
+  id,
+  branch,
+  isVisible,
+  anchorRef,
+}: {
+  id: string;
+  branch: SidebarBranchItem;
+  isVisible: boolean;
+  anchorRef: { current: HTMLButtonElement | null };
+}) {
+  // Start off-screen so tooltip is never briefly visible at (0,0) before coords are set
+  const [coords, setCoords] = useState({ top: -9999, left: -9999 });
+
+  // Update position when tooltip becomes visible
+  useEffect(() => {
+    if (isVisible && anchorRef.current) {
+      const rect = anchorRef.current.getBoundingClientRect();
+      setCoords({ top: rect.top, left: rect.right + 8 });
+    }
+  }, [isVisible, anchorRef]);
+
+  // Portals require document — skip during SSR
+  // (portal content is outside the component subtree so there is no hydration mismatch)
+  if (typeof document === 'undefined') return null;
+
+  return ReactDOM.createPortal(
     <div
       id={id}
       role="tooltip"
       className="
-        invisible group-hover:visible group-focus-within:visible
-        opacity-0 group-hover:opacity-100 group-focus-within:opacity-100
-        absolute bottom-full left-0 z-50 mb-1
+        fixed z-[9999]
         px-3 py-2 rounded-md shadow-lg
         bg-gray-950 text-xs text-gray-200 border border-gray-700
         whitespace-nowrap pointer-events-none
         transition-opacity duration-150
       "
+      style={{
+        top: coords.top,
+        left: coords.left,
+        opacity: isVisible ? 1 : 0,
+      }}
     >
       <p className="font-medium text-white">{branch.name}</p>
       <p className="text-gray-400">{branch.repositoryName}</p>
@@ -78,7 +111,8 @@ function BranchTooltip({ id, branch }: { id: string; branch: SidebarBranchItem }
       {branch.worktreePath && (
         <p className="text-gray-500 truncate max-w-xs">{branch.worktreePath}</p>
       )}
-    </div>
+    </div>,
+    document.body
   );
 }
 
@@ -105,11 +139,18 @@ export const BranchListItem = memo(function BranchListItem({
   showRepositoryName = true,
 }: BranchListItemProps) {
   const tooltipId = `tooltip-${branch.id}`;
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
   return (
     <button
+      ref={buttonRef}
       data-testid="branch-list-item"
       onClick={onClick}
+      onMouseEnter={() => setIsTooltipVisible(true)}
+      onMouseLeave={() => setIsTooltipVisible(false)}
+      onFocus={() => setIsTooltipVisible(true)}
+      onBlur={() => setIsTooltipVisible(false)}
       aria-current={isSelected ? 'true' : undefined}
       aria-describedby={tooltipId}
       aria-label={!showRepositoryName ? `${branch.name} - ${branch.repositoryName}` : undefined}
@@ -169,8 +210,13 @@ export const BranchListItem = memo(function BranchListItem({
         </div>
       )}
 
-      {/* Tooltip: shown on hover/focus, positioned above the item (Issue #651) */}
-      <BranchTooltip id={tooltipId} branch={branch} />
+      {/* Tooltip: portal to document.body to escape overflow clipping (Issue #651) */}
+      <BranchTooltip
+        id={tooltipId}
+        branch={branch}
+        isVisible={isTooltipVisible}
+        anchorRef={buttonRef}
+      />
     </button>
   );
 });

--- a/src/components/sidebar/SortSelector.tsx
+++ b/src/components/sidebar/SortSelector.tsx
@@ -58,6 +58,7 @@ export const SortSelector = memo(function SortSelector() {
       onSortDirectionChange={setSortDirection}
       options={SIDEBAR_SORT_OPTIONS}
       defaultDirections={SIDEBAR_DEFAULT_DIRECTIONS}
+      compact
     />
   );
 });

--- a/src/components/sidebar/SortSelectorBase.tsx
+++ b/src/components/sidebar/SortSelectorBase.tsx
@@ -36,6 +36,8 @@ export interface SortSelectorBaseProps {
   options: ReadonlyArray<SortOption>;
   /** Default directions per key (applied when switching to a new key) [CON-005] */
   defaultDirections?: Partial<Record<SortKey, SortDirection>>;
+  /** When true, hides the label text to save horizontal space (used in compact sidebar) */
+  compact?: boolean;
 }
 
 // ============================================================================
@@ -57,6 +59,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
   onSortDirectionChange,
   options,
   defaultDirections,
+  compact,
 }: SortSelectorBaseProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -133,7 +136,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
           "
         >
           <SortIcon className="w-3 h-3" />
-          <span className="hidden sm:inline">{currentLabel}</span>
+          <span className={compact ? 'hidden' : 'hidden sm:inline'}>{currentLabel}</span>
         </button>
 
         {/* Direction toggle */}

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -44,6 +44,12 @@ export const SIDEBAR_VIEW_MODE_STORAGE_KEY = 'mcbd-sidebar-view-mode';
 /** Default view mode */
 export const DEFAULT_VIEW_MODE: ViewMode = 'grouped';
 
+/** LocalStorage key for sidebar width */
+export const SIDEBAR_WIDTH_STORAGE_KEY = 'mcbd-sidebar-width';
+
+/** Legacy default width before Issue #651 compaction (for migration) */
+const LEGACY_SIDEBAR_WIDTH = 288;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -253,6 +259,21 @@ export function SidebarProvider({
     (stored) => {
       if (stored === 'grouped' || stored === 'flat') {
         dispatch({ type: 'SET_VIEW_MODE', viewMode: stored });
+      }
+    },
+  );
+
+  // Sync width with localStorage (load on mount, persist on change)
+  // Issue #651 follow-up: migrate legacy width 288 → 224
+  useLocalStorageSync(
+    SIDEBAR_WIDTH_STORAGE_KEY,
+    state.width,
+    () => String(state.width),
+    (stored) => {
+      const parsed = Number(stored);
+      if (!isNaN(parsed) && parsed > 0) {
+        const width = parsed === LEGACY_SIDEBAR_WIDTH ? DEFAULT_SIDEBAR_WIDTH : parsed;
+        dispatch({ type: 'SET_WIDTH', width });
       }
     },
   );


### PR DESCRIPTION
## Summary

- **ドラッグリサイズ**: PC版サイドバーの右端をドラッグして幅を変更可能（160〜480px）。幅はlocalStorageに永続化
- **同期ボタン溢れ修正**: `SortSelectorBase`に`compact`プロップを追加し、サイドバー内ではラベルテキストを非表示にすることでヘッダー内に収まるよう修正
- **グループヘッダー背景色削除**: ツリー表示のリポジトリグループヘッダーから`bg-gray-800/50 hover:bg-gray-800`を除去
- **ツールチップ修正**: `ReactDOM.createPortal`でdocument.bodyにレンダリングすることで`overflow-y:auto`によるクリッピングを解消。サイドバー右側に`position:fixed`で表示（左寄せ）

## Changed Files

| File | Change |
|------|--------|
| `src/components/layout/AppShell.tsx` | 動的width適用、ResizeHandleコンポーネント追加 |
| `src/contexts/SidebarContext.tsx` | width localStorage同期追加（288→224マイグレーション） |
| `src/components/sidebar/SortSelectorBase.tsx` | `compact`プロップ追加 |
| `src/components/sidebar/SortSelector.tsx` | `compact`を渡す |
| `src/components/layout/Sidebar.tsx` | GroupHeaderの背景色削除 |
| `src/components/sidebar/BranchListItem.tsx` | ツールチップをReact portalに変更 |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm run test:unit` — 334 files, 6319 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)