### PR TITLE
feat(sidebar): differentiate sidebar background and add DnD group reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "commandmate",
       "version": "0.5.4",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@marp-team/marp-core": "^4.3.0",
         "ansi-to-html": "^0.7.2",
         "autoprefixer": "^10.4.22",
@@ -713,6 +716,59 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "db:reset": "rm -f db.sqlite && npm run db:init"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@marp-team/marp-core": "^4.3.0",
     "ansi-to-html": "^0.7.2",
     "autoprefixer": "^10.4.22",

--- a/src/app/api/sidebar/group-order/route.ts
+++ b/src/app/api/sidebar/group-order/route.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /api/sidebar/group-order  — retrieve saved repository group order
+ * PUT /api/sidebar/group-order  — save repository group order
+ */
+
+import { NextResponse } from 'next/server';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getSidebarGroupOrder, setSidebarGroupOrder } from '@/lib/db/app-settings-db';
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const db = getDbInstance();
+    const order = getSidebarGroupOrder(db);
+    return NextResponse.json({ success: true, order });
+  } catch (error) {
+    console.error('GET /api/sidebar/group-order error:', error);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request): Promise<NextResponse> {
+  try {
+    const body: unknown = await request.json();
+
+    if (
+      !body ||
+      typeof body !== 'object' ||
+      !('order' in body) ||
+      !Array.isArray((body as { order: unknown }).order) ||
+      !(body as { order: unknown[] }).order.every((v) => typeof v === 'string')
+    ) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid request body: order must be an array of strings' },
+        { status: 400 }
+      );
+    }
+
+    const order = (body as { order: string[] }).order;
+
+    // Limit to prevent abuse
+    if (order.length > 500) {
+      return NextResponse.json(
+        { success: false, error: 'Too many items in order array' },
+        { status: 400 }
+      );
+    }
+
+    const db = getDbInstance();
+    setSidebarGroupOrder(db, order);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('PUT /api/sidebar/group-order error:', error);
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,9 @@
  * Main sidebar component containing the branch list.
  * Includes search/filter functionality, branch status display,
  * and repository-based grouping (Issue #449).
+ *
+ * Issue #651: Compact w-56 sidebar + tooltips.
+ * DnD group reordering (drag-and-drop) with DB persistence via /api/sidebar/group-order.
  */
 
 'use client';
@@ -11,6 +14,21 @@
 import React, { memo, useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useWorktreeSelection } from '@/contexts/WorktreeSelectionContext';
 import { useSidebarContext } from '@/contexts/SidebarContext';
 import { BranchListItem } from '@/components/sidebar/BranchListItem';
@@ -24,6 +42,7 @@ import { toBranchItem } from '@/types/sidebar';
 import { generateRepositoryColor } from '@/lib/sidebar-utils';
 import { useWorktreeList } from '@/hooks/useWorktreeList';
 import type { ViewMode } from '@/lib/sidebar-utils';
+import type { BranchGroup } from '@/lib/sidebar-utils';
 
 // ============================================================================
 // Constants
@@ -61,6 +80,27 @@ export const Sidebar = memo(function Sidebar() {
     }
   });
 
+  // Repository group display order (DB-backed, fetched on mount)
+  const [repositoryOrder, setRepositoryOrder] = useState<string[]>([]);
+  const orderLoadedRef = useRef(false);
+
+  // Fetch saved group order from server on mount
+  useEffect(() => {
+    if (orderLoadedRef.current) return;
+    orderLoadedRef.current = true;
+
+    fetch('/api/sidebar/group-order')
+      .then((res) => res.json())
+      .then((data: { success: boolean; order: string[] | null }) => {
+        if (data.success && Array.isArray(data.order)) {
+          setRepositoryOrder(data.order);
+        }
+      })
+      .catch(() => {
+        // Non-fatal: fall back to alphabetical order
+      });
+  }, []);
+
   // Convert worktrees to sidebar items
   const branchItems = useMemo(() => worktrees.map(toBranchItem), [worktrees]);
 
@@ -73,8 +113,27 @@ export const Sidebar = memo(function Sidebar() {
     filterText: searchQuery,
   });
 
+  // Apply saved repository order to groupedItems (only when not searching)
+  const orderedGroups: BranchGroup[] | null = useMemo(() => {
+    if (viewMode !== 'grouped' || !groupedItems) return null;
+
+    if (searchQuery.trim() || repositoryOrder.length === 0) {
+      // No custom order: use default (alphabetical from groupBranches)
+      return groupedItems;
+    }
+
+    // Place known repos first in saved order, then append any new repos at end
+    const orderMap = new Map(repositoryOrder.map((name, idx) => [name, idx]));
+    return [...groupedItems].sort((a, b) => {
+      const ia = orderMap.has(a.repositoryName) ? orderMap.get(a.repositoryName)! : Infinity;
+      const ib = orderMap.has(b.repositoryName) ? orderMap.get(b.repositoryName)! : Infinity;
+      if (ia === ib) return a.repositoryName.localeCompare(b.repositoryName);
+      return ia - ib;
+    });
+  }, [viewMode, groupedItems, repositoryOrder, searchQuery]);
+
   // Adapt groupedItems to match previous interface (null when flat mode)
-  const groupedBranches = viewMode === 'grouped' ? groupedItems : null;
+  const groupedBranches = viewMode === 'grouped' ? orderedGroups : null;
 
   // Persist groupCollapsed to localStorage
   useEffect(() => {
@@ -120,6 +179,40 @@ export const Sidebar = memo(function Sidebar() {
     };
   }, [selectWorktree, router, closeMobileDrawer]);
 
+  // DnD sensors: require 8px move before activating (distinguishes click from drag)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
+  // Handle group reorder via DnD
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id || !groupedBranches) return;
+
+      const currentOrder = groupedBranches.map((g) => g.repositoryName);
+      const oldIndex = currentOrder.indexOf(String(active.id));
+      const newIndex = currentOrder.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newOrder = arrayMove(currentOrder, oldIndex, newIndex);
+
+      // Optimistic update
+      setRepositoryOrder(newOrder);
+
+      // Persist to server
+      fetch('/api/sidebar/group-order', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order: newOrder }),
+      }).catch(() => {
+        // Revert on error
+        setRepositoryOrder(currentOrder);
+      });
+    },
+    [groupedBranches]
+  );
+
   // Check if list is empty (for both modes)
   const isEmpty = viewMode === 'flat'
     ? flatBranches.length === 0
@@ -129,7 +222,7 @@ export const Sidebar = memo(function Sidebar() {
     <nav
       data-testid="sidebar"
       aria-label="Branch navigation"
-      className="h-full flex flex-col bg-gray-900 text-white"
+      className="h-full flex flex-col bg-gray-800 text-white"
       role="navigation"
     >
       {/* Header */}
@@ -156,7 +249,7 @@ export const Sidebar = memo(function Sidebar() {
           onChange={(e) => setSearchQuery(e.target.value)}
           className="
             w-full px-3 py-2 rounded-md
-            bg-gray-800 text-white placeholder-gray-400
+            bg-gray-700 text-white placeholder-gray-400
             border border-gray-600
             focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent
           "
@@ -173,30 +266,32 @@ export const Sidebar = memo(function Sidebar() {
             {searchQuery ? 'No branches found' : 'No branches available'}
           </div>
         ) : viewMode === 'grouped' && groupedBranches ? (
-          // Grouped view
-          groupedBranches.map((group) => {
-            const isExpanded = !groupCollapsed[group.repositoryName] || !!searchQuery.trim();
-            return (
-              <div key={group.repositoryName}>
-                <GroupHeader
-                  repositoryName={group.repositoryName}
-                  branchCount={group.branches.length}
-                  isExpanded={isExpanded}
-                  onClick={() => toggleGroup(group.repositoryName)}
-                />
-                {isExpanded &&
-                  group.branches.map((branch) => (
-                    <BranchListItem
-                      key={branch.id}
-                      branch={branch}
-                      isSelected={branch.id === selectedWorktreeId}
-                      onClick={() => handleBranchClick(branch.id)}
-                      showRepositoryName={false}
-                    />
-                  ))}
-              </div>
-            );
-          })
+          // Grouped view with DnD reordering
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={groupedBranches.map((g) => g.repositoryName)}
+              strategy={verticalListSortingStrategy}
+            >
+              {groupedBranches.map((group) => {
+                const isExpanded = !groupCollapsed[group.repositoryName] || !!searchQuery.trim();
+                return (
+                  <SortableGroupItem
+                    key={group.repositoryName}
+                    group={group}
+                    isExpanded={isExpanded}
+                    selectedWorktreeId={selectedWorktreeId}
+                    onToggle={() => toggleGroup(group.repositoryName)}
+                    onBranchClick={handleBranchClick}
+                    isDragDisabled={!!searchQuery.trim()}
+                  />
+                );
+              })}
+            </SortableContext>
+          </DndContext>
         ) : (
           // Flat view
           flatBranches.map((branch) => (
@@ -223,6 +318,67 @@ export const Sidebar = memo(function Sidebar() {
     </nav>
   );
 });
+
+// ============================================================================
+// SortableGroupItem
+// ============================================================================
+
+/** Sortable wrapper for a repository group (DnD-enabled) */
+function SortableGroupItem({
+  group,
+  isExpanded,
+  selectedWorktreeId,
+  onToggle,
+  onBranchClick,
+  isDragDisabled,
+}: {
+  group: BranchGroup;
+  isExpanded: boolean;
+  selectedWorktreeId: string | null;
+  onToggle: () => void;
+  onBranchClick: (branchId: string) => void;
+  isDragDisabled: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: group.repositoryName, disabled: isDragDisabled });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <GroupHeader
+        repositoryName={group.repositoryName}
+        branchCount={group.branches.length}
+        isExpanded={isExpanded}
+        onClick={onToggle}
+        dragHandleRef={setActivatorNodeRef}
+        dragHandleListeners={isDragDisabled ? undefined : listeners}
+        dragHandleAttributes={isDragDisabled ? undefined : attributes}
+      />
+      {isExpanded &&
+        group.branches.map((branch) => (
+          <BranchListItem
+            key={branch.id}
+            branch={branch}
+            isSelected={branch.id === selectedWorktreeId}
+            onClick={() => onBranchClick(branch.id)}
+            showRepositoryName={false}
+          />
+        ))}
+    </div>
+  );
+}
 
 // ============================================================================
 // Helper Functions
@@ -262,36 +418,61 @@ export function parseGroupCollapsed(raw: string): Record<string, boolean> {
 // Inline Sub-components
 // ============================================================================
 
-/** Group header showing repository name with collapse/expand toggle */
+/** Group header showing repository name with collapse/expand toggle and drag handle */
 function GroupHeader({
   repositoryName,
   branchCount,
   isExpanded,
   onClick,
+  dragHandleRef,
+  dragHandleListeners,
+  dragHandleAttributes,
 }: {
   repositoryName: string;
   branchCount: number;
   isExpanded: boolean;
   onClick: () => void;
+  dragHandleRef?: (node: HTMLElement | null) => void;
+  dragHandleListeners?: React.HTMLAttributes<HTMLElement>;
+  dragHandleAttributes?: React.HTMLAttributes<HTMLElement>;
 }) {
   return (
-    <button
-      data-testid="group-header"
-      type="button"
-      onClick={onClick}
-      aria-expanded={isExpanded}
-      className="
-        w-full flex items-center gap-2 px-4 py-2
-        text-xs font-semibold text-gray-300 uppercase tracking-wider
-        focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500
-        transition-colors
-      "
-    >
-      <ChevronIcon isExpanded={isExpanded} />
-      <GroupIcon color={generateRepositoryColor(repositoryName)} />
-      <span className="flex-1 text-left truncate">{repositoryName}</span>
-      <span className="text-gray-500 font-normal">{branchCount}</span>
-    </button>
+    <div className="flex items-center w-full">
+      {/* Drag handle — separate from the clickable header button */}
+      {dragHandleListeners && (
+        <div
+          ref={dragHandleRef}
+          {...dragHandleListeners}
+          {...dragHandleAttributes}
+          aria-label="Drag to reorder group"
+          className="
+            flex-shrink-0 flex items-center justify-center
+            w-6 h-full pl-2 cursor-grab active:cursor-grabbing
+            text-gray-500 hover:text-gray-300 transition-colors
+          "
+        >
+          <GripVerticalIcon />
+        </div>
+      )}
+
+      <button
+        data-testid="group-header"
+        type="button"
+        onClick={onClick}
+        aria-expanded={isExpanded}
+        className="
+          flex-1 flex items-center gap-2 px-2 py-2
+          text-xs font-semibold text-gray-300 uppercase tracking-wider
+          focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500
+          transition-colors
+        "
+      >
+        <ChevronIcon isExpanded={isExpanded} />
+        <GroupIcon color={generateRepositoryColor(repositoryName)} />
+        <span className="flex-1 text-left truncate">{repositoryName}</span>
+        <span className="text-gray-500 font-normal pr-2">{branchCount}</span>
+      </button>
+    </div>
   );
 }
 
@@ -375,6 +556,25 @@ function FlatListIcon({ className = 'w-3 h-3' }: { className?: string }) {
       strokeWidth={2}
     >
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  );
+}
+
+/** Grip vertical (drag handle) icon */
+function GripVerticalIcon() {
+  return (
+    <svg
+      className="w-3 h-3"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle cx="9" cy="5" r="1.5" />
+      <circle cx="15" cy="5" r="1.5" />
+      <circle cx="9" cy="12" r="1.5" />
+      <circle cx="15" cy="12" r="1.5" />
+      <circle cx="9" cy="19" r="1.5" />
+      <circle cx="15" cy="19" r="1.5" />
     </svg>
   );
 }

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -156,9 +156,9 @@ export const BranchListItem = memo(function BranchListItem({
       aria-label={!showRepositoryName ? `${branch.name} - ${branch.repositoryName}` : undefined}
       className={`
         group relative w-full px-4 py-3 flex flex-col gap-1
-        hover:bg-gray-800 transition-colors
+        hover:bg-gray-700 transition-colors
         focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500
-        ${isSelected ? 'bg-gray-700 border-l-2 border-cyan-500' : 'border-l-2 border-transparent'}
+        ${isSelected ? 'bg-gray-600 border-l-2 border-cyan-500' : 'border-l-2 border-transparent'}
       `}
     >
       {/* Main row: CLI status dots, info, unread */}

--- a/src/components/sidebar/SortSelectorBase.tsx
+++ b/src/components/sidebar/SortSelectorBase.tsx
@@ -166,7 +166,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
           className="
             absolute right-0 top-full mt-1 z-50
             min-w-[140px] py-1 rounded-md shadow-lg
-            bg-gray-800 border border-gray-600
+            bg-gray-700 border border-gray-600
           "
         >
           {options.map((option) => (
@@ -179,7 +179,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
               className={`
                 w-full px-3 py-2 text-left text-sm
                 flex items-center justify-between
-                hover:bg-gray-700 transition-colors
+                hover:bg-gray-600 transition-colors
                 ${sortKey === option.key ? 'text-blue-400' : 'text-gray-300'}
               `}
             >

--- a/src/lib/db/app-settings-db.ts
+++ b/src/lib/db/app-settings-db.ts
@@ -1,0 +1,63 @@
+/**
+ * app-settings-db: Key-value store for application settings.
+ *
+ * Provides typed helpers for reading/writing the app_settings table
+ * created in migration v27.
+ */
+
+import type Database from 'better-sqlite3';
+
+// ============================================================================
+// Key constants
+// ============================================================================
+
+/** Storage key for sidebar repository group display order */
+const KEY_SIDEBAR_GROUP_ORDER = 'sidebar_group_order';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Get the sidebar repository group order.
+ *
+ * @returns Array of repository names in display order, or null if not set.
+ */
+export function getSidebarGroupOrder(db: Database.Database): string[] | null {
+  try {
+    const row = db
+      .prepare('SELECT value FROM app_settings WHERE key = ?')
+      .get(KEY_SIDEBAR_GROUP_ORDER) as { value: string } | undefined;
+
+    if (!row) return null;
+
+    const parsed = JSON.parse(row.value);
+    if (!Array.isArray(parsed)) return null;
+    if (!parsed.every((v) => typeof v === 'string')) return null;
+
+    return parsed as string[];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save the sidebar repository group order.
+ *
+ * @param order - Array of repository names in desired display order.
+ */
+export function setSidebarGroupOrder(
+  db: Database.Database,
+  order: string[]
+): void {
+  const value = JSON.stringify(order);
+  const now = Date.now();
+
+  db.prepare(`
+    INSERT INTO app_settings (key, value, created_at, updated_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(key) DO UPDATE SET
+      value = excluded.value,
+      updated_at = excluded.updated_at
+  `).run(KEY_SIDEBAR_GROUP_ORDER, value, now, now);
+}

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -9,6 +9,7 @@ import { v21_v23_migrations } from './v21-v23';
 import { v24_migrations } from './v24-daily-summaries';
 import { v25_migrations } from './v25-report-templates';
 import { v26_migrations } from './v26-repository-display-name';
+import { v27_migrations } from './v27-app-settings';
 
 /**
  * Complete ordered list of all migrations.
@@ -23,4 +24,5 @@ export const migrations: Migration[] = [
   ...v24_migrations,
   ...v25_migrations,
   ...v26_migrations,
+  ...v27_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 26;
+export const CURRENT_SCHEMA_VERSION = 27;
 
 /**
  * Get current schema version from database
@@ -221,7 +221,7 @@ export function validateSchema(db: Database.Database): boolean {
     `).all() as Array<{ name: string }>;
 
     const tableNames = tables.map(t => t.name);
-    const requiredTables = ['worktrees', 'chat_messages', 'session_states', 'schema_version', 'worktree_memos', 'external_apps', 'repositories', 'clone_jobs', 'scheduled_executions', 'execution_logs', 'daily_reports', 'report_templates'];
+    const requiredTables = ['worktrees', 'chat_messages', 'session_states', 'schema_version', 'worktree_memos', 'external_apps', 'repositories', 'clone_jobs', 'scheduled_executions', 'execution_logs', 'daily_reports', 'report_templates', 'app_settings'];
 
     const missingTables = requiredTables.filter(t => !tableNames.includes(t));
 

--- a/src/lib/db/migrations/v27-app-settings.ts
+++ b/src/lib/db/migrations/v27-app-settings.ts
@@ -1,0 +1,23 @@
+/** Migration v27: Add app_settings table for key-value application settings. */
+
+import type { Migration } from './runner';
+
+export const v27_migrations: Migration[] = [
+  {
+    version: 27,
+    name: 'add-app-settings-table',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS app_settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+        );
+      `);
+    },
+    down: (db) => {
+      db.exec('DROP TABLE IF EXISTS app_settings');
+    },
+  },
+];

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -230,7 +230,7 @@ describe('Sidebar', () => {
 
       await waitFor(() => {
         const sidebar = screen.getByTestId('sidebar');
-        expect(sidebar.className).toMatch(/bg-gray-900|bg-slate-900|bg-zinc-900/);
+        expect(sidebar.className).toMatch(/bg-gray-800|bg-gray-900|bg-slate-900|bg-zinc-900/);
       });
     });
   });

--- a/tests/unit/components/sidebar/BranchListItem.test.tsx
+++ b/tests/unit/components/sidebar/BranchListItem.test.tsx
@@ -91,7 +91,7 @@ describe('BranchListItem', () => {
       );
 
       const item = screen.getByTestId('branch-list-item');
-      expect(item.className).toMatch(/bg-gray-700|selected|border-l|border-cyan/);
+      expect(item.className).toMatch(/bg-gray-600|bg-gray-700|selected|border-l|border-cyan/);
     });
 
     it('should not apply selected styling when not selected', () => {
@@ -104,7 +104,8 @@ describe('BranchListItem', () => {
       );
 
       const item = screen.getByTestId('branch-list-item');
-      expect(item.className).not.toMatch(/bg-gray-700/);
+      // bg-gray-600 is the selected background; unselected should not have it
+      expect(item.className).not.toMatch(/(?<![a-z-])bg-gray-600/);
     });
 
     it('should have aria-current attribute when selected', () => {

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 24 after Migration #24', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(26);
+    it('should be 27 after Migration #27', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(27);
     });
   });
 
@@ -495,7 +495,7 @@ describe('db-migrations', () => {
   describe('rollbackMigrations', () => {
     it('should rollback Migration #17 and remove schedule tables', () => {
       runMigrations(db);
-      expect(getCurrentVersion(db)).toBe(26);
+      expect(getCurrentVersion(db)).toBe(27);
 
       rollbackMigrations(db, 16);
       expect(getCurrentVersion(db)).toBe(16);
@@ -508,7 +508,7 @@ describe('db-migrations', () => {
 
     it('should rollback Migration #16 and remove issue_no column', () => {
       runMigrations(db);
-      expect(getCurrentVersion(db)).toBe(26);
+      expect(getCurrentVersion(db)).toBe(27);
 
       rollbackMigrations(db, 15);
       expect(getCurrentVersion(db)).toBe(15);


### PR DESCRIPTION
## Summary

- **サイドバー背景色の変更**: `bg-gray-900` → `bg-gray-800` に変更し、メイン領域との視覚的コントラストを確保。ホバー/選択状態・検索入力・ソートドロップダウンも一段階暗く調整。
- **グループ表示順のドラッグ&ドロップ**: ツリー表示時にリポジトリグループを自由に並べ替え可能。
  - `@dnd-kit` でアクセシブルなDnD実装（PointerSensor、8px activationConstraint）
  - 各グループヘッダーにグリップハンドルを表示
  - 検索中はDnD無効（フィルタリング中は順序変更不要なため）
- **DB永続化 (migration v27)**: `app_settings` テーブル（キー/バリューストア）を新規作成し、グループ順を保存。`GET/PUT /api/sidebar/group-order` API経由でスマホや他ブラウザからも同じ順序が適用される。
- **楽観的更新**: ドラッグ完了時に即座にUI反映し、API失敗時のみロールバック。

## Test plan

- [ ] PC版サイドバーの背景色がメイン領域より暗くなっていることを確認
- [ ] ツリー表示でグループヘッダーにグリップアイコンが表示される
- [ ] グループをドラッグして並べ替えできる
- [ ] リロード後も順序が保持される
- [ ] 別ブラウザ/デバイスでも同じ順序が適用される
- [ ] 検索中はドラッグが無効（グリップアイコン非表示）
- [ ] フラット表示ではDnD非表示
- [ ] 全ユニットテストがパス (`npm run test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)