### PR TITLE
fix(sidebar): prevent spurious full-page reloads on rapid branch clicks

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -156,27 +156,36 @@ export const Sidebar = memo(function Sidebar() {
     }));
   }, []);
 
-  // Handle branch selection
-  // Fallback: if router.push fails to navigate (e.g., Next.js Router Cache corruption),
-  // use window.location.href after a short delay to ensure navigation succeeds.
+  // Ref to track the single active fallback timer.
+  // Using a ref (not state) so updates don't trigger re-renders.
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Handle branch selection.
+  // Fallback: if router.push silently fails (e.g., Next.js Router Cache corruption),
+  // navigate via window.location.href after a short delay.
+  //
+  // Bug fix: previously each click created a new timer whose cleanup was never
+  // invoked (useCallback return values are discarded by event handlers), and
+  // popstate does not fire on programmatic router.push calls. Accumulated timers
+  // compared stale target paths against the current pathname and triggered spurious
+  // full-page reloads. Using a single ref-tracked timer ensures only the latest
+  // click's fallback can fire.
   const handleBranchClick = useCallback((branchId: string) => {
     selectWorktree(branchId);
     const targetPath = `/worktrees/${branchId}`;
     router.push(targetPath);
     closeMobileDrawer();
-    // Fallback navigation if router.push silently fails
-    const timerId = setTimeout(() => {
+
+    // Cancel any timer from a previous click before setting a new one.
+    if (fallbackTimerRef.current !== null) {
+      clearTimeout(fallbackTimerRef.current);
+    }
+    fallbackTimerRef.current = setTimeout(() => {
+      fallbackTimerRef.current = null;
       if (window.location.pathname !== targetPath) {
         window.location.href = targetPath;
       }
-    }, 300);
-    // Cleanup: if route changes before timeout, cancel fallback
-    const handleRouteChange = () => clearTimeout(timerId);
-    window.addEventListener('popstate', handleRouteChange, { once: true });
-    return () => {
-      clearTimeout(timerId);
-      window.removeEventListener('popstate', handleRouteChange);
-    };
+    }, 500);
   }, [selectWorktree, router, closeMobileDrawer]);
 
   // DnD sensors: require 8px move before activating (distinguishes click from drag)


### PR DESCRIPTION
## Summary

サイドバーのブランチをクリックした際に画面全体がリロードされるケースがある問題の修正。

### 根本原因

`handleBranchClick` に3つのバグが重なっていた：

| バグ | 内容 |
|------|------|
| ① タイマーの蓄積 | クリックのたびに `setTimeout` を作成するが、返したクリーンアップ関数はイベントハンドラの戻り値なので**誰も呼ばない** |
| ② `popstate` が発火しない | `router.push()` は `history.pushState()` を使うため `popstate` は発火しない（ブラウザの戻る/進むのみ） |
| ③ 誤検知リロード | 素早く複数クリックすると古いタイマーが蓄積し、staleな `targetPath` と現在の pathname を比較して `window.location.href` によるフルリロードを起こす |

**例:** branchB → branchC と素早くクリック → 300ms後にbranchBのタイマーが `pathname=/worktrees/branchC ≠ /worktrees/branchB` と判定 → フルリロード

### 修正内容

- `fallbackTimerRef`（`useRef`）で単一のタイマーを管理
- 新しいクリック時に前のタイマーをキャンセルしてから新規セット
- 最後にクリックしたアイテムのフォールバックのみが機能するようになった
- 機能しなかった `popstate` リスナーを削除

## Test plan

- [ ] サイドバーを素早く連続クリックしても画面全体がリロードされない
- [ ] 通常クリックで正常にページ遷移できる
- [ ] router.push が失敗した場合のフォールバック（500ms後）が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)