### PR TITLE
style(assistant): refine AssistantChatPanel UI layout and visual design (#649)

### DIFF
--- a/src/components/home/AssistantChatPanel.tsx
+++ b/src/components/home/AssistantChatPanel.tsx
@@ -221,32 +221,34 @@ export function AssistantChatPanel() {
     [sessionActive],
   );
 
+  const selectedRepository = repositories.find((repo) => repo.path === selectedRepo);
+
   return (
     <div
-      className="mb-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden"
+      className="mb-6 overflow-hidden rounded-xl border border-slate-800 bg-slate-950/95 shadow-lg shadow-slate-950/20"
       data-testid="assistant-chat-panel"
     >
       {/* Header */}
       <button
         onClick={toggleCollapsed}
-        className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-750 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        className="flex w-full items-center justify-between border-b border-slate-800 bg-slate-900/90 px-4 py-3 transition-colors hover:bg-slate-900"
         data-testid="assistant-toggle-button"
       >
         <div className="flex items-center gap-2">
           <svg className="w-5 h-5 text-cyan-600 dark:text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
           </svg>
-          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          <span className="text-sm font-semibold text-slate-100">
             Assistant Chat
           </span>
           {sessionActive && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300">
+            <span className="inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-300">
               Active
             </span>
           )}
         </div>
         <svg
-          className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${collapsed ? '' : 'rotate-180'}`}
+          className={`h-4 w-4 text-slate-400 transition-transform ${collapsed ? '' : 'rotate-180'}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -257,67 +259,93 @@ export function AssistantChatPanel() {
 
       {/* Content */}
       {!collapsed && (
-        <div className="p-4 space-y-3" style={{ maxHeight: '50vh', display: 'flex', flexDirection: 'column' }}>
+        <div
+          className="space-y-4 bg-gradient-to-br from-slate-950 via-slate-900 to-cyan-950/80 p-4"
+          style={{ maxHeight: '50vh', display: 'flex', flexDirection: 'column' }}
+        >
+          <div className="rounded-lg border border-slate-700 bg-slate-900/70 p-3">
+            <p className="text-sm font-medium text-slate-100">
+              Start a local assistant session in a repository and chat from that working directory.
+            </p>
+            <p className="mt-1 text-xs text-slate-300">
+              The repository selection sets where the assistant starts running commands and reading files.
+            </p>
+          </div>
+
           {/* Controls */}
-          <div className="flex flex-wrap items-center gap-2">
-            {/* Repository selector */}
-            <select
-              value={selectedRepo}
-              onChange={(e) => handleRepoChange(e.target.value)}
-              disabled={repositories.length === 0}
-              className="text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded px-2 py-1 max-w-[200px] truncate"
-              data-testid="assistant-repo-select"
-            >
-              {repositories.length === 0 && (
-                <option value="">No repositories</option>
+          <div className="grid gap-3 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto] md:items-end">
+            <label className="block">
+              <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-300">
+                Repository to Work In
+              </span>
+              <select
+                value={selectedRepo}
+                onChange={(e) => handleRepoChange(e.target.value)}
+                disabled={repositories.length === 0}
+                className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-100 px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+                data-testid="assistant-repo-select"
+              >
+                {repositories.length === 0 && (
+                  <option value="">No repositories</option>
+                )}
+                {repositories.map((repo) => (
+                  <option key={repo.path} value={repo.path}>
+                    {repo.displayName || repo.name}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-slate-300">
+                {selectedRepository
+                  ? `Current start directory: ${selectedRepository.displayName || selectedRepository.name}`
+                  : 'Select the repository that will be used as the assistant session start directory.'}
+              </p>
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-300">
+                Assistant CLI
+              </span>
+              <select
+                value={selectedTool}
+                onChange={(e) => handleToolChange(e.target.value as CLIToolType)}
+                disabled={sessionActive}
+                className="mt-1 w-full rounded-lg border border-slate-600 bg-slate-100 px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+                data-testid="assistant-tool-select"
+              >
+                {availableTools.map((tool) => (
+                  <option key={tool.id} value={tool.id} disabled={!tool.installed}>
+                    {tool.name}{!tool.installed ? ' (not installed)' : ''}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="flex items-end">
+              {!sessionActive ? (
+                <button
+                  onClick={handleStart}
+                  disabled={!selectedRepo || starting}
+                  className="w-full rounded-lg bg-cyan-500 px-4 py-2 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-400 disabled:bg-slate-500 disabled:text-slate-300 md:w-auto"
+                  data-testid="assistant-start-button"
+                >
+                  {starting ? 'Starting...' : 'Start'}
+                </button>
+              ) : (
+                <button
+                  onClick={handleStop}
+                  disabled={stopping}
+                  className="w-full rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:bg-slate-500 disabled:text-slate-300 md:w-auto"
+                  data-testid="assistant-stop-button"
+                >
+                  {stopping ? 'Stopping...' : 'Stop'}
+                </button>
               )}
-              {repositories.map((repo) => (
-                <option key={repo.path} value={repo.path}>
-                  {repo.displayName || repo.name}
-                </option>
-              ))}
-            </select>
-
-            {/* CLI tool selector */}
-            <select
-              value={selectedTool}
-              onChange={(e) => handleToolChange(e.target.value as CLIToolType)}
-              disabled={sessionActive}
-              className="text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded px-2 py-1"
-              data-testid="assistant-tool-select"
-            >
-              {availableTools.map((tool) => (
-                <option key={tool.id} value={tool.id} disabled={!tool.installed}>
-                  {tool.name}{!tool.installed ? ' (not installed)' : ''}
-                </option>
-              ))}
-            </select>
-
-            {/* Start/Stop button */}
-            {!sessionActive ? (
-              <button
-                onClick={handleStart}
-                disabled={!selectedRepo || starting}
-                className="text-sm px-3 py-1 bg-cyan-600 hover:bg-cyan-700 text-white rounded disabled:bg-gray-400 dark:disabled:bg-gray-600 transition-colors"
-                data-testid="assistant-start-button"
-              >
-                {starting ? 'Starting...' : 'Start'}
-              </button>
-            ) : (
-              <button
-                onClick={handleStop}
-                disabled={stopping}
-                className="text-sm px-3 py-1 bg-red-600 hover:bg-red-700 text-white rounded disabled:bg-gray-400 dark:disabled:bg-gray-600 transition-colors"
-                data-testid="assistant-stop-button"
-              >
-                {stopping ? 'Stopping...' : 'Stop'}
-              </button>
-            )}
+            </div>
           </div>
 
           {/* Error display */}
           {error && (
-            <div className="p-2 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded text-sm text-red-800 dark:text-red-300">
+            <div className="rounded border border-red-800 bg-red-950/40 p-2 text-sm text-red-200">
               {error}
             </div>
           )}
@@ -328,7 +356,7 @@ export function AssistantChatPanel() {
             className="flex-1 min-h-[100px] max-h-[35vh] overflow-auto bg-gray-900 text-green-400 text-xs font-mono p-3 rounded border border-gray-700 whitespace-pre-wrap break-words"
             data-testid="assistant-output"
           >
-            {output || (sessionActive ? 'Waiting for output...' : 'Start a session to begin.')}
+            {output || (sessionActive ? 'Waiting for output...' : 'Select a repository and click Start to open an assistant session.')}
           </pre>
 
           {/* Message input */}

--- a/tests/unit/AssistantChatPanel.test.tsx
+++ b/tests/unit/AssistantChatPanel.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AssistantChatPanel } from '@/components/home/AssistantChatPanel';
+import { assistantApi } from '@/lib/api/assistant-api';
+
+vi.mock('@/lib/api/assistant-api', () => ({
+  assistantApi: {
+    getInstalledTools: vi.fn(),
+    startSession: vi.fn(),
+    stopSession: vi.fn(),
+    sendCommand: vi.fn(),
+    getCurrentOutput: vi.fn(),
+  },
+}));
+
+const mockFetch = vi.fn();
+
+describe('AssistantChatPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    global.fetch = mockFetch as typeof fetch;
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        repositories: [
+          { path: '/repos/alpha', name: 'alpha', displayName: 'Alpha Repo' },
+        ],
+      }),
+    } as Response);
+
+    vi.mocked(assistantApi.getInstalledTools).mockResolvedValue([
+      { id: 'claude', name: 'Claude Code', installed: true },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses a dark background treatment for the panel shell', () => {
+    render(<AssistantChatPanel />);
+
+    expect(screen.getByTestId('assistant-chat-panel')).toHaveClass('bg-slate-950/95');
+    expect(screen.getByTestId('assistant-toggle-button')).toHaveClass('bg-slate-900/90');
+  });
+
+  it('explains what the repository selector controls', async () => {
+    render(<AssistantChatPanel />);
+
+    fireEvent.click(screen.getByTestId('assistant-toggle-button'));
+
+    expect(
+      await screen.findByText(
+        'Start a local assistant session in a repository and chat from that working directory.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Repository to Work In')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The repository selection sets where the assistant starts running commands and reading files.',
+      ),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Current start directory: Alpha Repo')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a clearer empty-state prompt before the session starts', async () => {
+    render(<AssistantChatPanel />);
+
+    fireEvent.click(screen.getByTestId('assistant-toggle-button'));
+
+    expect(
+      await screen.findByText('Select a repository and click Start to open an assistant session.'),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

AssistantChatPanel のUI微調整。レイアウト・カラースキームの改善とリポジトリ説明テキストの追加。

## Changes

### Changed
- `src/components/home/AssistantChatPanel.tsx` — グリッドベースのレイアウトに変更、slate/cyanカラーパレットに統一、リポジトリ選択に説明テキスト・現在ディレクトリ表示を追加、ボタン・セレクトのスタイル改善

### Added
- `tests/unit/AssistantChatPanel.test.tsx` — UI変更に対応したテスト追加

## Test Results

- ESLint: 0 errors
- TypeScript: 0 errors
- Unit Tests: 6325 passed | 7 skipped

## Checklist

- [x] Unit tests pass
- [x] Lint check passes
- [x] Type check passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>