### PR TITLE
feat(assistant-chat): dedicated Chat tab with Claude/Codex non-interactive mode

### DIFF
--- a/src/app/api/assistant/conversation/route.ts
+++ b/src/app/api/assistant/conversation/route.ts
@@ -1,0 +1,62 @@
+/**
+ * Assistant Conversation API
+ * GET /api/assistant/conversation?repositoryId=...&cliToolId=...
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { isCliToolType } from '@/lib/cli-tools/types';
+import { getDbInstance } from '@/lib/db/db-instance';
+import {
+  getAssistantConversationByRepositoryAndCliTool,
+  updateAssistantConversation,
+} from '@/lib/db';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { hasSession } from '@/lib/tmux/tmux';
+import { getAssistantConversationSession } from '@/lib/assistant/conversation-session';
+import { isAssistantNonInteractiveTool } from '@/lib/assistant/tool-capabilities';
+import { reconcileAssistantConversationExecution } from '@/lib/assistant/non-interactive-execution-reconciler';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const repositoryId = searchParams.get('repositoryId');
+  const cliToolId = searchParams.get('cliToolId');
+
+  if (!repositoryId || typeof repositoryId !== 'string') {
+    return NextResponse.json({ error: 'Invalid repositoryId parameter' }, { status: 400 });
+  }
+
+  if (!cliToolId || !isCliToolType(cliToolId)) {
+    return NextResponse.json({ error: 'Invalid cliToolId parameter' }, { status: 400 });
+  }
+
+  const db = getDbInstance();
+  const repository = getRepositoryById(db, repositoryId);
+  if (!repository) {
+    return NextResponse.json({ error: 'Repository not found' }, { status: 404 });
+  }
+
+  const conversation = getAssistantConversationByRepositoryAndCliTool(db, repositoryId, cliToolId);
+  if (!conversation) {
+    return NextResponse.json({ conversation: null });
+  }
+
+  if (isAssistantNonInteractiveTool(cliToolId)) {
+    reconcileAssistantConversationExecution(db, conversation.id);
+    return NextResponse.json({
+      conversation: getAssistantConversationByRepositoryAndCliTool(db, repositoryId, cliToolId),
+    });
+  }
+
+  if (conversation.status === 'running') {
+    const { sessionName } = getAssistantConversationSession(cliToolId, conversation.id);
+    if (!await hasSession(sessionName)) {
+      const synced = updateAssistantConversation(db, conversation.id, {
+        status: 'stopped',
+        lastStoppedAt: new Date(),
+      });
+      return NextResponse.json({ conversation: synced });
+    }
+  }
+
+  return NextResponse.json({ conversation });
+}

--- a/src/app/api/assistant/current-output/route.ts
+++ b/src/app/api/assistant/current-output/route.ts
@@ -1,65 +1,97 @@
 /**
  * Assistant Current Output API endpoint
- * GET /api/assistant/current-output
- *
- * Issue #649: Capture terminal output from a global assistant session.
- * - No DB operations
- * - Uses tmux capturePane to get current terminal output
+ * GET /api/assistant/current-output?conversationId=...&cliToolId=...
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { isCliToolType } from '@/lib/cli-tools/types';
-import { CLIToolManager } from '@/lib/cli-tools/manager';
-import { GLOBAL_SESSION_WORKTREE_ID } from '@/lib/session/global-session-constants';
-import { hasSession, capturePane } from '@/lib/tmux/tmux';
+import { getDbInstance } from '@/lib/db/db-instance';
+import {
+  getAssistantConversationById,
+  getLatestAssistantExecutionByConversation,
+  getRunningAssistantExecutionByConversation,
+  updateAssistantConversation,
+} from '@/lib/db';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { capturePane, hasSession } from '@/lib/tmux/tmux';
+import { getAssistantConversationSession } from '@/lib/assistant/conversation-session';
 import { createLogger } from '@/lib/logger';
+import { isAssistantNonInteractiveTool } from '@/lib/assistant/tool-capabilities';
+import { reconcileAssistantConversationExecution } from '@/lib/assistant/non-interactive-execution-reconciler';
 
 const logger = createLogger('api/assistant/current-output');
 
-/** Default capture lines for output */
 const DEFAULT_CAPTURE_LINES = 1000;
 
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
+    const conversationId = searchParams.get('conversationId');
     const cliToolId = searchParams.get('cliToolId');
 
-    // Validate cliToolId
-    if (!cliToolId || !isCliToolType(cliToolId)) {
-      return NextResponse.json(
-        { error: 'Invalid cliToolId parameter' },
-        { status: 400 }
-      );
+    if (!conversationId || typeof conversationId !== 'string') {
+      return NextResponse.json({ error: 'Invalid conversationId parameter' }, { status: 400 });
     }
 
-    // Derive session name
-    const manager = CLIToolManager.getInstance();
-    const cliTool = manager.getTool(cliToolId);
-    const sessionName = cliTool.getSessionName(GLOBAL_SESSION_WORKTREE_ID);
+    if (!cliToolId || !isCliToolType(cliToolId)) {
+      return NextResponse.json({ error: 'Invalid cliToolId parameter' }, { status: 400 });
+    }
 
-    // Check session exists
-    const sessionExists = await hasSession(sessionName);
-    if (!sessionExists) {
+    const db = getDbInstance();
+    const conversation = getAssistantConversationById(db, conversationId);
+    if (!conversation || conversation.cliToolId !== cliToolId) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    }
+
+    const repository = getRepositoryById(db, conversation.repositoryId);
+    if (!repository) {
+      return NextResponse.json({ error: 'Conversation repository not found' }, { status: 404 });
+    }
+
+    if (isAssistantNonInteractiveTool(cliToolId)) {
+      reconcileAssistantConversationExecution(db, conversationId);
+
+      const runningExecution = getRunningAssistantExecutionByConversation(db, conversationId);
+      const latestExecution = runningExecution ?? getLatestAssistantExecutionByConversation(db, conversationId);
+      const output = [latestExecution?.stdoutText, latestExecution?.stderrText]
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+
+      if (!runningExecution && conversation.status === 'running') {
+        updateAssistantConversation(db, conversationId, {
+          status: 'ready',
+        });
+      }
+
       return NextResponse.json({
-        output: '',
-        sessionActive: false,
+        output,
+        sessionActive: Boolean(runningExecution),
       });
     }
 
-    // Capture output
-    const output = await capturePane(sessionName, DEFAULT_CAPTURE_LINES);
+    const { sessionName } = getAssistantConversationSession(cliToolId, conversationId);
+    const sessionActive = await hasSession(sessionName);
+    if (!sessionActive) {
+      if (conversation.status === 'running') {
+        updateAssistantConversation(db, conversationId, {
+          status: 'stopped',
+          lastStoppedAt: new Date(),
+        });
+      }
 
-    return NextResponse.json({
-      output,
-      sessionActive: true,
-    });
+      return NextResponse.json({ output: '', sessionActive: false });
+    }
+
+    const output = await capturePane(sessionName, DEFAULT_CAPTURE_LINES);
+    return NextResponse.json({ output, sessionActive: true });
   } catch (error) {
-    logger.error('current-output-api-error:', {
+    logger.error('current-output-api-error', {
       error: error instanceof Error ? error.message : String(error),
     });
     return NextResponse.json(
       { error: 'Failed to capture assistant output' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/assistant/messages/route.ts
+++ b/src/app/api/assistant/messages/route.ts
@@ -1,0 +1,119 @@
+/**
+ * Assistant Messages API
+ * GET /api/assistant/messages?conversationId=...
+ * DELETE /api/assistant/messages?conversationId=...
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDbInstance } from '@/lib/db/db-instance';
+import {
+  archiveAllAssistantMessages,
+  archiveAssistantMessagesFrom,
+  getAssistantConversationById,
+  getAssistantMessages,
+  getAssistantMessageById,
+  getRunningAssistantExecutionByConversation,
+  updateAssistantConversation,
+} from '@/lib/db';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { savePendingAssistantResponseForConversation } from '@/lib/assistant/conversation-response-saver';
+import { isAssistantNonInteractiveTool } from '@/lib/assistant/tool-capabilities';
+import { reconcileAssistantConversationExecution } from '@/lib/assistant/non-interactive-execution-reconciler';
+import { createLogger } from '@/lib/logger';
+
+const DEFAULT_LIMIT = 200;
+const logger = createLogger('api/assistant/messages');
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const conversationId = searchParams.get('conversationId');
+
+  if (!conversationId || typeof conversationId !== 'string') {
+    return NextResponse.json({ error: 'Invalid conversationId parameter' }, { status: 400 });
+  }
+
+  const db = getDbInstance();
+  const conversation = getAssistantConversationById(db, conversationId);
+  if (!conversation) {
+    return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+  }
+
+  const repository = getRepositoryById(db, conversation.repositoryId);
+  if (!repository) {
+    return NextResponse.json({ error: 'Conversation repository not found' }, { status: 404 });
+  }
+
+  if (isAssistantNonInteractiveTool(conversation.cliToolId)) {
+    reconcileAssistantConversationExecution(db, conversationId);
+  } else if (conversation.status === 'running') {
+    await savePendingAssistantResponseForConversation(db, conversationId, conversation.cliToolId);
+  }
+
+  const messages = getAssistantMessages(db, conversationId, { limit: DEFAULT_LIMIT })
+    .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+  return NextResponse.json({
+    conversationId,
+    messages,
+  });
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const conversationId = searchParams.get('conversationId');
+    const fromMessageId = searchParams.get('fromMessageId');
+
+    if (!conversationId || typeof conversationId !== 'string') {
+      return NextResponse.json({ error: 'Invalid conversationId parameter' }, { status: 400 });
+    }
+
+    const db = getDbInstance();
+    const conversation = getAssistantConversationById(db, conversationId);
+    if (!conversation) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    }
+
+    if (isAssistantNonInteractiveTool(conversation.cliToolId)) {
+      reconcileAssistantConversationExecution(db, conversationId);
+    }
+
+    if (getRunningAssistantExecutionByConversation(db, conversationId)) {
+      return NextResponse.json(
+        { error: 'Cannot clear history while a run is in progress' },
+        { status: 409 },
+      );
+    }
+
+    let archivedCount = 0;
+    if (fromMessageId) {
+      const target = getAssistantMessageById(db, fromMessageId);
+      if (!target || target.conversationId !== conversationId) {
+        return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+      }
+      archivedCount = archiveAssistantMessagesFrom(
+        db,
+        conversationId,
+        target.timestamp.getTime(),
+      );
+    } else {
+      archivedCount = archiveAllAssistantMessages(db, conversationId);
+    }
+
+    updateAssistantConversation(db, conversationId, {
+      resumeSessionId: null,
+    });
+
+    logger.info('messages:cleared', { conversationId, archivedCount, fromMessageId });
+
+    return NextResponse.json({ success: true, archivedCount });
+  } catch (error) {
+    logger.error('messages-delete-error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: 'Failed to clear assistant messages' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/assistant/session/route.ts
+++ b/src/app/api/assistant/session/route.ts
@@ -1,59 +1,92 @@
 /**
  * Assistant Session API endpoint
- * DELETE /api/assistant/session
- *
- * Issue #649: Stop a global assistant session.
- * - Stops polling
- * - Kills the tmux session
- * - No DB operations
+ * DELETE /api/assistant/session?conversationId=...&cliToolId=...
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { isCliToolType } from '@/lib/cli-tools/types';
-import { CLIToolManager } from '@/lib/cli-tools/manager';
-import { GLOBAL_SESSION_WORKTREE_ID } from '@/lib/session/global-session-constants';
-import { stopGlobalSessionPolling } from '@/lib/polling/global-session-poller';
-import { killSession } from '@/lib/tmux/tmux';
+import { getDbInstance } from '@/lib/db/db-instance';
+import {
+  deleteAssistantSessionState,
+  getAssistantConversationById,
+  getRunningAssistantExecutionByConversation,
+  updateAssistantConversation,
+} from '@/lib/db';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { stopAssistantConversationPolling } from '@/lib/polling/assistant-conversation-poller';
+import { savePendingAssistantResponseForConversation } from '@/lib/assistant/conversation-response-saver';
+import { getAssistantConversationSession } from '@/lib/assistant/conversation-session';
+import { hasSession } from '@/lib/tmux/tmux';
 import { createLogger } from '@/lib/logger';
+import { cancelAssistantExecutionProcess } from '@/lib/assistant/non-interactive-process-registry';
+import { isAssistantNonInteractiveTool } from '@/lib/assistant/tool-capabilities';
+import { reconcileAssistantConversationExecution } from '@/lib/assistant/non-interactive-execution-reconciler';
 
 const logger = createLogger('api/assistant/session');
 
 export async function DELETE(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
+    const conversationId = searchParams.get('conversationId');
     const cliToolId = searchParams.get('cliToolId');
 
-    // Validate cliToolId
-    if (!cliToolId || !isCliToolType(cliToolId)) {
-      return NextResponse.json(
-        { error: 'Invalid cliToolId parameter' },
-        { status: 400 }
-      );
+    if (!conversationId || typeof conversationId !== 'string') {
+      return NextResponse.json({ error: 'Invalid conversationId parameter' }, { status: 400 });
     }
 
-    // Stop polling
-    stopGlobalSessionPolling(cliToolId);
+    if (!cliToolId || !isCliToolType(cliToolId)) {
+      return NextResponse.json({ error: 'Invalid cliToolId parameter' }, { status: 400 });
+    }
 
-    // Kill the tmux session
-    const manager = CLIToolManager.getInstance();
-    const cliTool = manager.getTool(cliToolId);
-    const sessionName = cliTool.getSessionName(GLOBAL_SESSION_WORKTREE_ID);
+    const db = getDbInstance();
+    const conversation = getAssistantConversationById(db, conversationId);
+    if (!conversation || conversation.cliToolId !== cliToolId) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    }
 
-    const killed = await killSession(sessionName);
+    const repository = getRepositoryById(db, conversation.repositoryId);
+    if (!repository) {
+      return NextResponse.json({ error: 'Conversation repository not found' }, { status: 404 });
+    }
 
-    logger.info('session:stopped', { cliToolId, sessionName, killed });
+    if (isAssistantNonInteractiveTool(cliToolId)) {
+      reconcileAssistantConversationExecution(db, conversationId);
 
-    return NextResponse.json({
-      success: true,
-      killed,
+      const runningExecution = getRunningAssistantExecutionByConversation(db, conversationId);
+      const killed = runningExecution ? cancelAssistantExecutionProcess(conversationId) : false;
+
+      updateAssistantConversation(db, conversationId, {
+        status: 'stopped',
+        lastStoppedAt: new Date(),
+      });
+
+      logger.info('conversation:stopped', { conversationId, cliToolId, killed });
+      return NextResponse.json({ success: true, killed });
+    }
+
+    stopAssistantConversationPolling(conversationId, cliToolId);
+    await savePendingAssistantResponseForConversation(db, conversationId, cliToolId);
+
+    const { cliTool, sessionName, worktreeId } = getAssistantConversationSession(cliToolId, conversationId);
+    const sessionExists = await hasSession(sessionName);
+    const killed = sessionExists ? await cliTool.killSession(worktreeId) : false;
+
+    deleteAssistantSessionState(db, conversationId);
+    updateAssistantConversation(db, conversationId, {
+      status: 'stopped',
+      lastStoppedAt: new Date(),
     });
+
+    logger.info('session:stopped', { conversationId, cliToolId, sessionName, killed });
+
+    return NextResponse.json({ success: true, killed });
   } catch (error) {
-    logger.error('session-api-error:', {
+    logger.error('session-api-error', {
       error: error instanceof Error ? error.message : String(error),
     });
     return NextResponse.json(
       { error: 'Failed to stop assistant session' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/assistant/start/route.ts
+++ b/src/app/api/assistant/start/route.ts
@@ -2,107 +2,181 @@
  * Assistant Start API endpoint
  * POST /api/assistant/start
  *
- * Issue #649: Start a global assistant session.
- * - No DB operations (no worktree record required)
- * - Validates cliToolId and working directory
- * - Creates tmux session + sends initial context
+ * Starts or resumes a Home Assistant Chat conversation session.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { isCliToolType } from '@/lib/cli-tools/types';
-import { CLIToolManager } from '@/lib/cli-tools/manager';
-import { GLOBAL_SESSION_WORKTREE_ID } from '@/lib/session/global-session-constants';
-import { buildGlobalContext } from '@/lib/assistant/context-builder';
-import { pollGlobalSession } from '@/lib/polling/global-session-poller';
 import { getDbInstance } from '@/lib/db/db-instance';
-import { isSystemDirectory } from '@/config/system-directories';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import {
+  createAssistantConversation,
+  createAssistantMessage,
+  deleteAssistantSessionState,
+  getAssistantConversationByRepositoryAndCliTool,
+  getRunningAssistantExecutionByConversation,
+  updateAssistantSessionState,
+  updateAssistantConversation,
+} from '@/lib/db';
+import { CLIToolManager } from '@/lib/cli-tools/manager';
+import { hasSession } from '@/lib/tmux/tmux';
+import { buildAssistantStartupSnapshot, buildGlobalContext } from '@/lib/assistant/context-builder';
+import { getAssistantConversationSession } from '@/lib/assistant/conversation-session';
+import { pollAssistantConversation } from '@/lib/polling/assistant-conversation-poller';
 import { createLogger } from '@/lib/logger';
+import { captureSessionOutput } from '@/lib/session/cli-session';
+import { getAssistantExecutionMode, isAssistantNonInteractiveTool } from '@/lib/assistant/tool-capabilities';
+import { reconcileAssistantConversationExecution } from '@/lib/assistant/non-interactive-execution-reconciler';
 
 const logger = createLogger('api/assistant/start');
 
-/** Maximum working directory path length */
-const MAX_PATH_LENGTH = 4096;
-
 export async function POST(req: NextRequest) {
   try {
-    const { cliToolId, workingDirectory } = await req.json();
+    const { cliToolId, repositoryId } = await req.json();
 
-    // Validate cliToolId
     if (!cliToolId || typeof cliToolId !== 'string' || !isCliToolType(cliToolId)) {
+      return NextResponse.json({ error: 'Invalid cliToolId parameter' }, { status: 400 });
+    }
+
+    if (!isAssistantNonInteractiveTool(cliToolId)) {
       return NextResponse.json(
-        { error: 'Invalid cliToolId parameter' },
-        { status: 400 }
+        { error: `Assistant Chat supports only claude and codex (got '${cliToolId}')` },
+        { status: 400 },
       );
     }
 
-    // Validate workingDirectory
-    if (!workingDirectory || typeof workingDirectory !== 'string') {
-      return NextResponse.json(
-        { error: 'Missing workingDirectory parameter' },
-        { status: 400 }
-      );
+    if (!repositoryId || typeof repositoryId !== 'string') {
+      return NextResponse.json({ error: 'Invalid repositoryId parameter' }, { status: 400 });
     }
 
-    if (workingDirectory.length > MAX_PATH_LENGTH) {
-      return NextResponse.json(
-        { error: 'Invalid workingDirectory parameter' },
-        { status: 400 }
-      );
+    const db = getDbInstance();
+    const repository = getRepositoryById(db, repositoryId);
+    if (!repository) {
+      return NextResponse.json({ error: 'Repository not found' }, { status: 404 });
     }
 
-    // Null byte check (path traversal prevention)
-    if (workingDirectory.includes('\0')) {
-      return NextResponse.json(
-        { error: 'Invalid workingDirectory parameter' },
-        { status: 400 }
-      );
-    }
-
-    // System directory check
-    if (isSystemDirectory(workingDirectory)) {
-      return NextResponse.json(
-        { error: 'Invalid workingDirectory parameter' },
-        { status: 400 }
-      );
-    }
-
-    // Check CLI tool installation
     const manager = CLIToolManager.getInstance();
     const cliTool = manager.getTool(cliToolId);
-    const installed = await cliTool.isInstalled();
-    if (!installed) {
+    if (!await cliTool.isInstalled()) {
       return NextResponse.json(
         { error: `CLI tool '${cliToolId}' is not installed` },
-        { status: 400 }
+        { status: 503 },
       );
     }
 
-    // Start session using BaseCLITool.startSession with GLOBAL_SESSION_WORKTREE_ID
-    await cliTool.startSession(GLOBAL_SESSION_WORKTREE_ID, workingDirectory);
+    let conversation = getAssistantConversationByRepositoryAndCliTool(db, repositoryId, cliToolId);
+    if (!conversation) {
+      conversation = createAssistantConversation(db, {
+        repositoryId,
+        cliToolId,
+        workingDirectory: repository.path,
+        executionMode: getAssistantExecutionMode(cliToolId),
+        status: 'stopped',
+      });
+    }
 
-    // Build and send initial context
-    const db = getDbInstance();
-    const context = buildGlobalContext(cliToolId, db);
-    await cliTool.sendMessage(GLOBAL_SESSION_WORKTREE_ID, context);
+    if (isAssistantNonInteractiveTool(cliToolId)) {
+      reconcileAssistantConversationExecution(db, conversation.id);
+      const syncedConversation = getAssistantConversationByRepositoryAndCliTool(db, repositoryId, cliToolId);
+      conversation = syncedConversation ?? conversation;
 
-    // Start polling for session output
-    pollGlobalSession(cliToolId);
+      if (getRunningAssistantExecutionByConversation(db, conversation.id)) {
+        return NextResponse.json(
+          { error: 'Conversation already has a running execution' },
+          { status: 409 },
+        );
+      }
 
-    const sessionName = cliTool.getSessionName(GLOBAL_SESSION_WORKTREE_ID);
+      const snapshotTakenAt = new Date();
+      const contextSnapshot = buildAssistantStartupSnapshot(cliToolId, db, snapshotTakenAt);
+      conversation = updateAssistantConversation(db, conversation.id, {
+        executionMode: 'non_interactive',
+        workingDirectory: repository.path,
+        status: 'ready',
+        contextSentAt: snapshotTakenAt,
+        contextSnapshot,
+      }) ?? conversation;
 
-    logger.info('session:started', { cliToolId, sessionName });
+      logger.info('conversation:ready', {
+        conversationId: conversation.id,
+        cliToolId,
+        repositoryId,
+      });
+
+      return NextResponse.json({
+        success: true,
+        conversation,
+        executionMode: 'non_interactive',
+        resumeAvailable: Boolean(conversation.resumeSessionId),
+      });
+    }
+
+    const { worktreeId, sessionName } = getAssistantConversationSession(cliToolId, conversation.id);
+    const sessionExists = await hasSession(sessionName);
+
+    await cliTool.startSession(worktreeId, repository.path);
+
+    if (!sessionExists) {
+      try {
+        const startupOutput = await captureSessionOutput(worktreeId, cliToolId, 10000);
+        const startupLines = startupOutput.split('\n');
+        let startupLineCount = startupLines.length;
+        while (startupLineCount > 0 && startupLines[startupLineCount - 1].trim() === '') {
+          startupLineCount--;
+        }
+        updateAssistantSessionState(db, conversation.id, startupLineCount);
+      } catch {
+        // Ignore baseline capture failures and rely on later saves.
+      }
+    }
+
+    const now = new Date();
+    let contextSentAt = conversation.contextSentAt ?? null;
+    if (!sessionExists) {
+      const context = buildGlobalContext(cliToolId, db);
+      await cliTool.sendMessage(worktreeId, context);
+      contextSentAt = now;
+      deleteAssistantSessionState(db, conversation.id);
+      createAssistantMessage(db, {
+        conversationId: conversation.id,
+        role: 'system',
+        content: 'New assistant session started',
+        messageType: 'session_boundary',
+        timestamp: now,
+      });
+    }
+
+    conversation = updateAssistantConversation(db, conversation.id, {
+      executionMode: 'interactive',
+      workingDirectory: repository.path,
+      sessionName,
+      status: 'running',
+      lastStartedAt: now,
+      contextSentAt,
+    }) ?? conversation;
+
+    pollAssistantConversation(conversation.id, cliToolId);
+
+    logger.info('session:started', {
+      conversationId: conversation.id,
+      cliToolId,
+      sessionName,
+      repositoryId,
+    });
 
     return NextResponse.json({
       success: true,
-      sessionName,
+      conversation,
+      executionMode: 'interactive',
+      resumeAvailable: false,
     });
   } catch (error) {
-    logger.error('start-api-error:', {
+    logger.error('start-api-error', {
       error: error instanceof Error ? error.message : String(error),
     });
     return NextResponse.json(
       { error: 'Failed to start assistant session' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/assistant/terminal/route.ts
+++ b/src/app/api/assistant/terminal/route.ts
@@ -2,87 +2,149 @@
  * Assistant Terminal API endpoint
  * POST /api/assistant/terminal
  *
- * Issue #649: Send commands to a global assistant session.
- * - No DB operations
- * - Validates cliToolId and command
- * - Sends keys to the active tmux session
+ * Sends a user message to a conversation-backed tmux session.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { isCliToolType } from '@/lib/cli-tools/types';
-import { CLIToolManager } from '@/lib/cli-tools/manager';
-import { GLOBAL_SESSION_WORKTREE_ID } from '@/lib/session/global-session-constants';
-import { hasSession, sendKeys, sendSpecialKeys } from '@/lib/tmux/tmux';
-import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
-import { COPILOT_SEND_ENTER_DELAY_MS } from '@/config/copilot-constants';
+import { getDbInstance } from '@/lib/db/db-instance';
+import {
+  createAssistantMessage,
+  getAssistantConversationById,
+  getRunningAssistantExecutionByConversation,
+  updateAssistantMessageStatus,
+} from '@/lib/db';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { hasSession } from '@/lib/tmux/tmux';
+import { getAssistantConversationSession } from '@/lib/assistant/conversation-session';
+import { savePendingAssistantResponseForConversation } from '@/lib/assistant/conversation-response-saver';
 import { createLogger } from '@/lib/logger';
+import { isAssistantNonInteractiveTool } from '@/lib/assistant/tool-capabilities';
+import { reconcileAssistantConversationExecution } from '@/lib/assistant/non-interactive-execution-reconciler';
+import { startNonInteractiveAssistantExecution } from '@/lib/assistant/non-interactive-runner';
 
 const logger = createLogger('api/assistant/terminal');
 
-/** Maximum command length to prevent DoS */
 const MAX_COMMAND_LENGTH = 10000;
 
 export async function POST(req: NextRequest) {
   try {
-    const { cliToolId, command } = await req.json();
+    const { cliToolId, conversationId, command } = await req.json();
 
-    // Validate cliToolId
     if (!cliToolId || typeof cliToolId !== 'string' || !isCliToolType(cliToolId)) {
+      return NextResponse.json({ error: 'Invalid cliToolId parameter' }, { status: 400 });
+    }
+
+    if (!isAssistantNonInteractiveTool(cliToolId)) {
       return NextResponse.json(
-        { error: 'Invalid cliToolId parameter' },
-        { status: 400 }
+        { error: `Assistant Chat supports only claude and codex (got '${cliToolId}')` },
+        { status: 400 },
       );
     }
 
-    // Validate command
-    if (!command || typeof command !== 'string') {
-      return NextResponse.json(
-        { error: 'Missing command parameter' },
-        { status: 400 }
-      );
+    if (!conversationId || typeof conversationId !== 'string') {
+      return NextResponse.json({ error: 'Invalid conversationId parameter' }, { status: 400 });
     }
 
-    if (command.length > MAX_COMMAND_LENGTH) {
-      return NextResponse.json(
-        { error: 'Invalid command parameter' },
-        { status: 400 }
-      );
+    if (!command || typeof command !== 'string' || command.length > MAX_COMMAND_LENGTH) {
+      return NextResponse.json({ error: 'Invalid command parameter' }, { status: 400 });
     }
 
-    // Check session exists
-    const manager = CLIToolManager.getInstance();
-    const cliTool = manager.getTool(cliToolId);
-    const sessionName = cliTool.getSessionName(GLOBAL_SESSION_WORKTREE_ID);
-
-    const sessionExists = await hasSession(sessionName);
-    if (!sessionExists) {
-      return NextResponse.json(
-        { error: 'Session not found. Use start API to create a session first.' },
-        { status: 404 }
-      );
+    const db = getDbInstance();
+    const conversation = getAssistantConversationById(db, conversationId);
+    if (!conversation || conversation.cliToolId !== cliToolId) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
     }
 
-    // Send command to tmux session (same pattern as terminal/route.ts)
-    if (cliToolId === 'copilot') {
-      const copilotCommand = command.replace(/\n+/g, ' ').trim();
-      await sendKeys(sessionName, copilotCommand, false);
-      await new Promise(resolve => setTimeout(resolve, COPILOT_SEND_ENTER_DELAY_MS));
-      await sendSpecialKeys(sessionName, ['Enter']);
-    } else {
-      await sendKeys(sessionName, command);
+    const repository = getRepositoryById(db, conversation.repositoryId);
+    if (!repository) {
+      return NextResponse.json({ error: 'Conversation repository not found' }, { status: 404 });
     }
 
-    // Invalidate cache after sending command
-    invalidateCache(sessionName);
+    if (isAssistantNonInteractiveTool(cliToolId)) {
+      reconcileAssistantConversationExecution(db, conversationId);
 
-    return NextResponse.json({ success: true });
+      const latestConversation = getAssistantConversationById(db, conversationId);
+      if (!latestConversation || latestConversation.cliToolId !== cliToolId) {
+        return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+      }
+
+      if (latestConversation.status !== 'ready') {
+        return NextResponse.json(
+          { error: 'Conversation must be started before sending a message' },
+          { status: 409 },
+        );
+      }
+
+      if (getRunningAssistantExecutionByConversation(db, conversationId)) {
+        return NextResponse.json(
+          { error: 'Conversation already has a running execution' },
+          { status: 409 },
+        );
+      }
+
+      const now = new Date();
+      const userMessage = createAssistantMessage(db, {
+        conversationId,
+        role: 'user',
+        content: command,
+        messageType: 'normal',
+        deliveryStatus: 'pending',
+        timestamp: now,
+      });
+
+      try {
+        const { executionId } = await startNonInteractiveAssistantExecution({
+          db,
+          conversationId,
+          cliToolId,
+          repository,
+          userMessageId: userMessage.id,
+          userMessage: command,
+        });
+        return NextResponse.json({ success: true, messageId: userMessage.id, executionId });
+      } catch (error) {
+        updateAssistantMessageStatus(db, userMessage.id, 'failed');
+        throw error;
+      }
+    }
+
+    if (conversation.status !== 'running') {
+      return NextResponse.json({ error: 'Conversation session is not running' }, { status: 409 });
+    }
+
+    const { cliTool, worktreeId, sessionName } = getAssistantConversationSession(cliToolId, conversationId);
+    if (!await hasSession(sessionName)) {
+      return NextResponse.json({ error: 'Session not found. Start the session first.' }, { status: 404 });
+    }
+
+    await savePendingAssistantResponseForConversation(db, conversationId, cliToolId);
+
+    const now = new Date();
+    const userMessage = createAssistantMessage(db, {
+      conversationId,
+      role: 'user',
+      content: command,
+      messageType: 'normal',
+      deliveryStatus: 'pending',
+      timestamp: now,
+    });
+
+    try {
+      await cliTool.sendMessage(worktreeId, command);
+      updateAssistantMessageStatus(db, userMessage.id, 'sent');
+      return NextResponse.json({ success: true, messageId: userMessage.id });
+    } catch (error) {
+      updateAssistantMessageStatus(db, userMessage.id, 'failed');
+      throw error;
+    }
   } catch (error) {
-    logger.error('terminal-api-error:', {
+    logger.error('terminal-api-error', {
       error: error instanceof Error ? error.message : String(error),
     });
     return NextResponse.json(
       { error: 'Failed to send command to terminal' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * Chat Page (/chat)
+ *
+ * Dedicated page for the Assistant Chat (Home Assistant-style conversation)
+ * that was previously embedded in the Home page.
+ */
+
+'use client';
+
+import { AppShell } from '@/components/layout';
+import { AssistantChatPanel } from '@/components/home/AssistantChatPanel';
+
+export default function ChatPage() {
+  return (
+    <AppShell>
+      <div className="container-custom py-8 overflow-auto h-full">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Assistant Chat</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Converse with a local CLI assistant (Claude or Codex) scoped to a selected repository.
+          </p>
+        </div>
+
+        <AssistantChatPanel />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -169,4 +169,87 @@
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
     background-color: rgb(148 163 184);
   }
+
+  .assistant-md > *:first-child {
+    margin-top: 0;
+  }
+  .assistant-md > *:last-child {
+    margin-bottom: 0;
+  }
+  .assistant-md p {
+    margin: 0.4em 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+  .assistant-md h1,
+  .assistant-md h2,
+  .assistant-md h3,
+  .assistant-md h4 {
+    font-weight: 600;
+    margin: 0.8em 0 0.3em;
+    line-height: 1.3;
+  }
+  .assistant-md h1 { font-size: 1.1rem; }
+  .assistant-md h2 { font-size: 1.05rem; }
+  .assistant-md h3 { font-size: 1rem; }
+  .assistant-md ul,
+  .assistant-md ol {
+    margin: 0.4em 0;
+    padding-left: 1.4em;
+  }
+  .assistant-md li {
+    margin: 0.15em 0;
+  }
+  .assistant-md a {
+    color: rgb(103 232 249);
+    text-decoration: underline;
+    word-break: break-all;
+  }
+  .assistant-md code {
+    background-color: rgb(15 23 42 / 0.85);
+    padding: 0.08em 0.35em;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .assistant-md pre {
+    background-color: rgb(15 23 42 / 0.85);
+    border: 1px solid rgb(51 65 85);
+    border-radius: 6px;
+    padding: 0.6em 0.8em;
+    margin: 0.5em 0;
+    overflow-x: auto;
+    font-size: 0.85em;
+    line-height: 1.45;
+  }
+  .assistant-md pre code {
+    background: transparent;
+    padding: 0;
+    font-size: inherit;
+  }
+  .assistant-md blockquote {
+    margin: 0.5em 0;
+    padding-left: 0.8em;
+    border-left: 3px solid rgb(51 65 85);
+    color: rgb(203 213 225);
+  }
+  .assistant-md table {
+    border-collapse: collapse;
+    margin: 0.6em 0;
+    font-size: 0.85em;
+  }
+  .assistant-md th,
+  .assistant-md td {
+    border: 1px solid rgb(51 65 85);
+    padding: 0.3em 0.6em;
+    text-align: left;
+  }
+  .assistant-md th {
+    background-color: rgb(15 23 42 / 0.6);
+  }
+  .assistant-md hr {
+    border: none;
+    border-top: 1px solid rgb(51 65 85);
+    margin: 0.8em 0;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,6 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { AppShell } from '@/components/layout';
 import { HomeSessionSummary } from '@/components/home/HomeSessionSummary';
-import { AssistantChatPanel } from '@/components/home/AssistantChatPanel';
 import type { Worktree } from '@/types/models';
 
 /**
@@ -29,6 +28,16 @@ const BANNER_DISMISSED_KEY = 'commandmate-home-banner-dismissed';
  * Shortcut card data for navigation.
  */
 const SHORTCUT_CARDS = [
+  {
+    title: 'Chat',
+    description: 'Talk to a local CLI assistant scoped to a repository',
+    href: '/chat',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+      </svg>
+    ),
+  },
   {
     title: 'Sessions',
     description: 'View and manage all worktree sessions',
@@ -144,9 +153,6 @@ export default function Home() {
           </p>
         </div>
 
-        {/* Assistant Chat Panel */}
-        <AssistantChatPanel />
-
         {/* Session Summary */}
         <div className="mb-8">
           <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">Session Overview</h2>
@@ -154,7 +160,7 @@ export default function Home() {
         </div>
 
         {/* Shortcut Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
           {SHORTCUT_CARDS.map((card) => (
             <Link
               key={card.href}

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -193,6 +193,10 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
       logger.info(`Starting ${serverLabel} in background...`);
 
+      // Mark the daemon child as launched via the CommandMate CLI so the server
+      // can surface the appropriate command name (e.g. in the assistant context).
+      process.env.CM_LAUNCHED_BY = 'commandmate-cli';
+
       // Issue #331: Set auth environment variables in process.env so daemon.ts can forward them
       // to the child process. daemon.ts reads process.env[key] to build the child env object.
       if (authTokenHash) {
@@ -277,6 +281,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
       ...process.env,
       ...(mainEnvResult.parsed || {}),
       ...(envResult.parsed || {}),
+      CM_LAUNCHED_BY: 'commandmate-cli',
     };
 
     // Command line options override .env values

--- a/src/components/home/AssistantChatPanel.tsx
+++ b/src/components/home/AssistantChatPanel.tsx
@@ -1,135 +1,187 @@
 /**
  * AssistantChatPanel Component
- * Issue #649: Main assistant chat panel for the Home page.
- *
- * Features:
- * - Collapsible panel (max 50vh when expanded)
- * - Repository selection dropdown
- * - CLI tool selection
- * - Terminal output display with polling
- * - Session start/stop controls
- * - Dark mode support
- * - Mobile responsive layout
+ * Home page chat-first Assistant Chat UI.
  */
 
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { AssistantMessageInput } from './AssistantMessageInput';
+import { AssistantMessageList } from './AssistantMessageList';
 import { assistantApi } from '@/lib/api/assistant-api';
 import type { AssistantToolInfo } from '@/lib/api/assistant-api';
 import { GLOBAL_POLL_INTERVAL_MS } from '@/lib/session/global-session-constants';
 import type { CLIToolType } from '@/lib/cli-tools/types';
-import { CLI_TOOL_IDS } from '@/lib/cli-tools/types';
+import type {
+  AssistantConversation,
+  AssistantMessage,
+} from '@/lib/db/assistant-conversation-db';
 
-/** localStorage key for panel collapsed state */
-const COLLAPSED_KEY = 'commandmate-assistant-collapsed';
-
-/** localStorage key for selected CLI tool */
 const CLI_TOOL_KEY = 'commandmate-assistant-cli-tool';
+const ASSISTANT_ALLOWED_TOOLS: readonly CLIToolType[] = ['claude', 'codex'];
+
+function isAssistantAllowedTool(value: string): value is CLIToolType {
+  return (ASSISTANT_ALLOWED_TOOLS as readonly string[]).includes(value);
+}
 
 interface RepositoryOption {
+  id: string;
   path: string;
   name: string;
   displayName?: string;
 }
 
 export function AssistantChatPanel() {
-  const [collapsed, setCollapsed] = useState(true);
   const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
   const [availableTools, setAvailableTools] = useState<AssistantToolInfo[]>([]);
-  const [selectedRepo, setSelectedRepo] = useState('');
+  const [selectedRepoId, setSelectedRepoId] = useState('');
   const [selectedTool, setSelectedTool] = useState<CLIToolType>('claude');
-  const [sessionActive, setSessionActive] = useState(false);
-  const [output, setOutput] = useState('');
+  const [conversation, setConversation] = useState<AssistantConversation | null>(null);
+  const [messages, setMessages] = useState<AssistantMessage[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [stopping, setStopping] = useState(false);
-  const outputRef = useRef<HTMLPreElement>(null);
+  const [clearing, setClearing] = useState(false);
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Restore collapsed state from localStorage
+  const conversationActive = conversation?.status === 'ready' || conversation?.status === 'running';
+  const executionRunning = conversation?.status === 'running';
+  const canSend = conversation?.status === 'ready';
+  const selectedRepository = repositories.find((repo) => repo.id === selectedRepoId);
+  const allowedTools = useMemo(
+    () => availableTools.filter((tool) => isAssistantAllowedTool(tool.id)),
+    [availableTools],
+  );
+  const selectedToolInfo = allowedTools.find((tool) => tool.id === selectedTool);
+  const assistantLabel = selectedToolInfo?.name ?? selectedTool;
+
+  const loadMessages = useCallback(async (conversationId: string) => {
+    const nextMessages = await assistantApi.getMessages(conversationId);
+    setMessages(nextMessages);
+  }, []);
+
+  const loadConversation = useCallback(async () => {
+    if (!selectedRepoId) {
+      setConversation(null);
+      setMessages([]);
+      return;
+    }
+
+    const nextConversation = await assistantApi.getConversation(selectedRepoId, selectedTool);
+    setConversation(nextConversation);
+    if (nextConversation) {
+      await loadMessages(nextConversation.id);
+    } else {
+      setMessages([]);
+    }
+  }, [loadMessages, selectedRepoId, selectedTool]);
+
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem(COLLAPSED_KEY);
-      if (saved !== null) {
-        setCollapsed(saved === 'true');
-      }
       const savedTool = localStorage.getItem(CLI_TOOL_KEY);
-      if (savedTool && (CLI_TOOL_IDS as readonly string[]).includes(savedTool)) {
-        setSelectedTool(savedTool as CLIToolType);
+      if (savedTool && isAssistantAllowedTool(savedTool)) {
+        setSelectedTool(savedTool);
       }
     }
   }, []);
 
-  // Fetch repositories and installed tools
   useEffect(() => {
     async function fetchRepos() {
       try {
         const res = await fetch('/api/worktrees');
-        if (res.ok) {
-          const data = await res.json();
-          const repos: RepositoryOption[] = (data.repositories ?? []).map(
-            (r: { path: string; name: string; displayName?: string }) => ({
-              path: r.path,
-              name: r.name,
-              displayName: r.displayName,
-            }),
-          );
-          setRepositories(repos);
-          if (repos.length > 0 && !selectedRepo) {
-            setSelectedRepo(repos[0].path);
-          }
+        if (!res.ok) {
+          return;
+        }
+        const data = await res.json();
+        const repos: RepositoryOption[] = (data.repositories ?? []).map(
+          (repo: { id: string; path: string; name: string; displayName?: string }) => ({
+            id: repo.id,
+            path: repo.path,
+            name: repo.name,
+            displayName: repo.displayName,
+          }),
+        );
+        setRepositories(repos);
+        if (repos.length > 0) {
+          setSelectedRepoId((prev) => prev || repos[0].id);
         }
       } catch {
-        // Silently handle fetch errors
+        // Silent fetch failure
       }
     }
 
     async function fetchTools() {
       const tools = await assistantApi.getInstalledTools();
-      if (tools.length > 0) {
-        setAvailableTools(tools);
-        // Update selectedTool to first installed tool if current is not installed
-        const installedTool = tools.find((t) => t.installed);
-        if (installedTool) {
-          setSelectedTool((prev) => {
-            const prevInstalled = tools.find((t) => t.id === prev)?.installed;
-            return prevInstalled ? prev : installedTool.id;
-          });
-        }
+      setAvailableTools(tools);
+
+      const supportedTools = tools.filter((tool) => isAssistantAllowedTool(tool.id));
+      const installedTool = supportedTools.find((tool) => tool.installed);
+      if (installedTool) {
+        setSelectedTool((prev) => {
+          const prevTool = supportedTools.find((tool) => tool.id === prev);
+          return prevTool?.installed ? prev : installedTool.id;
+        });
       }
     }
 
     void fetchRepos();
     void fetchTools();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Polling for output
   useEffect(() => {
-    if (!sessionActive) {
-      if (pollIntervalRef.current) {
-        clearInterval(pollIntervalRef.current);
-        pollIntervalRef.current = null;
+    if (!selectedRepoId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const nextConversation = await assistantApi.getConversation(selectedRepoId, selectedTool);
+        if (cancelled) {
+          return;
+        }
+
+        setConversation(nextConversation);
+        if (nextConversation) {
+          const nextMessages = await assistantApi.getMessages(nextConversation.id);
+          if (!cancelled) {
+            setMessages(nextMessages);
+          }
+        } else {
+          setMessages([]);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load conversation');
+        }
       }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedRepoId, selectedTool]);
+
+  useEffect(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+
+    if (!conversation) {
       return;
     }
 
     const poll = async () => {
       try {
-        const data = await assistantApi.getCurrentOutput(selectedTool);
-        setOutput(data.output);
-        if (!data.sessionActive) {
-          setSessionActive(false);
-        }
+        await loadConversation();
       } catch {
-        // Silently handle poll errors
+        // Silent poll failure
       }
     };
 
-    // Initial poll
     void poll();
-
     pollIntervalRef.current = setInterval(poll, GLOBAL_POLL_INTERVAL_MS);
 
     return () => {
@@ -138,26 +190,12 @@ export function AssistantChatPanel() {
         pollIntervalRef.current = null;
       }
     };
-  }, [sessionActive, selectedTool]);
-
-  // Auto-scroll output to bottom
-  useEffect(() => {
-    if (outputRef.current) {
-      outputRef.current.scrollTop = outputRef.current.scrollHeight;
-    }
-  }, [output]);
-
-  const toggleCollapsed = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      if (typeof window !== 'undefined') {
-        localStorage.setItem(COLLAPSED_KEY, String(next));
-      }
-      return next;
-    });
-  }, []);
+  }, [conversation?.id, loadConversation, conversation]);
 
   const handleToolChange = useCallback((tool: CLIToolType) => {
+    if (!isAssistantAllowedTool(tool)) {
+      return;
+    }
     setSelectedTool(tool);
     if (typeof window !== 'undefined') {
       localStorage.setItem(CLI_TOOL_KEY, tool);
@@ -165,116 +203,137 @@ export function AssistantChatPanel() {
   }, []);
 
   const handleStart = useCallback(async () => {
-    if (!selectedRepo || starting) return;
+    if (!selectedRepoId || starting) {
+      return;
+    }
 
     setStarting(true);
     setError(null);
     try {
-      await assistantApi.startSession(selectedTool, selectedRepo);
-      setSessionActive(true);
-      setOutput('');
+      const result = await assistantApi.startSession(selectedTool, selectedRepoId);
+      setConversation(result.conversation);
+      await loadMessages(result.conversation.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start session');
     } finally {
       setStarting(false);
     }
-  }, [selectedRepo, selectedTool, starting]);
+  }, [loadMessages, selectedRepoId, selectedTool, starting]);
 
   const handleStop = useCallback(async () => {
-    if (stopping) return;
+    if (!conversation || stopping) {
+      return;
+    }
 
     setStopping(true);
     setError(null);
     try {
-      await assistantApi.stopSession(selectedTool);
-      setSessionActive(false);
+      await assistantApi.stopSession(selectedTool, conversation.id);
+      await loadConversation();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to stop session');
     } finally {
       setStopping(false);
     }
-  }, [selectedTool, stopping]);
+  }, [conversation, loadConversation, selectedTool, stopping]);
+
+  const handleClearHistory = useCallback(async () => {
+    if (!conversation || clearing || executionRunning) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      'Clear all chat history for this repository and CLI? Past messages will no longer be sent back to the assistant.',
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setClearing(true);
+    setError(null);
+    try {
+      await assistantApi.clearMessages(conversation.id);
+      await loadConversation();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clear history');
+    } finally {
+      setClearing(false);
+    }
+  }, [clearing, conversation, executionRunning, loadConversation]);
 
   const handleSendMessage = useCallback(
     async (message: string) => {
+      if (!conversation || !canSend) {
+        return;
+      }
+
       setError(null);
       try {
-        await assistantApi.sendCommand(selectedTool, message);
+        await assistantApi.sendCommand(selectedTool, conversation.id, message);
+        setConversation((prev) => (prev ? { ...prev, status: 'running' } : prev));
+        await Promise.all([
+          loadMessages(conversation.id),
+          loadConversation(),
+        ]);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to send message');
         throw err;
       }
     },
-    [selectedTool],
+    [canSend, conversation, loadConversation, loadMessages, selectedTool],
+  );
+
+  const handleEditMessage = useCallback(
+    async (target: AssistantMessage, newContent: string) => {
+      if (!conversation || !canSend) {
+        throw new Error('Session is not ready to resend messages');
+      }
+
+      setError(null);
+      await assistantApi.clearMessages(conversation.id, { fromMessageId: target.id });
+      await assistantApi.sendCommand(selectedTool, conversation.id, newContent);
+      setConversation((prev) => (prev ? { ...prev, status: 'running' } : prev));
+      await Promise.all([
+        loadMessages(conversation.id),
+        loadConversation(),
+      ]);
+    },
+    [canSend, conversation, loadConversation, loadMessages, selectedTool],
   );
 
   const handleRepoChange = useCallback(
-    (newRepo: string) => {
-      if (sessionActive) {
+    async (newRepoId: string) => {
+      if (conversationActive) {
         const confirmed = window.confirm(
-          'Changing repository will not affect the active session. Do you want to continue?',
+          'Changing repository will stop the active conversation. Do you want to continue?',
         );
-        if (!confirmed) return;
-      }
-      setSelectedRepo(newRepo);
-    },
-    [sessionActive],
-  );
+        if (!confirmed) {
+          return;
+        }
 
-  const selectedRepository = repositories.find((repo) => repo.path === selectedRepo);
+        try {
+          await assistantApi.stopSession(selectedTool, conversation.id);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Failed to stop session');
+          return;
+        }
+      }
+
+      setSelectedRepoId(newRepoId);
+      setError(null);
+    },
+    [conversation, conversationActive, selectedTool],
+  );
 
   return (
     <div
-      className="mb-6 overflow-hidden rounded-xl border border-slate-800 bg-slate-950/95 shadow-lg shadow-slate-950/20"
+      className="overflow-hidden rounded-xl border border-slate-800 bg-slate-950/95 shadow-lg shadow-slate-950/20"
       data-testid="assistant-chat-panel"
     >
-      {/* Header */}
-      <button
-        onClick={toggleCollapsed}
-        className="flex w-full items-center justify-between border-b border-slate-800 bg-slate-900/90 px-4 py-3 transition-colors hover:bg-slate-900"
-        data-testid="assistant-toggle-button"
+      <div
+        className="flex h-[78vh] min-h-[34rem] max-h-[48rem] flex-col gap-4 overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-cyan-950/80 p-4"
       >
-        <div className="flex items-center gap-2">
-          <svg className="w-5 h-5 text-cyan-600 dark:text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-          </svg>
-          <span className="text-sm font-semibold text-slate-100">
-            Assistant Chat
-          </span>
-          {sessionActive && (
-            <span className="inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-300">
-              Active
-            </span>
-          )}
-        </div>
-        <svg
-          className={`h-4 w-4 text-slate-400 transition-transform ${collapsed ? '' : 'rotate-180'}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-
-      {/* Content */}
-      {!collapsed && (
-        <div
-          className="space-y-4 bg-gradient-to-br from-slate-950 via-slate-900 to-cyan-950/80 p-4"
-          style={{ maxHeight: '50vh', display: 'flex', flexDirection: 'column' }}
-        >
-          <div className="rounded-lg border border-slate-700 bg-slate-900/70 p-3">
-            <p className="text-sm font-medium text-slate-100">
-              Start a local assistant session in a repository and chat from that working directory.
-            </p>
-            <p className="mt-1 text-xs text-slate-300">
-              The repository selection sets where the assistant starts running commands and reading files.
-            </p>
-          </div>
-
-          {/* Controls */}
           <div className="flex flex-col gap-1">
-            {/* Labels row */}
             <div className="grid gap-3 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto]">
               <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-300">
                 Repository to Work In
@@ -284,20 +343,18 @@ export function AssistantChatPanel() {
               </span>
               <span className="hidden md:block" />
             </div>
-            {/* Selects + button row — all items aligned to center */}
+
             <div className="grid gap-3 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto] md:items-center">
               <select
-                value={selectedRepo}
-                onChange={(e) => handleRepoChange(e.target.value)}
+                value={selectedRepoId}
+                onChange={(e) => void handleRepoChange(e.target.value)}
                 disabled={repositories.length === 0}
                 className="w-full rounded-lg border border-slate-600 bg-slate-100 px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:bg-slate-300"
                 data-testid="assistant-repo-select"
               >
-                {repositories.length === 0 && (
-                  <option value="">No repositories</option>
-                )}
+                {repositories.length === 0 && <option value="">No repositories</option>}
                 {repositories.map((repo) => (
-                  <option key={repo.path} value={repo.path}>
+                  <option key={repo.id} value={repo.id}>
                     {repo.displayName || repo.name}
                   </option>
                 ))}
@@ -306,11 +363,11 @@ export function AssistantChatPanel() {
               <select
                 value={selectedTool}
                 onChange={(e) => handleToolChange(e.target.value as CLIToolType)}
-                disabled={sessionActive}
+                disabled={conversationActive}
                 className="w-full rounded-lg border border-slate-600 bg-slate-100 px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 disabled:cursor-not-allowed disabled:bg-slate-300"
                 data-testid="assistant-tool-select"
               >
-                {availableTools.map((tool) => (
+                {allowedTools.map((tool) => (
                   <option key={tool.id} value={tool.id} disabled={!tool.installed}>
                     {tool.name}{!tool.installed ? ' (not installed)' : ''}
                   </option>
@@ -318,10 +375,10 @@ export function AssistantChatPanel() {
               </select>
 
               <div>
-                {!sessionActive ? (
+                {!conversationActive ? (
                   <button
                     onClick={handleStart}
-                    disabled={!selectedRepo || starting}
+                    disabled={!selectedRepoId || starting}
                     className="w-full rounded-lg bg-cyan-500 px-4 py-2 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-400 disabled:bg-slate-500 disabled:text-slate-300 md:w-auto"
                     data-testid="assistant-start-button"
                   >
@@ -339,38 +396,59 @@ export function AssistantChatPanel() {
                 )}
               </div>
             </div>
-            {/* Description below selects */}
+
             <p className="text-xs text-slate-300">
               {selectedRepository
-                ? `Start directory: ${selectedRepository.displayName || selectedRepository.name}`
+                ? `Start directory: ${selectedRepository.displayName || selectedRepository.name} (${selectedRepository.path})`
                 : 'Select the repository used as the assistant session start directory.'}
             </p>
           </div>
 
-          {/* Error display */}
           {error && (
             <div className="rounded border border-red-800 bg-red-950/40 p-2 text-sm text-red-200">
               {error}
             </div>
           )}
 
-          {/* Terminal output */}
-          <pre
-            ref={outputRef}
-            className="flex-1 min-h-[100px] max-h-[35vh] overflow-auto bg-gray-900 text-green-400 text-xs font-mono p-3 rounded border border-gray-700 whitespace-pre-wrap break-words"
-            data-testid="assistant-output"
-          >
-            {output || (sessionActive ? 'Waiting for output...' : 'Select a repository and click Start to open an assistant session.')}
-          </pre>
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+            <div className="flex shrink-0 items-center justify-between">
+              <span className="text-xs font-medium uppercase tracking-[0.14em] text-slate-400">
+                History
+              </span>
+              <button
+                type="button"
+                onClick={handleClearHistory}
+                disabled={!conversation || clearing || executionRunning || messages.length === 0}
+                className="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/80 px-2.5 py-1 text-xs font-medium text-slate-200 transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-slate-900/40 disabled:text-slate-500"
+                data-testid="assistant-clear-button"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" />
+                </svg>
+                {clearing ? 'Clearing...' : 'Clear history'}
+              </button>
+            </div>
 
-          {/* Message input */}
-          <AssistantMessageInput
-            onSend={handleSendMessage}
-            disabled={!sessionActive}
-            placeholder={sessionActive ? 'Type your message... (Enter to send)' : 'Start a session first'}
-          />
-        </div>
-      )}
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <AssistantMessageList
+                messages={messages}
+                assistantLabel={assistantLabel}
+                sessionActive={conversationActive}
+                waitingForResponse={executionRunning}
+                canEdit={canSend}
+                onEditMessage={handleEditMessage}
+              />
+            </div>
+
+            <div className="shrink-0">
+              <AssistantMessageInput
+                onSend={handleSendMessage}
+                disabled={!canSend}
+                placeholder={canSend ? 'Type your message... (Enter to send)' : conversationActive ? 'Waiting for the current run to finish' : 'Start a session first'}
+              />
+            </div>
+          </div>
+      </div>
     </div>
   );
 }

--- a/src/components/home/AssistantMessageInput.tsx
+++ b/src/components/home/AssistantMessageInput.tsx
@@ -118,7 +118,7 @@ export const AssistantMessageInput = memo(function AssistantMessageInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex items-center gap-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 focus-within:border-cyan-500 focus-within:ring-1 focus-within:ring-cyan-500"
+      className="flex shrink-0 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-1.5 focus-within:border-cyan-500 focus-within:ring-1 focus-within:ring-cyan-500 dark:border-gray-600 dark:bg-gray-800"
       data-testid="assistant-message-input"
     >
       <textarea

--- a/src/components/home/AssistantMessageList.tsx
+++ b/src/components/home/AssistantMessageList.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import rehypeHighlight from 'rehype-highlight';
+import 'highlight.js/styles/github-dark.css';
+import type { AssistantMessage } from '@/lib/db/assistant-conversation-db';
+import { copyToClipboard } from '@/lib/clipboard-utils';
+
+interface AssistantMessageListProps {
+  messages: AssistantMessage[];
+  assistantLabel: string;
+  sessionActive: boolean;
+  waitingForResponse?: boolean;
+  canEdit?: boolean;
+  onEditMessage?: (message: AssistantMessage, newContent: string) => Promise<void>;
+}
+
+function formatTimestamp(timestamp: Date): string {
+  return timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function IconCopy() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+function IconPencil() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+    </svg>
+  );
+}
+
+interface CopyButtonProps {
+  text: string;
+  className?: string;
+  label?: string;
+}
+
+function CopyButton({ text, className = '', label = 'Copy' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    try {
+      await copyToClipboard(text);
+      setCopied(true);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore - copyToClipboard handles fallback
+    }
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/70 px-2 py-0.5 text-[11px] font-medium text-slate-300 transition-colors hover:bg-slate-800 ${className}`}
+      aria-label={copied ? 'Copied' : label}
+      title={copied ? 'Copied!' : label}
+    >
+      {copied ? <IconCheck /> : <IconCopy />}
+      <span>{copied ? 'Copied' : label}</span>
+    </button>
+  );
+}
+
+function SystemMessageBubble({ message }: { message: AssistantMessage }) {
+  return (
+    <div className="text-center text-xs font-medium uppercase tracking-[0.14em] text-slate-400">
+      <span className="rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1">
+        {message.content}
+      </span>
+    </div>
+  );
+}
+
+interface UserMessageBubbleProps {
+  message: AssistantMessage;
+  canEdit: boolean;
+  onEdit?: (message: AssistantMessage, newContent: string) => Promise<void>;
+}
+
+function UserMessageBubble({ message, canEdit, onEdit }: UserMessageBubbleProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(message.content);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const statusText = message.deliveryStatus
+    ? message.deliveryStatus === 'pending'
+      ? 'Sending'
+      : message.deliveryStatus === 'failed'
+        ? 'Failed'
+        : 'Sent'
+    : null;
+
+  const handleStartEdit = useCallback(() => {
+    setDraft(message.content);
+    setError(null);
+    setEditing(true);
+  }, [message.content]);
+
+  const handleCancel = useCallback(() => {
+    setEditing(false);
+    setError(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!onEdit || saving) {
+      return;
+    }
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === message.content.trim()) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onEdit(message, trimmed);
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to resubmit message');
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, message, onEdit, saving]);
+
+  return (
+    <div className="group ml-auto max-w-[88%] rounded-2xl border border-cyan-500/40 bg-cyan-500/12 px-4 py-3 text-cyan-50 shadow-sm">
+      <div className="mb-2 flex items-center justify-between gap-3 text-[11px] uppercase tracking-[0.12em] text-slate-400">
+        <span>You</span>
+        <span>{formatTimestamp(message.timestamp)}</span>
+      </div>
+
+      {editing ? (
+        <div className="space-y-2">
+          <textarea
+            className="w-full resize-y rounded border border-slate-600 bg-slate-950/70 p-2 text-sm text-slate-100 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={Math.max(3, Math.min(12, draft.split('\n').length + 1))}
+            disabled={saving}
+            data-testid="assistant-edit-textarea"
+          />
+          {error && <p className="text-[11px] text-red-300">{error}</p>}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={saving}
+              className="rounded border border-slate-700 bg-slate-900/70 px-3 py-1 text-[11px] text-slate-200 transition-colors hover:bg-slate-800 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || !draft.trim()}
+              className="rounded bg-cyan-500 px-3 py-1 text-[11px] font-medium text-slate-950 transition-colors hover:bg-cyan-400 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300"
+              data-testid="assistant-edit-save"
+            >
+              {saving ? 'Resending...' : 'Save & Resend'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <p className="whitespace-pre-wrap break-words text-sm leading-6">{message.content}</p>
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <span
+              className={`text-[11px] font-medium ${
+                message.deliveryStatus === 'failed' ? 'text-red-300' : 'text-slate-400'
+              }`}
+            >
+              {statusText ?? ''}
+            </span>
+            <div className="flex items-center gap-1.5 opacity-60 transition-opacity group-hover:opacity-100">
+              <CopyButton text={message.content} />
+              {canEdit && onEdit && (
+                <button
+                  type="button"
+                  onClick={handleStartEdit}
+                  className="inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/70 px-2 py-0.5 text-[11px] font-medium text-slate-300 transition-colors hover:bg-slate-800"
+                  aria-label="Edit message"
+                  data-testid="assistant-edit-button"
+                  title="Edit and resend"
+                >
+                  <IconPencil />
+                  <span>Edit</span>
+                </button>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function AssistantMessageBubble({
+  message,
+  assistantLabel,
+}: {
+  message: AssistantMessage;
+  assistantLabel: string;
+}) {
+  return (
+    <div className="group mr-auto max-w-[88%] rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 text-slate-100 shadow-sm">
+      <div className="mb-2 flex items-center justify-between gap-3 text-[11px] uppercase tracking-[0.12em] text-slate-400">
+        <span>{assistantLabel}</span>
+        <span>{formatTimestamp(message.timestamp)}</span>
+      </div>
+      <div className="assistant-md text-sm leading-6">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[rehypeSanitize, rehypeHighlight]}
+        >
+          {message.content}
+        </ReactMarkdown>
+      </div>
+      <div className="mt-2 flex justify-end opacity-60 transition-opacity group-hover:opacity-100">
+        <CopyButton text={message.content} />
+      </div>
+    </div>
+  );
+}
+
+export function AssistantMessageList({
+  messages,
+  assistantLabel,
+  sessionActive,
+  waitingForResponse = false,
+  canEdit = false,
+  onEditMessage,
+}: AssistantMessageListProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const shouldStickToBottomRef = useRef(true);
+
+  const lastMessageKey = useMemo(() => {
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage) {
+      return `empty:${waitingForResponse ? 'waiting' : 'idle'}`;
+    }
+
+    return `${messages.length}:${lastMessage.id}:${lastMessage.deliveryStatus ?? ''}:${lastMessage.content.length}:${waitingForResponse ? 'waiting' : 'idle'}`;
+  }, [messages, waitingForResponse]);
+
+  useEffect(() => {
+    if (containerRef.current && shouldStickToBottomRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [lastMessageKey]);
+
+  const emptyState = useMemo(() => {
+    const lastMessage = messages[messages.length - 1];
+    if (
+      sessionActive &&
+      lastMessage &&
+      lastMessage.role === 'user' &&
+      lastMessage.deliveryStatus !== 'failed'
+    ) {
+      return 'Assistant is working...';
+    }
+
+    return 'Select a repository and click Start to open an assistant session.';
+  }, [messages, sessionActive]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full min-h-0 overflow-y-scroll rounded-xl border border-slate-700 bg-slate-950/70 p-3"
+      style={{ scrollbarGutter: 'stable' }}
+      onScroll={(event) => {
+        const element = event.currentTarget;
+        const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
+        shouldStickToBottomRef.current = distanceFromBottom < 48;
+      }}
+      data-testid="assistant-message-list"
+    >
+      {messages.length === 0 && !waitingForResponse ? (
+        <div className="flex h-full min-h-[160px] items-center justify-center text-sm text-slate-300">
+          {emptyState}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {messages.map((message) => {
+            if (message.role === 'system' && message.messageType === 'session_boundary') {
+              return <SystemMessageBubble key={message.id} message={message} />;
+            }
+            if (message.role === 'user') {
+              return (
+                <UserMessageBubble
+                  key={message.id}
+                  message={message}
+                  canEdit={canEdit}
+                  onEdit={onEditMessage}
+                />
+              );
+            }
+            return (
+              <AssistantMessageBubble
+                key={message.id}
+                message={message}
+                assistantLabel={assistantLabel}
+              />
+            );
+          })}
+          {waitingForResponse && (
+            <div
+              className="mr-auto flex max-w-[88%] items-center gap-3 rounded-2xl border border-slate-700 bg-slate-900 px-4 py-3 shadow-sm"
+              data-testid="assistant-waiting-indicator"
+              aria-live="polite"
+            >
+              <svg
+                className="h-4 w-4 animate-spin text-cyan-400"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              <span className="text-sm text-slate-200">
+                {assistantLabel} is thinking...
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,6 +22,7 @@ export interface HeaderProps {
  */
 const NAV_ITEMS: Array<{ label: string; href: string; isActive: (pathname: string) => boolean }> = [
   { label: 'Home', href: '/', isActive: (p) => p === '/' },
+  { label: 'Chat', href: '/chat', isActive: (p) => p.startsWith('/chat') },
   { label: 'Sessions', href: '/sessions', isActive: (p) => p.startsWith('/sessions') },
   { label: 'Repos', href: '/repositories', isActive: (p) => p.startsWith('/repositories') },
   { label: 'Review/Report', href: '/review', isActive: (p) => p.startsWith('/review') },

--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -33,6 +33,12 @@ const HomeIcon = () => (
   </svg>
 );
 
+const ChatIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+  </svg>
+);
+
 const SessionsIcon = () => (
   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
@@ -56,8 +62,9 @@ const MoreIcon = () => (
  */
 const MOBILE_NAV_TABS: MobileNavTab[] = [
   { label: 'Home', href: '/', isActive: (p) => p === '/', icon: <HomeIcon /> },
+  { label: 'Chat', href: '/chat', isActive: (p) => p.startsWith('/chat'), icon: <ChatIcon /> },
   { label: 'Sessions', href: '/sessions', isActive: (p) => p.startsWith('/sessions'), icon: <SessionsIcon /> },
-  { label: 'Review/Report', href: '/review', isActive: (p) => p.startsWith('/review'), icon: <ReviewIcon /> },
+  { label: 'Review', href: '/review', isActive: (p) => p.startsWith('/review'), icon: <ReviewIcon /> },
   { label: 'More', href: '/more', isActive: (p) => p.startsWith('/more'), icon: <MoreIcon /> },
 ];
 

--- a/src/lib/api/assistant-api.ts
+++ b/src/lib/api/assistant-api.ts
@@ -1,15 +1,18 @@
 /**
- * Assistant API client
- * Issue #649: Client-side API calls for assistant chat feature
- *
- * Provides a typed interface for interacting with /api/assistant/* endpoints.
+ * Assistant API client for Home Assistant Chat.
  */
 
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import type {
-  StartAssistantResponse,
+  AssistantConversationResponse,
   AssistantCurrentOutputResponse,
+  AssistantMessagesResponse,
+  StartAssistantResponse,
 } from '@/types/assistant';
+import type {
+  AssistantConversation,
+  AssistantMessage,
+} from '@/lib/db/assistant-conversation-db';
 
 export interface AssistantToolInfo {
   id: CLIToolType;
@@ -17,26 +20,89 @@ export interface AssistantToolInfo {
   installed: boolean;
 }
 
-/**
- * Assistant API client object.
- * All methods throw on network errors; callers should handle errors appropriately.
- */
+function reviveConversation(
+  conversation: AssistantConversation | null
+): AssistantConversation | null {
+  if (!conversation) {
+    return null;
+  }
+
+  return {
+    ...conversation,
+    createdAt: new Date(conversation.createdAt),
+    updatedAt: new Date(conversation.updatedAt),
+    lastStartedAt: conversation.lastStartedAt ? new Date(conversation.lastStartedAt) : undefined,
+    lastStoppedAt: conversation.lastStoppedAt ? new Date(conversation.lastStoppedAt) : undefined,
+    contextSentAt: conversation.contextSentAt ? new Date(conversation.contextSentAt) : undefined,
+  };
+}
+
+function reviveMessage(message: AssistantMessage): AssistantMessage {
+  return {
+    ...message,
+    timestamp: new Date(message.timestamp),
+  };
+}
+
 export const assistantApi = {
-  /**
-   * Start a new assistant session.
-   *
-   * @param cliToolId - CLI tool to use
-   * @param workingDirectory - Working directory path
-   * @returns StartAssistantResponse
-   */
+  async getConversation(
+    repositoryId: string,
+    cliToolId: CLIToolType,
+  ): Promise<AssistantConversation | null> {
+    const res = await fetch(
+      `/api/assistant/conversation?repositoryId=${encodeURIComponent(repositoryId)}&cliToolId=${encodeURIComponent(cliToolId)}`,
+    );
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || `Failed to get conversation (${res.status})`);
+    }
+
+    const data = (await res.json()) as AssistantConversationResponse;
+    return reviveConversation(data.conversation);
+  },
+
+  async getMessages(conversationId: string): Promise<AssistantMessage[]> {
+    const res = await fetch(
+      `/api/assistant/messages?conversationId=${encodeURIComponent(conversationId)}`,
+    );
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || `Failed to get messages (${res.status})`);
+    }
+
+    const data = (await res.json()) as AssistantMessagesResponse;
+    return data.messages.map(reviveMessage);
+  },
+
+  async clearMessages(
+    conversationId: string,
+    options?: { fromMessageId?: string },
+  ): Promise<{ archivedCount: number }> {
+    const params = new URLSearchParams({ conversationId });
+    if (options?.fromMessageId) {
+      params.set('fromMessageId', options.fromMessageId);
+    }
+    const res = await fetch(`/api/assistant/messages?${params.toString()}`, { method: 'DELETE' });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || `Failed to clear messages (${res.status})`);
+    }
+
+    const data = await res.json();
+    return { archivedCount: data.archivedCount ?? 0 };
+  },
+
   async startSession(
     cliToolId: CLIToolType,
-    workingDirectory: string,
+    repositoryId: string,
   ): Promise<StartAssistantResponse> {
     const res = await fetch('/api/assistant/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cliToolId, workingDirectory }),
+      body: JSON.stringify({ cliToolId, repositoryId }),
     });
 
     if (!res.ok) {
@@ -44,23 +110,22 @@ export const assistantApi = {
       throw new Error(data.error || `Failed to start session (${res.status})`);
     }
 
-    return res.json();
+    const data = (await res.json()) as StartAssistantResponse;
+    return {
+      ...data,
+      conversation: reviveConversation(data.conversation)!,
+    };
   },
 
-  /**
-   * Send a command/message to the assistant session.
-   *
-   * @param cliToolId - CLI tool ID for the active session
-   * @param command - Command text to send
-   */
   async sendCommand(
     cliToolId: CLIToolType,
+    conversationId: string,
     command: string,
   ): Promise<void> {
     const res = await fetch('/api/assistant/terminal', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cliToolId, command }),
+      body: JSON.stringify({ cliToolId, conversationId, command }),
     });
 
     if (!res.ok) {
@@ -69,17 +134,12 @@ export const assistantApi = {
     }
   },
 
-  /**
-   * Get current terminal output from the assistant session.
-   *
-   * @param cliToolId - CLI tool ID for the active session
-   * @returns AssistantCurrentOutputResponse
-   */
   async getCurrentOutput(
     cliToolId: CLIToolType,
+    conversationId: string,
   ): Promise<AssistantCurrentOutputResponse> {
     const res = await fetch(
-      `/api/assistant/current-output?cliToolId=${encodeURIComponent(cliToolId)}`,
+      `/api/assistant/current-output?cliToolId=${encodeURIComponent(cliToolId)}&conversationId=${encodeURIComponent(conversationId)}`,
     );
 
     if (!res.ok) {
@@ -90,17 +150,12 @@ export const assistantApi = {
     return res.json();
   },
 
-  /**
-   * Stop the assistant session.
-   *
-   * @param cliToolId - CLI tool ID for the session to stop
-   * @returns Object with success and killed fields
-   */
   async stopSession(
     cliToolId: CLIToolType,
+    conversationId: string,
   ): Promise<{ success: boolean; killed: boolean }> {
     const res = await fetch(
-      `/api/assistant/session?cliToolId=${encodeURIComponent(cliToolId)}`,
+      `/api/assistant/session?cliToolId=${encodeURIComponent(cliToolId)}&conversationId=${encodeURIComponent(conversationId)}`,
       { method: 'DELETE' },
     );
 
@@ -112,11 +167,6 @@ export const assistantApi = {
     return res.json();
   },
 
-  /**
-   * Get list of installed CLI tools.
-   *
-   * @returns Array of tool info with installation status
-   */
   async getInstalledTools(): Promise<AssistantToolInfo[]> {
     const res = await fetch('/api/assistant/tools');
     if (!res.ok) {

--- a/src/lib/assistant/context-builder.ts
+++ b/src/lib/assistant/context-builder.ts
@@ -1,59 +1,132 @@
 /**
- * Context builder for assistant chat sessions
- * Issue #649: Builds initial context message for global assistant sessions
+ * Context builder for assistant chat sessions.
  *
  * Generates a context string containing:
- * - CLI tool usage instructions
- * - Registered repository information
+ * - CommandMate CLI command reference
+ * - Registered repositories (name, path, alias, worktree count)
+ * - Active worktree session statuses (snapshot at session start; not refreshed per message)
  */
 
 import type { CLIToolType } from '@/lib/cli-tools/types';
-import { getCliToolDisplayName } from '@/lib/cli-tools/types';
+import { getCliToolDisplayName, CLI_TOOL_DISPLAY_NAMES } from '@/lib/cli-tools/types';
 import { getAllRepositories, type Repository } from '@/lib/db/db-repository';
+import { getWorktrees } from '@/lib/db/worktree-db';
 import type Database from 'better-sqlite3';
 
-/**
- * Build a context string for a global assistant session.
- *
- * The context includes:
- * 1. A system prompt explaining the assistant's role
- * 2. List of registered repositories with paths
- *
- * @param cliToolId - The CLI tool being used
- * @param db - Database instance for querying repositories
- * @returns Context string to send as the initial message
- */
-export function buildGlobalContext(cliToolId: CLIToolType, db: Database.Database): string {
-  const toolName = getCliToolDisplayName(cliToolId);
+const COMMANDMATE_CLI_REFERENCE = `## CommandMate CLI Reference
+
+The user runs a CommandMate server locally. These are the CLI commands available from their terminal:
+
+- \`commandmate --version\` — Show version
+- \`commandmate init [--defaults]\` — Initialize configuration (interactive / non-interactive)
+- \`commandmate start [--dev] [--daemon] [--issue N] [--port N] [--auto-port]\` — Start the server (foreground / dev / background / issue-scoped)
+- \`commandmate stop [--issue N]\` — Stop the server
+- \`commandmate status [--all] [--issue N]\` — Show running server status
+- \`commandmate ls [--json] [--quiet] [--branch PREFIX]\` — List worktrees
+- \`commandmate send <worktree-id> "message" [--agent NAME] [--auto-yes] [--duration T]\` — Send a message to an agent session
+- \`commandmate wait <worktree-id>... [--timeout N] [--stall-timeout N] [--on-prompt TYPE]\` — Wait until the agent finishes or a prompt appears
+- \`commandmate respond <worktree-id> "answer" [--agent NAME]\` — Respond to an agent prompt
+- \`commandmate capture <worktree-id> [--json] [--agent NAME]\` — Capture the current terminal output of a session
+- \`commandmate auto-yes <worktree-id> [--enable] [--disable] [--duration T] [--stop-pattern PAT]\` — Toggle Auto-Yes
+- \`--duration\` accepts values like \`1h\`, \`3h\`, \`8h\`.
+- \`--agent\` selects the CLI tool: \`claude\`, \`codex\`, \`gemini\`, \`vibe-local\`, \`opencode\`, \`copilot\`.
+`;
+
+function buildRepositoriesSection(db: Database.Database): string {
   const repositories = getAllRepositories(db);
-
-  const lines: string[] = [];
-
-  lines.push(`You are an assistant using ${toolName}.`);
-  lines.push('');
-
-  if (repositories.length > 0) {
-    lines.push('## Registered Repositories');
-    lines.push('');
-    for (const repo of repositories) {
-      const displayName = repo.displayName || repo.name;
-      const enabledStatus = repo.enabled ? '' : ' (disabled)';
-      lines.push(`- ${displayName}: ${repo.path}${enabledStatus}`);
-    }
-  } else {
-    lines.push('No repositories are currently registered.');
+  if (repositories.length === 0) {
+    return '## Registered Repositories\n\nNo repositories are currently registered.';
   }
 
+  const lines: string[] = ['## Registered Repositories', ''];
+  lines.push('| Alias | Name | Path | Worktrees | Enabled |');
+  lines.push('|-------|------|------|-----------|---------|');
+  for (const repo of repositories) {
+    const alias = repo.displayName && repo.displayName !== repo.name ? repo.displayName : '-';
+    const worktreeCount = getWorktrees(db, repo.path).length;
+    const enabled = repo.enabled ? 'yes' : 'no';
+    lines.push(`| ${alias} | ${repo.name} | ${repo.path} | ${worktreeCount} | ${enabled} |`);
+  }
+  return lines.join('\n');
+}
+
+function formatCliLabel(cliToolId: string | null | undefined): string {
+  if (!cliToolId) {
+    return '-';
+  }
+  const asType = cliToolId as CLIToolType;
+  return CLI_TOOL_DISPLAY_NAMES[asType] ?? cliToolId;
+}
+
+const ACTIVE_WORKTREE_SNAPSHOT_LIMIT = 30;
+
+function buildActiveWorktreesSection(db: Database.Database, takenAt: Date): string {
+  const worktrees = getWorktrees(db);
+  const active = worktrees
+    .filter((w) => w.status && w.status !== 'done')
+    .slice(0, ACTIVE_WORKTREE_SNAPSHOT_LIMIT);
+
+  const lines: string[] = [
+    '## Active Worktree Session Snapshot',
+    `Snapshot taken at: ${takenAt.toISOString()} (not refreshed per message)`,
+    '',
+  ];
+
+  if (active.length === 0) {
+    lines.push('_No worktree sessions had an active status at snapshot time._');
+    return lines.join('\n');
+  }
+
+  lines.push('| Repository | Branch | CLI | Status | Path |');
+  lines.push('|------------|--------|-----|--------|------|');
+  for (const w of active) {
+    const repo = w.repositoryDisplayName || w.repositoryName || '-';
+    const branch = w.name;
+    const cli = formatCliLabel(w.cliToolId);
+    const status = w.status ?? '-';
+    lines.push(`| ${repo} | ${branch} | ${cli} | ${status} | ${w.path} |`);
+  }
   return lines.join('\n');
 }
 
 /**
- * Get enabled repositories from the database.
- * Utility function for external consumers that only need enabled repos.
+ * Build the startup context snapshot for the assistant conversation.
  *
- * @param db - Database instance
- * @returns Array of enabled Repository objects
+ * Called once at session start. The returned string is stored on the
+ * conversation record and reused verbatim on every subsequent message
+ * so repository/worktree state does not silently drift mid-conversation.
+ */
+export function buildAssistantStartupSnapshot(
+  cliToolId: CLIToolType,
+  db: Database.Database,
+  takenAt: Date = new Date(),
+): string {
+  const toolName = getCliToolDisplayName(cliToolId);
+
+  return [
+    `You are an assistant using ${toolName}, running inside CommandMate.`,
+    '',
+    COMMANDMATE_CLI_REFERENCE,
+    buildRepositoriesSection(db),
+    '',
+    buildActiveWorktreesSection(db, takenAt),
+  ].join('\n');
+}
+
+/**
+ * Build a context string for an assistant session.
+ *
+ * For interactive (tmux) sessions this is called once at session start.
+ * For non-interactive sessions the stored `conversation.contextSnapshot`
+ * is preferred; this function is the fallback when no snapshot exists yet.
+ */
+export function buildGlobalContext(cliToolId: CLIToolType, db: Database.Database): string {
+  return buildAssistantStartupSnapshot(cliToolId, db);
+}
+
+/**
+ * Get enabled repositories from the database.
  */
 export function getEnabledRepositories(db: Database.Database): Repository[] {
-  return getAllRepositories(db).filter(r => r.enabled);
+  return getAllRepositories(db).filter((r) => r.enabled);
 }

--- a/src/lib/assistant/context-builder.ts
+++ b/src/lib/assistant/context-builder.ts
@@ -13,24 +13,30 @@ import { getAllRepositories, type Repository } from '@/lib/db/db-repository';
 import { getWorktrees } from '@/lib/db/worktree-db';
 import type Database from 'better-sqlite3';
 
-const COMMANDMATE_CLI_REFERENCE = `## CommandMate CLI Reference
+function resolveCommandMateBinary(): string {
+  return process.env.CM_LAUNCHED_BY === 'commandmate-cli' ? 'commandmate' : 'commandmatedev';
+}
+
+function buildCommandMateCliReference(bin: string): string {
+  return `## CommandMate CLI Reference
 
 The user runs a CommandMate server locally. These are the CLI commands available from their terminal:
 
-- \`commandmate --version\` — Show version
-- \`commandmate init [--defaults]\` — Initialize configuration (interactive / non-interactive)
-- \`commandmate start [--dev] [--daemon] [--issue N] [--port N] [--auto-port]\` — Start the server (foreground / dev / background / issue-scoped)
-- \`commandmate stop [--issue N]\` — Stop the server
-- \`commandmate status [--all] [--issue N]\` — Show running server status
-- \`commandmate ls [--json] [--quiet] [--branch PREFIX]\` — List worktrees
-- \`commandmate send <worktree-id> "message" [--agent NAME] [--auto-yes] [--duration T]\` — Send a message to an agent session
-- \`commandmate wait <worktree-id>... [--timeout N] [--stall-timeout N] [--on-prompt TYPE]\` — Wait until the agent finishes or a prompt appears
-- \`commandmate respond <worktree-id> "answer" [--agent NAME]\` — Respond to an agent prompt
-- \`commandmate capture <worktree-id> [--json] [--agent NAME]\` — Capture the current terminal output of a session
-- \`commandmate auto-yes <worktree-id> [--enable] [--disable] [--duration T] [--stop-pattern PAT]\` — Toggle Auto-Yes
+- \`${bin} --version\` — Show version
+- \`${bin} init [--defaults]\` — Initialize configuration (interactive / non-interactive)
+- \`${bin} start [--dev] [--daemon] [--issue N] [--port N] [--auto-port]\` — Start the server (foreground / dev / background / issue-scoped)
+- \`${bin} stop [--issue N]\` — Stop the server
+- \`${bin} status [--all] [--issue N]\` — Show running server status
+- \`${bin} ls [--json] [--quiet] [--branch PREFIX]\` — List worktrees
+- \`${bin} send <worktree-id> "message" [--agent NAME] [--auto-yes] [--duration T]\` — Send a message to an agent session
+- \`${bin} wait <worktree-id>... [--timeout N] [--stall-timeout N] [--on-prompt TYPE]\` — Wait until the agent finishes or a prompt appears
+- \`${bin} respond <worktree-id> "answer" [--agent NAME]\` — Respond to an agent prompt
+- \`${bin} capture <worktree-id> [--json] [--agent NAME]\` — Capture the current terminal output of a session
+- \`${bin} auto-yes <worktree-id> [--enable] [--disable] [--duration T] [--stop-pattern PAT]\` — Toggle Auto-Yes
 - \`--duration\` accepts values like \`1h\`, \`3h\`, \`8h\`.
 - \`--agent\` selects the CLI tool: \`claude\`, \`codex\`, \`gemini\`, \`vibe-local\`, \`opencode\`, \`copilot\`.
 `;
+}
 
 function buildRepositoriesSection(db: Database.Database): string {
   const repositories = getAllRepositories(db);
@@ -102,11 +108,12 @@ export function buildAssistantStartupSnapshot(
   takenAt: Date = new Date(),
 ): string {
   const toolName = getCliToolDisplayName(cliToolId);
+  const cliBinary = resolveCommandMateBinary();
 
   return [
     `You are an assistant using ${toolName}, running inside CommandMate.`,
     '',
-    COMMANDMATE_CLI_REFERENCE,
+    buildCommandMateCliReference(cliBinary),
     buildRepositoriesSection(db),
     '',
     buildActiveWorktreesSection(db, takenAt),

--- a/src/lib/assistant/conversation-response-saver.ts
+++ b/src/lib/assistant/conversation-response-saver.ts
@@ -1,0 +1,139 @@
+/**
+ * Persists completed assistant responses for Home Assistant Chat conversations.
+ */
+
+import type Database from 'better-sqlite3';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import { captureSessionOutput } from '@/lib/session/cli-session';
+import { extractResponse } from '@/lib/polling/response-checker';
+import { cleanCliResponse } from '@/lib/assistant-response-saver';
+import {
+  createAssistantMessage,
+  getAssistantSessionState,
+  updateAssistantSessionState,
+  type AssistantMessage,
+} from '@/lib/db';
+import { getAssistantConversationWorktreeId } from './conversation-session';
+import { createLogger } from '@/lib/logger';
+import { stripAnsi } from '@/lib/detection/cli-patterns';
+
+const logger = createLogger('assistant/conversation-response-saver');
+
+const SESSION_OUTPUT_BUFFER_SIZE = 10000;
+
+interface CodexExtractionResult {
+  response: string;
+  lineCount: number;
+}
+
+function isCodexTransientStatus(content: string): boolean {
+  const normalized = content.trim();
+  return (
+    /^•\s+Working\s+\(\d+s\s+•\s+esc to interrupt\)$/i.test(normalized) ||
+    /^•\s+Thinking\s+\(\d+s\s+•\s+esc to interrupt\)$/i.test(normalized) ||
+    /^•\s+Running/i.test(normalized)
+  );
+}
+
+function extractCodexConversationResponse(
+  output: string,
+  lastCapturedLine: number
+): CodexExtractionResult | null {
+  const rawLines = output.split('\n');
+  let trimmedLength = rawLines.length;
+  while (trimmedLength > 0 && rawLines[trimmedLength - 1].trim() === '') {
+    trimmedLength--;
+  }
+
+  const lines = rawLines.slice(0, trimmedLength);
+  const promptIndices: number[] = [];
+
+  for (let i = Math.max(0, lastCapturedLine); i < lines.length; i++) {
+    const cleanLine = stripAnsi(lines[i]).trimEnd();
+    if (/^›(?:\s+.*)?$/.test(cleanLine)) {
+      promptIndices.push(i);
+    }
+  }
+
+  if (promptIndices.length < 2) {
+    return null;
+  }
+
+  const startPromptIndex = promptIndices[promptIndices.length - 2];
+  const endPromptIndex = promptIndices[promptIndices.length - 1];
+  const response = stripAnsi(lines.slice(startPromptIndex + 1, endPromptIndex).join('\n')).trim();
+
+  if (!response) {
+    return {
+      response: '',
+      lineCount: endPromptIndex,
+    };
+  }
+
+  if (isCodexTransientStatus(response)) {
+    return null;
+  }
+
+  return {
+    response,
+    lineCount: endPromptIndex,
+  };
+}
+
+export async function savePendingAssistantResponseForConversation(
+  db: Database.Database,
+  conversationId: string,
+  cliToolId: CLIToolType,
+  timestamp: Date = new Date()
+): Promise<AssistantMessage | null> {
+  try {
+    const sessionState = getAssistantSessionState(db, conversationId);
+    const lastCapturedLine = sessionState?.lastCapturedLine ?? 0;
+    const worktreeId = getAssistantConversationWorktreeId(conversationId);
+    const output = await captureSessionOutput(worktreeId, cliToolId, SESSION_OUTPUT_BUFFER_SIZE);
+    const codexResult = cliToolId === 'codex'
+      ? extractCodexConversationResponse(output, lastCapturedLine)
+      : null;
+    const result = codexResult
+      ? {
+          response: codexResult.response,
+          isComplete: true,
+          lineCount: codexResult.lineCount,
+          bufferReset: false,
+        }
+      : extractResponse(output, lastCapturedLine, cliToolId);
+
+    if (!result || !result.isComplete) {
+      return null;
+    }
+
+    if (!result.bufferReset && result.lineCount <= lastCapturedLine) {
+      return null;
+    }
+
+    const cleanedResponse = cleanCliResponse(result.response, cliToolId);
+    if (!cleanedResponse || cleanedResponse.trim() === '' || cleanedResponse === '[No content]') {
+      updateAssistantSessionState(db, conversationId, result.lineCount);
+      return null;
+    }
+
+    const message = createAssistantMessage(db, {
+      conversationId,
+      role: 'assistant',
+      content: cleanedResponse,
+      messageType: 'normal',
+      timestamp,
+    });
+
+    updateAssistantSessionState(db, conversationId, result.lineCount);
+
+    return message;
+  } catch (error) {
+    logger.debug('save:skipped', {
+      conversationId,
+      cliToolId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/src/lib/assistant/conversation-session.ts
+++ b/src/lib/assistant/conversation-session.ts
@@ -1,0 +1,18 @@
+/**
+ * Helpers for mapping assistant conversations to tmux session identities.
+ */
+
+import { CLIToolManager } from '@/lib/cli-tools/manager';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+export function getAssistantConversationWorktreeId(conversationId: string): string {
+  return `assistant-${conversationId}`;
+}
+
+export function getAssistantConversationSession(cliToolId: CLIToolType, conversationId: string) {
+  const cliTool = CLIToolManager.getInstance().getTool(cliToolId);
+  const worktreeId = getAssistantConversationWorktreeId(conversationId);
+  const sessionName = cliTool.getSessionName(worktreeId);
+
+  return { cliTool, worktreeId, sessionName };
+}

--- a/src/lib/assistant/non-interactive-execution-reconciler.ts
+++ b/src/lib/assistant/non-interactive-execution-reconciler.ts
@@ -1,0 +1,46 @@
+import type Database from 'better-sqlite3';
+import {
+  getAssistantConversationById,
+  getRunningAssistantExecutionByConversation,
+  listRunningAssistantExecutions,
+  updateAssistantConversation,
+  updateAssistantExecution,
+} from '@/lib/db';
+import { getAssistantExecutionProcessByConversation } from './non-interactive-process-registry';
+
+export function reconcileAssistantConversationExecution(
+  db: Database.Database,
+  conversationId: string,
+): void {
+  const conversation = getAssistantConversationById(db, conversationId);
+  if (!conversation) {
+    return;
+  }
+
+  const runningExecution = getRunningAssistantExecutionByConversation(db, conversationId);
+  const registeredProcess = getAssistantExecutionProcessByConversation(conversationId);
+
+  if (!runningExecution || registeredProcess) {
+    return;
+  }
+
+  updateAssistantExecution(db, runningExecution.id, {
+    status: 'failed',
+    finishedAt: new Date(),
+    stderrText: [
+      runningExecution.stderrText ?? '',
+      '[Execution reconciled after process registry loss]',
+    ].filter(Boolean).join('\n'),
+  });
+
+  updateAssistantConversation(db, conversationId, {
+    status: 'ready',
+  });
+}
+
+export function reconcileAllAssistantExecutions(db: Database.Database): void {
+  const runningExecutions = listRunningAssistantExecutions(db);
+  for (const execution of runningExecutions) {
+    reconcileAssistantConversationExecution(db, execution.conversationId);
+  }
+}

--- a/src/lib/assistant/non-interactive-output-parser.ts
+++ b/src/lib/assistant/non-interactive-output-parser.ts
@@ -1,0 +1,160 @@
+import { stripAnsi } from '@/lib/detection/cli-patterns';
+
+interface ParsedAssistantOutput {
+  finalMessage: string | null;
+  resumeSessionId: string | null;
+}
+
+function collectStringValues(value: unknown, values: string[]): void {
+  if (typeof value === 'string' && value.trim() !== '') {
+    values.push(value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStringValues(item, values);
+    }
+    return;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const nested of Object.values(value)) {
+      collectStringValues(nested, values);
+    }
+  }
+}
+
+function findResumeSessionId(value: unknown): string | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  for (const [key, nested] of entries) {
+    if (
+      typeof nested === 'string' &&
+      ['session_id', 'sessionId', 'conversation_id', 'conversationId', 'thread_id', 'threadId']
+        .includes(key)
+    ) {
+      return nested;
+    }
+  }
+
+  for (const [, nested] of entries) {
+    const candidate = findResumeSessionId(nested);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function extractCandidateMessage(parsed: Record<string, unknown>): string | null {
+  const directCandidates = [
+    parsed.final_message,
+    parsed.finalMessage,
+    parsed.text,
+    parsed.content,
+    parsed.message,
+    parsed.output,
+    parsed.result,
+  ];
+
+  const values: string[] = [];
+  for (const candidate of directCandidates) {
+    collectStringValues(candidate, values);
+  }
+
+  const joined = values.join('\n').trim();
+  return joined || null;
+}
+
+function parseStructuredStdout(stdout: string): ParsedAssistantOutput {
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let lastMessage: string | null = null;
+  let resumeSessionId: string | null = null;
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      const candidateMessage = extractCandidateMessage(parsed);
+      if (candidateMessage) {
+        lastMessage = candidateMessage;
+      }
+
+      const candidateResumeId = findResumeSessionId(parsed);
+      if (candidateResumeId) {
+        resumeSessionId = candidateResumeId;
+      }
+    } catch {
+      // Ignore malformed lines. Structured output is best-effort parsed line by line.
+    }
+  }
+
+  return {
+    finalMessage: lastMessage ? stripAnsi(lastMessage).trim() : null,
+    resumeSessionId,
+  };
+}
+
+export function parseClaudeStructuredOutput(stdout: string): ParsedAssistantOutput {
+  return parseStructuredStdout(stdout);
+}
+
+function extractCodexAgentMessage(parsed: Record<string, unknown>): string | null {
+  if (parsed.type !== 'item.completed') {
+    return null;
+  }
+
+  const item = parsed.item;
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+
+  const itemRecord = item as Record<string, unknown>;
+  if (itemRecord.type !== 'agent_message') {
+    return null;
+  }
+
+  const text = itemRecord.text;
+  return typeof text === 'string' && text.trim() !== '' ? text : null;
+}
+
+export function parseCodexStructuredOutput(stdout: string): ParsedAssistantOutput {
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let lastMessage: string | null = null;
+  let resumeSessionId: string | null = null;
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+
+      const agentMessage = extractCodexAgentMessage(parsed);
+      if (agentMessage) {
+        lastMessage = agentMessage;
+      }
+
+      const candidateResumeId = findResumeSessionId(parsed);
+      if (candidateResumeId) {
+        resumeSessionId = candidateResumeId;
+      }
+    } catch {
+      // Ignore malformed lines.
+    }
+  }
+
+  return {
+    finalMessage: lastMessage ? stripAnsi(lastMessage).trim() : null,
+    resumeSessionId,
+  };
+}

--- a/src/lib/assistant/non-interactive-process-registry.ts
+++ b/src/lib/assistant/non-interactive-process-registry.ts
@@ -1,0 +1,71 @@
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+
+interface RegisteredExecution {
+  executionId: string;
+  conversationId: string;
+  process: ChildProcessWithoutNullStreams;
+  cancellationRequested: boolean;
+}
+
+const executionsById = new Map<string, RegisteredExecution>();
+const executionIdsByConversation = new Map<string, string>();
+
+export function registerAssistantExecutionProcess(
+  executionId: string,
+  conversationId: string,
+  process: ChildProcessWithoutNullStreams,
+): void {
+  const entry: RegisteredExecution = {
+    executionId,
+    conversationId,
+    process,
+    cancellationRequested: false,
+  };
+
+  executionsById.set(executionId, entry);
+  executionIdsByConversation.set(conversationId, executionId);
+}
+
+export function unregisterAssistantExecutionProcess(executionId: string): void {
+  const entry = executionsById.get(executionId);
+  if (!entry) {
+    return;
+  }
+
+  executionIdsByConversation.delete(entry.conversationId);
+  executionsById.delete(executionId);
+}
+
+export function getAssistantExecutionProcess(executionId: string): RegisteredExecution | null {
+  return executionsById.get(executionId) ?? null;
+}
+
+export function getAssistantExecutionProcessByConversation(
+  conversationId: string,
+): RegisteredExecution | null {
+  const executionId = executionIdsByConversation.get(conversationId);
+  if (!executionId) {
+    return null;
+  }
+
+  return executionsById.get(executionId) ?? null;
+}
+
+export function isAssistantExecutionCancellationRequested(executionId: string): boolean {
+  return executionsById.get(executionId)?.cancellationRequested ?? false;
+}
+
+export function cancelAssistantExecutionProcess(conversationId: string): boolean {
+  const entry = getAssistantExecutionProcessByConversation(conversationId);
+  if (!entry) {
+    return false;
+  }
+
+  entry.cancellationRequested = true;
+
+  if (entry.process.killed) {
+    return false;
+  }
+
+  return entry.process.kill('SIGTERM');
+}

--- a/src/lib/assistant/non-interactive-prompt-builder.ts
+++ b/src/lib/assistant/non-interactive-prompt-builder.ts
@@ -1,0 +1,49 @@
+import type Database from 'better-sqlite3';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import type { Repository } from '@/lib/db/db-repository';
+import type {
+  AssistantConversation,
+  AssistantMessage,
+} from '@/lib/db/assistant-conversation-db';
+import { buildAssistantStartupSnapshot } from './context-builder';
+
+const MAX_HISTORY_MESSAGES = 12;
+
+function formatHistory(messages: AssistantMessage[]): string {
+  const recentMessages = messages.slice(-MAX_HISTORY_MESSAGES);
+  if (recentMessages.length === 0) {
+    return 'No prior conversation history.';
+  }
+
+  return recentMessages
+    .filter((message) => message.messageType === 'normal')
+    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+    .join('\n\n');
+}
+
+export function buildNonInteractivePrompt(params: {
+  db: Database.Database;
+  cliToolId: CLIToolType;
+  repository: Repository;
+  messages: AssistantMessage[];
+  userMessage: string;
+  conversation?: AssistantConversation;
+}): string {
+  const { db, cliToolId, repository, messages, userMessage, conversation } = params;
+
+  const startupContext = conversation?.contextSnapshot
+    ?? buildAssistantStartupSnapshot(cliToolId, db);
+
+  return [
+    startupContext,
+    '',
+    '## Active Repository',
+    `${repository.displayName || repository.name}: ${repository.path}`,
+    '',
+    '## Conversation History',
+    formatHistory(messages),
+    '',
+    '## New User Message',
+    userMessage,
+  ].join('\n');
+}

--- a/src/lib/assistant/non-interactive-runner.ts
+++ b/src/lib/assistant/non-interactive-runner.ts
@@ -1,0 +1,216 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import type Database from 'better-sqlite3';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import type { Repository } from '@/lib/db/db-repository';
+import { sanitizeEnvForChildProcess } from '@/lib/security/env-sanitizer';
+import {
+  createAssistantExecution,
+  createAssistantMessage,
+  getAssistantConversationById,
+  getAssistantMessages,
+  updateAssistantConversation,
+  updateAssistantExecution,
+  updateAssistantMessageStatus,
+} from '@/lib/db';
+import { buildNonInteractivePrompt } from './non-interactive-prompt-builder';
+import {
+  cancelAssistantExecutionProcess,
+  isAssistantExecutionCancellationRequested,
+  registerAssistantExecutionProcess,
+  unregisterAssistantExecutionProcess,
+} from './non-interactive-process-registry';
+import {
+  parseClaudeStructuredOutput,
+  parseCodexStructuredOutput,
+} from './non-interactive-output-parser';
+
+const EXECUTION_TIMEOUT_MS = 15 * 60 * 1000;
+
+function getCommandForTool(cliToolId: CLIToolType): string {
+  return cliToolId;
+}
+
+function buildCommandArgs(cliToolId: CLIToolType, resumeSessionId?: string): string[] {
+  switch (cliToolId) {
+    case 'claude': {
+      const base = ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
+      return resumeSessionId ? [...base, '--resume', resumeSessionId] : base;
+    }
+    case 'codex': {
+      const autoFlags = ['--full-auto'];
+      return resumeSessionId
+        ? ['exec', 'resume', resumeSessionId, '--json', ...autoFlags]
+        : ['exec', '--json', ...autoFlags];
+    }
+    default:
+      return [];
+  }
+}
+
+function parseExecutionOutput(cliToolId: CLIToolType, stdout: string) {
+  if (cliToolId === 'claude') {
+    return parseClaudeStructuredOutput(stdout);
+  }
+
+  return parseCodexStructuredOutput(stdout);
+}
+
+export async function startNonInteractiveAssistantExecution(params: {
+  db: Database.Database;
+  conversationId: string;
+  cliToolId: CLIToolType;
+  repository: Repository;
+  userMessageId: string;
+  userMessage: string;
+}): Promise<{ executionId: string }> {
+  const { db, conversationId, cliToolId, repository, userMessageId, userMessage } = params;
+  const conversation = getAssistantConversationById(db, conversationId);
+  if (!conversation) {
+    throw new Error('Conversation not found');
+  }
+
+  const history = getAssistantMessages(db, conversationId, { limit: 50 })
+    .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  const promptText = buildNonInteractivePrompt({
+    db,
+    cliToolId,
+    repository,
+    messages: history,
+    userMessage,
+    conversation,
+  });
+  const args = buildCommandArgs(cliToolId, conversation.resumeSessionId);
+  const command = getCommandForTool(cliToolId);
+  const commandLine = `${command} ${args.join(' ')}`.trim();
+  const startedAt = new Date();
+
+  const execution = createAssistantExecution(db, {
+    conversationId,
+    cliToolId,
+    status: 'queued',
+    commandLine,
+    promptText,
+    resumeSessionIdBefore: conversation.resumeSessionId,
+    startedAt,
+  });
+
+  const child = spawn(command, args, {
+    cwd: repository.path,
+    env: sanitizeEnvForChildProcess(),
+    stdio: 'pipe',
+  });
+
+  const processEntry = child as ChildProcessWithoutNullStreams;
+  registerAssistantExecutionProcess(execution.id, conversationId, processEntry);
+
+  updateAssistantExecution(db, execution.id, {
+    status: 'running',
+    pid: child.pid ?? null,
+    startedAt,
+  });
+  updateAssistantConversation(db, conversationId, {
+    status: 'running',
+    lastStartedAt: startedAt,
+    lastExecutionId: execution.id,
+  });
+  updateAssistantMessageStatus(db, userMessageId, 'sent');
+
+  let stdout = '';
+  let stderr = '';
+
+  child.stdout.on('data', (chunk: Buffer | string) => {
+    stdout += chunk.toString();
+    updateAssistantExecution(db, execution.id, { stdoutText: stdout });
+  });
+
+  child.stderr.on('data', (chunk: Buffer | string) => {
+    stderr += chunk.toString();
+    updateAssistantExecution(db, execution.id, { stderrText: stderr });
+  });
+
+  child.on('error', (error) => {
+    unregisterAssistantExecutionProcess(execution.id);
+    updateAssistantExecution(db, execution.id, {
+      status: 'failed',
+      stderrText: `${stderr}\n${error.message}`.trim(),
+      finishedAt: new Date(),
+    });
+    updateAssistantMessageStatus(db, userMessageId, 'failed');
+    updateAssistantConversation(db, conversationId, {
+      status: 'ready',
+    });
+  });
+
+  child.on('close', (exitCode) => {
+    const cancelled = isAssistantExecutionCancellationRequested(execution.id);
+    const finishedAt = new Date();
+    unregisterAssistantExecutionProcess(execution.id);
+
+    if (cancelled) {
+      const latestConversation = getAssistantConversationById(db, conversationId);
+      updateAssistantExecution(db, execution.id, {
+        status: 'cancelled',
+        stdoutText: stdout,
+        stderrText: stderr,
+        exitCode,
+        finishedAt,
+      });
+      if (latestConversation?.status !== 'stopped') {
+        updateAssistantConversation(db, conversationId, {
+          status: 'ready',
+          resumeSessionId: null,
+        });
+      }
+      return;
+    }
+
+    const parsed = parseExecutionOutput(cliToolId, stdout);
+    const completed = exitCode === 0 && parsed.finalMessage;
+
+    updateAssistantExecution(db, execution.id, {
+      status: completed ? 'completed' : 'failed',
+      stdoutText: stdout,
+      stderrText: stderr,
+      finalMessageText: parsed.finalMessage,
+      exitCode,
+      resumeSessionIdAfter: parsed.resumeSessionId,
+      finishedAt,
+    });
+
+    if (!completed) {
+      updateAssistantMessageStatus(db, userMessageId, 'failed');
+      updateAssistantConversation(db, conversationId, {
+        status: 'ready',
+        resumeSessionId: null,
+      });
+      return;
+    }
+
+    createAssistantMessage(db, {
+      conversationId,
+      role: 'assistant',
+      content: parsed.finalMessage!,
+      messageType: 'normal',
+      timestamp: finishedAt,
+    });
+
+    updateAssistantConversation(db, conversationId, {
+      status: 'ready',
+      resumeSessionId: parsed.resumeSessionId ?? conversation.resumeSessionId ?? null,
+      lastExecutionId: execution.id,
+    });
+  });
+
+  child.stdin.write(promptText);
+  child.stdin.end();
+
+  const timeout = setTimeout(() => {
+    cancelAssistantExecutionProcess(conversationId);
+  }, EXECUTION_TIMEOUT_MS);
+
+  child.on('close', () => {
+    clearTimeout(timeout);
+  });
+
+  return { executionId: execution.id };
+}

--- a/src/lib/assistant/tool-capabilities.ts
+++ b/src/lib/assistant/tool-capabilities.ts
@@ -1,0 +1,12 @@
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import type { AssistantConversationExecutionMode } from '@/lib/db';
+
+const NON_INTERACTIVE_TOOLS = new Set<CLIToolType>(['claude', 'codex']);
+
+export function getAssistantExecutionMode(cliToolId: CLIToolType): AssistantConversationExecutionMode {
+  return NON_INTERACTIVE_TOOLS.has(cliToolId) ? 'non_interactive' : 'interactive';
+}
+
+export function isAssistantNonInteractiveTool(cliToolId: CLIToolType): boolean {
+  return getAssistantExecutionMode(cliToolId) === 'non_interactive';
+}

--- a/src/lib/db/assistant-conversation-db.ts
+++ b/src/lib/db/assistant-conversation-db.ts
@@ -1,0 +1,772 @@
+/**
+ * Assistant conversation database operations.
+ * Home Assistant Chat uses its own conversation/message/state tables.
+ */
+
+import { randomUUID } from 'crypto';
+import type Database from 'better-sqlite3';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+export type AssistantConversationStatus = 'ready' | 'running' | 'stopped';
+export type AssistantConversationExecutionMode = 'interactive' | 'non_interactive';
+export type AssistantMessageRole = 'user' | 'assistant' | 'system';
+export type AssistantMessageType = 'normal' | 'session_boundary';
+export type AssistantMessageDeliveryStatus = 'pending' | 'sent' | 'failed';
+export type AssistantExecutionStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export const MAX_ASSISTANT_PROMPT_BYTES = 64 * 1024;
+export const MAX_ASSISTANT_LOG_BYTES = 256 * 1024;
+export const MAX_ASSISTANT_FINAL_MESSAGE_BYTES = 64 * 1024;
+
+export interface AssistantConversation {
+  id: string;
+  repositoryId: string;
+  cliToolId: CLIToolType;
+  workingDirectory: string;
+  executionMode: AssistantConversationExecutionMode;
+  resumeSessionId?: string;
+  lastExecutionId?: string;
+  sessionName?: string;
+  status: AssistantConversationStatus;
+  lastStartedAt?: Date;
+  lastStoppedAt?: Date;
+  contextSentAt?: Date;
+  contextSnapshot?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  archived: boolean;
+}
+
+export interface AssistantMessage {
+  id: string;
+  conversationId: string;
+  role: AssistantMessageRole;
+  content: string;
+  summary?: string;
+  timestamp: Date;
+  messageType: AssistantMessageType;
+  deliveryStatus?: AssistantMessageDeliveryStatus;
+  archived: boolean;
+}
+
+export interface AssistantSessionState {
+  conversationId: string;
+  lastCapturedLine: number;
+  inProgressMessageId: string | null;
+}
+
+export interface AssistantExecution {
+  id: string;
+  conversationId: string;
+  cliToolId: CLIToolType;
+  status: AssistantExecutionStatus;
+  pid?: number;
+  commandLine: string;
+  promptText: string;
+  stdoutText?: string;
+  stderrText?: string;
+  finalMessageText?: string;
+  exitCode?: number | null;
+  resumeSessionIdBefore?: string;
+  resumeSessionIdAfter?: string;
+  startedAt?: Date;
+  finishedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface AssistantConversationRow {
+  id: string;
+  repository_id: string;
+  cli_tool_id: string;
+  working_directory: string;
+  execution_mode?: string | null;
+  resume_session_id?: string | null;
+  last_execution_id?: string | null;
+  session_name: string | null;
+  status: string;
+  last_started_at: number | null;
+  last_stopped_at: number | null;
+  context_sent_at: number | null;
+  context_snapshot?: string | null;
+  created_at: number;
+  updated_at: number;
+  archived: number;
+}
+
+interface AssistantMessageRow {
+  id: string;
+  conversation_id: string;
+  role: AssistantMessageRole;
+  content: string;
+  summary: string | null;
+  timestamp: number;
+  message_type: AssistantMessageType;
+  delivery_status: AssistantMessageDeliveryStatus | null;
+  archived: number;
+}
+
+interface AssistantExecutionRow {
+  id: string;
+  conversation_id: string;
+  cli_tool_id: string;
+  status: AssistantExecutionStatus;
+  pid: number | null;
+  command_line: string;
+  prompt_text: string;
+  stdout_text: string | null;
+  stderr_text: string | null;
+  final_message_text: string | null;
+  exit_code: number | null;
+  resume_session_id_before: string | null;
+  resume_session_id_after: string | null;
+  started_at: number | null;
+  finished_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, 'utf-8') <= maxBytes) {
+    return value;
+  }
+
+  const truncated = Buffer.from(value, 'utf-8').subarray(0, maxBytes).toString('utf-8');
+  return truncated;
+}
+
+function mapConversationRow(row: AssistantConversationRow): AssistantConversation {
+  return {
+    id: row.id,
+    repositoryId: row.repository_id,
+    cliToolId: row.cli_tool_id as CLIToolType,
+    workingDirectory: row.working_directory,
+    executionMode: (row.execution_mode ?? 'interactive') as AssistantConversationExecutionMode,
+    resumeSessionId: row.resume_session_id ?? undefined,
+    lastExecutionId: row.last_execution_id ?? undefined,
+    sessionName: row.session_name ?? undefined,
+    status: (row.status === 'idle' ? 'stopped' : row.status) as AssistantConversationStatus,
+    lastStartedAt: row.last_started_at ? new Date(row.last_started_at) : undefined,
+    lastStoppedAt: row.last_stopped_at ? new Date(row.last_stopped_at) : undefined,
+    contextSentAt: row.context_sent_at ? new Date(row.context_sent_at) : undefined,
+    contextSnapshot: row.context_snapshot ?? undefined,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+    archived: row.archived === 1,
+  };
+}
+
+function mapMessageRow(row: AssistantMessageRow): AssistantMessage {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    role: row.role,
+    content: row.content,
+    summary: row.summary ?? undefined,
+    timestamp: new Date(row.timestamp),
+    messageType: row.message_type,
+    deliveryStatus: row.delivery_status ?? undefined,
+    archived: row.archived === 1,
+  };
+}
+
+function mapExecutionRow(row: AssistantExecutionRow): AssistantExecution {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    cliToolId: row.cli_tool_id as CLIToolType,
+    status: row.status,
+    pid: row.pid ?? undefined,
+    commandLine: row.command_line,
+    promptText: row.prompt_text,
+    stdoutText: row.stdout_text ?? undefined,
+    stderrText: row.stderr_text ?? undefined,
+    finalMessageText: row.final_message_text ?? undefined,
+    exitCode: row.exit_code,
+    resumeSessionIdBefore: row.resume_session_id_before ?? undefined,
+    resumeSessionIdAfter: row.resume_session_id_after ?? undefined,
+    startedAt: row.started_at ? new Date(row.started_at) : undefined,
+    finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+function touchConversation(
+  db: Database.Database,
+  conversationId: string,
+  timestamp: Date
+): void {
+  db.prepare(`
+    UPDATE assistant_conversations
+    SET updated_at = ?
+    WHERE id = ?
+  `).run(timestamp.getTime(), conversationId);
+}
+
+export function getAssistantConversationById(
+  db: Database.Database,
+  conversationId: string,
+  options: { includeArchived?: boolean } = {}
+): AssistantConversation | null {
+  const query = `
+    SELECT *
+    FROM assistant_conversations
+    WHERE id = ?
+      ${options.includeArchived ? '' : 'AND archived = 0'}
+    LIMIT 1
+  `;
+
+  const row = db.prepare(query).get(conversationId) as AssistantConversationRow | undefined;
+  return row ? mapConversationRow(row) : null;
+}
+
+export function getAssistantConversationByRepositoryAndCliTool(
+  db: Database.Database,
+  repositoryId: string,
+  cliToolId: CLIToolType,
+  options: { includeArchived?: boolean } = {}
+): AssistantConversation | null {
+  const query = `
+    SELECT *
+    FROM assistant_conversations
+    WHERE repository_id = ?
+      AND cli_tool_id = ?
+      ${options.includeArchived ? '' : 'AND archived = 0'}
+    LIMIT 1
+  `;
+
+  const row = db.prepare(query).get(repositoryId, cliToolId) as AssistantConversationRow | undefined;
+  return row ? mapConversationRow(row) : null;
+}
+
+export function createAssistantConversation(
+  db: Database.Database,
+  input: {
+    repositoryId: string;
+    cliToolId: CLIToolType;
+    workingDirectory: string;
+    executionMode?: AssistantConversationExecutionMode;
+    resumeSessionId?: string;
+    lastExecutionId?: string;
+    sessionName?: string;
+    status?: AssistantConversationStatus;
+    contextSentAt?: Date;
+    lastStartedAt?: Date;
+    lastStoppedAt?: Date;
+  }
+): AssistantConversation {
+  const id = randomUUID();
+  const now = Date.now();
+
+  db.prepare(`
+    INSERT INTO assistant_conversations (
+      id, repository_id, cli_tool_id, working_directory, execution_mode, resume_session_id,
+      last_execution_id, session_name, status,
+      last_started_at, last_stopped_at, context_sent_at, created_at, updated_at, archived
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+  `).run(
+    id,
+    input.repositoryId,
+    input.cliToolId,
+    input.workingDirectory,
+    input.executionMode ?? 'interactive',
+    input.resumeSessionId ?? null,
+    input.lastExecutionId ?? null,
+    input.sessionName ?? null,
+    input.status ?? 'stopped',
+    input.lastStartedAt?.getTime() ?? null,
+    input.lastStoppedAt?.getTime() ?? null,
+    input.contextSentAt?.getTime() ?? null,
+    now,
+    now
+  );
+
+  return {
+    id,
+    repositoryId: input.repositoryId,
+    cliToolId: input.cliToolId,
+    workingDirectory: input.workingDirectory,
+    executionMode: input.executionMode ?? 'interactive',
+    resumeSessionId: input.resumeSessionId,
+    lastExecutionId: input.lastExecutionId,
+    sessionName: input.sessionName,
+    status: input.status ?? 'stopped',
+    contextSentAt: input.contextSentAt,
+    lastStartedAt: input.lastStartedAt,
+    lastStoppedAt: input.lastStoppedAt,
+    createdAt: new Date(now),
+    updatedAt: new Date(now),
+    archived: false,
+  };
+}
+
+interface UpdateAssistantConversationInput {
+  workingDirectory?: string;
+  executionMode?: AssistantConversationExecutionMode;
+  resumeSessionId?: string | null;
+  lastExecutionId?: string | null;
+  sessionName?: string | null;
+  status?: AssistantConversationStatus;
+  lastStartedAt?: Date | null;
+  lastStoppedAt?: Date | null;
+  contextSentAt?: Date | null;
+  contextSnapshot?: string | null;
+  archived?: boolean;
+  updatedAt?: Date;
+}
+
+export function updateAssistantConversation(
+  db: Database.Database,
+  conversationId: string,
+  updates: UpdateAssistantConversationInput
+): AssistantConversation | null {
+  const assignments: string[] = [];
+  const params: Array<string | number | null> = [];
+
+  if (updates.workingDirectory !== undefined) {
+    assignments.push('working_directory = ?');
+    params.push(updates.workingDirectory);
+  }
+
+  if (updates.executionMode !== undefined) {
+    assignments.push('execution_mode = ?');
+    params.push(updates.executionMode);
+  }
+
+  if (updates.resumeSessionId !== undefined) {
+    assignments.push('resume_session_id = ?');
+    params.push(updates.resumeSessionId);
+  }
+
+  if (updates.lastExecutionId !== undefined) {
+    assignments.push('last_execution_id = ?');
+    params.push(updates.lastExecutionId);
+  }
+
+  if (updates.sessionName !== undefined) {
+    assignments.push('session_name = ?');
+    params.push(updates.sessionName);
+  }
+
+  if (updates.status !== undefined) {
+    assignments.push('status = ?');
+    params.push(updates.status);
+  }
+
+  if (updates.lastStartedAt !== undefined) {
+    assignments.push('last_started_at = ?');
+    params.push(updates.lastStartedAt?.getTime() ?? null);
+  }
+
+  if (updates.lastStoppedAt !== undefined) {
+    assignments.push('last_stopped_at = ?');
+    params.push(updates.lastStoppedAt?.getTime() ?? null);
+  }
+
+  if (updates.contextSentAt !== undefined) {
+    assignments.push('context_sent_at = ?');
+    params.push(updates.contextSentAt?.getTime() ?? null);
+  }
+
+  if (updates.contextSnapshot !== undefined) {
+    assignments.push('context_snapshot = ?');
+    params.push(updates.contextSnapshot ?? null);
+  }
+
+  if (updates.archived !== undefined) {
+    assignments.push('archived = ?');
+    params.push(updates.archived ? 1 : 0);
+  }
+
+  const updatedAt = updates.updatedAt ?? new Date();
+  assignments.push('updated_at = ?');
+  params.push(updatedAt.getTime());
+  params.push(conversationId);
+
+  db.prepare(`
+    UPDATE assistant_conversations
+    SET ${assignments.join(', ')}
+    WHERE id = ?
+  `).run(...params);
+
+  return getAssistantConversationById(db, conversationId, { includeArchived: true });
+}
+
+export function createAssistantMessage(
+  db: Database.Database,
+  message: Omit<AssistantMessage, 'id' | 'archived'>
+): AssistantMessage {
+  const id = randomUUID();
+
+  db.prepare(`
+    INSERT INTO assistant_messages (
+      id, conversation_id, role, content, summary, timestamp, message_type, delivery_status, archived
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
+  `).run(
+    id,
+    message.conversationId,
+    message.role,
+    message.content,
+    message.summary ?? null,
+    message.timestamp.getTime(),
+    message.messageType,
+    message.deliveryStatus ?? null
+  );
+
+  touchConversation(db, message.conversationId, message.timestamp);
+
+  return {
+    id,
+    ...message,
+    archived: false,
+  };
+}
+
+export function updateAssistantMessageStatus(
+  db: Database.Database,
+  messageId: string,
+  deliveryStatus: AssistantMessageDeliveryStatus
+): void {
+  db.prepare(`
+    UPDATE assistant_messages
+    SET delivery_status = ?
+    WHERE id = ?
+  `).run(deliveryStatus, messageId);
+}
+
+export function getAssistantMessages(
+  db: Database.Database,
+  conversationId: string,
+  options: { limit?: number; before?: Date; includeArchived?: boolean } = {}
+): AssistantMessage[] {
+  const { limit = 200, before, includeArchived = false } = options;
+
+  const params: Array<string | number | null> = [conversationId, before?.getTime() ?? null, before?.getTime() ?? null];
+  let query = `
+    SELECT *
+    FROM assistant_messages
+    WHERE conversation_id = ?
+      AND (? IS NULL OR timestamp < ?)
+  `;
+
+  if (!includeArchived) {
+    query += ' AND archived = 0';
+  }
+
+  query += ' ORDER BY timestamp DESC LIMIT ?';
+  params.push(limit);
+
+  const rows = db.prepare(query).all(...params) as AssistantMessageRow[];
+  return rows.map(mapMessageRow);
+}
+
+export function archiveAllAssistantMessages(
+  db: Database.Database,
+  conversationId: string
+): number {
+  const result = db.prepare(`
+    UPDATE assistant_messages
+    SET archived = 1
+    WHERE conversation_id = ?
+      AND archived = 0
+  `).run(conversationId);
+
+  return result.changes;
+}
+
+export function archiveAssistantMessagesFrom(
+  db: Database.Database,
+  conversationId: string,
+  fromTimestampMs: number
+): number {
+  const result = db.prepare(`
+    UPDATE assistant_messages
+    SET archived = 1
+    WHERE conversation_id = ?
+      AND archived = 0
+      AND timestamp >= ?
+  `).run(conversationId, fromTimestampMs);
+
+  return result.changes;
+}
+
+export function getAssistantMessageById(
+  db: Database.Database,
+  messageId: string
+): AssistantMessage | null {
+  const row = db.prepare(`
+    SELECT * FROM assistant_messages WHERE id = ?
+  `).get(messageId) as AssistantMessageRow | undefined;
+
+  return row ? mapMessageRow(row) : null;
+}
+
+export function createAssistantExecution(
+  db: Database.Database,
+  input: {
+    conversationId: string;
+    cliToolId: CLIToolType;
+    status?: AssistantExecutionStatus;
+    pid?: number;
+    commandLine: string;
+    promptText: string;
+    stdoutText?: string;
+    stderrText?: string;
+    finalMessageText?: string;
+    exitCode?: number | null;
+    resumeSessionIdBefore?: string;
+    resumeSessionIdAfter?: string;
+    startedAt?: Date;
+    finishedAt?: Date;
+  }
+): AssistantExecution {
+  const id = randomUUID();
+  const now = Date.now();
+
+  db.prepare(`
+    INSERT INTO assistant_executions (
+      id, conversation_id, cli_tool_id, status, pid, command_line, prompt_text,
+      stdout_text, stderr_text, final_message_text, exit_code, resume_session_id_before,
+      resume_session_id_after, started_at, finished_at, created_at, updated_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    input.conversationId,
+    input.cliToolId,
+    input.status ?? 'queued',
+    input.pid ?? null,
+    input.commandLine,
+    truncateUtf8(input.promptText, MAX_ASSISTANT_PROMPT_BYTES),
+    truncateUtf8(input.stdoutText ?? '', MAX_ASSISTANT_LOG_BYTES) || null,
+    truncateUtf8(input.stderrText ?? '', MAX_ASSISTANT_LOG_BYTES) || null,
+    input.finalMessageText
+      ? truncateUtf8(input.finalMessageText, MAX_ASSISTANT_FINAL_MESSAGE_BYTES)
+      : null,
+    input.exitCode ?? null,
+    input.resumeSessionIdBefore ?? null,
+    input.resumeSessionIdAfter ?? null,
+    input.startedAt?.getTime() ?? null,
+    input.finishedAt?.getTime() ?? null,
+    now,
+    now,
+  );
+
+  touchConversation(db, input.conversationId, new Date(now));
+
+  return {
+    id,
+    conversationId: input.conversationId,
+    cliToolId: input.cliToolId,
+    status: input.status ?? 'queued',
+    pid: input.pid,
+    commandLine: input.commandLine,
+    promptText: truncateUtf8(input.promptText, MAX_ASSISTANT_PROMPT_BYTES),
+    stdoutText: input.stdoutText ? truncateUtf8(input.stdoutText, MAX_ASSISTANT_LOG_BYTES) : undefined,
+    stderrText: input.stderrText ? truncateUtf8(input.stderrText, MAX_ASSISTANT_LOG_BYTES) : undefined,
+    finalMessageText: input.finalMessageText
+      ? truncateUtf8(input.finalMessageText, MAX_ASSISTANT_FINAL_MESSAGE_BYTES)
+      : undefined,
+    exitCode: input.exitCode,
+    resumeSessionIdBefore: input.resumeSessionIdBefore,
+    resumeSessionIdAfter: input.resumeSessionIdAfter,
+    startedAt: input.startedAt,
+    finishedAt: input.finishedAt,
+    createdAt: new Date(now),
+    updatedAt: new Date(now),
+  };
+}
+
+interface UpdateAssistantExecutionInput {
+  status?: AssistantExecutionStatus;
+  pid?: number | null;
+  stdoutText?: string | null;
+  stderrText?: string | null;
+  finalMessageText?: string | null;
+  exitCode?: number | null;
+  resumeSessionIdAfter?: string | null;
+  startedAt?: Date | null;
+  finishedAt?: Date | null;
+  updatedAt?: Date;
+}
+
+export function updateAssistantExecution(
+  db: Database.Database,
+  executionId: string,
+  updates: UpdateAssistantExecutionInput,
+): AssistantExecution | null {
+  const assignments: string[] = [];
+  const params: Array<string | number | null> = [];
+
+  if (updates.status !== undefined) {
+    assignments.push('status = ?');
+    params.push(updates.status);
+  }
+
+  if (updates.pid !== undefined) {
+    assignments.push('pid = ?');
+    params.push(updates.pid);
+  }
+
+  if (updates.stdoutText !== undefined) {
+    assignments.push('stdout_text = ?');
+    params.push(updates.stdoutText ? truncateUtf8(updates.stdoutText, MAX_ASSISTANT_LOG_BYTES) : null);
+  }
+
+  if (updates.stderrText !== undefined) {
+    assignments.push('stderr_text = ?');
+    params.push(updates.stderrText ? truncateUtf8(updates.stderrText, MAX_ASSISTANT_LOG_BYTES) : null);
+  }
+
+  if (updates.finalMessageText !== undefined) {
+    assignments.push('final_message_text = ?');
+    params.push(
+      updates.finalMessageText
+        ? truncateUtf8(updates.finalMessageText, MAX_ASSISTANT_FINAL_MESSAGE_BYTES)
+        : null,
+    );
+  }
+
+  if (updates.exitCode !== undefined) {
+    assignments.push('exit_code = ?');
+    params.push(updates.exitCode);
+  }
+
+  if (updates.resumeSessionIdAfter !== undefined) {
+    assignments.push('resume_session_id_after = ?');
+    params.push(updates.resumeSessionIdAfter);
+  }
+
+  if (updates.startedAt !== undefined) {
+    assignments.push('started_at = ?');
+    params.push(updates.startedAt?.getTime() ?? null);
+  }
+
+  if (updates.finishedAt !== undefined) {
+    assignments.push('finished_at = ?');
+    params.push(updates.finishedAt?.getTime() ?? null);
+  }
+
+  const updatedAt = updates.updatedAt ?? new Date();
+  assignments.push('updated_at = ?');
+  params.push(updatedAt.getTime(), executionId);
+
+  db.prepare(`
+    UPDATE assistant_executions
+    SET ${assignments.join(', ')}
+    WHERE id = ?
+  `).run(...params);
+
+  return getAssistantExecutionById(db, executionId);
+}
+
+export function getAssistantExecutionById(
+  db: Database.Database,
+  executionId: string,
+): AssistantExecution | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM assistant_executions
+    WHERE id = ?
+    LIMIT 1
+  `).get(executionId) as AssistantExecutionRow | undefined;
+
+  return row ? mapExecutionRow(row) : null;
+}
+
+export function getLatestAssistantExecutionByConversation(
+  db: Database.Database,
+  conversationId: string,
+): AssistantExecution | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM assistant_executions
+    WHERE conversation_id = ?
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(conversationId) as AssistantExecutionRow | undefined;
+
+  return row ? mapExecutionRow(row) : null;
+}
+
+export function getRunningAssistantExecutionByConversation(
+  db: Database.Database,
+  conversationId: string,
+): AssistantExecution | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM assistant_executions
+    WHERE conversation_id = ?
+      AND status = 'running'
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(conversationId) as AssistantExecutionRow | undefined;
+
+  return row ? mapExecutionRow(row) : null;
+}
+
+export function listRunningAssistantExecutions(
+  db: Database.Database,
+): AssistantExecution[] {
+  const rows = db.prepare(`
+    SELECT *
+    FROM assistant_executions
+    WHERE status = 'running'
+    ORDER BY created_at DESC
+  `).all() as AssistantExecutionRow[];
+
+  return rows.map(mapExecutionRow);
+}
+
+export function getAssistantSessionState(
+  db: Database.Database,
+  conversationId: string
+): AssistantSessionState | null {
+  const row = db.prepare(`
+    SELECT conversation_id, last_captured_line, in_progress_message_id
+    FROM assistant_session_states
+    WHERE conversation_id = ?
+  `).get(conversationId) as {
+    conversation_id: string;
+    last_captured_line: number;
+    in_progress_message_id: string | null;
+  } | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    conversationId: row.conversation_id,
+    lastCapturedLine: row.last_captured_line,
+    inProgressMessageId: row.in_progress_message_id,
+  };
+}
+
+export function updateAssistantSessionState(
+  db: Database.Database,
+  conversationId: string,
+  lastCapturedLine: number,
+  inProgressMessageId?: string | null
+): void {
+  db.prepare(`
+    INSERT INTO assistant_session_states (conversation_id, last_captured_line, in_progress_message_id)
+    VALUES (?, ?, ?)
+    ON CONFLICT(conversation_id) DO UPDATE SET
+      last_captured_line = excluded.last_captured_line,
+      in_progress_message_id = excluded.in_progress_message_id
+  `).run(conversationId, lastCapturedLine, inProgressMessageId ?? null);
+}
+
+export function deleteAssistantSessionState(
+  db: Database.Database,
+  conversationId: string
+): void {
+  db.prepare(`
+    DELETE FROM assistant_session_states
+    WHERE conversation_id = ?
+  `).run(conversationId);
+}

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -97,3 +97,38 @@ export {
   updateDailyReportContent,
 } from './daily-report-db';
 export type { DailyReport } from './daily-report-db';
+
+// assistant-conversation-db
+export {
+  getAssistantConversationById,
+  getAssistantConversationByRepositoryAndCliTool,
+  createAssistantConversation,
+  updateAssistantConversation,
+  createAssistantMessage,
+  updateAssistantMessageStatus,
+  getAssistantMessages,
+  getAssistantMessageById,
+  archiveAllAssistantMessages,
+  archiveAssistantMessagesFrom,
+  createAssistantExecution,
+  updateAssistantExecution,
+  getAssistantExecutionById,
+  getLatestAssistantExecutionByConversation,
+  getRunningAssistantExecutionByConversation,
+  listRunningAssistantExecutions,
+  getAssistantSessionState,
+  updateAssistantSessionState,
+  deleteAssistantSessionState,
+} from './assistant-conversation-db';
+export type {
+  AssistantConversation,
+  AssistantConversationStatus,
+  AssistantConversationExecutionMode,
+  AssistantMessage,
+  AssistantMessageRole,
+  AssistantMessageType,
+  AssistantMessageDeliveryStatus,
+  AssistantExecution,
+  AssistantExecutionStatus,
+  AssistantSessionState,
+} from './assistant-conversation-db';

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -10,6 +10,9 @@ import { v24_migrations } from './v24-daily-summaries';
 import { v25_migrations } from './v25-report-templates';
 import { v26_migrations } from './v26-repository-display-name';
 import { v27_migrations } from './v27-app-settings';
+import { v28_migrations } from './v28-assistant-conversations';
+import { v29_migrations } from './v29-assistant-non-interactive';
+import { v30_migrations } from './v30-assistant-context-snapshot';
 
 /**
  * Complete ordered list of all migrations.
@@ -25,4 +28,7 @@ export const migrations: Migration[] = [
   ...v25_migrations,
   ...v26_migrations,
   ...v27_migrations,
+  ...v28_migrations,
+  ...v29_migrations,
+  ...v30_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 27;
+export const CURRENT_SCHEMA_VERSION = 30;
 
 /**
  * Get current schema version from database
@@ -221,7 +221,24 @@ export function validateSchema(db: Database.Database): boolean {
     `).all() as Array<{ name: string }>;
 
     const tableNames = tables.map(t => t.name);
-    const requiredTables = ['worktrees', 'chat_messages', 'session_states', 'schema_version', 'worktree_memos', 'external_apps', 'repositories', 'clone_jobs', 'scheduled_executions', 'execution_logs', 'daily_reports', 'report_templates', 'app_settings'];
+    const requiredTables = [
+      'worktrees',
+      'chat_messages',
+      'session_states',
+      'schema_version',
+      'worktree_memos',
+      'external_apps',
+      'repositories',
+      'clone_jobs',
+      'scheduled_executions',
+      'execution_logs',
+      'daily_reports',
+      'report_templates',
+      'app_settings',
+      'assistant_conversations',
+      'assistant_messages',
+      'assistant_session_states',
+    ];
 
     const missingTables = requiredTables.filter(t => !tableNames.includes(t));
 

--- a/src/lib/db/migrations/v28-assistant-conversations.ts
+++ b/src/lib/db/migrations/v28-assistant-conversations.ts
@@ -1,0 +1,69 @@
+/** Migration v28: Add assistant conversation tables for Home Assistant Chat. */
+
+import type { Migration } from './runner';
+
+export const v28_migrations: Migration[] = [
+  {
+    version: 28,
+    name: 'add-assistant-conversation-tables',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS assistant_conversations (
+          id TEXT PRIMARY KEY,
+          repository_id TEXT NOT NULL,
+          cli_tool_id TEXT NOT NULL,
+          working_directory TEXT NOT NULL,
+          session_name TEXT,
+          status TEXT NOT NULL DEFAULT 'idle',
+          last_started_at INTEGER,
+          last_stopped_at INTEGER,
+          context_sent_at INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          archived INTEGER NOT NULL DEFAULT 0,
+          UNIQUE(repository_id, cli_tool_id),
+          FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_assistant_conversations_repository_tool
+        ON assistant_conversations(repository_id, cli_tool_id);
+
+        CREATE INDEX IF NOT EXISTS idx_assistant_conversations_status
+        ON assistant_conversations(status, archived, updated_at DESC);
+
+        CREATE TABLE IF NOT EXISTS assistant_messages (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system')),
+          content TEXT NOT NULL,
+          summary TEXT,
+          timestamp INTEGER NOT NULL,
+          message_type TEXT NOT NULL DEFAULT 'normal',
+          delivery_status TEXT CHECK(delivery_status IN ('pending', 'sent', 'failed')),
+          archived INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY (conversation_id) REFERENCES assistant_conversations(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_assistant_messages_conversation_time
+        ON assistant_messages(conversation_id, timestamp DESC);
+
+        CREATE INDEX IF NOT EXISTS idx_assistant_messages_delivery
+        ON assistant_messages(conversation_id, delivery_status, timestamp DESC);
+
+        CREATE TABLE IF NOT EXISTS assistant_session_states (
+          conversation_id TEXT PRIMARY KEY,
+          last_captured_line INTEGER NOT NULL DEFAULT 0,
+          in_progress_message_id TEXT,
+          FOREIGN KEY (conversation_id) REFERENCES assistant_conversations(id) ON DELETE CASCADE
+        );
+      `);
+    },
+    down: (db) => {
+      db.exec(`
+        DROP TABLE IF EXISTS assistant_session_states;
+        DROP TABLE IF EXISTS assistant_messages;
+        DROP TABLE IF EXISTS assistant_conversations;
+      `);
+    },
+  },
+];

--- a/src/lib/db/migrations/v29-assistant-non-interactive.ts
+++ b/src/lib/db/migrations/v29-assistant-non-interactive.ts
@@ -1,0 +1,66 @@
+/** Migration v29: Add non-interactive assistant execution support. */
+
+import type { Migration } from './runner';
+
+export const v29_migrations: Migration[] = [
+  {
+    version: 29,
+    name: 'add-assistant-non-interactive-executions',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE assistant_conversations
+        ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'interactive';
+
+        ALTER TABLE assistant_conversations
+        ADD COLUMN resume_session_id TEXT;
+
+        ALTER TABLE assistant_conversations
+        ADD COLUMN last_execution_id TEXT;
+
+        UPDATE assistant_conversations
+        SET status = CASE
+          WHEN status = 'idle' THEN 'stopped'
+          ELSE status
+        END;
+
+        UPDATE assistant_conversations
+        SET execution_mode = CASE
+          WHEN cli_tool_id IN ('claude', 'codex') THEN 'non_interactive'
+          ELSE 'interactive'
+        END;
+
+        CREATE TABLE IF NOT EXISTS assistant_executions (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          cli_tool_id TEXT NOT NULL,
+          status TEXT NOT NULL,
+          pid INTEGER,
+          command_line TEXT NOT NULL,
+          prompt_text TEXT NOT NULL,
+          stdout_text TEXT,
+          stderr_text TEXT,
+          final_message_text TEXT,
+          exit_code INTEGER,
+          resume_session_id_before TEXT,
+          resume_session_id_after TEXT,
+          started_at INTEGER,
+          finished_at INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          FOREIGN KEY (conversation_id) REFERENCES assistant_conversations(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_assistant_executions_conversation
+        ON assistant_executions(conversation_id, created_at DESC);
+
+        CREATE INDEX IF NOT EXISTS idx_assistant_executions_status
+        ON assistant_executions(status, updated_at DESC);
+      `);
+    },
+    down: (db) => {
+      db.exec(`
+        DROP TABLE IF EXISTS assistant_executions;
+      `);
+    },
+  },
+];

--- a/src/lib/db/migrations/v30-assistant-context-snapshot.ts
+++ b/src/lib/db/migrations/v30-assistant-context-snapshot.ts
@@ -1,0 +1,22 @@
+/** Migration v30: Add startup context snapshot column for assistant conversations. */
+
+import type { Migration } from './runner';
+
+export const v30_migrations: Migration[] = [
+  {
+    version: 30,
+    name: 'add-assistant-context-snapshot',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE assistant_conversations
+        ADD COLUMN context_snapshot TEXT;
+      `);
+    },
+    down: (db) => {
+      db.exec(`
+        ALTER TABLE assistant_conversations
+        DROP COLUMN context_snapshot;
+      `);
+    },
+  },
+];

--- a/src/lib/db/worktree-db.ts
+++ b/src/lib/db/worktree-db.ts
@@ -169,6 +169,7 @@ export function getWorktrees(
  * Get list of unique repositories from worktrees
  */
 export function getRepositories(db: Database.Database): Array<{
+  id?: string;
   path: string;
   name: string;
   displayName?: string;
@@ -176,6 +177,7 @@ export function getRepositories(db: Database.Database): Array<{
 }> {
   const stmt = db.prepare(`
     SELECT
+      r.id as id,
       w.repository_path as path,
       w.repository_name as name,
       r.display_name as display_name,
@@ -188,6 +190,7 @@ export function getRepositories(db: Database.Database): Array<{
   `);
 
   const rows = stmt.all() as Array<{
+    id: string | null;
     path: string;
     name: string;
     display_name: string | null;
@@ -195,6 +198,7 @@ export function getRepositories(db: Database.Database): Array<{
   }>;
 
   return rows.map((row) => ({
+    id: row.id || undefined,
     path: row.path,
     name: row.name,
     displayName: row.display_name || undefined,

--- a/src/lib/polling/assistant-conversation-poller.ts
+++ b/src/lib/polling/assistant-conversation-poller.ts
@@ -1,0 +1,110 @@
+/**
+ * Server-side polling for assistant conversations.
+ * Persists completed assistant responses independent of the active UI tab.
+ */
+
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import { getDbInstance } from '@/lib/db/db-instance';
+import {
+  deleteAssistantSessionState,
+  getAssistantConversationById,
+  updateAssistantConversation,
+} from '@/lib/db';
+import {
+  GLOBAL_POLL_INTERVAL_MS,
+  GLOBAL_POLL_MAX_RETRIES,
+} from '@/lib/session/global-session-constants';
+import { hasSession } from '@/lib/tmux/tmux';
+import { createLogger } from '@/lib/logger';
+import { getAssistantConversationSession } from '@/lib/assistant/conversation-session';
+import { savePendingAssistantResponseForConversation } from '@/lib/assistant/conversation-response-saver';
+
+const logger = createLogger('assistant-conversation-poller');
+
+const activePollers = new Map<string, NodeJS.Timeout>();
+const pollerIterations = new Map<string, number>();
+
+function getPollerKey(conversationId: string, cliToolId: CLIToolType): string {
+  return `${conversationId}:${cliToolId}`;
+}
+
+export function pollAssistantConversation(
+  conversationId: string,
+  cliToolId: CLIToolType
+): void {
+  stopAssistantConversationPolling(conversationId, cliToolId);
+
+  const pollerKey = getPollerKey(conversationId, cliToolId);
+  pollerIterations.set(pollerKey, 0);
+  scheduleNextPoll(conversationId, cliToolId);
+}
+
+export function stopAssistantConversationPolling(
+  conversationId: string,
+  cliToolId: CLIToolType
+): void {
+  const pollerKey = getPollerKey(conversationId, cliToolId);
+  const timerId = activePollers.get(pollerKey);
+  if (timerId) {
+    clearTimeout(timerId);
+    activePollers.delete(pollerKey);
+    pollerIterations.delete(pollerKey);
+  }
+}
+
+export function stopAllAssistantConversationPolling(): void {
+  for (const timerId of activePollers.values()) {
+    clearTimeout(timerId);
+  }
+  activePollers.clear();
+  pollerIterations.clear();
+}
+
+function scheduleNextPoll(conversationId: string, cliToolId: CLIToolType): void {
+  const pollerKey = getPollerKey(conversationId, cliToolId);
+
+  const timerId = setTimeout(async () => {
+    const iteration = pollerIterations.get(pollerKey) ?? 0;
+    if (iteration >= GLOBAL_POLL_MAX_RETRIES) {
+      stopAssistantConversationPolling(conversationId, cliToolId);
+      return;
+    }
+
+    pollerIterations.set(pollerKey, iteration + 1);
+
+    try {
+      const db = getDbInstance();
+      const conversation = getAssistantConversationById(db, conversationId);
+      if (!conversation || conversation.cliToolId !== cliToolId || conversation.status !== 'running') {
+        stopAssistantConversationPolling(conversationId, cliToolId);
+        return;
+      }
+
+      const { sessionName } = getAssistantConversationSession(cliToolId, conversationId);
+      const sessionExists = await hasSession(sessionName);
+      if (!sessionExists) {
+        updateAssistantConversation(db, conversationId, {
+          status: 'stopped',
+          lastStoppedAt: new Date(),
+        });
+        deleteAssistantSessionState(db, conversationId);
+        stopAssistantConversationPolling(conversationId, cliToolId);
+        return;
+      }
+
+      await savePendingAssistantResponseForConversation(db, conversationId, cliToolId);
+    } catch (error) {
+      logger.error('poll:error', {
+        conversationId,
+        cliToolId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    if (activePollers.has(pollerKey)) {
+      scheduleNextPoll(conversationId, cliToolId);
+    }
+  }, GLOBAL_POLL_INTERVAL_MS);
+
+  activePollers.set(pollerKey, timerId);
+}

--- a/src/lib/polling/response-checker.ts
+++ b/src/lib/polling/response-checker.ts
@@ -50,7 +50,7 @@ import { getPollerKey, stopPolling, GEMINI_LOADING_INDICATORS } from './response
 /**
  * Return type for extractResponse(), representing partial or complete response extraction.
  */
-interface ExtractionResult {
+export interface ExtractionResult {
   response: string;
   isComplete: boolean;
   lineCount: number;
@@ -140,7 +140,7 @@ export function detectPromptWithOptions(
  * @param cliToolId - CLI tool ID (claude, codex, gemini)
  * @returns Extracted response or null if incomplete
  */
-function extractResponse(
+export function extractResponse(
   output: string,
   lastCapturedLine: number,
   cliToolId: CLIToolType

--- a/src/types/assistant.ts
+++ b/src/types/assistant.ts
@@ -1,51 +1,47 @@
 /**
- * Type definitions for the assistant chat feature
- * Issue #649: Assistant chat with global (non-worktree) sessions
- *
- * These types define the API request/response shapes for:
- * - Starting an assistant session
- * - Sending terminal commands
- * - Retrieving current output
+ * Types for Home Assistant Chat conversation APIs.
  */
 
 import type { CLIToolType } from '@/lib/cli-tools/types';
+import type {
+  AssistantConversation,
+  AssistantMessage,
+} from '@/lib/db/assistant-conversation-db';
 
-/**
- * Request body for POST /api/assistant/start
- */
 export interface StartAssistantRequest {
-  /** CLI tool to use for the session (claude, codex, gemini, etc.) */
   cliToolId: CLIToolType;
-  /** Working directory path for the session */
-  workingDirectory: string;
+  repositoryId: string;
 }
 
-/**
- * Response body for POST /api/assistant/start
- */
 export interface StartAssistantResponse {
-  /** Whether the session was started successfully */
   success: boolean;
-  /** The tmux session name that was created */
-  sessionName: string;
+  conversation: AssistantConversation;
+  executionMode?: 'interactive' | 'non_interactive';
+  resumeAvailable?: boolean;
 }
 
-/**
- * Request body for POST /api/assistant/terminal
- */
+export interface AssistantConversationResponse {
+  conversation: AssistantConversation | null;
+}
+
+export interface AssistantMessagesResponse {
+  conversationId: string;
+  messages: AssistantMessage[];
+}
+
 export interface AssistantTerminalRequest {
-  /** CLI tool ID for the active session */
   cliToolId: CLIToolType;
-  /** Command/message to send to the session */
+  conversationId: string;
   command: string;
 }
 
-/**
- * Response body for GET /api/assistant/current-output
- */
 export interface AssistantCurrentOutputResponse {
-  /** Captured terminal output */
   output: string;
-  /** Whether the session is still active */
   sessionActive: boolean;
+}
+
+export interface AssistantSendResponse {
+  success: boolean;
+  messageId: string;
+  executionId?: string;
 }

--- a/tests/unit/AssistantChatPanel.test.tsx
+++ b/tests/unit/AssistantChatPanel.test.tsx
@@ -4,13 +4,15 @@
 
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { AssistantChatPanel } from '@/components/home/AssistantChatPanel';
 import { assistantApi } from '@/lib/api/assistant-api';
 
 vi.mock('@/lib/api/assistant-api', () => ({
   assistantApi: {
     getInstalledTools: vi.fn(),
+    getConversation: vi.fn(),
+    getMessages: vi.fn(),
     startSession: vi.fn(),
     stopSession: vi.fn(),
     sendCommand: vi.fn(),
@@ -30,7 +32,12 @@ describe('AssistantChatPanel', () => {
       ok: true,
       json: async () => ({
         repositories: [
-          { path: '/repos/alpha', name: 'alpha', displayName: 'Alpha Repo' },
+          {
+            id: 'repo-1',
+            path: '/repos/alpha',
+            name: 'alpha',
+            displayName: 'Alpha Repo',
+          },
         ],
       }),
     } as Response);
@@ -38,6 +45,12 @@ describe('AssistantChatPanel', () => {
     vi.mocked(assistantApi.getInstalledTools).mockResolvedValue([
       { id: 'claude', name: 'Claude Code', installed: true },
     ]);
+    vi.mocked(assistantApi.getConversation).mockResolvedValue(null);
+    vi.mocked(assistantApi.getMessages).mockResolvedValue([]);
+    vi.mocked(assistantApi.getCurrentOutput).mockResolvedValue({
+      output: '',
+      sessionActive: false,
+    });
   });
 
   afterEach(() => {
@@ -48,35 +61,20 @@ describe('AssistantChatPanel', () => {
     render(<AssistantChatPanel />);
 
     expect(screen.getByTestId('assistant-chat-panel')).toHaveClass('bg-slate-950/95');
-    expect(screen.getByTestId('assistant-toggle-button')).toHaveClass('bg-slate-900/90');
   });
 
-  it('explains what the repository selector controls', async () => {
+  it('shows repository selector and start directory hint', async () => {
     render(<AssistantChatPanel />);
 
-    fireEvent.click(screen.getByTestId('assistant-toggle-button'));
-
-    expect(
-      await screen.findByText(
-        'Start a local assistant session in a repository and chat from that working directory.',
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Repository to Work In')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'The repository selection sets where the assistant starts running commands and reading files.',
-      ),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Repository to Work In')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText('Start directory: Alpha Repo')).toBeInTheDocument();
+      expect(screen.getByText('Start directory: Alpha Repo (/repos/alpha)')).toBeInTheDocument();
     });
   });
 
   it('shows a clearer empty-state prompt before the session starts', async () => {
     render(<AssistantChatPanel />);
-
-    fireEvent.click(screen.getByTestId('assistant-toggle-button'));
 
     expect(
       await screen.findByText('Select a repository and click Start to open an assistant session.'),

--- a/tests/unit/GlobalMobileNav.test.tsx
+++ b/tests/unit/GlobalMobileNav.test.tsx
@@ -34,11 +34,12 @@ describe('GlobalMobileNav', () => {
     mockRouterPush.mockClear();
   });
 
-  it('should render 4 tabs: Home, Sessions, Review/Report, More', () => {
+  it('should render 5 tabs: Home, Chat, Sessions, Review, More', () => {
     render(<GlobalMobileNav />);
     expect(screen.getByText('Home')).toBeDefined();
+    expect(screen.getByText('Chat')).toBeDefined();
     expect(screen.getByText('Sessions')).toBeDefined();
-    expect(screen.getByText('Review/Report')).toBeDefined();
+    expect(screen.getByText('Review')).toBeDefined();
     expect(screen.getByText('More')).toBeDefined();
   });
 
@@ -51,11 +52,13 @@ describe('GlobalMobileNav', () => {
   it('should have correct hrefs for tabs', () => {
     render(<GlobalMobileNav />);
     const homeLink = screen.getByText('Home').closest('a');
+    const chatLink = screen.getByText('Chat').closest('a');
     const sessionsLink = screen.getByText('Sessions').closest('a');
-    const reviewLink = screen.getByText('Review/Report').closest('a');
+    const reviewLink = screen.getByText('Review').closest('a');
     const moreLink = screen.getByText('More').closest('a');
 
     expect(homeLink?.getAttribute('href')).toBe('/');
+    expect(chatLink?.getAttribute('href')).toBe('/chat');
     expect(sessionsLink?.getAttribute('href')).toBe('/sessions');
     expect(reviewLink?.getAttribute('href')).toBe('/review');
     expect(moreLink?.getAttribute('href')).toBe('/more');
@@ -75,10 +78,10 @@ describe('GlobalMobileNav', () => {
     expect(sessionsLink?.className).toContain('text-cyan-600');
   });
 
-  it('should highlight active Review/Report tab when on /review', () => {
+  it('should highlight active Review tab when on /review', () => {
     mockPathname.mockReturnValue('/review');
     render(<GlobalMobileNav />);
-    const reviewLink = screen.getByText('Review/Report').closest('a');
+    const reviewLink = screen.getByText('Review').closest('a');
     expect(reviewLink?.className).toContain('text-cyan-600');
   });
 

--- a/tests/unit/assistant-context-builder.test.ts
+++ b/tests/unit/assistant-context-builder.test.ts
@@ -12,6 +12,12 @@ vi.mock('@/lib/db/db-repository', () => ({
   getAllRepositories: (...args: unknown[]) => mockGetAllRepositories(...args),
 }));
 
+// Mock getWorktrees (context builder reports worktree counts and an active snapshot)
+const mockGetWorktrees = vi.fn();
+vi.mock('@/lib/db/worktree-db', () => ({
+  getWorktrees: (...args: unknown[]) => mockGetWorktrees(...args),
+}));
+
 import { buildGlobalContext, getEnabledRepositories } from '@/lib/assistant/context-builder';
 
 // Create a mock DB instance
@@ -34,6 +40,7 @@ function createMockRepository(overrides: Partial<Repository> = {}): Repository {
 describe('buildGlobalContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetWorktrees.mockReturnValue([]);
   });
 
   it('should include the CLI tool display name', () => {
@@ -81,7 +88,9 @@ describe('buildGlobalContext', () => {
 
     const context = buildGlobalContext('claude', mockDb);
 
-    expect(context).toContain('(disabled)');
+    expect(context).toContain('disabled-repo');
+    // Repositories table now uses an Enabled column with yes/no
+    expect(context).toMatch(/disabled-repo.*\|.*no/);
   });
 
   it('should show message when no repositories exist', () => {

--- a/tests/unit/lib/assistant-conversation-db.test.ts
+++ b/tests/unit/lib/assistant-conversation-db.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { createRepository } from '@/lib/db/db-repository';
+import {
+  createAssistantConversation,
+  createAssistantExecution,
+  createAssistantMessage,
+  deleteAssistantSessionState,
+  getAssistantConversationById,
+  getLatestAssistantExecutionByConversation,
+  getRunningAssistantExecutionByConversation,
+  getAssistantConversationByRepositoryAndCliTool,
+  getAssistantMessages,
+  getAssistantSessionState,
+  updateAssistantConversation,
+  updateAssistantExecution,
+  updateAssistantMessageStatus,
+  updateAssistantSessionState,
+} from '@/lib/db';
+
+describe('assistant-conversation-db', () => {
+  let db: Database.Database;
+  let repositoryId: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+
+    repositoryId = createRepository(db, {
+      name: 'repo-alpha',
+      path: '/tmp/repo-alpha',
+      cloneSource: 'local',
+    }).id;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates and reloads a conversation by repository and tool', () => {
+    const conversation = createAssistantConversation(db, {
+      repositoryId,
+      cliToolId: 'codex',
+      workingDirectory: '/tmp/repo-alpha',
+      status: 'stopped',
+    });
+
+    const byId = getAssistantConversationById(db, conversation.id);
+    const bySelector = getAssistantConversationByRepositoryAndCliTool(db, repositoryId, 'codex');
+
+    expect(byId?.id).toBe(conversation.id);
+    expect(bySelector?.id).toBe(conversation.id);
+    expect(bySelector?.workingDirectory).toBe('/tmp/repo-alpha');
+  });
+
+  it('stores delivery status and chronological messages', () => {
+    const conversation = createAssistantConversation(db, {
+      repositoryId,
+      cliToolId: 'codex',
+      workingDirectory: '/tmp/repo-alpha',
+      executionMode: 'non_interactive',
+      status: 'ready',
+    });
+
+    const userMessage = createAssistantMessage(db, {
+      conversationId: conversation.id,
+      role: 'user',
+      content: 'hello',
+      messageType: 'normal',
+      deliveryStatus: 'pending',
+      timestamp: new Date('2026-04-14T10:00:00.000Z'),
+    });
+    updateAssistantMessageStatus(db, userMessage.id, 'sent');
+
+    createAssistantMessage(db, {
+      conversationId: conversation.id,
+      role: 'assistant',
+      content: 'hi',
+      messageType: 'normal',
+      timestamp: new Date('2026-04-14T10:00:01.000Z'),
+    });
+
+    const messages = getAssistantMessages(db, conversation.id);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe('hi');
+    expect(messages[1].deliveryStatus).toBe('sent');
+  });
+
+  it('tracks and deletes assistant session state', () => {
+    const conversation = createAssistantConversation(db, {
+      repositoryId,
+      cliToolId: 'codex',
+      workingDirectory: '/tmp/repo-alpha',
+      status: 'running',
+    });
+
+    updateAssistantSessionState(db, conversation.id, 42, 'message-1');
+    expect(getAssistantSessionState(db, conversation.id)).toEqual({
+      conversationId: conversation.id,
+      lastCapturedLine: 42,
+      inProgressMessageId: 'message-1',
+    });
+
+    deleteAssistantSessionState(db, conversation.id);
+    expect(getAssistantSessionState(db, conversation.id)).toBeNull();
+  });
+
+  it('stores and updates assistant executions', () => {
+    const conversation = createAssistantConversation(db, {
+      repositoryId,
+      cliToolId: 'codex',
+      workingDirectory: '/tmp/repo-alpha',
+      executionMode: 'non_interactive',
+      status: 'ready',
+    });
+
+    const execution = createAssistantExecution(db, {
+      conversationId: conversation.id,
+      cliToolId: 'codex',
+      status: 'running',
+      commandLine: 'codex exec --json',
+      promptText: 'hello',
+      startedAt: new Date('2026-04-14T10:00:00.000Z'),
+    });
+
+    expect(getRunningAssistantExecutionByConversation(db, conversation.id)?.id).toBe(execution.id);
+
+    updateAssistantExecution(db, execution.id, {
+      status: 'completed',
+      stdoutText: 'stdout',
+      finalMessageText: 'assistant reply',
+      finishedAt: new Date('2026-04-14T10:00:02.000Z'),
+    });
+    updateAssistantConversation(db, conversation.id, {
+      lastExecutionId: execution.id,
+      resumeSessionId: 'resume-1',
+    });
+
+    const reloadedConversation = getAssistantConversationById(db, conversation.id);
+    const latestExecution = getLatestAssistantExecutionByConversation(db, conversation.id);
+
+    expect(reloadedConversation?.lastExecutionId).toBe(execution.id);
+    expect(reloadedConversation?.resumeSessionId).toBe('resume-1');
+    expect(latestExecution?.status).toBe('completed');
+    expect(latestExecution?.finalMessageText).toBe('assistant reply');
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 27 after Migration #27', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(27);
+    it('should be 30 after Migration #30', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(30);
     });
   });
 
@@ -63,6 +63,29 @@ describe('db-migrations', () => {
       expect(history.length).toBe(CURRENT_SCHEMA_VERSION);
       expect(history.find(m => m.version === 16)?.name).toBe('add-issue-no-to-external-apps');
       expect(history.find(m => m.version === 17)?.name).toBe('add-scheduled-executions-and-execution-logs');
+    });
+
+    it('should create assistant conversation tables', () => {
+      runMigrations(db);
+
+      const tables = db.prepare(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table'
+          AND name IN (
+            'assistant_conversations',
+            'assistant_messages',
+            'assistant_session_states',
+            'assistant_executions'
+          )
+        ORDER BY name
+      `).all() as Array<{ name: string }>;
+
+      expect(tables.map((table) => table.name)).toEqual([
+        'assistant_conversations',
+        'assistant_executions',
+        'assistant_messages',
+        'assistant_session_states',
+      ]);
     });
   });
 
@@ -495,7 +518,7 @@ describe('db-migrations', () => {
   describe('rollbackMigrations', () => {
     it('should rollback Migration #17 and remove schedule tables', () => {
       runMigrations(db);
-      expect(getCurrentVersion(db)).toBe(27);
+      expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
 
       rollbackMigrations(db, 16);
       expect(getCurrentVersion(db)).toBe(16);
@@ -508,7 +531,7 @@ describe('db-migrations', () => {
 
     it('should rollback Migration #16 and remove issue_no column', () => {
       runMigrations(db);
-      expect(getCurrentVersion(db)).toBe(27);
+      expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
 
       rollbackMigrations(db, 15);
       expect(getCurrentVersion(db)).toBe(15);


### PR DESCRIPTION
## Summary
- Introduce a dedicated `/chat` tab that hosts the Assistant Chat, migrated out of the Home page; PC header and mobile nav both gain a Chat entry.
- Restrict Assistant Chat to `claude` / `codex` and drive them through non-interactive execution (`claude -p --output-format stream-json --verbose --permission-mode bypassPermissions`, `codex exec --json --full-auto`).
- Persist a startup context snapshot on the conversation (CLI reference, repositories with worktree counts, active worktree status) so the prompt stays stable across messages; CLI reference shows `commandmate` when launched via `commandmate start` and `commandmatedev` otherwise (driven by `CM_LAUNCHED_BY`).
- Add Markdown rendering, copy button, edit-and-resend for chat messages, a "thinking" spinner during execution, and a clear-history action that also truncates from an edited message onward.
- Add migrations v28–v30 and supporting DB/API layer (assistant conversations, executions, session states, context snapshot); fix Codex output parsing to read `item.completed` agent messages.

## Test plan
- [ ] `/chat` loads, Home page no longer embeds Assistant Chat, nav highlights correct tab.
- [ ] Tool selector only shows Claude / Codex; `gemini` and other tools are rejected with 400 from `/api/assistant/start` and `/api/assistant/terminal`.
- [ ] With `./scripts/build-and-start.sh --daemon` launch, assistant context lists commands as `commandmatedev ...`; with `commandmate start` the same section shows `commandmate ...`.
- [ ] Sending a simple message to Claude returns a completed execution (`exit_code: 0`, final message shown).
- [ ] Sending a message that triggers a tool use (e.g. "run ls") completes without permission prompts (Claude `bypassPermissions`, Codex `--full-auto`).
- [ ] Editing a prior user message archives it + subsequent replies, resets `resume_session_id`, and sends the edited content as a fresh turn.
- [ ] Clear history wipes the displayed chat and resets the resume session.
- [ ] Markdown rendering works (code blocks, GFM tables); copy button writes the raw text; edit button is disabled while an execution is running.
- [ ] `npx tsc --noEmit` passes, `npx vitest run tests/unit/AssistantChatPanel.test.tsx tests/unit/lib/assistant-conversation-db.test.ts tests/unit/lib/db-migrations.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)