### PR TITLE
fix(#675): stop MarkdownEditor re-render loop blocking worktree URL updates

### DIFF
--- a/dev-reports/bug-fix/20260424_201916_issue675/acceptance-context.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/acceptance-context.json
@@ -1,0 +1,73 @@
+{
+  "bug_id": "20260424_201916_issue675",
+  "issue_number": 675,
+  "bug_description": ".md ファイル表示中にサイドバーから別ブランチを選択しても URL が更新されず画面遷移しない。",
+  "fix_summary": "(A案) WorktreeDetailRefactored.tsx:1298-1317 の 4 つの useCallback (handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange) の deps を [fileTabs] から [fileTabs.dispatch] に変更してコールバック identity を安定化。(B案) useFileTabs.ts の SET_DIRTY reducer で対象 tab の isDirty が同値なら state を同一参照で返す no-op 判定を追加。結果として MarkdownEditor の useEffect が不要に発火しなくなり、無限 re-render ループが解消され、router.push の transition が starve しなくなる。",
+  "commit": "e91e1928",
+  "branch": "feature/675-worktree",
+  "changed_files": [
+    "src/components/worktree/WorktreeDetailRefactored.tsx",
+    "src/hooks/useFileTabs.ts",
+    "tests/unit/hooks/useFileTabs.test.ts"
+  ],
+  "acceptance_criteria": [
+    "SET_DIRTY 同値 dispatch で state 参照が変わらない (unit test で検証済)",
+    "SET_DIRTY で isDirty が真に変化する場合は従来通り新 state が返る (既存テストで回帰なし)",
+    "useCallback deps 変更後も handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange の動作は変わらない (既存統合テスト / 型チェックで担保)",
+    "ESLint (npm run lint) がパスする",
+    "TypeScript 型チェック (npx tsc --noEmit) がパスする",
+    "Unit テスト (npm run test:unit) 全件パスする",
+    "ビルド (npm run build) がパスする"
+  ],
+  "test_scenarios": [
+    {
+      "id": "S1",
+      "type": "automated-unit",
+      "description": "B案の no-op 検証: SET_DIRTY で isDirty=false → false の 2 回 dispatch で state 参照が変わらない",
+      "verification_method": "npm run test:unit -- tests/unit/hooks/useFileTabs.test.ts"
+    },
+    {
+      "id": "S2",
+      "type": "automated-unit",
+      "description": "B案の回帰防止: SET_DIRTY で isDirty=false → true の dispatch で新 state 参照が返り、tabs[i].isDirty が更新される",
+      "verification_method": "npm run test:unit -- tests/unit/hooks/useFileTabs.test.ts"
+    },
+    {
+      "id": "S3",
+      "type": "static",
+      "description": "A案の適用確認: WorktreeDetailRefactored.tsx の 4 つの useCallback deps が [fileTabs.dispatch] になっている",
+      "verification_method": "grep で deps を確認"
+    },
+    {
+      "id": "S4",
+      "type": "automated-full",
+      "description": "全ユニットテスト通過 / ESLint / TypeScript / ビルド",
+      "verification_method": "npm run lint && npx tsc --noEmit && npm run test:unit && npm run build"
+    },
+    {
+      "id": "S5",
+      "type": "manual (optional)",
+      "description": "手動受入: Worktree A で .md ファイルを開いた状態 → サイドバーから Worktree B を選択 → URL が /worktrees/B に変わる",
+      "verification_method": "サーバーを起動 (commandmate start) して実機確認"
+    },
+    {
+      "id": "S6",
+      "type": "manual (optional)",
+      "description": "手動受入: .yaml / .yml でも同様に遷移する (MarkdownEditor 経由の拡張子)",
+      "verification_method": "実機確認"
+    },
+    {
+      "id": "S7",
+      "type": "manual-regression (optional)",
+      "description": "回帰確認: .png / .json 表示中でもサイドバー遷移が動作する (もともと再現しないので挙動維持)",
+      "verification_method": "実機確認"
+    }
+  ],
+  "out_of_scope": [
+    "WorktreeDetailRefactored.tsx L551/L570/L581/L875/L904 の同種アンチパターン修正 (別 Issue 化予定)"
+  ],
+  "notes": [
+    "S5-S7 の手動受入は本セッション内では実機起動せず、コードレベルでの検証 (S1-S4) のみを実施してください。ユーザー側で必要に応じて実機確認します。",
+    "acceptance-test-agent は自動検証 (S1-S4) を実行し、結果を acceptance-result.json に記録してください。"
+  ]
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/acceptance-result.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/acceptance-result.json
@@ -1,0 +1,126 @@
+{
+  "bug_id": "20260424_201916_issue675",
+  "issue_number": 675,
+  "branch": "feature/675-worktree",
+  "commit": "e91e1928",
+  "executed_at": "2026-04-24T20:34:00+09:00",
+  "overall_result": "PASS",
+  "summary": "Issue #675 バグ修正 (A案: useCallback deps 安定化 / B案: SET_DIRTY no-op short-circuit) の自動受入テスト (S1-S4) をすべて実施し、全項目 PASS を確認。実機テスト (S5-S7) は指示通りスキップ。",
+  "scenarios": [
+    {
+      "id": "S1",
+      "description": "B案の no-op 検証: SET_DIRTY で isDirty=false → false の 2 回 dispatch で state 参照が変わらない",
+      "result": "PASS",
+      "evidence": {
+        "test_file": "tests/unit/hooks/useFileTabs.test.ts",
+        "test_cases": [
+          "SET_DIRTY should return same state reference when isDirty is already the same value (false→false) (line 455)",
+          "SET_DIRTY should return same state reference when isDirty is already the same value (true→true) (line 466)",
+          "SET_DIRTY applied twice with the same value returns a stable reference (line 477)"
+        ],
+        "implementation": "src/hooks/useFileTabs.ts:242 `if (current && current.isDirty === action.isDirty) return state;`",
+        "test_run": "44 passed (44) — tests/unit/hooks/useFileTabs.test.ts"
+      }
+    },
+    {
+      "id": "S2",
+      "description": "B案の回帰防止: SET_DIRTY で isDirty=false → true で新 state 参照が返り tabs[i].isDirty が更新される",
+      "result": "PASS",
+      "evidence": {
+        "test_file": "tests/unit/hooks/useFileTabs.test.ts",
+        "test_cases": [
+          "SET_DIRTY should set isDirty to true for the specified tab (line 406)",
+          "SET_DIRTY should set isDirty to false for the specified tab (line 417)",
+          "SET_DIRTY should only affect the specified tab (line 428)",
+          "SET_DIRTY should return same state if path not found (line 443)"
+        ],
+        "test_run": "44 passed (44) — tests/unit/hooks/useFileTabs.test.ts"
+      }
+    },
+    {
+      "id": "S3",
+      "description": "A案の適用確認: WorktreeDetailRefactored.tsx の 4 useCallback deps が [fileTabs.dispatch]",
+      "result": "PASS",
+      "evidence": {
+        "command": "grep -n \"fileTabs.dispatch\\]\" src/components/worktree/WorktreeDetailRefactored.tsx",
+        "matches": [
+          "1304:  }, [fileTabs.dispatch]);  // handleLoadContent",
+          "1309:  }, [fileTabs.dispatch]);  // handleLoadError",
+          "1314:  }, [fileTabs.dispatch]);  // handleSetLoading",
+          "1320:  }, [fileTabs.dispatch]);  // handleDirtyChange"
+        ],
+        "count": 4,
+        "expected": 4
+      }
+    },
+    {
+      "id": "S4",
+      "description": "lint / typecheck / unit test / build が全て通る",
+      "result": "PASS",
+      "evidence": {
+        "lint": {
+          "command": "npm run lint",
+          "result": "PASS",
+          "output": "✔ No ESLint warnings or errors"
+        },
+        "typecheck": {
+          "command": "npx tsc --noEmit",
+          "result": "PASS",
+          "output": "(no output = success, exit 0)"
+        },
+        "unit_test": {
+          "command": "npm run test:unit",
+          "result": "PASS",
+          "output": "Test Files 340 passed (340); Tests 6384 passed | 7 skipped (6391); Duration 13.54s",
+          "note": "stderr に出力された 'useWorktreeSelection / useSidebarContext must be used within Provider' / 'Report generation failed' などはテスト側が意図的にエラー分岐を検証しているケースで、テスト結果は all passed。"
+        },
+        "build": {
+          "command": "npm run build",
+          "result": "PASS",
+          "output": "✓ Compiled successfully",
+          "note": "ビルド中に /api/assistant/current-output の 'Dynamic server usage' ログが表示されるが、これは Next.js 14 が dynamic route を情報ログとして出しているもので、ビルド出力でも該当ルートは 'ƒ (Dynamic)' としてマークされており、成功を阻害しない。"
+        }
+      }
+    },
+    {
+      "id": "S5",
+      "description": "手動受入: Worktree A で .md を開いた状態 → サイドバーから Worktree B 選択で URL が更新",
+      "result": "SKIPPED",
+      "reason": "指示により実機起動は行わない (S5-S7 はユーザー側で実機確認予定)"
+    },
+    {
+      "id": "S6",
+      "description": "手動受入: .yaml / .yml でも同様に遷移",
+      "result": "SKIPPED",
+      "reason": "指示により実機起動は行わない"
+    },
+    {
+      "id": "S7",
+      "description": "回帰確認: .png / .json 表示中でもサイドバー遷移が動作",
+      "result": "SKIPPED",
+      "reason": "指示により実機起動は行わない"
+    }
+  ],
+  "supplementary_checks": [
+    {
+      "name": "B案 実装確認 (useFileTabs.ts)",
+      "command": "grep -n \"current.isDirty === action.isDirty\" src/hooks/useFileTabs.ts",
+      "result": "PASS",
+      "match": "242:      if (current && current.isDirty === action.isDirty) return state;"
+    }
+  ],
+  "acceptance_criteria_status": [
+    { "criterion": "SET_DIRTY 同値 dispatch で state 参照が変わらない", "status": "PASS", "scenario": "S1" },
+    { "criterion": "SET_DIRTY で isDirty が真に変化する場合は従来通り新 state が返る", "status": "PASS", "scenario": "S2" },
+    { "criterion": "useCallback deps 変更後も 4 ハンドラの動作は変わらない", "status": "PASS", "scenario": "S3 (static) + S4 (unit/type)" },
+    { "criterion": "ESLint (npm run lint) がパスする", "status": "PASS", "scenario": "S4" },
+    { "criterion": "TypeScript 型チェック (npx tsc --noEmit) がパスする", "status": "PASS", "scenario": "S4" },
+    { "criterion": "Unit テスト (npm run test:unit) 全件パスする", "status": "PASS", "scenario": "S4" },
+    { "criterion": "ビルド (npm run build) がパスする", "status": "PASS", "scenario": "S4" }
+  ],
+  "failures": [],
+  "recommendations": [
+    "本セッションで自動検証は全て通過したので、ユーザーは実機 (commandmate start) で S5-S7 を確認することを推奨: Worktree A(.md/.yaml/.yml 開いた状態) → サイドバーで Worktree B 選択 → URL が /worktrees/{B} に更新される / 非対象拡張子 (.png/.json) でも遷移する。",
+    "out_of_scope の WorktreeDetailRefactored.tsx L551/L570/L581/L875/L904 の同種アンチパターン (useCallback deps に Object 全体を渡しているパターン) は別 Issue で扱う予定のため、本受入では検証対象外。"
+  ]
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/investigation-context.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/investigation-context.json
@@ -1,0 +1,60 @@
+{
+  "issue_number": 675,
+  "issue_title": "fix: Markdown ファイル表示中にサイドバーからのブランチ遷移が効かない (onDirtyChange 無限ループ)",
+  "issue_description": "Files タブから .md ファイルを開いて表示している状態で、サイドバーから別のブランチを選択しても URL が変化せず画面遷移しない。クリックハンドラや router.push は発火しているが、Next.js App Router の navigation transition が commit されない。",
+  "reported_root_cause": "MarkdownEditor の onDirtyChange が毎レンダー identity が変わる useCallback を prop として受け取り、useEffect([isDirty, onDirtyChange]) が毎レンダー発火 → dispatch SET_DIRTY (同値でも新 state 生成) → 再レンダー連鎖。useEffect 内 dispatch が高優先度更新としてキューに常時積まれ続け、router.push 内部の startTransition (低優先度 transition) が割り込まれて commit されない。",
+  "reported_chain": [
+    "useFileTabs.ts: return 戻り値が毎レンダー新オブジェクト (分割代入なしで返すため deps に fileTabs 全体を置くと参照が毎回変わる)",
+    "WorktreeDetailRefactored.tsx: useCallback の deps が [fileTabs] なので毎レンダー新関数 (handleDirtyChange / handleLoadContent / handleLoadError / handleSetLoading)",
+    "FilePanelContent.tsx: useMemo deps に変動する onDirtyChange を含むためラッパーも毎回新しい",
+    "MarkdownEditor.tsx: useEffect deps の onDirtyChange が毎回新しいので useEffect が毎レンダー発火",
+    "useFileTabs.ts SET_DIRTY reducer: 同値でも常に新しい state を返すため再レンダーが必ず起きる"
+  ],
+  "affected_files": [
+    "src/hooks/useFileTabs.ts",
+    "src/components/worktree/WorktreeDetailRefactored.tsx",
+    "src/components/worktree/FilePanelContent.tsx",
+    "src/components/worktree/MarkdownEditor.tsx"
+  ],
+  "specific_line_references": {
+    "src/hooks/useFileTabs.ts:239-246": "SET_DIRTY reducer (同値判定なし)",
+    "src/hooks/useFileTabs.ts:384": "return { state, dispatch, openFile, ... } が毎レンダー新オブジェクト",
+    "src/components/worktree/WorktreeDetailRefactored.tsx:1298-1313": "handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange が deps=[fileTabs] で不安定",
+    "src/components/worktree/FilePanelContent.tsx:563-568": "useMemo で onDirtyChange をラップ",
+    "src/components/worktree/MarkdownEditor.tsx:226-228": "useEffect([isDirty, onDirtyChange]) で onDirtyChange 呼び出し"
+  },
+  "reproduction_steps": [
+    "1. 任意の Worktree を開く",
+    "2. 左ペインの Files タブから任意の .md ファイルを選択し、右ペインのファイルパネルに表示する",
+    "3. サイドバーから別のブランチを選択（クリック）する"
+  ],
+  "observed_behaviors": [
+    "URL が変化しない",
+    "ファイルタブを全て閉じると正常に遷移する",
+    ".png / .json などの他ファイル種別では再現しない（.md 限定）",
+    "最大化状態とは無関係",
+    "history.pushState 直叩きだと URL は更新される",
+    "サイドバー onClick は発火している"
+  ],
+  "proposed_fixes": {
+    "A": {
+      "title": "useCallback deps を fileTabs.dispatch のみに絞る",
+      "target": "src/components/worktree/WorktreeDetailRefactored.tsx:1298-1313",
+      "rationale": "dispatch は useReducer 由来で stable。コールバック identity 安定化で無限ループを切る"
+    },
+    "B": {
+      "title": "SET_DIRTY reducer で同値時 no-op",
+      "target": "src/hooks/useFileTabs.ts:239-246",
+      "rationale": "将来 deps が崩れても同値 dispatch は state 変更を起こさず再レンダーしない防衛線"
+    }
+  },
+  "environment": {
+    "os": "macOS (Darwin 25.4.0)",
+    "browser": "Chrome (desktop)",
+    "branch": "develop",
+    "related_commit": "edc7193d fix(#673): make PDF preview work on real Chrome (desktop + mobile)",
+    "node_version": "unknown"
+  },
+  "severity_hint": "high",
+  "investigation_request": "1) Issue 本文に記載されたコード位置が現行コードと一致しているか検証する。2) 分析（無限ループで router.push が discard される構造）が妥当か、追加で留意すべき副作用箇所がないか確認する。3) 同じアンチパターン（useCallback/useMemo の deps にオブジェクト全体を置いている）が他に潜んでいないかをざっと確認する。出力は investigation-result.json に保存してください。"
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/investigation-result.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/investigation-result.json
@@ -1,0 +1,205 @@
+{
+  "status": "completed",
+  "investigation_summary": {
+    "issue_description": "Files タブで .md を表示中、サイドバーのブランチ切替で URL 遷移が commit されない。原因は MarkdownEditor の useEffect([isDirty, onDirtyChange]) が毎レンダー再実行され、dispatch({type: 'SET_DIRTY'}) の同値更新でも新 state を生成して再レンダーが続き、router.push が起動した transition が低優先度のまま scheduler に starve される挙動。",
+    "error_type": "React re-render loop starving App Router transition",
+    "affected_files": [
+      "src/hooks/useFileTabs.ts",
+      "src/components/worktree/WorktreeDetailRefactored.tsx",
+      "src/components/worktree/FilePanelContent.tsx",
+      "src/components/worktree/MarkdownEditor.tsx"
+    ],
+    "reproduction_confirmed": "code-level (ソースコード上で再現メカニズムを確認。実機再現は Issue の再現手順に記載済み)"
+  },
+  "code_location_verification": {
+    "useFileTabs_SET_DIRTY_reducer": {
+      "issue_claim": "src/hooks/useFileTabs.ts:239-246 SET_DIRTY reducer は同値判定なし",
+      "verified": true,
+      "note": "L239-246 の reducer は updateTabByPath(...) → {...state, tabs: newTabs} を常に返すため、同値(例: isDirty=false → false)でも新 state 参照を返す。",
+      "evidence": "updateTabByPath(tabs, action.path, (tab) => ({...tab, isDirty: action.isDirty})) は配列コピー + オブジェクトコピーを無条件で実施"
+    },
+    "useFileTabs_return_object": {
+      "issue_claim": "src/hooks/useFileTabs.ts:384 return { state, dispatch, openFile, ... } が毎レンダー新オブジェクト",
+      "verified": true,
+      "note": "L384 で毎レンダー新オブジェクトリテラルを返すため、呼び出し側で deps=[fileTabs] にすると毎回 deps 変化。個々のメンバ(dispatch は useReducer 由来で stable、openFile/closeTab/activateTab/onFileRenamed/onFileDeleted/moveToFront は useCallback([]) で stable)は安定しているのに、ラッパーオブジェクトだけが不安定。"
+    },
+    "WorktreeDetailRefactored_callbacks_deps": {
+      "issue_claim": "L1298-1313 handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange の useCallback deps=[fileTabs]",
+      "verified": true,
+      "note": "L1300, L1304, L1308, L1313 すべて deps=[fileTabs]。fileTabs ラッパーが毎レンダー新参照なので 4 つのコールバックも毎レンダー再生成される。"
+    },
+    "FilePanelContent_handleDirtyChange_memo": {
+      "issue_claim": "src/components/worktree/FilePanelContent.tsx:563-568 useMemo で onDirtyChange をラップ (deps=[onDirtyChange, tab.path])",
+      "verified": true,
+      "note": "親から渡る onDirtyChange が毎回新参照のため、handleDirtyChange useMemo も毎回新関数。下位 (MarkdownEditor 他) に伝播。"
+    },
+    "MarkdownEditor_useEffect": {
+      "issue_claim": "src/components/worktree/MarkdownEditor.tsx:226-228 useEffect([isDirty, onDirtyChange]) で onDirtyChange?.(isDirty) を呼ぶ",
+      "verified": true,
+      "note": "L226-228 は isDirty が false 継続でも、onDirtyChange identity が毎レンダー変わるため effect が毎レンダー発火 → dispatch SET_DIRTY を親が呼ぶ → SET_DIRTY reducer が無条件で新 state → 親再レンダー → onDirtyChange 再生成 → ... の連鎖を構成。"
+    }
+  },
+  "analysis_validity": {
+    "infinite_loop_mechanism": {
+      "verdict": "概ね妥当",
+      "comment": "『useEffect 内 dispatch が高優先度更新としてキューに積まれ続け、router.push の transition が discard される』という説明は半分正しい。React 18 の並行レンダリングでは、sync(既定) priority の setState が繰り返し発生すると transition (低優先度) は commit されず、実質的にスターブ(starve)する。厳密には『discard』ではなく『repeatedly deferred / starved』。ただし現象としては URL が反映されないことに変わりなく、Issue 本文の原因分析としては成立する。修正方針 (A/B どちらも) によって dispatch が停止 → transition が commit できる、という結論は正しい。"
+    },
+    "md_only_reason": {
+      "verdict": "半分正しい (より正確には MarkdownEditor を描画する拡張子で再現)",
+      "comment": "FilePanelContent.tsx を確認: (1) content.extension === 'md' → MarkdownWithSearch → MarkdownEditor、(2) isEditableExtension('.'+ext) → MarkdownWithSearch → MarkdownEditor (YAML/YML等)、(3) MarpEditorWithSlides → MarkdownEditor。よって .yaml/.yml などの『編集可能テキスト』でも同じループが起きるはず。また HtmlPreview は onDirtyChange prop を type 受領するだけで本体は呼び出さないため、.html は無関係。ImageViewer / CodeViewerWithSearch / PdfPreview は onDirtyChange を受け取らないため無関係。Issue 本文の『.png/.json 等では再現しない』観察は正しいが、『.md 限定』は言い過ぎで .yaml/.yml でも再現する可能性が高い。受け入れテストに含めることを推奨。",
+      "triggering_components": [
+        "MarkdownEditor (src/components/worktree/MarkdownEditor.tsx)"
+      ],
+      "triggering_file_types": [".md", ".yaml", ".yml", "(isEditableExtension() が true を返す全拡張子)"]
+    }
+  },
+  "root_cause_analysis": {
+    "category": "コードバグ (React hooks deps 不安定 + reducer 無条件 state 更新)",
+    "primary_cause": "useFileTabs.ts:384 の戻り値オブジェクトが毎レンダー新参照になるため、WorktreeDetailRefactored.tsx:1298-1313 の useCallback が毎レンダー再生成される。それが FilePanelContent → MarkdownEditor と伝播し、MarkdownEditor.tsx:226-228 の useEffect が毎レンダー発火し、SET_DIRTY reducer が同値でも新 state を返すため再レンダーが無限連鎖。結果として App Router の router.push transition が commit できない。",
+    "evidence": [
+      "useFileTabs.ts:384 の return は毎レンダー新オブジェクトリテラル (個々のメンバは安定でもラッパーは不安定)",
+      "WorktreeDetailRefactored.tsx:1300/1304/1308/1313 すべて deps=[fileTabs] でラッパー全体を依存にしている",
+      "MarkdownEditor.tsx:226-228 の useEffect deps に onDirtyChange を含む (関数 identity 依存)",
+      "useFileTabs.ts:239-246 の SET_DIRTY reducer は同値判定なし (updateTabByPath が無条件で新配列/新オブジェクトを返す)",
+      "観察された挙動『.md のみ再現、画像/JSON/PDF では再現しない』は MarkdownEditor を描画する経路だけが onDirtyChange useEffect を持つこととキレイに一致"
+    ]
+  },
+  "severity_assessment": {
+    "severity": "high",
+    "impact": "サイドバーからのブランチ切替という主要ナビゲーションが .md / .yaml 等の編集可能テキストファイルを表示中に機能しない。ユーザの作業フローを阻害する。データ破壊はない。",
+    "data_loss_risk": "なし (編集内容は保存ボタン/オートセーブ経路で別管理)"
+  },
+  "recommended_actions": [
+    {
+      "action_id": "1",
+      "priority": "high",
+      "title": "A案: useCallback deps を fileTabs.dispatch のみに絞る",
+      "description": "WorktreeDetailRefactored.tsx:1298-1313 の handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange の deps を [fileTabs] から [fileTabs.dispatch] に変更。dispatch は useReducer 由来で identity が stable (React 保証) なのでコールバックも毎レンダー同一参照になり、FilePanelContent の useMemo と MarkdownEditor の useEffect が発火しなくなる。",
+      "files_to_modify": ["src/components/worktree/WorktreeDetailRefactored.tsx"],
+      "risk_level": "low",
+      "side_effects": [
+        "1298-1313 の 4 コールバックのみ変更すれば十分。rightPaneMemo (L1427) の deps は handleDirtyChange 他の identity が安定した時点で不要に更新されなくなるため副次的にレンダー回数が減る (改善)。",
+        "他箇所で fileTabs.state / fileTabs.openFile / fileTabs.onFileRenamed / fileTabs.onFileDeleted を使う handleFilePathClick(L542-551) / handleFileSelect(L559-570) / handleOpenFile(L576-581) / handleRename(L849-875) / handleDelete(L878-904) は本修正と無関係 (別のアンチパターンは残るが、Issue #675 の再現経路とは別系統)。",
+        "ESLint react-hooks/exhaustive-deps が警告を出す可能性あり。dispatch は safe to omit だが、明示的に [fileTabs.dispatch] と書くか eslint-disable-next-line で抑止する必要あり。"
+      ]
+    },
+    {
+      "action_id": "2",
+      "priority": "high",
+      "title": "B案: SET_DIRTY reducer で同値時 no-op",
+      "description": "useFileTabs.ts:239-246 の SET_DIRTY case で、対象 tab の isDirty が既に同じ値なら state をそのまま返す (参照不変)。useReducer は state 参照が同一なら再レンダーをスキップするため、仮に今後別経路で deps が崩れても同値 dispatch は無害化できる多層防御。",
+      "files_to_modify": ["src/hooks/useFileTabs.ts"],
+      "risk_level": "low",
+      "side_effects": [
+        "SET_DIRTY dispatcher は現時点で WorktreeDetailRefactored.tsx:1312 の 1 箇所のみ。他経路への波及なし。",
+        "既存テスト tests/unit/hooks/useFileTabs.test.ts:406-452 は true↔false の実際の変化に対する検証で、no-op 追加とは互いに直交。既存アサーションに影響なし。",
+        "updateTabByPath 本体は変更しない。他の action (SET_CONTENT/SET_LOADING/SET_ERROR/RENAME_FILE) は同値判定を持たないが、それらはユーザ操作起点で頻発しないため現状問題視されていない。SET_DIRTY のみローカル変更で十分。"
+      ]
+    },
+    {
+      "action_id": "3",
+      "priority": "medium",
+      "title": "推奨: A+B両方適用 (多層防御)",
+      "description": "A案で根本原因(不安定 deps)を断ち、B案で将来の再発を予防。単独適用でもバグは治るが、今回の事例は『ラッパーオブジェクト全体を deps に置く』という書き間違いが原因であり、別のコールバックで同じミスが再発する余地が大きい。B案を入れておけば SET_DIRTY 経路の暴走は構造的に防げる。",
+      "files_to_modify": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx",
+        "src/hooks/useFileTabs.ts"
+      ],
+      "risk_level": "low"
+    },
+    {
+      "action_id": "4",
+      "priority": "low",
+      "title": "将来的な検討: useFileTabs の return を useMemo でラップ or 個別 export",
+      "description": "L384 の return オブジェクトを useMemo 化するか、個別の値を分割 export する API に変えると、呼び出し側で deps=[fileTabs] を書いても安定になる。ただし今回のスコープ外とし、別 Issue として切り出すのが望ましい。",
+      "files_to_modify": ["src/hooks/useFileTabs.ts"],
+      "risk_level": "medium"
+    }
+  ],
+  "related_antipatterns_in_codebase": {
+    "summary": "WorktreeDetailRefactored.tsx 内で useCallback/useMemo の deps に fileTabs ラッパーオブジェクト全体を置いている箇所は 7 箇所あった。Issue #675 の直接原因は L1298-1313 の 4 箇所だが、他 3 箇所も将来の不具合リスクを内包する。",
+    "occurrences": [
+      {
+        "line": "551",
+        "context": "handleFilePathClick: deps=[isMobile, fileTabs, showTabLimitToast]",
+        "note": "fileTabs.openFile のみ参照。[isMobile, fileTabs.openFile, showTabLimitToast] で安全。現状機能している副作用は onClick 起点のみのため顕在化していない。"
+      },
+      {
+        "line": "570",
+        "context": "handleFileSelect: deps=[isMobile, fileTabs, showTabLimitToast]",
+        "note": "同上。fileTabs.openFile のみ使用。"
+      },
+      {
+        "line": "581",
+        "context": "handleOpenFile: deps=[fileTabs, showTabLimitToast]",
+        "note": "fileTabs.openFile のみ使用。"
+      },
+      {
+        "line": "875",
+        "context": "handleRename: deps=[worktreeId, fileTabs, tError]",
+        "note": "fileTabs.onFileRenamed のみ使用。"
+      },
+      {
+        "line": "904",
+        "context": "handleDelete: deps=[worktreeId, editorFilePath, fileTabs, tCommon, tError]",
+        "note": "fileTabs.onFileDeleted のみ使用。"
+      },
+      {
+        "line": "1300, 1304, 1308, 1313",
+        "context": "handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange: deps=[fileTabs]",
+        "note": "Issue #675 の直接原因。fileTabs.dispatch のみ使用。"
+      },
+      {
+        "line": "1427",
+        "context": "rightPaneMemo: deps=[..., fileTabs.state, fileTabs.closeTab, fileTabs.activateTab, fileTabs.moveToFront, ...]",
+        "note": "個別メンバ参照になっており、これ単独では不安定化しない。ただし上流コールバック(handleLoadContent 等) が毎レンダー変わるため結局 invalidate される。A案で上流を修正すれば rightPaneMemo も安定化する。"
+      }
+    ],
+    "recommendation": "Issue #675 の修正スコープは L1298-1313 のみで十分。他 5 箇所 (L551, L570, L581, L875, L904) は別 Issue / refactoring スコープで『React hooks deps に object whole を置かない』規約として一括整理を推奨。"
+  },
+  "recommended_test_cases": [
+    {
+      "id": "T1",
+      "type": "unit (reducer)",
+      "file": "tests/unit/hooks/useFileTabs.test.ts",
+      "case": "SET_DIRTY で isDirty が既に同値の場合、state が同一参照で返ること (result === stateWithTab) を assert。B案の不変条件を検証。"
+    },
+    {
+      "id": "T2",
+      "type": "unit (hook)",
+      "file": "tests/unit/hooks/useFileTabs.test.ts (または新規)",
+      "case": "renderHook で dispatch の identity が複数レンダーで同一であることを確認 (React 保証の再確認)。A案の前提検証。"
+    },
+    {
+      "id": "T3",
+      "type": "unit (component)",
+      "file": "tests/unit/components/MarkdownEditor.test.tsx",
+      "case": "onDirtyChange を同一参照で渡した場合、isDirty が変化しない限り onDirtyChange が再呼び出しされないこと (= useEffect が余計に発火しないこと)。既存の mockClear を使ったアサーションの追補。"
+    },
+    {
+      "id": "T4",
+      "type": "integration/e2e",
+      "file": "tests/e2e (or integration)",
+      "case": "Worktree 詳細で .md を開いた状態 → サイドバーから別ブランチを選択 → URL が想定通り変化することを検証。再現テスト。",
+      "note": ".yaml/.yml でも同様のテストを追加することを推奨 (Issue 本文の『md 限定』仮説への補足確認)。"
+    },
+    {
+      "id": "T5",
+      "type": "manual verification",
+      "case": "Chrome DevTools Profiler で MarkdownEditor 表示中のレンダー回数を録画し、修正前後でレンダー無限ループが止まっていることを視覚的に確認。"
+    }
+  ],
+  "notes_for_implementer": [
+    "A案を採用する場合、ESLint react-hooks/exhaustive-deps のルール違反にならないよう、deps は [fileTabs.dispatch] と書く (個別メンバ参照)。fileTabs 全体を外すとルール違反になる。",
+    "B案の no-op 実装例: case 'SET_DIRTY' の updateTabByPath 呼び出し前に const tab = state.tabs.find(t => t.path === action.path); if (tab && tab.isDirty === action.isDirty) return state; を追加。",
+    "修正後、useFileContentPolling の挙動 (isDirty=true でポーリング停止) に影響しないことを確認。SET_DIRTY の真の状態遷移は引き続き反映される必要がある。",
+    "rightPaneMemo (L1397-1428) の deps は今回触らなくてよい。上流のコールバック identity が安定化すれば自動的に無駄な再評価が減る。",
+    "今回のスコープでは『ラッパーオブジェクト全体を deps に置く』別箇所 (L551, L570, L581, L875, L904) は修正しない方針が妥当。Issue のスコープを膨らませないため。別 Issue 化を推奨。"
+  ],
+  "next_steps": [
+    "A案 + B案の両方を採用する方針で実装計画を作成",
+    "T1 (reducer no-op)、T3 (MarkdownEditor onDirtyChange stability) のユニットテストを先に追加 (TDD)",
+    "実装後、T4 (navigation E2E) で .md / .yaml の両方を検証",
+    "修正対象外の L551/L570/L581/L875/L904 の『fileTabs 全体 deps』は別 Issue として起票を推奨"
+  ]
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/progress-context.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/progress-context.json
@@ -1,0 +1,65 @@
+{
+  "bug_id": "20260424_201916_issue675",
+  "issue_number": 675,
+  "issue_title": "fix: Markdown ファイル表示中にサイドバーからのブランチ遷移が効かない (onDirtyChange 無限ループ)",
+  "branch": "feature/675-worktree",
+  "commit": "e91e1928",
+  "phases": {
+    "phase1_investigation": {
+      "result_file": "dev-reports/bug-fix/20260424_201916_issue675/investigation-result.json",
+      "summary": "Issue 本文記載のコード位置を全て検証・一致確認。根本原因 (useFileTabs return が毎レンダー新オブジェクト → WorktreeDetailRefactored useCallback deps=[fileTabs] が毎レンダー再生成 → FilePanelContent/MarkdownEditor に不安定 prop 伝播 → MarkdownEditor useEffect 発火 → SET_DIRTY reducer が同値でも新 state → 無限ループ) は妥当。ただし『.md 限定』は言い過ぎで .yaml/.yml 等 isEditableExtension() が true の拡張子でも再現する可能性あり。同種アンチパターンが同ファイル内 5 箇所 (L551/570/581/875/904) に残存、別 Issue 化を推奨。"
+    },
+    "phase2_user_feedback": {
+      "selected_actions": "A案 + B案 両方適用",
+      "out_of_scope_handling": "他 5 箇所のアンチパターンは別 Issue 化"
+    },
+    "phase3_work_plan": {
+      "context_file": "dev-reports/bug-fix/20260424_201916_issue675/work-plan-context.json",
+      "summary": "A案 (WorktreeDetailRefactored.tsx の 4 useCallback deps → [fileTabs.dispatch]) と B案 (useFileTabs.ts SET_DIRTY reducer で同値 no-op) を 1 コミットで実装。TDD で B案の reducer テストを先行追加。"
+    },
+    "phase4_tdd_fix": {
+      "result_file": "dev-reports/bug-fix/20260424_201916_issue675/tdd-fix-result.json",
+      "red_phase": "tests/unit/hooks/useFileTabs.test.ts に SET_DIRTY 同値 no-op 検証 3 件 (false→false / true→true / double-apply) を追加。初回実行で 3 FAIL / 6381 PASS (Red 成立)。",
+      "green_phase": "B案 (useFileTabs.ts SET_DIRTY reducer に find + 同値判定追加) → A案 (WorktreeDetailRefactored.tsx の 4 useCallback deps 変更、exhaustive-deps 警告対策に eslint-disable-next-line 付与) を順次適用。追加テスト含む全ユニットテスト 6384 PASS / 7 skipped。",
+      "refactor_phase": "スコープ最小維持。updateTabByPath 本体や他 reducer case、対象外の L551/570/581/875/904 アンチパターンは非変更。",
+      "files_changed": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx (+11 -4)",
+        "src/hooks/useFileTabs.ts (+3 -0)",
+        "tests/unit/hooks/useFileTabs.test.ts (+36 -0)"
+      ],
+      "commit": "e91e1928 fix(#675): stop re-render loop blocking worktree URL updates"
+    },
+    "phase5_acceptance": {
+      "result_file": "dev-reports/bug-fix/20260424_201916_issue675/acceptance-result.json",
+      "overall": "PASS",
+      "automated_checks": {
+        "lint": "PASS (No ESLint warnings or errors)",
+        "typecheck": "PASS (tsc --noEmit exit 0)",
+        "unit_test": "PASS (340 files, 6384 passed, 7 skipped, 0 failed)",
+        "build": "PASS (Next.js compiled successfully)",
+        "static_grep_A": "PASS (WorktreeDetailRefactored.tsx 4 箇所すべて [fileTabs.dispatch])",
+        "static_grep_B": "PASS (useFileTabs.ts:242 に同値判定存在)"
+      },
+      "manual_checks_skipped": [
+        "S5 実機: .md 表示中にサイドバーからブランチ遷移",
+        "S6 実機: .yaml/.yml での同様挙動",
+        "S7 実機: .png/.json の回帰確認"
+      ]
+    }
+  },
+  "key_decisions": [
+    "A案 + B案 両方適用で多層防御 (Issue 本文の推奨どおり)",
+    "ESLint exhaustive-deps が member-access deps でも警告を出す問題は eslint-disable-next-line で局所抑止 (dispatch は useReducer 由来で stable という React 保証に依拠)",
+    "同ファイル内の他 5 箇所のアンチパターンは別 Issue として切り出す"
+  ],
+  "follow_ups": [
+    "別 Issue 起票: WorktreeDetailRefactored.tsx L551/L570/L581/L875/L904 の『fileTabs 全体を deps に置く』アンチパターンの一括整理",
+    "別 Issue 候補: useFileTabs の return を useMemo でラップ or 個別 export (呼び出し側で deps=[fileTabs] を書いてもループしない API に改善)",
+    "実機受入 (S5/S6/S7): .md + サイドバー遷移、.yaml/.yml、.png/.json の回帰確認はユーザー側で実施を推奨"
+  ],
+  "next_steps": [
+    "PR 作成 (/create-pr または gh pr create) で develop へマージ依頼",
+    "実機受入後、問題なければマージ",
+    "上記 follow-up Issue を適宜起票"
+  ]
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/progress-report.md
+++ b/dev-reports/bug-fix/20260424_201916_issue675/progress-report.md
@@ -1,0 +1,170 @@
+# バグ修正完了レポート - Issue #675
+
+## 概要
+
+| 項目 | 内容 |
+|------|------|
+| Issue 番号 | #675 |
+| タイトル | fix: Markdown ファイル表示中にサイドバーからのブランチ遷移が効かない (onDirtyChange 無限ループ) |
+| ブランチ | `feature/675-worktree` |
+| 修正コミット | `e91e1928` |
+| 報告日時 | 2026-04-24 20:35 JST |
+| 総合ステータス | PASS (自動受入全件通過、実機受入は別途推奨) |
+
+### 症状
+
+Files タブで `.md` ファイルを表示中、サイドバーのブランチ切替をクリックしても URL 遷移 (router.push) が commit されない。画像/JSON/PDF 表示中は問題なし。
+
+---
+
+## 根本原因 (サマリ)
+
+React 18 の並行レンダリング下で発生する re-render ループが、App Router の transition (低優先度更新) を継続的に defer させていた。連鎖の起点は次の 2 点。
+
+1. **`useFileTabs` の return が毎レンダー新オブジェクト**
+   → 呼び出し側 `WorktreeDetailRefactored.tsx` の 4 useCallback (`handleLoadContent` / `handleLoadError` / `handleSetLoading` / `handleDirtyChange`) の deps が `[fileTabs]` だったため、コールバックが毎レンダー再生成 → `FilePanelContent` → `MarkdownEditor` と伝播。
+2. **`SET_DIRTY` reducer に同値判定なし**
+   → `MarkdownEditor` の `useEffect([isDirty, onDirtyChange])` が不安定 prop で毎レンダー発火 → dispatch が同値でも新 state 参照 → 親の再レンダー → 無限連鎖。
+
+`.md` に限らず `isEditableExtension()` が true を返す拡張子 (`.yaml` / `.yml` 等) でも MarkdownEditor 経路で再現しうる。画像/JSON/PDF ビューアは `onDirtyChange` を受け取らないため影響なし。
+
+---
+
+## Phase 別結果
+
+### Phase 1: 調査 (investigation)
+
+- Issue 本文記載のコード位置 5 箇所 (useFileTabs L239-246 / L384、WorktreeDetailRefactored L1298-1313、FilePanelContent L563-568、MarkdownEditor L226-228) を実コードと照合し全て一致を確認。
+- メカニズム分析は概ね妥当。ただし「`.md` 限定」は言い過ぎで MarkdownEditor を描画する編集可能拡張子全般で再現する可能性を指摘。
+- 同種アンチパターン (`fileTabs` 全体を useCallback deps に置く) を同ファイル内に 5 箇所残存確認 (L551/L570/L581/L875/L904) → 別 Issue 化を推奨。
+- 成果物: `investigation-result.json`
+
+### Phase 2: ユーザー確認
+
+- **採用方針**: A案 + B案 両方適用 (多層防御)
+- **スコープ外**: 他 5 箇所のアンチパターンは別 Issue として分離
+
+### Phase 3: 作業計画
+
+- A案 (WorktreeDetailRefactored の 4 useCallback deps → `[fileTabs.dispatch]`) と B案 (useFileTabs.ts SET_DIRTY 同値 no-op) を 1 コミットで実装。
+- TDD で B案の reducer テストを先行追加する方針に決定。
+- 成果物: `work-plan-context.json`
+
+### Phase 4: TDD 修正 (tdd-fix)
+
+| フェーズ | 結果 |
+|---------|------|
+| Red | `tests/unit/hooks/useFileTabs.test.ts` に同値 no-op 検証 3 件 (false→false / true→true / 二重適用) を追加。初回実行で 3 FAIL / 6381 PASS (Red 成立)。 |
+| Green | B案 (useFileTabs.ts に `find` + 同値判定) → A案 (4 useCallback deps 変更、`eslint-disable-next-line react-hooks/exhaustive-deps` 付与) を順次適用。全ユニットテスト 6384 PASS / 7 skipped。 |
+| Refactor | スコープ最小維持。対象外の 5 箇所のアンチパターンは非変更。 |
+
+- コミット: `e91e1928 fix(#675): stop re-render loop blocking worktree URL updates`
+
+### Phase 5: 受入テスト (acceptance)
+
+| シナリオ | 内容 | 結果 |
+|---------|------|------|
+| S1 | B案: SET_DIRTY 同値 dispatch で state 参照不変 (false→false / true→true / 二重適用) | PASS |
+| S2 | B案: SET_DIRTY で真に変化する場合は従来通り新 state を返す | PASS |
+| S3 | A案: WorktreeDetailRefactored の 4 useCallback deps が `[fileTabs.dispatch]` | PASS |
+| S4 | lint / typecheck / unit test / build 全通過 | PASS |
+| S5 | 実機: `.md` 表示中のサイドバーブランチ遷移 | SKIPPED (実機確認はユーザー側) |
+| S6 | 実機: `.yaml` / `.yml` での同挙動確認 | SKIPPED |
+| S7 | 実機: `.png` / `.json` 回帰確認 | SKIPPED |
+
+---
+
+## 変更ファイル一覧
+
+| ファイル | 変更 |
+|---------|------|
+| `src/hooks/useFileTabs.ts` | +3 -0 |
+| `src/components/worktree/WorktreeDetailRefactored.tsx` | +11 -4 |
+| `tests/unit/hooks/useFileTabs.test.ts` | +36 -0 |
+
+### Diff サマリ
+
+**`src/hooks/useFileTabs.ts`** (SET_DIRTY case, L237 付近)
+
+```ts
+case 'SET_DIRTY': {
+  // [Issue #675] Short-circuit no-op dispatches so upstream useReducer skips re-render
+  const current = state.tabs.find((t) => t.path === action.path);
+  if (current && current.isDirty === action.isDirty) return state;
+  const newTabs = updateTabByPath(state.tabs, action.path, (tab) => ({
+    ...tab,
+    isDirty: action.isDirty,
+  }));
+  ...
+}
+```
+
+**`src/components/worktree/WorktreeDetailRefactored.tsx`** (L1295 付近の 4 useCallback)
+
+```tsx
+// deps を [fileTabs] → [fileTabs.dispatch] に変更 (4 箇所)
+const handleLoadContent = useCallback((path, content) => {
+  fileTabs.dispatch({ type: 'SET_CONTENT', path, content });
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [fileTabs.dispatch]);
+// handleLoadError / handleSetLoading / handleDirtyChange も同様
+```
+
+**`tests/unit/hooks/useFileTabs.test.ts`**: SET_DIRTY 同値 no-op 検証 3 件を追加。
+
+---
+
+## 自動検証結果
+
+| チェック | コマンド | 結果 |
+|---------|---------|------|
+| ESLint | `npm run lint` | PASS (No ESLint warnings or errors) |
+| TypeScript | `npx tsc --noEmit` | PASS (exit 0) |
+| Unit Test | `npm run test:unit` | PASS (340 files, 6384 passed, 7 skipped, 0 failed) |
+| Build | `npm run build` | PASS (Next.js compiled successfully) |
+| Static grep (A案) | `WorktreeDetailRefactored.tsx` の 4 箇所すべて `[fileTabs.dispatch]` | PASS |
+| Static grep (B案) | `useFileTabs.ts:242` に同値判定存在 | PASS |
+
+全自動チェック通過。
+
+---
+
+## スコープ外 (別 Issue 化推奨)
+
+1. **`WorktreeDetailRefactored.tsx` 内の同種アンチパターン 5 箇所**
+   - L551 `handleFilePathClick` (fileTabs.openFile のみ使用)
+   - L570 `handleFileSelect` (同上)
+   - L581 `handleOpenFile` (同上)
+   - L875 `handleRename` (fileTabs.onFileRenamed のみ使用)
+   - L904 `handleDelete` (fileTabs.onFileDeleted のみ使用)
+   - いずれも `deps=[..., fileTabs, ...]` で object 全体を依存しているが、顕在化していない。一括整理を推奨。
+
+2. **`useFileTabs` の return を `useMemo` ラップ or 個別 export 化**
+   - 呼び出し側で `deps=[fileTabs]` と書いてもループしない API に改善。根本的な API 設計課題。
+
+---
+
+## 推奨フォローアップ
+
+1. **実機受入 (S5/S6/S7) のユーザー実施**
+   - `commandmate start` でサーバ起動
+   - Worktree A で `.md` / `.yaml` / `.yml` を開いた状態 → サイドバーで Worktree B を選択 → URL が `/worktrees/{B}` に更新されることを確認
+   - `.png` / `.json` (非対象拡張子) でも遷移することを回帰確認
+
+2. **PR 作成**
+   - `/create-pr` または `gh pr create` で `develop` へマージ依頼
+   - 実機受入 OK 後にマージ
+
+3. **別 Issue 起票**
+   - 「WorktreeDetailRefactored.tsx 内の useCallback deps 安定化 (L551/L570/L581/L875/L904)」
+   - 「useFileTabs の戻り値安定化 API リファクタリング」
+
+---
+
+## 備考
+
+- A案 + B案 両方適用により、根本原因を断ちつつ将来の同種バグに対する多層防御を確保。
+- `eslint-disable-next-line react-hooks/exhaustive-deps` は `useReducer` 由来の dispatch が stable という React 保証に依拠する局所抑止であり、各箇所にコメントで理由を明記済み。
+- データ破壊リスクなし (編集内容は保存ボタン / オートセーブ経路で別管理)。
+
+**Issue #675 のバグ修正は自動検証レベルで完了しました。実機受入後にマージ推奨です。**

--- a/dev-reports/bug-fix/20260424_201916_issue675/tdd-fix-context.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/tdd-fix-context.json
@@ -1,0 +1,70 @@
+{
+  "bug_id": "20260424_201916_issue675",
+  "issue_number": 675,
+  "branch": "feature/675-worktree",
+  "bug_description": ".md ファイル表示中にサイドバーから別ブランチを選択しても URL が更新されない。MarkdownEditor 経由の onDirtyChange useEffect が毎レンダー発火して SET_DIRTY reducer を無限に呼び、高優先度 dispatch が router.push の transition を starve させる。",
+  "selected_actions": [
+    {
+      "action_id": "A",
+      "title": "WorktreeDetailRefactored.tsx の useCallback deps 修正",
+      "description": "L1298-1313 の handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange の useCallback deps を [fileTabs] から [fileTabs.dispatch] に変更する。dispatch は useReducer 由来で identity が stable。コールバック identity を安定化させ、FilePanelContent → MarkdownEditor への不安定 prop 伝播を止めて、MarkdownEditor.tsx:226-228 の useEffect が毎レンダー発火する状態を解消する。",
+      "files_to_modify": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx"
+      ],
+      "specific_changes": [
+        "handleLoadContent useCallback deps: [fileTabs] → [fileTabs.dispatch]",
+        "handleLoadError useCallback deps: [fileTabs] → [fileTabs.dispatch]",
+        "handleSetLoading useCallback deps: [fileTabs] → [fileTabs.dispatch]",
+        "handleDirtyChange useCallback deps: [fileTabs] → [fileTabs.dispatch]"
+      ]
+    },
+    {
+      "action_id": "B",
+      "title": "useFileTabs.ts SET_DIRTY reducer で同値 no-op",
+      "description": "SET_DIRTY case で、対象 tab の isDirty が既に同じ値なら state を同一参照のまま返す。updateTabByPath を呼ばずに早期 return することで、useReducer が再レンダーをスキップする。将来別経路で deps が崩れた時の多層防御。",
+      "files_to_modify": [
+        "src/hooks/useFileTabs.ts"
+      ],
+      "specific_changes": [
+        "SET_DIRTY case 冒頭で const tab = state.tabs.find(t => t.path === action.path); を行い、tab が存在し tab.isDirty === action.isDirty の場合は return state; を追加"
+      ]
+    }
+  ],
+  "tdd_requirements": {
+    "red_phase": "先に失敗するテストを書く",
+    "test_cases": [
+      {
+        "id": "T1",
+        "file": "tests/unit/hooks/useFileTabs.test.ts",
+        "description": "SET_DIRTY dispatch で対象 tab の isDirty が既に同値 (false→false もしくは true→true) の場合、reducer の戻り値が呼び出し前の state と同一参照 (===) であることを検証する。B案の不変条件を担保。",
+        "expected_before_fix": "FAIL (現状は updateTabByPath が無条件に新 state を返すため state 参照が変わる)",
+        "expected_after_fix": "PASS"
+      },
+      {
+        "id": "T2",
+        "file": "tests/unit/hooks/useFileTabs.test.ts",
+        "description": "SET_DIRTY で isDirty が真に変化する場合 (false→true / true→false) は従来通り新 state を返し、tabs 配列内の対象 tab の isDirty が正しく更新されていることを検証。既存挙動の回帰防止。",
+        "expected_before_fix": "PASS (既存挙動)",
+        "expected_after_fix": "PASS"
+      }
+    ]
+  },
+  "quality_requirements": {
+    "lint": "npm run lint",
+    "typecheck": "npx tsc --noEmit",
+    "unit_test": "npm run test:unit",
+    "coverage_target": 80
+  },
+  "implementation_notes": [
+    "A案適用時、ESLint react-hooks/exhaustive-deps は fileTabs.dispatch を個別メンバ参照にすれば警告を出さない (プロジェクトの既存ルール確認)。",
+    "B案適用時、updateTabByPath 本体は変更しない。SET_DIRTY case にのみ同値判定を追加。他の action (SET_CONTENT / SET_LOADING / SET_ERROR / RENAME_FILE) には手を入れない。",
+    "既存テスト (tests/unit/hooks/useFileTabs.test.ts) の true↔false 遷移テストは変更不要 (直交)。",
+    "rightPaneMemo や他の useCallback/useMemo は今回触らない。上流の identity が安定すれば自動的に無駄な再評価が減る。",
+    "コメントは最小限に。WHY が自明でない箇所 (例: dispatch identity stability を明示するコメント) のみ 1 行で。"
+  ],
+  "out_of_scope": [
+    "WorktreeDetailRefactored.tsx L551/L570/L581/L875/L904 の同種アンチパターン (別 Issue 化予定)",
+    "useFileTabs return の useMemo 化や API 変更 (別 Issue 候補)"
+  ],
+  "target_coverage": 80
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/tdd-fix-result.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/tdd-fix-result.json
@@ -1,0 +1,136 @@
+{
+  "bug_id": "20260424_201916_issue675",
+  "issue_number": 675,
+  "branch": "feature/675-worktree",
+  "mode": "subagent",
+  "status": "success",
+  "summary": "Applied Plan A (useCallback deps: [fileTabs] -> [fileTabs.dispatch] in WorktreeDetailRefactored.tsx) and Plan B (SET_DIRTY no-op short-circuit in useFileTabs.ts) following strict Red-Green-Refactor TDD. All lint, typecheck, and unit tests pass.",
+  "phases": {
+    "red": {
+      "description": "Added 3 failing tests to tests/unit/hooks/useFileTabs.test.ts covering the SET_DIRTY same-value no-op invariant (B plan contract).",
+      "tests_added": [
+        {
+          "name": "SET_DIRTY should return same state reference when isDirty is already the same value (false→false)",
+          "file": "tests/unit/hooks/useFileTabs.test.ts"
+        },
+        {
+          "name": "SET_DIRTY should return same state reference when isDirty is already the same value (true→true)",
+          "file": "tests/unit/hooks/useFileTabs.test.ts"
+        },
+        {
+          "name": "SET_DIRTY applied twice with the same value returns a stable reference",
+          "file": "tests/unit/hooks/useFileTabs.test.ts"
+        }
+      ],
+      "initial_test_run": {
+        "command": "npm run test:unit -- tests/unit/hooks/useFileTabs.test.ts",
+        "result": "FAIL",
+        "failed_tests": 3,
+        "passed_tests": 6381,
+        "reason": "Reducer always returned a new state object for SET_DIRTY regardless of whether the value actually changed."
+      }
+    },
+    "green": {
+      "description": "Implemented both plans. B in useFileTabs SET_DIRTY reducer (same-value short-circuit). A in WorktreeDetailRefactored.tsx (4 useCallback deps switched to fileTabs.dispatch with targeted eslint-disable-next-line for react-hooks/exhaustive-deps).",
+      "changes": [
+        {
+          "file": "src/hooks/useFileTabs.ts",
+          "change": "In SET_DIRTY case: find the target tab first and return state unchanged if current.isDirty === action.isDirty. Keeps existing behaviour when tab is missing or when value truly changes."
+        },
+        {
+          "file": "src/components/worktree/WorktreeDetailRefactored.tsx",
+          "change": "handleLoadContent, handleLoadError, handleSetLoading, handleDirtyChange useCallback deps: [fileTabs] -> [fileTabs.dispatch]. Added a single WHY comment above the block and eslint-disable-next-line react-hooks/exhaustive-deps on each dep-array line because the linter cannot see that useReducer dispatch identity is stable."
+        }
+      ],
+      "test_run_after_fix": {
+        "command": "npm run test:unit -- tests/unit/hooks/useFileTabs.test.ts",
+        "result": "PASS",
+        "tests_passed": 6384,
+        "tests_skipped": 7,
+        "tests_failed": 0
+      }
+    },
+    "refactor": {
+      "description": "Minimal change set; no extra refactoring performed. Scope held to the two files listed in the plan. Added only WHY comments (Issue #675 rationale for dispatch-only deps; Issue #675 rationale for short-circuit). Out-of-scope anti-patterns (L551/L570/L581/L875/L904) intentionally left untouched for a separate Issue.",
+      "notes": [
+        "Did not alter other reducer cases (SET_CONTENT / SET_LOADING / SET_ERROR / RENAME_FILE / MOVE_TO_FRONT).",
+        "Did not alter updateTabByPath helper.",
+        "Existing SET_DIRTY true/false transition tests continue to pass unchanged (regression-free).",
+        "All other useCallback/useMemo call sites in WorktreeDetailRefactored.tsx were not modified."
+      ]
+    }
+  },
+  "files_modified": [
+    {
+      "path": "src/hooks/useFileTabs.ts",
+      "lines_added": 3,
+      "lines_removed": 0,
+      "diff_summary": "SET_DIRTY case prefixed with find + same-value short-circuit (return state)."
+    },
+    {
+      "path": "src/components/worktree/WorktreeDetailRefactored.tsx",
+      "lines_added": 11,
+      "lines_removed": 4,
+      "diff_summary": "Replaced [fileTabs] with [fileTabs.dispatch] in 4 useCallbacks (handleLoadContent, handleLoadError, handleSetLoading, handleDirtyChange). Added WHY comment + per-hook eslint-disable-next-line react-hooks/exhaustive-deps pragmas."
+    },
+    {
+      "path": "tests/unit/hooks/useFileTabs.test.ts",
+      "lines_added": 36,
+      "lines_removed": 0,
+      "diff_summary": "Added 3 tests under the 'isDirty flag' describe block asserting same-reference return for no-op SET_DIRTY dispatches."
+    }
+  ],
+  "quality_checks": {
+    "lint": {
+      "command": "npm run lint",
+      "exit_code": 0,
+      "result": "PASS",
+      "details": "No ESLint warnings or errors. The 4 deliberately-disabled react-hooks/exhaustive-deps warnings are suppressed with line-level pragmas that include a WHY comment at the block header."
+    },
+    "typecheck": {
+      "command": "npx tsc --noEmit",
+      "exit_code": 0,
+      "result": "PASS",
+      "details": "No type errors."
+    },
+    "unit_tests": {
+      "command": "npm run test:unit",
+      "exit_code": 0,
+      "result": "PASS",
+      "test_files": 340,
+      "tests_passed": 6384,
+      "tests_skipped": 7,
+      "tests_failed": 0,
+      "delta_vs_baseline": "+3 new tests (all pass). No regressions in the remaining 6381."
+    },
+    "targeted_tests": {
+      "command": "npm run test:unit -- tests/unit/hooks/useFileTabs.test.ts tests/unit/components/MarkdownEditor.test.tsx",
+      "exit_code": 0,
+      "result": "PASS",
+      "note": "Full suite runs and all pass; vitest's positional args filter by test-file name."
+    }
+  },
+  "commit": {
+    "hash": "e91e1928ad3feba137c85a408125d225f4b55dd1",
+    "branch": "feature/675-worktree",
+    "message_subject": "fix(#675): stop re-render loop blocking worktree URL updates",
+    "files_in_commit": [
+      "src/components/worktree/WorktreeDetailRefactored.tsx",
+      "src/hooks/useFileTabs.ts",
+      "tests/unit/hooks/useFileTabs.test.ts"
+    ]
+  },
+  "success_criteria": {
+    "red_green_cycle_complete": true,
+    "all_tests_pass": true,
+    "lint_clean": true,
+    "typecheck_clean": true,
+    "committed": true,
+    "coverage_target_met": "not-measured-in-this-run (target 80; unit suite expanded from 6381 to 6384 tests, all passing)"
+  },
+  "notes": [
+    "The claim in the context that `[fileTabs.dispatch]` alone would silence react-hooks/exhaustive-deps was not accurate for this ESLint configuration (next/core-web-vitals); the rule still flags fileTabs as a missing dependency when any member of it is referenced in the callback body. A minimal eslint-disable-next-line pragma was added on each dep-array line, with a single WHY comment at the block header explaining dispatch stability. This preserves the original intent (keep deps minimal) without introducing rule-wide suppression.",
+    "Out-of-scope anti-patterns noted in the context (L551/L570/L581/L875/L904 in WorktreeDetailRefactored.tsx) were intentionally left untouched and should be addressed in a follow-up issue.",
+    "No DB, API, or contract-level changes. Pure React render-loop guard."
+  ]
+}

--- a/dev-reports/bug-fix/20260424_201916_issue675/work-plan-context.json
+++ b/dev-reports/bug-fix/20260424_201916_issue675/work-plan-context.json
@@ -1,0 +1,75 @@
+{
+  "bug_id": "20260424_201916_issue675",
+  "issue_number": 675,
+  "bug_description": ".md ファイル表示中にサイドバーから別ブランチを選択しても URL が更新されず画面遷移しない。MarkdownEditor 経由で発生する onDirtyChange 無限 re-render ループが router.push の transition を starve させることが原因。",
+  "selected_actions": [
+    {
+      "action_id": "A",
+      "title": "useCallback deps を fileTabs.dispatch のみに絞る (根本修正)",
+      "description": "WorktreeDetailRefactored.tsx:1298-1313 の handleLoadContent / handleLoadError / handleSetLoading / handleDirtyChange の useCallback deps を [fileTabs] から [fileTabs.dispatch] に変更。dispatch は useReducer 由来で identity が stable なため、コールバックが毎レンダー再生成されなくなり、FilePanelContent → MarkdownEditor への不安定 prop 伝播が止まる。",
+      "files_to_modify": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx"
+      ],
+      "change_points": [
+        "L1298-1300: handleLoadContent useCallback deps [fileTabs] → [fileTabs.dispatch]",
+        "L1302-1304: handleLoadError useCallback deps [fileTabs] → [fileTabs.dispatch]",
+        "L1306-1308: handleSetLoading useCallback deps [fileTabs] → [fileTabs.dispatch]",
+        "L1310-1313: handleDirtyChange useCallback deps [fileTabs] → [fileTabs.dispatch]"
+      ]
+    },
+    {
+      "action_id": "B",
+      "title": "SET_DIRTY reducer で同値時 no-op (防衛線)",
+      "description": "useFileTabs.ts:239-246 の SET_DIRTY case で、対象 tab の isDirty が既に同じ値なら state を同一参照のまま返す。useReducer は state 参照が同一なら再レンダーをスキップするため、将来別経路で deps が崩れても同値 dispatch は無害化できる。",
+      "files_to_modify": [
+        "src/hooks/useFileTabs.ts"
+      ],
+      "change_points": [
+        "SET_DIRTY case 先頭で対象 tab を検索し、isDirty が同値なら return state;"
+      ]
+    }
+  ],
+  "out_of_scope": [
+    "WorktreeDetailRefactored.tsx L551/L570/L581/L875/L904 の『fileTabs 全体を deps に置く』アンチパターン → 別 Issue 化"
+  ],
+  "deliverables": [
+    "src/components/worktree/WorktreeDetailRefactored.tsx (useCallback deps 修正)",
+    "src/hooks/useFileTabs.ts (SET_DIRTY reducer no-op 追加)",
+    "tests/unit/hooks/useFileTabs.test.ts (SET_DIRTY no-op テスト追加)",
+    "tests/unit/components/MarkdownEditor.test.tsx (既存テストで onDirtyChange stable 時の再呼び出し抑止を検証、または必要なら追加)"
+  ],
+  "test_strategy": {
+    "tdd_cycle": "Red-Green-Refactor",
+    "red_phase_tests": [
+      {
+        "id": "T1",
+        "type": "unit",
+        "file": "tests/unit/hooks/useFileTabs.test.ts",
+        "description": "SET_DIRTY に同値 (現在 isDirty=false の tab に対して isDirty:false) を dispatch した場合、result === previousState が成立することを assert。現状実装では新 state を返すので Red。",
+        "target": "useFileTabs reducer"
+      },
+      {
+        "id": "T2",
+        "type": "unit",
+        "file": "tests/unit/hooks/useFileTabs.test.ts",
+        "description": "SET_DIRTY で isDirty が真に変化した場合は新 state を返し、tabs[i].isDirty が更新されること。既存挙動の退行防止。",
+        "target": "useFileTabs reducer"
+      }
+    ],
+    "acceptance_tests": [
+      "T3 (手動): Worktree A で .md を開いた状態でサイドバーから Worktree B を選択 → URL が /worktrees/B に変わる",
+      "T4 (手動): .yaml / .yml でも同様に動作することを確認 (investigation で特定された拡張範囲)",
+      ".png / .json で回帰しないことを確認 (もともと再現しないので変化なし想定)"
+    ]
+  },
+  "definition_of_done": [
+    "T1/T2 の unit test が green",
+    "npm run lint がパス",
+    "npx tsc --noEmit がパス",
+    "npm run test:unit がパス",
+    "手動受入: .md / .yaml / .yml 表示中でもサイドバーからのブランチ遷移で URL が更新される"
+  ],
+  "risk_level": "low",
+  "estimated_loc_change": "WorktreeDetailRefactored.tsx: 4行修正 / useFileTabs.ts: 3-4行追加 / tests: +10行程度",
+  "target_coverage": 80
+}

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -1295,22 +1295,29 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   // Issue #438: File panel loading callbacks (memoized for FilePanelSplit)
   // ========================================================================
 
+  // [Issue #675] Depend on the stable useReducer dispatch identity only; depending on
+  // the whole fileTabs object (re-created every render) triggers a SET_DIRTY feedback
+  // loop that starves router.push transitions. exhaustive-deps can't infer dispatch stability.
   const handleLoadContent = useCallback((path: string, content: FileContent) => {
     fileTabs.dispatch({ type: 'SET_CONTENT', path, content });
-  }, [fileTabs]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileTabs.dispatch]);
 
   const handleLoadError = useCallback((path: string, errorMsg: string) => {
     fileTabs.dispatch({ type: 'SET_ERROR', path, error: errorMsg });
-  }, [fileTabs]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileTabs.dispatch]);
 
   const handleSetLoading = useCallback((path: string, isLoading: boolean) => {
     fileTabs.dispatch({ type: 'SET_LOADING', path, loading: isLoading });
-  }, [fileTabs]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileTabs.dispatch]);
 
   // [Issue #469] isDirty state change callback for file content polling control
   const handleDirtyChange = useCallback((path: string, isDirty: boolean) => {
     fileTabs.dispatch({ type: 'SET_DIRTY', path, isDirty });
-  }, [fileTabs]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileTabs.dispatch]);
 
   // ========================================================================
   // Memoized Panes (Issue #411: avoid re-render on polling)

--- a/src/hooks/useFileTabs.ts
+++ b/src/hooks/useFileTabs.ts
@@ -237,6 +237,9 @@ export function fileTabsReducer(state: FileTabsState, action: FileTabsAction): F
     }
 
     case 'SET_DIRTY': {
+      // [Issue #675] Short-circuit no-op dispatches so upstream useReducer skips re-render
+      const current = state.tabs.find((t) => t.path === action.path);
+      if (current && current.isDirty === action.isDirty) return state;
       const newTabs = updateTabByPath(state.tabs, action.path, (tab) => ({
         ...tab,
         isDirty: action.isDirty,

--- a/tests/unit/hooks/useFileTabs.test.ts
+++ b/tests/unit/hooks/useFileTabs.test.ts
@@ -450,6 +450,42 @@ describe('fileTabsReducer', () => {
 
       expect(result).toBe(stateWithTab);
     });
+
+    // [Issue #675] Re-render loop guard: same-value SET_DIRTY must be a no-op
+    it('SET_DIRTY should return same state reference when isDirty is already the same value (false→false)', () => {
+      const stateWithTab: FileTabsState = {
+        tabs: [{ path: 'a.ts', name: 'a.ts', content: null, loading: false, error: null, isDirty: false }],
+        activeIndex: 0,
+      };
+      const action: FileTabsAction = { type: 'SET_DIRTY', path: 'a.ts', isDirty: false };
+      const result = fileTabsReducer(stateWithTab, action);
+
+      expect(result).toBe(stateWithTab);
+    });
+
+    it('SET_DIRTY should return same state reference when isDirty is already the same value (true→true)', () => {
+      const stateWithTab: FileTabsState = {
+        tabs: [{ path: 'a.ts', name: 'a.ts', content: null, loading: false, error: null, isDirty: true }],
+        activeIndex: 0,
+      };
+      const action: FileTabsAction = { type: 'SET_DIRTY', path: 'a.ts', isDirty: true };
+      const result = fileTabsReducer(stateWithTab, action);
+
+      expect(result).toBe(stateWithTab);
+    });
+
+    it('SET_DIRTY applied twice with the same value returns a stable reference', () => {
+      const stateWithTab: FileTabsState = {
+        tabs: [{ path: 'a.ts', name: 'a.ts', content: null, loading: false, error: null, isDirty: false }],
+        activeIndex: 0,
+      };
+      const action: FileTabsAction = { type: 'SET_DIRTY', path: 'a.ts', isDirty: true };
+      const first = fileTabsReducer(stateWithTab, action);
+      const second = fileTabsReducer(first, action);
+
+      expect(first.tabs[0].isDirty).toBe(true);
+      expect(second).toBe(first);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

`.md` ファイル表示中にサイドバーから別ブランチを選択しても URL が更新されず画面遷移しないバグを修正。`MarkdownEditor` 経由で発生していた無限 re-render ループが `router.push` の App Router transition を starve させていた根本原因を A案 + B案 の多層防御で解消。

Closes #675

## Root Cause

`useFileTabs` の return が毎レンダー新オブジェクト参照を返すため、`WorktreeDetailRefactored` の 4 つの `useCallback` (deps=`[fileTabs]`) が毎レンダー再生成される。これが `FilePanelContent` → `MarkdownEditor` へ不安定 prop として伝播し、`useEffect([isDirty, onDirtyChange])` が毎レンダー発火 → `dispatch({type:'SET_DIRTY'})` → reducer が同値でも新 state を返す → 上流再レンダー → ループ。高優先度 dispatch が積まれ続けるため `router.push` が起動した低優先度 transition が starve し URL が commit されない。`.md` 以外で再現しないのは `MarkdownEditor` だけが `onDirtyChange` useEffect を持つため。

## Changes

### Fixed
- **A案**: `src/components/worktree/WorktreeDetailRefactored.tsx` の `handleLoadContent` / `handleLoadError` / `handleSetLoading` / `handleDirtyChange` の `useCallback` deps を `[fileTabs]` から `[fileTabs.dispatch]` に変更。`dispatch` は `useReducer` 由来で identity stable なためコールバック identity が安定し、下流への不安定 prop 伝播が止まる。
- **B案**: `src/hooks/useFileTabs.ts` の `SET_DIRTY` reducer で対象 tab の `isDirty` が既に同値なら `state` を同一参照のまま返す no-op 判定を追加。`useReducer` は state 参照が同一なら再レンダーをスキップするため、将来別経路で deps が崩れても SET_DIRTY 経由のループは構造的に防がれる多層防御。

### Added
- `tests/unit/hooks/useFileTabs.test.ts`: SET_DIRTY 同値 no-op 検証 3 件 (`false→false` / `true→true` / double-apply による state 参照安定性)。

## Out of Scope

同ファイル (`WorktreeDetailRefactored.tsx`) 内の他 5 箇所 (L551/L570/L581/L875/L904) にも『`fileTabs` 全体を `deps` に置く』同種アンチパターンが残るが、Issue #675 の再現経路とは別系統のため別 Issue として起票予定。

## Test Results

### Unit Tests
```
npm run test:unit
Test Files  340 passed (340)
Tests       6384 passed | 7 skipped (6391)
Duration    14.27s
```

### Lint & Type Check
- ESLint: 0 errors / 0 warnings
- TypeScript: 0 errors (tsc --noEmit exit 0)

### Build
```
npm run build
Compiled successfully
```

## Manual Verification (recommended before merge)

- [ ] Worktree A で `.md` を開いた状態でサイドバーから Worktree B を選択 → URL が `/worktrees/B` に変わる
- [ ] `.yaml` / `.yml` でも同様に遷移する (`MarkdownEditor` を経由する全拡張子で同じ構造のため)
- [ ] `.png` / `.json` / `.pdf` で回帰なし (元々再現しないので挙動維持のはず)

## Checklist

- [x] Unit tests pass
- [x] Lint check passes
- [x] Type check passes
- [x] Build succeeds
- [x] No console.log in production code
- [x] Scope kept minimal (no unrelated refactoring)

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>