### PR TITLE
fix(#676): prevent stuck sidebar branch tooltip (A+B+C)

### DIFF
--- a/dev-reports/bug-fix/issue676_20260424_201938/acceptance-context.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/acceptance-context.json
@@ -1,0 +1,36 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "bug_description": "サイドバーのブランチ tooltip が isTooltipVisible=true で固着し残り続ける。Issue #675 の無限ループ中に mouseleave 合成イベントのレースで state が true のまま固定される。",
+  "fix_summary": "A+B+C 併用で防御的修正を実施: (A) 選択中ブランチでは tooltip を出さない、(B) click 時に明示的に setIsTooltipVisible(false)、(C) isVisible=false のとき portal の中身を null にして DOM から物理除去、加えて aria-describedby も tooltip が実在するときだけ付与する形に変更。",
+  "files_modified": [
+    "src/components/sidebar/BranchListItem.tsx",
+    "tests/unit/components/sidebar/BranchListItem.test.tsx",
+    "tests/unit/components/layout/Sidebar.test.tsx"
+  ],
+  "acceptance_criteria": [
+    "選択中ブランチでは tooltip が表示されないこと（isSelected=true）",
+    "マウスを別要素に移動すると tooltip が消えること（mouseLeave）",
+    "button を click すると tooltip が消えること（click 時の明示的リセット）",
+    "focus → blur でも tooltip が消えること",
+    "isVisible=false のとき tooltip div が DOM に存在しないこと（最終防御線）",
+    "aria-describedby は tooltip が DOM に実在するときだけ button に付与されること",
+    "既存の tooltip 表示機能（mouseEnter/focus で表示、branch 情報を表示）が壊れていないこと",
+    "lint/tsc/unit test 全てパス"
+  ],
+  "test_scenarios": [
+    "シナリオ1: 未選択ブランチをホバー → tooltip 表示 → マウス離脱 → tooltip 消失",
+    "シナリオ2: ブランチをクリック → tooltip 即座に消失 → onClick コールバック発火",
+    "シナリオ3: 既に選択中のブランチをホバー → tooltip が表示されない（A 案）",
+    "シナリオ4: キーボード focus → tooltip 表示 → blur → tooltip 消失",
+    "シナリオ5: 初期レンダリング直後 → tooltip が DOM に存在しない（C 案）",
+    "シナリオ6: tooltip 非表示時 → button に aria-describedby が付いていない"
+  ],
+  "verification_commands": [
+    "npm run lint",
+    "npx tsc --noEmit",
+    "npm run test:unit -- tests/unit/components/sidebar/BranchListItem.test.tsx",
+    "npm run test:unit"
+  ],
+  "tdd_result_file": "dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-result.json"
+}

--- a/dev-reports/bug-fix/issue676_20260424_201938/acceptance-result.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/acceptance-result.json
@@ -1,0 +1,161 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "result": "passed",
+  "summary": "All 7 acceptance criteria verified by unit tests (45/45 in BranchListItem.test.tsx, 9 new Issue #676 tests). All quality gates pass: lint clean, tsc clean, full unit suite 6390 passed / 7 skipped / 0 failed. Implementation correctly applies defensive strategies A+B+C to src/components/sidebar/BranchListItem.tsx. Hook ordering is preserved in BranchTooltip, SSR guard intact, scope strictly contained to sidebar BranchListItem (with one unrelated Sidebar.test.tsx count relaxation that is logically consistent with the DOM change).",
+  "acceptance_criteria_results": [
+    {
+      "criterion": "選択中ブランチでは tooltip が表示されないこと (isSelected=true)",
+      "status": "passed",
+      "evidence": "BranchListItem.tsx L158: showTooltip = isTooltipVisible && !isSelected. Verified by 'should not render tooltip when isSelected=true even on mouseEnter (A + C)' test that fires mouseEnter on a selected branch and asserts queryByRole('tooltip') is absent."
+    },
+    {
+      "criterion": "マウスを別要素に移動すると tooltip が消えること (mouseLeave)",
+      "status": "passed",
+      "evidence": "BranchListItem.tsx L174: onMouseLeave={() => setIsTooltipVisible(false)}. Verified by 'should hide tooltip on mouseLeave' test which enters then leaves and asserts tooltip is removed from DOM."
+    },
+    {
+      "criterion": "button を click すると tooltip が消えること (click 時の明示的リセット)",
+      "status": "passed",
+      "evidence": "BranchListItem.tsx L163-166: handleClick wraps onClick and calls setIsTooltipVisible(false) first. Verified by 'should hide tooltip on click (B)' and 'should still invoke onClick when click hides the tooltip (B)' tests (onClick vi.fn called exactly once)."
+    },
+    {
+      "criterion": "focus → blur でも tooltip が消えること",
+      "status": "passed",
+      "evidence": "BranchListItem.tsx L175-176: onFocus/onBlur toggle isTooltipVisible. Verified by 'should show tooltip on focus and hide on blur' test."
+    },
+    {
+      "criterion": "isVisible=false のとき tooltip div が DOM に存在しないこと (最終防御線)",
+      "status": "passed",
+      "evidence": "BranchListItem.tsx L95: 'if (!isVisible) return null;' placed AFTER the useEffect so Hook order is stable. The obsolete opacity-based always-mounted rendering was removed. Verified by 'should not render tooltip in DOM on initial render (C)' test."
+    },
+    {
+      "criterion": "aria-describedby は tooltip が DOM に実在するときだけ button に付与されること",
+      "status": "passed",
+      "evidence": "BranchListItem.tsx L178: aria-describedby={showTooltip ? tooltipId : undefined}. Verified by 'should not attach aria-describedby on initial render' and 'should not attach aria-describedby when isSelected=true (A)' tests."
+    },
+    {
+      "criterion": "既存の tooltip 表示機能 (mouseEnter/focus で表示, branch 情報を表示) が壊れていないこと",
+      "status": "passed",
+      "evidence": "10 existing tooltip tests were updated to fire mouseEnter first and all pass. 'should show tooltip on mouseEnter' explicitly asserts tooltip becomes present. Tooltip content rendering (name, repositoryName, status, worktreePath, description) in BranchTooltip JSX is unchanged."
+    }
+  ],
+  "quality_gate_results": {
+    "lint": {
+      "command": "npm run lint",
+      "status": "passed",
+      "output": "No ESLint warnings or errors"
+    },
+    "typecheck": {
+      "command": "npx tsc --noEmit",
+      "status": "passed",
+      "output": "No type errors"
+    },
+    "unit_tests_target": {
+      "command": "npx vitest run tests/unit/components/sidebar/BranchListItem.test.tsx",
+      "status": "passed",
+      "total": 45,
+      "passed": 45,
+      "failed": 0,
+      "output": "Test Files 1 passed (1); Tests 45 passed (45); Duration ~712ms"
+    },
+    "unit_tests_full": {
+      "command": "npm run test:unit",
+      "status": "passed",
+      "total_files": 340,
+      "total": 6397,
+      "passed": 6390,
+      "skipped": 7,
+      "failed": 0,
+      "output": "Test Files 340 passed (340); Tests 6390 passed | 7 skipped (6397); Duration ~13.87s. Matches TDD result baseline exactly; no regressions introduced."
+    }
+  },
+  "test_scenarios_results": [
+    {
+      "scenario": "シナリオ1: 未選択ブランチをホバー → tooltip 表示 → マウス離脱 → tooltip 消失",
+      "status": "passed",
+      "evidence": "'should show tooltip on mouseEnter' + 'should hide tooltip on mouseLeave'"
+    },
+    {
+      "scenario": "シナリオ2: ブランチをクリック → tooltip 即座に消失 → onClick コールバック発火",
+      "status": "passed",
+      "evidence": "'should hide tooltip on click (B)' + 'should still invoke onClick when click hides the tooltip (B)'"
+    },
+    {
+      "scenario": "シナリオ3: 既に選択中のブランチをホバー → tooltip が表示されない (A 案)",
+      "status": "passed",
+      "evidence": "'should not render tooltip when isSelected=true even on mouseEnter (A + C)'"
+    },
+    {
+      "scenario": "シナリオ4: キーボード focus → tooltip 表示 → blur → tooltip 消失",
+      "status": "passed",
+      "evidence": "'should show tooltip on focus and hide on blur'"
+    },
+    {
+      "scenario": "シナリオ5: 初期レンダリング直後 → tooltip が DOM に存在しない (C 案)",
+      "status": "passed",
+      "evidence": "'should not render tooltip in DOM on initial render (C)'"
+    },
+    {
+      "scenario": "シナリオ6: tooltip 非表示時 → button に aria-describedby が付いていない",
+      "status": "passed",
+      "evidence": "'should not attach aria-describedby on initial render' + 'should not attach aria-describedby when isSelected=true (A)'"
+    }
+  ],
+  "code_review_findings": [
+    {
+      "severity": "info",
+      "area": "Hook ordering",
+      "finding": "BranchTooltip preserves stable Hook order: useState → useEffect → SSR guard (typeof document) → visibility early return → createPortal. The early `if (!isVisible) return null;` is placed AFTER the useEffect, so React never observes a changing number of Hook calls. Correctly implemented as described in the issue spec."
+    },
+    {
+      "severity": "info",
+      "area": "SSR safety",
+      "finding": "The `typeof document === 'undefined'` guard is retained before the visibility guard (BranchListItem.tsx L91), so SSR behavior is unchanged."
+    },
+    {
+      "severity": "info",
+      "area": "Accessibility",
+      "finding": "aria-describedby is now conditionally attached only when the tooltip is actually in the DOM (L178). This is the accessible behavior and avoids screen readers following a dangling reference when the tooltip node does not exist."
+    },
+    {
+      "severity": "info",
+      "area": "Scope containment",
+      "finding": "Production code changes are limited to src/components/sidebar/BranchListItem.tsx. Other sidebar features (CliStatusDot, unread indicator, description rendering, showRepositoryName inline display, aria-current, aria-label, focus ring) are untouched. Issue #675 infinite-loop code is not modified, confirming the requested scope separation."
+    },
+    {
+      "severity": "info",
+      "area": "Style cleanup",
+      "finding": "The obsolete `opacity: isVisible ? 1 : 0` inline style was removed along with the always-mounted portal strategy; the `transition-opacity` CSS class remains but is now a no-op (no dynamic opacity change). Harmless, but a minor follow-up could strip `transition-opacity duration-150` from the className for clarity. Not a blocker."
+    },
+    {
+      "severity": "info",
+      "area": "Sidebar.test.tsx relaxation",
+      "finding": "Adjacent test 'should show repository name for each branch' was relaxed from >=3 to >=1 occurrences. Justified: in grouped view branch items already use showRepositoryName={false}, so the previous >=3 only passed because the always-mounted tooltip DOM duplicated the repo-name text. With tooltips now mounting only on hover, >=1 (group header) is the correct expectation and accurately reflects user-visible content."
+    },
+    {
+      "severity": "info",
+      "area": "Alignment with Issue #676 directive",
+      "finding": "Implementation applies all three strategies A + B + C as requested in the Issue body and TDD plan. Each strategy is independently verifiable via dedicated tests, which provides good defense-in-depth against future regressions."
+    }
+  ],
+  "risk_assessment": {
+    "scope_contained_to_sidebar_branch_list_item": true,
+    "issue_675_untouched": true,
+    "ssr_portal_guard_preserved": true,
+    "accessibility_regressions": "none detected; aria-describedby behavior is stricter (only when tooltip actually exists), aria-current / aria-label unchanged, keyboard focus path unchanged",
+    "existing_functionality_regressions": "none detected; full 6390-test suite passes, target file 45/45 passes, 10 existing tooltip tests updated to still assert tooltip content after mouseEnter",
+    "notable_considerations": [
+      "Existing Sidebar.test.tsx count assertion was relaxed due to the DOM node no longer being always-mounted. This is a consequence of the fix, not a functional regression; the grouped-view repository name is still rendered once in the group header and the branch-level name remains accessible via the tooltip on hover.",
+      "The CSS `transition-opacity duration-150` class on the tooltip div is now largely cosmetic since mount/unmount happens instead of opacity fading. Minor follow-up opportunity, not a defect.",
+      "Hook ordering inside BranchTooltip relies on the early return being placed AFTER useState/useEffect. This is currently satisfied but worth calling out in a future code review so it is not accidentally reshuffled."
+    ]
+  },
+  "recommendation": "Approve. The fix correctly implements the A+B+C defensive strategies prescribed in Issue #676, all acceptance criteria are covered by automated tests, and every quality gate (lint, tsc, target-file tests, full unit suite) passes with zero regressions. Scope is tightly contained to the sidebar BranchListItem component, aligning with the instruction to keep Issue #675 infinite-loop code out of scope. Ready to proceed to PR / UAT stage.",
+  "evidence_files": [
+    "src/components/sidebar/BranchListItem.tsx (commit 54d62d91)",
+    "tests/unit/components/sidebar/BranchListItem.test.tsx (45 tests, +9 new, 10 updated)",
+    "tests/unit/components/layout/Sidebar.test.tsx (1 assertion relaxed)",
+    "dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-result.json"
+  ]
+}

--- a/dev-reports/bug-fix/issue676_20260424_201938/investigation-result.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/investigation-result.json
@@ -1,0 +1,13 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "title": "サイドバーのブランチ tooltip が isTooltipVisible=true で固着し残り続ける",
+  "root_cause": "BranchListItem.tsx の isTooltipVisible state が true のまま固定される。Issue #675 の無限ループ中に mouseleave 合成イベントと React 18 concurrent rendering のレースで setIsTooltipVisible(false) が dispatch されない。加えて tooltip は portal で DOM に常時存在し opacity 制御のみのため、state 異常時にユーザー画面から除去できない構造になっている。",
+  "affected_files": [
+    "src/components/sidebar/BranchListItem.tsx"
+  ],
+  "severity": "high",
+  "related_issues": [675],
+  "recommended_fix": "A+B+C 併用（Issue 本文記載の通り）",
+  "skipped_reason": "Issue #676 本文に調査済みの根本原因・修正方針・テスト方針が既に詳細に記載済みのため、investigation-agent 呼び出しをスキップ。実ファイル (src/components/sidebar/BranchListItem.tsx) で Issue 記載の行番号・コード構造と一致することを確認済み。"
+}

--- a/dev-reports/bug-fix/issue676_20260424_201938/progress-context.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/progress-context.json
@@ -1,0 +1,58 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "issue_title": "fix: サイドバーのブランチ tooltip が isTooltipVisible=true で固着し残り続ける",
+  "severity": "high",
+  "branch": "feature/676-worktree",
+  "commit": "54d62d91",
+  "phases": {
+    "phase1_investigation": {
+      "status": "completed",
+      "note": "Issue #676 本文に詳細な根本原因分析と A/B/C 対策案が既に記載済みのため investigation-agent 呼び出しはスキップ。実ファイルとの整合性は確認済み。",
+      "result_file": "dev-reports/bug-fix/issue676_20260424_201938/investigation-result.json"
+    },
+    "phase2_proposal": {
+      "status": "completed",
+      "user_selection": "A+B+C 全て適用 (推奨)"
+    },
+    "phase3_work_plan": {
+      "status": "completed",
+      "result_file": "dev-reports/bug-fix/issue676_20260424_201938/work-plan-context.json"
+    },
+    "phase4_tdd_fix": {
+      "status": "passed",
+      "result_file": "dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-result.json",
+      "metrics": {
+        "new_tests": 9,
+        "updated_tests": 10,
+        "target_file_tests": "45/45 passed",
+        "full_suite": "6390 passed / 7 skipped / 0 failed"
+      }
+    },
+    "phase5_acceptance": {
+      "status": "passed",
+      "result_file": "dev-reports/bug-fix/issue676_20260424_201938/acceptance-result.json",
+      "acceptance_criteria": "7/7 met",
+      "quality_gates": "lint/tsc/unit test 全て pass"
+    }
+  },
+  "root_cause": "BranchListItem.tsx の isTooltipVisible state が true のまま固定される。Issue #675 の無限ループ中に mouseleave 合成イベントと React 18 concurrent rendering のレースで setIsTooltipVisible(false) が dispatch されない。加えて tooltip は portal で常時 DOM に存在し opacity 制御のみのため、state 異常時にユーザー画面から物理除去できない構造になっていた。",
+  "fix_applied": {
+    "A": "選択中ブランチでは tooltip を表示しない (showTooltip = isTooltipVisible && !isSelected)",
+    "B": "click ラッパーで setIsTooltipVisible(false) 後に props.onClick を呼ぶ",
+    "C": "BranchTooltip を isVisible=false のとき return null で DOM から物理除去（useEffect の後）。aria-describedby は tooltip 実在時のみ button に付与"
+  },
+  "files_changed": [
+    "src/components/sidebar/BranchListItem.tsx",
+    "tests/unit/components/sidebar/BranchListItem.test.tsx",
+    "tests/unit/components/layout/Sidebar.test.tsx"
+  ],
+  "risks_accepted": [
+    "Issue #675 の無限ループ本体は本 issue 範囲外のため未修正（別 issue で対応）。本修正は race に対する多層防御であり、#675 修正後も適切に動作する設計。"
+  ],
+  "next_steps": [
+    "PR 作成（/create-pr）",
+    "develop への マージ後、実機で再現条件（.md ファイル表示中）での UAT（/uat）",
+    "Issue #675（無限ループ本体）を別途対応"
+  ]
+}

--- a/dev-reports/bug-fix/issue676_20260424_201938/progress-report.md
+++ b/dev-reports/bug-fix/issue676_20260424_201938/progress-report.md
@@ -1,0 +1,176 @@
+# Bug Fix Progress Report: Issue #676
+
+## 1. 概要
+
+| 項目 | 値 |
+|------|-----|
+| Issue 番号 | #676 |
+| タイトル | サイドバーのブランチ tooltip が `isTooltipVisible=true` で固着し残り続ける |
+| 重大度 | high |
+| ブランチ | `feature/676-worktree` |
+| Commit | `54d62d91bc4d06fe06402e458e592a643ec41534` |
+| 採用方針 | A + B + C 全て適用（多層防御） |
+| 最終ステータス | **passed**（全フェーズ完了、全品質ゲート pass） |
+
+フェーズ進行:
+
+| フェーズ | ステータス | 備考 |
+|---------|-----------|------|
+| Phase 1: 調査 | completed | Issue 本文に詳細な根本原因分析・対策案が既に記載済みのため investigation-agent 呼び出しをスキップ。実ファイルとの整合性は確認済み。 |
+| Phase 2: 方針選定 | completed | ユーザー選定: `A+B+C 全て適用 (推奨)` |
+| Phase 3: 作業計画 | completed | A/B/C の修正対象ファイル・行番号を確定 |
+| Phase 4: TDD 修正 | passed | target file 45/45 passed、full suite 6390 passed / 7 skipped / 0 failed |
+| Phase 5: 受入テスト | passed | 受入基準 7/7 met、lint/tsc/unit test 全 pass |
+
+---
+
+## 2. 根本原因
+
+`src/components/sidebar/BranchListItem.tsx` の `isTooltipVisible` state が `true` のまま固定されるバグ。
+
+- Issue #675 の無限ループが発生している最中、合成 `mouseleave` イベントと React 18 concurrent rendering のレースで `setIsTooltipVisible(false)` が dispatch されないケースがある。
+- tooltip は portal によって **常時 DOM に存在し `opacity` で制御** しているだけの構造のため、state が異常な値になるとユーザー画面から物理的に除去できない。
+
+結果としてユーザー体感上「選択済みのブランチに tooltip が貼り付いたまま残り続ける」という症状が発生していた。
+Issue #675 の無限ループ本体修正は本 Issue スコープ外だが、本修正は **レースに対する多層防御** として `#675` 修正後も整合する設計にしてある。
+
+---
+
+## 3. 実施した修正内容
+
+対象: `src/components/sidebar/BranchListItem.tsx`（本体）＋テスト 2 本
+
+### 案 A: 選択中ブランチでは tooltip を表示しない
+
+- 親コンポーネントで `showTooltip = isTooltipVisible && !isSelected` を算出し、`<BranchTooltip isVisible={showTooltip} />` に渡すように変更。
+- 選択中ブランチの情報はメイン画面側に出ているため、そもそも tooltip を出す必要が薄い。スクショ症状（選択済みブランチの残留 tooltip）を根元から解消。
+
+### 案 B: click 時に明示的に `setIsTooltipVisible(false)` を呼ぶ
+
+- `handleClick` ラッパーを導入し、`setIsTooltipVisible(false)` を先に実行してから上位 `onClick` を呼ぶようにした。
+- `click` という確実に発火するトリガで state を強制的に落とすため、`onMouseLeave` がスキップされるレースに依存しなくなる。
+
+### 案 C: `isVisible=false` のとき portal 内部を `return null` で物理的に除去
+
+- `BranchTooltip` の useEffect 宣言**後**に `if (!isVisible) return null;` を配置し、非表示時は DOM ノード自体が存在しないようにした。
+- 従来の `opacity: isVisible ? 1 : 0` 制御は廃止し、常時マウント戦略を止めた（最終防御線）。
+- `aria-describedby` は `showTooltip === true` のときだけ button に付与するよう変更（dangling reference 回避）。
+- `BranchTooltip` の JSDoc コメントを「Always present in DOM / CSS-controlled visibility」から「mount-on-visible」ライフサイクル記述に更新。
+
+### Hook 安全性の担保
+
+`BranchTooltip` 内の Hook 呼び出し順序は `useState → useEffect → SSR ガード(typeof document) → 可視性 early return → createPortal` の順を厳守。`if (!isVisible) return null;` を必ず useEffect の**後**に置くことで、React が観測する Hook 呼び出し数は常に一定。SSR ガードも保持。
+
+---
+
+## 4. 変更ファイル一覧
+
+| ファイル | 種別 | 概要 |
+|---------|------|------|
+| `src/components/sidebar/BranchListItem.tsx` | modified (本体) | A/B/C 全てを反映。`showTooltip` 算出、`handleClick` ラッパー、`BranchTooltip` の `!isVisible` 早期 return、`aria-describedby` のゲート、JSDoc 更新、`opacity` スタイル除去。 |
+| `tests/unit/components/sidebar/BranchListItem.test.tsx` | modified (テスト) | 新 describe `Tooltip visibility lifecycle (Issue #676)` を追加（9 テスト）。既存 10 テストは「mouseEnter を先に発火してから tooltip 検証」に更新。`showRepositoryName` 系は DOM 部分木で `>=1` を検証する形に調整。 |
+| `tests/unit/components/layout/Sidebar.test.tsx` | modified (隣接テスト) | `should show repository name for each branch` のカウント期待値を `>=3` から `>=1` に緩和。従来値は「常時マウントされた tooltip DOM の重複」に暗黙依存していたための調整で、グループヘッダに 1 回出る実ユーザー視認仕様と整合。 |
+
+---
+
+## 5. テスト結果
+
+### 5.1 TDD サイクル
+
+| フェーズ | 結果 |
+|---------|------|
+| Red | 修正前コードに対して 9 新規テストと更新 8 既存テストを追加・実行。**7 テストが failing** することを確認。 |
+| Green | `BranchListItem.tsx` に A+B+C を適用。target file **45/45 passed**。 |
+| Refactor | `BranchTooltip` の JSDoc を新ライフサイクル仕様に更新。古い `opacity` スタイルを削除。Issue #675 スコープ外のコードには触れず最小修正範囲を維持。 |
+
+### 5.2 メトリクス
+
+| 指標 | 修正前 | 修正後 | 増減 |
+|------|--------|--------|------|
+| target file (BranchListItem.test.tsx) | 36 | 45 | +9 |
+| full suite total | 6388 | 6397 | +9 |
+| full suite passed | 6381 | 6390 | +9 |
+| skipped | 7 | 7 | ±0 |
+| failed | 0 | 0 | ±0 |
+
+新規追加 9 テスト:
+
+- `should not render tooltip in DOM on initial render (C)`
+- `should not attach aria-describedby on initial render (accessibility)`
+- `should show tooltip on mouseEnter`
+- `should hide tooltip on mouseLeave`
+- `should hide tooltip on click (B)`
+- `should still invoke onClick when click hides the tooltip (B)`
+- `should not render tooltip when isSelected=true even on mouseEnter (A + C)`
+- `should not attach aria-describedby when isSelected=true (A)`
+- `should show tooltip on focus and hide on blur`
+
+### 5.3 受入テスト（7/7 met）
+
+| # | 受入基準 | 結果 |
+|---|---------|------|
+| 1 | 選択中ブランチでは tooltip が表示されないこと | passed |
+| 2 | mouseLeave で tooltip が消えること | passed |
+| 3 | click で tooltip が消えること（明示的リセット） | passed |
+| 4 | focus → blur で tooltip が消えること | passed |
+| 5 | `isVisible=false` のとき tooltip div が DOM に存在しないこと | passed |
+| 6 | `aria-describedby` は tooltip 実在時のみ button に付くこと | passed |
+| 7 | 既存の tooltip 表示機能（表示内容・トリガ）が壊れていないこと | passed |
+
+### 5.4 品質ゲート
+
+| チェック | コマンド | 結果 |
+|---------|---------|------|
+| Lint | `npm run lint` | passed（警告・エラーなし） |
+| TypeCheck | `npx tsc --noEmit` | passed（型エラーなし） |
+| Unit Tests (target) | `npx vitest run tests/unit/components/sidebar/BranchListItem.test.tsx` | **45 / 45 passed**（約 712ms） |
+| Unit Tests (full) | `npm run test:unit` | 340 files / **6390 passed** / 7 skipped / 0 failed（約 13.87s） |
+
+### 5.5 カバレッジ（branches covered）
+
+- `BranchTooltip` の `!isVisible` 早期 return
+- `BranchTooltip` の `isVisible=true` 通常描画
+- `showTooltip = isTooltipVisible && !isSelected` の両分岐
+- `handleClick` における visibility リセット → 上位 onClick 呼び出し順序
+- `aria-describedby` の `showTooltip` ゲート
+- `mouseEnter / mouseLeave / focus / blur` 各トリガ遷移
+
+---
+
+## 6. リスクと次のステップ
+
+### 6.1 受容済みリスク
+
+- **Issue #675（無限ループ本体）は未修正**。本 Issue スコープ外のため別 Issue で対応。本修正は race に対する多層防御であり、`#675` 修正後も破綻しない設計。
+
+### 6.2 留意事項（致命的ではないが将来の考慮点）
+
+- `transition-opacity duration-150` クラスはマウント/アンマウント方式に切り替わった現在は cosmetic のみで実効なし。将来的なクリーンアップ候補（非ブロッカー）。
+- `BranchTooltip` 内の Hook 順序は「early return を `useState/useEffect` の後ろに置く」ことで保たれている。将来のリファクタで並びを崩さないようコードレビューで注意するとよい。
+- Adjacent の `Sidebar.test.tsx` アサーションを `>=3` → `>=1` に緩和したのは DOM 構造変更の当然の帰結であり、機能的 regression ではない。
+
+### 6.3 次のステップ
+
+1. `/create-pr` で PR を作成（feature/676-worktree → develop）。
+2. develop へのマージ後、**再現条件（`.md` ファイル表示中での選択操作）** を含む実機 UAT を `/uat` で実施。
+3. Issue #675（無限ループ本体）を別途着手。
+
+---
+
+## 7. 関連 Issue（#675 との関係）
+
+- Issue #675: サイドバーで発生する無限ループの本体（root cause は同画面の別コンポーネント由来）。
+- 本 Issue #676 は、`#675` によるレース状況下で顕在化する「選択済みブランチ tooltip の残留」を修正する。
+  - `#675` が直った場合でも、本修正で導入した A/B/C の防御は冗長な保険として機能し、副作用はない。
+  - 逆に `#675` が未修正のままでも、本修正によりユーザー可視の残留 tooltip は解消される（C 案の DOM 物理除去が最終防御線）。
+- よって本修正は **`#675` の解決を待たずに単独でマージしてよい** と判断する。
+
+---
+
+## 参考
+
+- `dev-reports/bug-fix/issue676_20260424_201938/investigation-result.json`
+- `dev-reports/bug-fix/issue676_20260424_201938/work-plan-context.json`
+- `dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-result.json`
+- `dev-reports/bug-fix/issue676_20260424_201938/acceptance-result.json`
+- commit `54d62d91bc4d06fe06402e458e592a643ec41534` on `feature/676-worktree`

--- a/dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-context.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-context.json
@@ -1,0 +1,61 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "bug_description": "サイドバーのブランチ tooltip が isTooltipVisible=true で固着し残り続ける。Issue #675 の無限ループ中に mouseleave 合成イベントと React concurrent rendering のレースで state が true のまま固定される。",
+  "selected_actions": [
+    {
+      "action_id": "A",
+      "title": "選択中ブランチでは tooltip を出さない",
+      "description": "BranchListItem.tsx の BranchTooltip に渡す isVisible を `isTooltipVisible && !isSelected` に変更。",
+      "target_location": "src/components/sidebar/BranchListItem.tsx の BranchTooltip 呼び出し箇所（222行付近）"
+    },
+    {
+      "action_id": "B",
+      "title": "click 時に明示的に state を false にする",
+      "description": "onClick ハンドラを wrapper 化し、setIsTooltipVisible(false) を先に呼んでから props.onClick を呼ぶ。",
+      "target_location": "src/components/sidebar/BranchListItem.tsx の button onClick（154行）"
+    },
+    {
+      "action_id": "C",
+      "title": "state false 時は portal の中身を null にする",
+      "description": "BranchTooltip の createPortal の第1引数を `isVisible ? <div>...</div> : null` に変更。旧コメント『Always present in DOM』『CSS-controlled visibility so aria-describedby works』は実態と乖離するので整合するように削除/更新。aria-describedby の tooltip は存在しないとスクリーンリーダーから参照先なしになるため、button 側の aria-describedby は isTooltipVisible && !isSelected が true のときのみ付与するか、従来通り常に付与するかは既存挙動維持（既存テスト tooltip-{id} が一致するという期待あり line 398）を優先すべきか、修正により tooltip 要素が存在しないときは aria-describedby を付けない方が仕様として正しい。→ 判断: 『isVisible が false のとき aria-describedby を付けない』が正しいが、既存テストが aria-describedby=tooltip-{id} を期待しているので、その既存テストも合わせて hover/focus 状態で検証するよう更新する。",
+      "target_location": "src/components/sidebar/BranchListItem.tsx の BranchTooltip 本体 createPortal（91-121行）と button の aria-describedby（160行）"
+    }
+  ],
+  "files_to_modify": [
+    "src/components/sidebar/BranchListItem.tsx",
+    "tests/unit/components/sidebar/BranchListItem.test.tsx"
+  ],
+  "test_strategy": {
+    "new_tests_to_add": [
+      "『選択中ブランチでは tooltip 要素が DOM に存在しない』- isSelected=true のとき mouseEnter しても `screen.queryByRole('tooltip')` が null である（A+C 検証）",
+      "『click 時に tooltip が消える』- mouseEnter でツールチップ表示 → click → screen.queryByRole('tooltip') が null（B+C 検証）",
+      "『初期状態では tooltip が DOM に存在しない』- render 直後に queryByRole('tooltip') が null（C 検証）",
+      "『mouseEnter で tooltip が表示される』- mouseEnter で getByRole('tooltip') が存在（基本動作の維持確認）",
+      "『mouseLeave で tooltip が消える』- mouseEnter → mouseLeave で queryByRole('tooltip') が null（基本動作の維持確認）"
+    ],
+    "existing_tests_to_update": [
+      "『should display branch name』line 54: tooltip 非表示前提に修正 or そのまま（>=1 なので問題なし）",
+      "『should display repository name』line 67: >=1 なので問題なし",
+      "『showRepositoryName prop』- line 337, 351: `>=2` 期待を hover 後に検証する or `>=1` に緩和する（推奨: インラインのみ存在を検証する形に修正）",
+      "『Tooltip (Issue #651)』line 374-481: 各テストで mouseEnter を事前に行って tooltip を表示させてから検証する形に全て更新する",
+      "『should truncate long branch names』line 304-323: closest('[role=\"tooltip\"]') フィルタが tooltip 非在時でも安全に動くこと確認"
+    ]
+  },
+  "target_coverage": 80,
+  "definition_of_done": [
+    "npm run lint がパス",
+    "npx tsc --noEmit がパス",
+    "npm run test:unit -- tests/unit/components/sidebar/BranchListItem.test.tsx がパス（新規テスト含む）",
+    "全 npm run test:unit がパス（他の既存テストに影響を出していないこと）",
+    "isSelected=true のときは tooltip が DOM に存在しないこと",
+    "click 時に tooltip が消えること",
+    "mouseEnter で tooltip が表示され mouseLeave で消えること"
+  ],
+  "important_notes": [
+    "BranchTooltip 内部の useState/useEffect の順序維持に注意（isVisible が false → true になるときに useEffect で座標計算する既存フロー）",
+    "aria-describedby は従来 button に常時付与されていたが、tooltip 要素が DOM に存在しないと無意味な参照になるため、tooltip が表示されているときだけ付与する形に変更する（アクセシビリティ的にも正しい）",
+    "既存の BranchTooltip コメント（60-63行）『Always present in DOM』は実態と乖離するため更新する",
+    "修正は最小限に。リファクタリングや別バグ修正に手を広げない"
+  ]
+}

--- a/dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-result.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/tdd-fix-result.json
@@ -1,0 +1,115 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "status": "passed",
+  "summary": "Applied A+B+C fix to BranchListItem: (A) suppress tooltip for selected branch, (B) explicitly reset visibility on click, (C) unmount portal contents and drop aria-describedby when not visible. All new TDD tests and the full unit test suite pass.",
+  "selected_actions": ["A", "B", "C"],
+  "files_changed": [
+    {
+      "path": "src/components/sidebar/BranchListItem.tsx",
+      "change_type": "modified",
+      "summary": "BranchTooltip returns null when !isVisible (C, removed opacity-0 stale DOM node). Parent component computes showTooltip = isTooltipVisible && !isSelected (A) and passes it to BranchTooltip. onClick is now wrapped via handleClick which calls setIsTooltipVisible(false) before invoking the upstream onClick (B). aria-describedby is only attached while showTooltip is true. JSDoc updated to reflect new lifecycle; useState/useEffect ordering in BranchTooltip preserved (early return for !isVisible placed after the useEffect)."
+    },
+    {
+      "path": "tests/unit/components/sidebar/BranchListItem.test.tsx",
+      "change_type": "modified",
+      "summary": "Existing Tooltip (Issue #651) tests updated to fire mouseEnter before asserting tooltip presence/attributes. showRepositoryName tests now verify inline-only presence (>=1 via DOM subtree filter) instead of expecting tooltip duplicates. Added new describe block 'Tooltip visibility lifecycle (Issue #676)' with 9 tests covering initial absence, mouseEnter/mouseLeave, focus/blur, click-dismisses-tooltip, onClick still fires, selected-branch suppression, and aria-describedby gating."
+    },
+    {
+      "path": "tests/unit/components/layout/Sidebar.test.tsx",
+      "change_type": "modified",
+      "summary": "Relaxed 'should show repository name for each branch' from >=3 to >=1 because that assertion implicitly relied on tooltips always being mounted in the DOM. In grouped view the repository name now comes solely from the group header (branch items have showRepositoryName={false})."
+    }
+  ],
+  "tdd_cycle": {
+    "red": {
+      "description": "Added 9 new tests in 'Tooltip visibility lifecycle (Issue #676)' and updated 8 existing Tooltip tests to fire mouseEnter first. Confirmed 7 tests failed against the unchanged implementation before applying the fix.",
+      "failing_tests_before_fix": 7
+    },
+    "green": {
+      "description": "Applied A+B+C in BranchListItem.tsx. Re-ran target test file: 45/45 passed.",
+      "passing_tests_after_fix": 45
+    },
+    "refactor": {
+      "description": "Updated JSDoc on BranchTooltip to describe new mount-on-visible lifecycle. Removed obsolete `opacity: isVisible ? 1 : 0` style. No further refactoring to stay within the minimal-fix scope."
+    }
+  },
+  "test_summary": {
+    "target_file": "tests/unit/components/sidebar/BranchListItem.test.tsx",
+    "target_file_tests_total": 45,
+    "target_file_tests_passed": 45,
+    "target_file_tests_failed": 0,
+    "new_tests_added": 9,
+    "existing_tests_updated": 10,
+    "suite_total": 6397,
+    "suite_passed": 6390,
+    "suite_skipped": 7,
+    "suite_failed": 0,
+    "baseline_before_fix": "36 tests in target file, 6381 tests across suite (all passing)",
+    "after_fix": "45 tests in target file (+9), 6390 tests across suite (+9, all passing)"
+  },
+  "new_tests": [
+    "should not render tooltip in DOM on initial render (C)",
+    "should not attach aria-describedby on initial render (accessibility)",
+    "should show tooltip on mouseEnter",
+    "should hide tooltip on mouseLeave",
+    "should hide tooltip on click (B)",
+    "should still invoke onClick when click hides the tooltip (B)",
+    "should not render tooltip when isSelected=true even on mouseEnter (A + C)",
+    "should not attach aria-describedby when isSelected=true (A)",
+    "should show tooltip on focus and hide on blur"
+  ],
+  "quality_checks": {
+    "lint": {
+      "command": "npm run lint",
+      "status": "passed",
+      "output_summary": "No ESLint warnings or errors"
+    },
+    "typecheck": {
+      "command": "npx tsc --noEmit",
+      "status": "passed",
+      "output_summary": "No type errors"
+    },
+    "unit_tests_target": {
+      "command": "npx vitest run tests/unit/components/sidebar/BranchListItem.test.tsx",
+      "status": "passed",
+      "output_summary": "45 passed, 0 failed"
+    },
+    "unit_tests_full": {
+      "command": "npm run test:unit",
+      "status": "passed",
+      "output_summary": "340 test files passed, 6390 tests passed, 7 skipped, 0 failed"
+    }
+  },
+  "coverage": {
+    "note": "Coverage not measured separately in this task; existing and new unit tests cover all modified branches (BranchListItem render states: hover/click/focus/blur, selected vs unselected, initial mount, aria-describedby gating).",
+    "branches_covered": [
+      "BranchTooltip early return when !isVisible",
+      "BranchTooltip rendered when isVisible",
+      "showTooltip = isTooltipVisible && !isSelected (both sides)",
+      "handleClick resets visibility before invoking onClick",
+      "aria-describedby gated on showTooltip",
+      "mouseEnter/mouseLeave/focus/blur transitions"
+    ]
+  },
+  "definition_of_done": {
+    "npm run lint pass": true,
+    "npx tsc --noEmit pass": true,
+    "target test file pass (with new tests)": true,
+    "full npm run test:unit pass": true,
+    "isSelected=true => tooltip absent from DOM": true,
+    "click => tooltip hidden": true,
+    "mouseEnter shows tooltip, mouseLeave hides": true
+  },
+  "important_notes_addressed": [
+    "BranchTooltip useState/useEffect order preserved: the early `if (!isVisible) return null;` is placed AFTER the useEffect declaration, so hook order is stable regardless of visibility transitions.",
+    "aria-describedby is now conditionally attached only while the tooltip is mounted, which is the accessible behavior and avoids a dangling reference.",
+    "Updated BranchTooltip JSDoc to replace the stale 'Always present in DOM / CSS-controlled visibility so aria-describedby works' note with a description of the new mount-on-visible lifecycle.",
+    "Scope kept minimal: did not touch Issue #675 infinite-loop code; no unrelated refactoring. Only one adjacent test (Sidebar.test.tsx 'should show repository name for each branch') was tweaked because it implicitly depended on tooltips always being mounted; the change is a straight relaxation of the count expectation."
+  ],
+  "commit": {
+    "hash": "54d62d91bc4d06fe06402e458e592a643ec41534",
+    "branch": "feature/676-worktree",
+    "message_subject": "fix(#676): prevent stuck sidebar branch tooltip (A+B+C)"
+  }
+}

--- a/dev-reports/bug-fix/issue676_20260424_201938/work-plan-context.json
+++ b/dev-reports/bug-fix/issue676_20260424_201938/work-plan-context.json
@@ -1,0 +1,40 @@
+{
+  "bug_id": "issue676_20260424_201938",
+  "issue_number": 676,
+  "bug_description": "サイドバーのブランチ tooltip が isTooltipVisible=true で固着し残り続ける",
+  "selected_actions": [
+    {
+      "action_id": "A",
+      "title": "選択中ブランチでは tooltip を出さない",
+      "description": "BranchListItem.tsx の BranchTooltip に渡す isVisible を `isTooltipVisible && !isSelected` に変更。選択中ブランチの情報はメイン画面に出ているため tooltip として見せる必要は薄く、スクショ症状（選択済みブランチの tooltip 残留）をこれで解消。",
+      "files_to_modify": ["src/components/sidebar/BranchListItem.tsx"],
+      "target_line": 222
+    },
+    {
+      "action_id": "B",
+      "title": "click 時に明示的に state を false にする",
+      "description": "onClick ハンドラで setIsTooltipVisible(false) を先に呼ぶ。click という確実なトリガで state を落とせるため、onMouseLeave スキップに依存しなくなる。",
+      "files_to_modify": ["src/components/sidebar/BranchListItem.tsx"],
+      "target_line": 154
+    },
+    {
+      "action_id": "C",
+      "title": "state false 時は portal の中身を null にする",
+      "description": "BranchTooltip の createPortal の children を `isVisible ? <div>...</div> : null` に変更。opacity 制御のみだと DOM 常時存在で state 異常時に必ず残留するため、物理的に除去する最終防御線。従来コメントの「Always present in DOM」の前提も改め、コメントも合わせて更新する。",
+      "files_to_modify": ["src/components/sidebar/BranchListItem.tsx"],
+      "target_line_range": "91-121"
+    }
+  ],
+  "deliverables": [
+    "src/components/sidebar/BranchListItem.tsx の修正",
+    "tests/unit/components/sidebar/BranchListItem.test.tsx への対応テスト追加"
+  ],
+  "definition_of_done": [
+    "isSelected=true のとき tooltip div 要素が DOM に描画されない（A+C 検証）",
+    "click 時に setIsTooltipVisible(false) が呼ばれる（B 検証）",
+    "isVisible=false のとき portal 内部が null で tooltip div が DOM に存在しない（C 検証）",
+    "既存の tooltip 関連テストが壊れないこと",
+    "npm run lint と npx tsc --noEmit がパス",
+    "npm run test:unit がパス"
+  ]
+}

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -58,9 +58,10 @@ function CliStatusDot({ status, label }: { status: BranchStatus; label: string }
 }
 
 /**
- * Tooltip shown on hover/focus with branch details (Issue #651).
+ * Tooltip shown on hover/focus with branch details (Issue #651, #676).
  * Rendered via React portal to escape the sidebar's overflow-y:auto clipping.
- * Always present in DOM (CSS-controlled visibility) so aria-describedby works.
+ * Only mounted into the DOM while `isVisible` is true (Issue #676 fix) to avoid
+ * stuck-tooltip states caused by missed `mouseleave`/`blur` events.
  */
 function BranchTooltip({
   id,
@@ -77,6 +78,7 @@ function BranchTooltip({
   const [coords, setCoords] = useState({ top: -9999, left: -9999 });
 
   // Update position when tooltip becomes visible
+  // (Hook ordering kept intact: this effect runs unconditionally on every render.)
   useEffect(() => {
     if (isVisible && anchorRef.current) {
       const rect = anchorRef.current.getBoundingClientRect();
@@ -87,6 +89,10 @@ function BranchTooltip({
   // Portals require document — skip during SSR
   // (portal content is outside the component subtree so there is no hydration mismatch)
   if (typeof document === 'undefined') return null;
+
+  // Issue #676: Unmount tooltip content when not visible so a stale
+  // `isTooltipVisible=true` can never cause the tooltip to linger in the DOM.
+  if (!isVisible) return null;
 
   return ReactDOM.createPortal(
     <div
@@ -102,7 +108,6 @@ function BranchTooltip({
       style={{
         top: coords.top,
         left: coords.left,
-        opacity: isVisible ? 1 : 0,
       }}
     >
       <p className="font-medium text-white whitespace-nowrap">{branch.name}</p>
@@ -147,17 +152,30 @@ export const BranchListItem = memo(function BranchListItem({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
+  // Issue #676 (A): selected branches never show the tooltip so a stuck
+  // `isTooltipVisible=true` does not leave a tooltip lingering next to the
+  // currently-focused item.
+  const showTooltip = isTooltipVisible && !isSelected;
+
+  // Issue #676 (B): clicking closes the tooltip explicitly before firing the
+  // upstream onClick, so even if a subsequent re-render misses the mouseleave
+  // event, the tooltip state is reset.
+  const handleClick = () => {
+    setIsTooltipVisible(false);
+    onClick();
+  };
+
   return (
     <button
       ref={buttonRef}
       data-testid="branch-list-item"
-      onClick={onClick}
+      onClick={handleClick}
       onMouseEnter={() => setIsTooltipVisible(true)}
       onMouseLeave={() => setIsTooltipVisible(false)}
       onFocus={() => setIsTooltipVisible(true)}
       onBlur={() => setIsTooltipVisible(false)}
       aria-current={isSelected ? 'true' : undefined}
-      aria-describedby={tooltipId}
+      aria-describedby={showTooltip ? tooltipId : undefined}
       aria-label={!showRepositoryName ? `${branch.name} - ${branch.repositoryName}` : undefined}
       className={`
         group relative w-full px-4 py-3 flex flex-col gap-1
@@ -219,7 +237,7 @@ export const BranchListItem = memo(function BranchListItem({
       <BranchTooltip
         id={tooltipId}
         branch={branch}
-        isVisible={isTooltipVisible}
+        isVisible={showTooltip}
         anchorRef={buttonRef}
       />
     </button>

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -165,9 +165,11 @@ describe('Sidebar', () => {
       );
 
       await waitFor(() => {
+        // In grouped mode the repository name is rendered once in the group
+        // header (branch items use showRepositoryName={false} and the per-item
+        // tooltip is only mounted on hover — Issue #676).
         const repoNames = screen.getAllByText('MyRepo');
-        // 3 branch items + 1 group header = 4 in grouped mode
-        expect(repoNames.length).toBeGreaterThanOrEqual(3);
+        expect(repoNames.length).toBeGreaterThanOrEqual(1);
       });
     });
   });

--- a/tests/unit/components/sidebar/BranchListItem.test.tsx
+++ b/tests/unit/components/sidebar/BranchListItem.test.tsx
@@ -50,7 +50,7 @@ describe('BranchListItem', () => {
         />
       );
 
-      // Branch name appears in both inline display and tooltip
+      // Branch name appears in inline display (tooltip is only in DOM when hovered)
       expect(screen.getAllByText('feature/test').length).toBeGreaterThanOrEqual(1);
     });
 
@@ -63,7 +63,7 @@ describe('BranchListItem', () => {
         />
       );
 
-      // Repository name appears in both inline display and tooltip
+      // Repository name appears in inline display (tooltip is only in DOM when hovered)
       expect(screen.getAllByText('MyRepo').length).toBeGreaterThanOrEqual(1);
     });
 
@@ -333,8 +333,10 @@ describe('BranchListItem', () => {
         />
       );
 
-      // Repository name should appear at least twice: inline + tooltip
-      expect(screen.getAllByText('MyRepo').length).toBeGreaterThanOrEqual(2);
+      // Repository name should appear inline (tooltip only in DOM when hovered)
+      const branchInfoTexts = screen.getByTestId('branch-list-item').querySelectorAll('p');
+      const inlineTexts = Array.from(branchInfoTexts).map((el) => el.textContent);
+      expect(inlineTexts).toContain('MyRepo');
     });
 
     it('should display repository name inline when showRepositoryName is true', () => {
@@ -347,8 +349,10 @@ describe('BranchListItem', () => {
         />
       );
 
-      // Repository name should appear at least twice: inline + tooltip
-      expect(screen.getAllByText('MyRepo').length).toBeGreaterThanOrEqual(2);
+      // Repository name should appear inline (tooltip only in DOM when hovered)
+      const branchInfoTexts = screen.getByTestId('branch-list-item').querySelectorAll('p');
+      const inlineTexts = Array.from(branchInfoTexts).map((el) => el.textContent);
+      expect(inlineTexts).toContain('MyRepo');
     });
 
     it('should not display repository name when showRepositoryName is false', () => {
@@ -372,7 +376,7 @@ describe('BranchListItem', () => {
   });
 
   describe('Tooltip (Issue #651)', () => {
-    it('should render a tooltip with role="tooltip"', () => {
+    it('should render a tooltip with role="tooltip" on mouseEnter', () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -381,10 +385,11 @@ describe('BranchListItem', () => {
         />
       );
 
+      fireEvent.mouseEnter(screen.getByRole('button'));
       expect(screen.getByRole('tooltip')).toBeInTheDocument();
     });
 
-    it('should have tooltip id matching aria-describedby on button', () => {
+    it('should have tooltip id matching aria-describedby on button when tooltip is visible', () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -394,6 +399,8 @@ describe('BranchListItem', () => {
       );
 
       const button = screen.getByTestId('branch-list-item');
+      fireEvent.mouseEnter(button);
+
       const tooltipId = `tooltip-${defaultBranch.id}`;
       expect(button).toHaveAttribute('aria-describedby', tooltipId);
 
@@ -410,6 +417,7 @@ describe('BranchListItem', () => {
         />
       );
 
+      fireEvent.mouseEnter(screen.getByRole('button'));
       const tooltip = screen.getByRole('tooltip');
       expect(tooltip.textContent).toContain('feature/test');
     });
@@ -423,6 +431,7 @@ describe('BranchListItem', () => {
         />
       );
 
+      fireEvent.mouseEnter(screen.getByRole('button'));
       const tooltip = screen.getByRole('tooltip');
       expect(tooltip.textContent).toContain('MyRepo');
     });
@@ -436,6 +445,7 @@ describe('BranchListItem', () => {
         />
       );
 
+      fireEvent.mouseEnter(screen.getByRole('button'));
       const tooltip = screen.getByRole('tooltip');
       expect(tooltip.textContent).toContain('running');
     });
@@ -449,6 +459,7 @@ describe('BranchListItem', () => {
         />
       );
 
+      fireEvent.mouseEnter(screen.getByRole('button'));
       const tooltip = screen.getByRole('tooltip');
       expect(tooltip.textContent).toContain('/path/to/worktree');
     });
@@ -462,6 +473,7 @@ describe('BranchListItem', () => {
         />
       );
 
+      fireEvent.mouseEnter(screen.getByRole('button'));
       const tooltip = screen.getByRole('tooltip');
       expect(tooltip).toBeInTheDocument();
     });
@@ -477,6 +489,141 @@ describe('BranchListItem', () => {
 
       const button = screen.getByTestId('branch-list-item');
       expect(button.className).toMatch(/group/);
+    });
+  });
+
+  describe('Tooltip visibility lifecycle (Issue #676)', () => {
+    it('should not render tooltip in DOM on initial render (C)', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should not attach aria-describedby on initial render (accessibility)', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const button = screen.getByTestId('branch-list-item');
+      expect(button).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('should show tooltip on mouseEnter', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      fireEvent.mouseEnter(screen.getByRole('button'));
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+
+    it('should hide tooltip on mouseLeave', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      fireEvent.mouseEnter(button);
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+      fireEvent.mouseLeave(button);
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should hide tooltip on click (B)', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      fireEvent.mouseEnter(button);
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+      fireEvent.click(button);
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should still invoke onClick when click hides the tooltip (B)', () => {
+      const onClick = vi.fn();
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={onClick}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      fireEvent.mouseEnter(button);
+      fireEvent.click(button);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not render tooltip when isSelected=true even on mouseEnter (A + C)', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={true}
+          onClick={() => {}}
+        />
+      );
+
+      fireEvent.mouseEnter(screen.getByRole('button'));
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('should not attach aria-describedby when isSelected=true (A)', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={true}
+          onClick={() => {}}
+        />
+      );
+
+      fireEvent.mouseEnter(screen.getByRole('button'));
+      const button = screen.getByTestId('branch-list-item');
+      expect(button).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('should show tooltip on focus and hide on blur', () => {
+      render(
+        <BranchListItem
+          branch={defaultBranch}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      fireEvent.focus(button);
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+      fireEvent.blur(button);
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

サイドバーのブランチ tooltip が `isTooltipVisible=true` のまま固着し、mouseleave/blur 後も画面に残り続ける不具合を、多層防御 (A+B+C) で修正します。Issue #675 の無限ループ中に React の mouseleave 合成イベントがレース状態に陥り state が落ちないケースに対する防御的修正です。

Closes #676

## Root cause

`BranchListItem.tsx` の tooltip は portal で DOM に常時存在し、opacity のみで表示制御していたため、`setIsTooltipVisible(false)` が dispatch されない瞬間に state が true で固定されるとユーザーから永久に残って見える構造でした。state を信頼しすぎない実装へ変更します。

## Changes

### Fixed (A+B+C)
- **A**: 選択中ブランチでは tooltip を表示しない
  - `showTooltip = isTooltipVisible && !isSelected` でゲート
  - スクショ症状（選択済みブランチで tooltip 残留）を解消
- **B**: click 時に明示的に state を false にする
  - `handleClick` ラッパーで `setIsTooltipVisible(false)` 後に props.onClick を呼ぶ
  - `onMouseLeave` スキップに依存しない確実なトリガを追加
- **C**: `isVisible=false` 時に portal の中身を `null` にして DOM から物理除去
  - Hook 順序維持のため `useState` → `useEffect` → early return の順
  - stale な `opacity: isVisible ? 1 : 0` スタイルと「Always present in DOM」JSDoc を削除
  - `aria-describedby` は tooltip が実際に DOM に存在する時のみ button に付与（アクセシビリティ改善）

### Tests
- 新規 9 テスト追加（初期非表示、mouseEnter/mouseLeave、focus/blur、click 消去、onClick 発火、選択中抑止、aria-describedby ゲート）
- 既存 10 テスト更新（`mouseEnter` を事前発火して tooltip 表示状態を明示）
- `Sidebar.test.tsx` の `>=3` を `>=1` に緩和（常時マウント前提だった暗黙の期待を修正）

## Files changed

- `src/components/sidebar/BranchListItem.tsx`
- `tests/unit/components/sidebar/BranchListItem.test.tsx`
- `tests/unit/components/layout/Sidebar.test.tsx`
- `dev-reports/bug-fix/issue676_20260424_201938/` (investigation/work-plan/TDD/acceptance artifacts)

## Test Results

- **ESLint**: 0 errors / 0 warnings
- **TypeScript** (`tsc --noEmit`): 0 errors
- **Unit tests**: 6390 passed / 7 skipped / 0 failed (340 files)
  - `BranchListItem.test.tsx`: 45/45 passed
- **Build** (`npm run build`): success

## Acceptance criteria

- [x] 選択中ブランチでは tooltip が表示されない
- [x] mouseLeave で tooltip が消える
- [x] click で tooltip が即座に消える
- [x] focus→blur で tooltip が消える
- [x] `isVisible=false` のとき tooltip div が DOM に存在しない
- [x] `aria-describedby` は tooltip 実在時のみ付与
- [x] 既存の tooltip 表示機能・CLI status dots・unread indicator に影響なし
- [x] lint/tsc/unit test/build 全 pass

## Related

- Issue #675 (onDirtyChange 無限ループ) は本 issue の発生頻度を増幅する要因ですが本 PR の範囲外です。別途対応予定。本修正は race に対する多層防御のため #675 の未修正状態でも効果があります。

## Checklist

- [x] Unit tests pass
- [x] Lint check passes
- [x] Type check passes
- [x] Build succeeds
- [x] No console.log in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>