### PR TITLE
release: v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-04-27
+
+### Added
+- PDF: PDFファイルプレビュー機能を追加（Blob URL + iframe sandbox方式） (Issue #673)
+
+### Fixed
+- PDF: 実際のChrome（デスクトップ・モバイル）でPDFプレビューが動作するよう修正 (Issue #673)
+- Sidebar: ブランチ切り替え時にツールチップが固定表示される問題を修正 (Issue #676)
+- Worktree: 再レンダリングループによってworktree URL更新がブロックされる問題を修正 (Issue #675)
+- Proxy: External AppsへのWebSocket upgradeをプロキシで中継するよう修正 (Issue #671)
+- Proxy: プロキシ応答から `content-encoding` / `content-length` ヘッダを除去
+
+### Refactored
+- PDF: `normalizeExtension` の共有化と冗長コメントの整理 (Issue #673)
+
 ## [0.5.5] - 2026-04-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

v0.5.6 リリース PR。`/release patch` スキルから生成。

### 変更
- `package.json` / `package-lock.json` を v0.5.6 に更新
- `CHANGELOG.md` に v0.5.6 セクションを追加（Issue #671, #673, #675, #676 を反映）

### 品質チェック
- npm run lint
- npx tsc --noEmit
- npm run test:unit
- npm run build

すべてパス済み。マージ後にタグ `v0.5.6` を打ち、GitHub Releases を作成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)