### PR TITLE
feat: sidebar reorder flash fix + repository visibility + collapsible pane + timestamp improvements

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -59,8 +59,49 @@ const SIDEBAR_GROUP_COLLAPSED_STORAGE_KEY = 'mcbd-sidebar-group-collapsed';
 /** LocalStorage key for branch list scroll position */
 const SIDEBAR_SCROLL_TOP_STORAGE_KEY = 'mcbd-sidebar-scroll-top';
 
+/** LocalStorage key for repository group order cache */
+const SIDEBAR_GROUP_ORDER_CACHE_STORAGE_KEY = 'mcbd-sidebar-group-order-cache';
+
 /** In-memory cache used across client-side remounts */
 let lastSidebarScrollTop = 0;
+let lastRepositoryOrder: string[] | null = null;
+
+function parseRepositoryOrder(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((value): value is string => typeof value === 'string')
+      .slice(0, 500);
+  } catch {
+    return [];
+  }
+}
+
+function readRepositoryOrderCache(): string[] {
+  if (typeof window === 'undefined') return lastRepositoryOrder ?? [];
+
+  try {
+    const stored = localStorage.getItem(SIDEBAR_GROUP_ORDER_CACHE_STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = parseRepositoryOrder(stored);
+    lastRepositoryOrder = parsed.length > 0 ? parsed : null;
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function persistRepositoryOrderCache(order: string[]): void {
+  lastRepositoryOrder = order;
+  if (typeof window === 'undefined') return;
+
+  try {
+    localStorage.setItem(SIDEBAR_GROUP_ORDER_CACHE_STORAGE_KEY, JSON.stringify(order));
+  } catch {
+    // Ignore localStorage errors
+  }
+}
 
 function readSidebarScrollTop(): number {
   if (typeof window === 'undefined') return lastSidebarScrollTop;
@@ -133,7 +174,7 @@ export const Sidebar = memo(function Sidebar() {
   });
 
   // Repository group display order (DB-backed, fetched on mount)
-  const [repositoryOrder, setRepositoryOrder] = useState<string[]>([]);
+  const [repositoryOrder, setRepositoryOrder] = useState<string[]>(readRepositoryOrderCache);
   const orderLoadedRef = useRef(false);
 
   // Fetch saved group order from server on mount
@@ -146,6 +187,7 @@ export const Sidebar = memo(function Sidebar() {
       .then((data: { success: boolean; order: string[] | null }) => {
         if (data.success && Array.isArray(data.order)) {
           setRepositoryOrder(data.order);
+          persistRepositoryOrderCache(data.order);
         }
       })
       .catch(() => {
@@ -334,6 +376,7 @@ export const Sidebar = memo(function Sidebar() {
 
       // Optimistic update
       setRepositoryOrder(newOrder);
+      persistRepositoryOrderCache(newOrder);
 
       // Persist to server
       fetch('/api/sidebar/group-order', {
@@ -343,6 +386,7 @@ export const Sidebar = memo(function Sidebar() {
       }).catch(() => {
         // Revert on error
         setRepositoryOrder(currentOrder);
+        persistRepositoryOrderCache(currentOrder);
       });
     },
     [groupedBranches]

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,7 +11,7 @@
 
 'use client';
 
-import React, { memo, useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import React, { memo, useState, useMemo, useCallback, useEffect, useLayoutEffect, useRef, useDeferredValue } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import {
@@ -214,19 +214,27 @@ export const Sidebar = memo(function Sidebar() {
   // Convert worktrees to sidebar items
   const branchItems = useMemo(() => visibleWorktrees.map(toBranchItem), [visibleWorktrees]);
 
+  // Defer poll-driven branchItems updates so the list order only changes when
+  // React's scheduler has idle time (i.e. the pointer is not moving).
+  // This prevents visible reorders while the user's cursor is in transit toward
+  // a branch — a window not covered by the hover-freeze below.
+  const stableBranchItems = useDeferredValue(branchItems);
+
   // ---- Hover-freeze: snapshot list ORDER while cursor is over the branch list ----
   // Polling updates lastActivity every 5s for active sessions, causing sort-order
   // changes that visually reorder the list while the user is interacting with it.
   // We freeze the display ORDER while the cursor is inside the list (and for 1s
   // after it leaves) so items never jump under the pointer or during a click.
-  // Item DATA (status dots, hasUnread, description) remains live — only positions
-  // are frozen. This prevents both the visible reorder flash and scroll position
-  // shifts caused by items moving above the viewport mid-interaction.
+  //
+  // Design: the freeze is entirely ref-based — no forced re-render on activation.
+  // The freeze "activates" only when branchItems next changes (next poll), at
+  // which point effectiveBranchItems returns frozen.items instead of the new live
+  // order. This avoids any flash that occurred when a forced re-render combined
+  // a new freezeVersion with a concurrently-committed poll transition.
   const frozenBranchItemsRef = useRef<{
     items: SidebarBranchItem[];
     expiresAt: number;
   } | null>(null);
-  const [freezeVersion, setFreezeVersion] = useState(0);
   const freezeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
@@ -234,38 +242,44 @@ export const Sidebar = memo(function Sidebar() {
   }, []);
 
   const effectiveBranchItems = useMemo(() => {
-    void freezeVersion;
     const frozen = frozenBranchItemsRef.current;
-    if (!frozen || Date.now() >= frozen.expiresAt) return branchItems;
-    // Return the fully-frozen snapshot including lastActivity.
-    // "Live data, frozen order" is insufficient: useWorktreeList re-sorts
-    // by lastActivity, so live lastActivity values would override the frozen
-    // order. Returning frozen.items (with frozen lastActivity) keeps the
-    // sort output stable for the ~1s hover window.
+    if (!frozen || Date.now() >= frozen.expiresAt) return stableBranchItems;
     return frozen.items;
-  }, [branchItems, freezeVersion]);
+  }, [stableBranchItems]);
 
-  // Activate freeze when cursor enters the branch list: snapshot current order,
-  // hold indefinitely until cursor leaves. Capturing branchItems here is
-  // intentional — this is the order we want to lock in.
+  // Track the currently-rendered items (updated after each committed render,
+  // before paint). handleListMouseEnter reads this to freeze exactly what
+  // the user is seeing — not just the live branchItems closure.
+  const displayedItemsRef = useRef<SidebarBranchItem[]>(effectiveBranchItems);
+  useLayoutEffect(() => {
+    displayedItemsRef.current = effectiveBranchItems;
+  });
+
   const handleListMouseEnter = useCallback(() => {
     if (freezeTimerRef.current !== null) {
       clearTimeout(freezeTimerRef.current);
       freezeTimerRef.current = null;
     }
-    frozenBranchItemsRef.current = { items: branchItems, expiresAt: Infinity };
-    setFreezeVersion(v => v + 1);
-  }, [branchItems]);
+    const currentFrozen = frozenBranchItemsRef.current;
+    if (currentFrozen && Date.now() < currentFrozen.expiresAt) {
+      // Re-entering during the 1s leave window: just extend to Infinity.
+      // No state update, no re-render.
+      frozenBranchItemsRef.current = { ...currentFrozen, expiresAt: Infinity };
+      return;
+    }
+    // New freeze: silently lock in the currently-displayed order.
+    // No setFreezeVersion → no re-render on hover, so nothing can flash.
+    frozenBranchItemsRef.current = { items: displayedItemsRef.current, expiresAt: Infinity };
+  }, []);
 
   // Hold freeze for 1s after cursor leaves (covers click + re-render settling),
-  // then release so the list reflects the live order again.
+  // then silently release so the list reflects the live order on the next poll.
   const handleListMouseLeave = useCallback(() => {
     if (!frozenBranchItemsRef.current) return;
     frozenBranchItemsRef.current = { ...frozenBranchItemsRef.current, expiresAt: Date.now() + 1000 };
     if (freezeTimerRef.current !== null) clearTimeout(freezeTimerRef.current);
     freezeTimerRef.current = setTimeout(() => {
       frozenBranchItemsRef.current = null;
-      setFreezeVersion(v => v + 1);
     }, 1000);
   }, []);
   // ---- end hover-freeze ----

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -195,18 +195,12 @@ export const Sidebar = memo(function Sidebar() {
     void freezeVersion;
     const frozen = frozenBranchItemsRef.current;
     if (!frozen || Date.now() >= frozen.expiresAt) return branchItems;
-    // Live data, frozen order: preserve positions from the hover-time snapshot
-    // but replace each item's data with the latest live version so status dots
-    // and unread indicators continue to update while positions stay stable.
-    const liveById = new Map(branchItems.map(item => [item.id, item]));
-    const frozenIds = new Set(frozen.items.map(item => item.id));
-    return [
-      ...frozen.items
-        .filter(item => liveById.has(item.id))
-        .map(item => liveById.get(item.id)!),
-      // Items that appeared after the freeze was taken append at the end
-      ...branchItems.filter(item => !frozenIds.has(item.id)),
-    ];
+    // Return the fully-frozen snapshot including lastActivity.
+    // "Live data, frozen order" is insufficient: useWorktreeList re-sorts
+    // by lastActivity, so live lastActivity values would override the frozen
+    // order. Returning frozen.items (with frozen lastActivity) keeps the
+    // sort output stable for the ~1s hover window.
+    return frozen.items;
   }, [branchItems, freezeVersion]);
 
   // Activate freeze when cursor enters the branch list: snapshot current order,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -172,12 +172,14 @@ export const Sidebar = memo(function Sidebar() {
   // Convert worktrees to sidebar items
   const branchItems = useMemo(() => visibleWorktrees.map(toBranchItem), [visibleWorktrees]);
 
-  // ---- Click-freeze: snapshot the list for 1s after branch click ----
+  // ---- Hover-freeze: snapshot list ORDER while cursor is over the branch list ----
   // Polling updates lastActivity every 5s for active sessions, causing sort-order
-  // changes that reorder the list right after the user clicks a branch. We freeze
-  // the display list for 1s so the list doesn't jump while the click interaction
-  // is still settling. selectedWorktreeId remains live, so the newly-selected
-  // branch is highlighted correctly even while the list order is frozen.
+  // changes that visually reorder the list while the user is interacting with it.
+  // We freeze the display ORDER while the cursor is inside the list (and for 1s
+  // after it leaves) so items never jump under the pointer or during a click.
+  // Item DATA (status dots, hasUnread, description) remains live — only positions
+  // are frozen. This prevents both the visible reorder flash and scroll position
+  // shifts caused by items moving above the viewport mid-interaction.
   const frozenBranchItemsRef = useRef<{
     items: SidebarBranchItem[];
     expiresAt: number;
@@ -190,12 +192,47 @@ export const Sidebar = memo(function Sidebar() {
   }, []);
 
   const effectiveBranchItems = useMemo(() => {
-    void freezeVersion; // ensure we recompute when the freeze lifts
+    void freezeVersion;
     const frozen = frozenBranchItemsRef.current;
-    if (frozen && Date.now() < frozen.expiresAt) return frozen.items;
-    return branchItems;
+    if (!frozen || Date.now() >= frozen.expiresAt) return branchItems;
+    // Live data, frozen order: preserve positions from the hover-time snapshot
+    // but replace each item's data with the latest live version so status dots
+    // and unread indicators continue to update while positions stay stable.
+    const liveById = new Map(branchItems.map(item => [item.id, item]));
+    const frozenIds = new Set(frozen.items.map(item => item.id));
+    return [
+      ...frozen.items
+        .filter(item => liveById.has(item.id))
+        .map(item => liveById.get(item.id)!),
+      // Items that appeared after the freeze was taken append at the end
+      ...branchItems.filter(item => !frozenIds.has(item.id)),
+    ];
   }, [branchItems, freezeVersion]);
-  // ---- end click-freeze ----
+
+  // Activate freeze when cursor enters the branch list: snapshot current order,
+  // hold indefinitely until cursor leaves. Capturing branchItems here is
+  // intentional — this is the order we want to lock in.
+  const handleListMouseEnter = useCallback(() => {
+    if (freezeTimerRef.current !== null) {
+      clearTimeout(freezeTimerRef.current);
+      freezeTimerRef.current = null;
+    }
+    frozenBranchItemsRef.current = { items: branchItems, expiresAt: Infinity };
+    setFreezeVersion(v => v + 1);
+  }, [branchItems]);
+
+  // Hold freeze for 1s after cursor leaves (covers click + re-render settling),
+  // then release so the list reflects the live order again.
+  const handleListMouseLeave = useCallback(() => {
+    if (!frozenBranchItemsRef.current) return;
+    frozenBranchItemsRef.current = { ...frozenBranchItemsRef.current, expiresAt: Date.now() + 1000 };
+    if (freezeTimerRef.current !== null) clearTimeout(freezeTimerRef.current);
+    freezeTimerRef.current = setTimeout(() => {
+      frozenBranchItemsRef.current = null;
+      setFreezeVersion(v => v + 1);
+    }, 1000);
+  }, []);
+  // ---- end hover-freeze ----
 
   // Use shared useWorktreeList hook for sorting, filtering, and grouping (Issue #600 Task 3.8)
   const { sortedItems: flatBranches, groupedItems } = useWorktreeList({
@@ -253,7 +290,11 @@ export const Sidebar = memo(function Sidebar() {
     persistSidebarScrollTop(branchListRef.current?.scrollTop ?? 0);
   }, []);
 
-  // Restore saved scroll position after the list content has rendered.
+  // Restore saved scroll position when items first appear (initial data load) and
+  // on viewMode change. Intentionally NOT triggered by every list-length change —
+  // that would cause visible scroll jumps whenever the hover-freeze/unfreeze cycle
+  // briefly changes the rendered item count.
+  const hasAnyItems = flatBranches.length > 0 || (groupedBranches?.length ?? 0) > 0;
   useEffect(() => {
     const branchList = branchListRef.current;
     if (!branchList) return;
@@ -265,7 +306,7 @@ export const Sidebar = memo(function Sidebar() {
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [flatBranches.length, groupedBranches?.length, viewMode]);
+  }, [hasAnyItems, viewMode]);
 
   // Handle branch selection.
   // Note: no fallback timer — Next.js App Router defers history.pushState to a React
@@ -273,20 +314,11 @@ export const Sidebar = memo(function Sidebar() {
   // A fallback timer that checks window.location.pathname would fire before the URL
   // updates and trigger a spurious full-page reload on every navigation.
   const handleBranchClick = useCallback((branchId: string) => {
-    // Freeze display list for 1s so polling-induced sort-order changes don't
-    // visually reorder items right after the user clicks a branch.
-    frozenBranchItemsRef.current = { items: branchItems, expiresAt: Date.now() + 1000 };
-    if (freezeTimerRef.current !== null) clearTimeout(freezeTimerRef.current);
-    freezeTimerRef.current = setTimeout(() => {
-      frozenBranchItemsRef.current = null;
-      setFreezeVersion((v) => v + 1);
-    }, 1000);
-
     saveBranchListScroll();
     selectWorktree(branchId);
     router.push(`/worktrees/${branchId}`);
     closeMobileDrawer();
-  }, [branchItems, saveBranchListScroll, selectWorktree, router, closeMobileDrawer]);
+  }, [saveBranchListScroll, selectWorktree, router, closeMobileDrawer]);
 
   // DnD sensors: require 8px move before activating (distinguishes click from drag)
   const sensors = useSensors(
@@ -370,6 +402,8 @@ export const Sidebar = memo(function Sidebar() {
         ref={branchListRef}
         data-testid="branch-list"
         onScroll={saveBranchListScroll}
+        onMouseEnter={handleListMouseEnter}
+        onMouseLeave={handleListMouseLeave}
         className="flex-1 overflow-y-auto"
       >
         {isEmpty ? (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -39,6 +39,7 @@ import { LogoutButton } from '@/components/common/LogoutButton';
 import { useToast, ToastContainer } from '@/components/common/Toast';
 import { repositoryApi, ApiError } from '@/lib/api-client';
 import { toBranchItem } from '@/types/sidebar';
+import type { SidebarBranchItem } from '@/types/sidebar';
 import {
   generateRepositoryColor,
   buildHiddenRepositoryPathSet,
@@ -171,9 +172,34 @@ export const Sidebar = memo(function Sidebar() {
   // Convert worktrees to sidebar items
   const branchItems = useMemo(() => visibleWorktrees.map(toBranchItem), [visibleWorktrees]);
 
+  // ---- Click-freeze: snapshot the list for 1s after branch click ----
+  // Polling updates lastActivity every 5s for active sessions, causing sort-order
+  // changes that reorder the list right after the user clicks a branch. We freeze
+  // the display list for 1s so the list doesn't jump while the click interaction
+  // is still settling. selectedWorktreeId remains live, so the newly-selected
+  // branch is highlighted correctly even while the list order is frozen.
+  const frozenBranchItemsRef = useRef<{
+    items: SidebarBranchItem[];
+    expiresAt: number;
+  } | null>(null);
+  const [freezeVersion, setFreezeVersion] = useState(0);
+  const freezeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (freezeTimerRef.current !== null) clearTimeout(freezeTimerRef.current);
+  }, []);
+
+  const effectiveBranchItems = useMemo(() => {
+    void freezeVersion; // ensure we recompute when the freeze lifts
+    const frozen = frozenBranchItemsRef.current;
+    if (frozen && Date.now() < frozen.expiresAt) return frozen.items;
+    return branchItems;
+  }, [branchItems, freezeVersion]);
+  // ---- end click-freeze ----
+
   // Use shared useWorktreeList hook for sorting, filtering, and grouping (Issue #600 Task 3.8)
   const { sortedItems: flatBranches, groupedItems } = useWorktreeList({
-    items: branchItems,
+    items: effectiveBranchItems,
     sortKey,
     sortDirection,
     viewMode,
@@ -247,11 +273,20 @@ export const Sidebar = memo(function Sidebar() {
   // A fallback timer that checks window.location.pathname would fire before the URL
   // updates and trigger a spurious full-page reload on every navigation.
   const handleBranchClick = useCallback((branchId: string) => {
+    // Freeze display list for 1s so polling-induced sort-order changes don't
+    // visually reorder items right after the user clicks a branch.
+    frozenBranchItemsRef.current = { items: branchItems, expiresAt: Date.now() + 1000 };
+    if (freezeTimerRef.current !== null) clearTimeout(freezeTimerRef.current);
+    freezeTimerRef.current = setTimeout(() => {
+      frozenBranchItemsRef.current = null;
+      setFreezeVersion((v) => v + 1);
+    }, 1000);
+
     saveBranchListScroll();
     selectWorktree(branchId);
     router.push(`/worktrees/${branchId}`);
     closeMobileDrawer();
-  }, [saveBranchListScroll, selectWorktree, router, closeMobileDrawer]);
+  }, [branchItems, saveBranchListScroll, selectWorktree, router, closeMobileDrawer]);
 
   // DnD sensors: require 8px move before activating (distinguishes click from drag)
   const sensors = useSensors(

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -127,6 +127,18 @@ function BranchTooltip({
 }
 
 // ============================================================================
+// Module-level tooltip suppression
+// ============================================================================
+
+/**
+ * Timestamp (ms) until which onMouseEnter should NOT open a tooltip.
+ * Set by handleClick so that list reorders caused by React re-renders
+ * after a branch click don't immediately show a tooltip on whichever
+ * element lands under the cursor.
+ */
+let suppressMouseEnterUntil = 0;
+
+// ============================================================================
 // Component
 // ============================================================================
 
@@ -179,6 +191,10 @@ export const BranchListItem = memo(function BranchListItem({
   // upstream onClick, so even if a subsequent re-render misses the mouseleave
   // event, the tooltip state is reset.
   const handleClick = () => {
+    // Suppress mouseenter-triggered tooltips for 400ms so that list reorders
+    // caused by the re-render following this click don't immediately show a
+    // tooltip on whichever element lands under the cursor.
+    suppressMouseEnterUntil = Date.now() + 400;
     setIsTooltipVisible(false);
     onClick();
   };
@@ -188,7 +204,11 @@ export const BranchListItem = memo(function BranchListItem({
       ref={buttonRef}
       data-testid="branch-list-item"
       onClick={handleClick}
-      onMouseEnter={() => setIsTooltipVisible(true)}
+      onMouseEnter={() => {
+        if (Date.now() >= suppressMouseEnterUntil) {
+          setIsTooltipVisible(true);
+        }
+      }}
       onMouseLeave={() => setIsTooltipVisible(false)}
       onFocus={(e) => {
         // Show tooltip only for keyboard focus (:focus-visible), not pointer clicks.

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -157,6 +157,16 @@ export const BranchListItem = memo(function BranchListItem({
   // currently-focused item.
   const showTooltip = isTooltipVisible && !isSelected;
 
+  // Safety net: reset tooltip whenever isSelected becomes true.
+  // Covers React concurrent-mode timing gaps (router.push inside startTransition
+  // defers the sidebar re-render), onFocus/onClick inter-batch races, and
+  // group-expansion onMouseEnter triggers that fire before the selection lands.
+  useEffect(() => {
+    if (isSelected) {
+      setIsTooltipVisible(false);
+    }
+  }, [isSelected]);
+
   // Issue #676 (B): clicking closes the tooltip explicitly before firing the
   // upstream onClick, so even if a subsequent re-render misses the mouseleave
   // event, the tooltip state is reset.

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -138,6 +138,11 @@ function BranchTooltip({
  */
 let suppressMouseEnterUntil = 0;
 
+/** Exported only for tests — reset click-triggered tooltip suppression. */
+export function __resetMouseEnterSuppression(): void {
+  suppressMouseEnterUntil = 0;
+}
+
 // ============================================================================
 // Component
 // ============================================================================

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import React, { memo, useRef, useState, useEffect } from 'react';
+import React, { memo, useRef, useState, useEffect, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import type { SidebarBranchItem, BranchStatus } from '@/types/sidebar';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
@@ -163,6 +163,19 @@ export const BranchListItem = memo(function BranchListItem({
   const tooltipId = `tooltip-${branch.id}`;
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+  // Timer for the 150ms show-delay (prevents spurious tooltips from
+  // DOM-reflow mouseenter events triggered by polling list reorders).
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearShowTimer = useCallback(() => {
+    if (showTimerRef.current !== null) {
+      clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  // Cancel the pending timer when the component unmounts.
+  useEffect(() => () => clearShowTimer(), [clearShowTimer]);
 
   // Issue #676 (A): selected branches never show the tooltip so a stuck
   // `isTooltipVisible=true` does not leave a tooltip lingering next to the
@@ -191,6 +204,7 @@ export const BranchListItem = memo(function BranchListItem({
   // upstream onClick, so even if a subsequent re-render misses the mouseleave
   // event, the tooltip state is reset.
   const handleClick = () => {
+    clearShowTimer();
     // Suppress mouseenter-triggered tooltips for 400ms so that list reorders
     // caused by the re-render following this click don't immediately show a
     // tooltip on whichever element lands under the cursor.
@@ -205,20 +219,35 @@ export const BranchListItem = memo(function BranchListItem({
       data-testid="branch-list-item"
       onClick={handleClick}
       onMouseEnter={() => {
+        clearShowTimer();
         if (Date.now() >= suppressMouseEnterUntil) {
-          setIsTooltipVisible(true);
+          // 150ms delay: filters out spurious mouseenter events fired when the
+          // browser moves a DOM element under the stationary cursor (polling
+          // list reorders). An intentional hover outlasts this delay easily.
+          showTimerRef.current = setTimeout(() => {
+            setIsTooltipVisible(true);
+          }, 150);
         }
       }}
-      onMouseLeave={() => setIsTooltipVisible(false)}
+      onMouseLeave={() => {
+        clearShowTimer();
+        setIsTooltipVisible(false);
+      }}
       onFocus={(e) => {
+        clearShowTimer();
         // Show tooltip only for keyboard focus (:focus-visible), not pointer clicks.
         // onFocus fires on mousedown which races with handleClick, causing a
         // brief tooltip flash even after the click handler closes it.
         if ((e.target as HTMLElement).matches(':focus-visible')) {
-          setIsTooltipVisible(true);
+          showTimerRef.current = setTimeout(() => {
+            setIsTooltipVisible(true);
+          }, 150);
         }
       }}
-      onBlur={() => setIsTooltipVisible(false)}
+      onBlur={() => {
+        clearShowTimer();
+        setIsTooltipVisible(false);
+      }}
       aria-current={isSelected ? 'true' : undefined}
       aria-describedby={showTooltip ? tooltipId : undefined}
       aria-label={!showRepositoryName ? `${branch.name} - ${branch.repositoryName}` : undefined}

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -157,15 +157,23 @@ export const BranchListItem = memo(function BranchListItem({
   // currently-focused item.
   const showTooltip = isTooltipVisible && !isSelected;
 
-  // Safety net: reset tooltip whenever isSelected becomes true.
-  // Covers React concurrent-mode timing gaps (router.push inside startTransition
-  // defers the sidebar re-render), onFocus/onClick inter-batch races, and
-  // group-expansion onMouseEnter triggers that fire before the selection lands.
+  // Safety net A: reset tooltip whenever isSelected becomes true.
   useEffect(() => {
     if (isSelected) {
       setIsTooltipVisible(false);
     }
   }, [isSelected]);
+
+  // Safety net B: close this tooltip on ANY document click.
+  // This handles the case where onMouseLeave doesn't fire (fast cursor moves,
+  // DOM changes from polling during click, React concurrent re-renders) and
+  // another branch's tooltip stays visible showing wrong-repository content.
+  useEffect(() => {
+    if (!isTooltipVisible) return;
+    const close = () => setIsTooltipVisible(false);
+    document.addEventListener('click', close);
+    return () => document.removeEventListener('click', close);
+  }, [isTooltipVisible]);
 
   // Issue #676 (B): clicking closes the tooltip explicitly before firing the
   // upstream onClick, so even if a subsequent re-render misses the mouseleave
@@ -182,7 +190,14 @@ export const BranchListItem = memo(function BranchListItem({
       onClick={handleClick}
       onMouseEnter={() => setIsTooltipVisible(true)}
       onMouseLeave={() => setIsTooltipVisible(false)}
-      onFocus={() => setIsTooltipVisible(true)}
+      onFocus={(e) => {
+        // Show tooltip only for keyboard focus (:focus-visible), not pointer clicks.
+        // onFocus fires on mousedown which races with handleClick, causing a
+        // brief tooltip flash even after the click handler closes it.
+        if ((e.target as HTMLElement).matches(':focus-visible')) {
+          setIsTooltipVisible(true);
+        }
+      }}
       onBlur={() => setIsTooltipVisible(false)}
       aria-current={isSelected ? 'true' : undefined}
       aria-describedby={showTooltip ? tooltipId : undefined}

--- a/src/hooks/useWorktreesCache.ts
+++ b/src/hooks/useWorktreesCache.ts
@@ -7,7 +7,7 @@
 
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, startTransition } from 'react';
 import type { Worktree } from '@/types/models';
 import type { RepositorySummary } from '@/lib/api-client';
 
@@ -65,8 +65,13 @@ export function useWorktreesCache(): UseWorktreesCacheReturn {
       const data = await response.json();
       const wts = data.worktrees ?? [];
       const repos = data.repositories ?? [];
-      setWorktrees(wts);
-      setRepositories(repos);
+      // Mark polling state updates as low-priority transitions so urgent
+      // user interactions (clicks, keypresses) are never blocked by a
+      // poll-induced list reorder landing mid-click.
+      startTransition(() => {
+        setWorktrees(wts);
+        setRepositories(repos);
+      });
       worktreesRef.current = wts;
     } catch (err) {
       const fetchError = err instanceof Error ? err : new Error(String(err));

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/lib/api-client', async (importOriginal) => {
 import { worktreeApi, repositoryApi, ApiError } from '@/lib/api-client';
 
 const originalLocation = window.location;
+const originalFetch = global.fetch;
 
 const mockWorktrees: Worktree[] = [
   {
@@ -96,6 +97,7 @@ describe('Sidebar', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    global.fetch = originalFetch;
     vi.useRealTimers();
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -845,6 +847,75 @@ describe('Sidebar', () => {
         expect(screen.getAllByText('z-feature').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('a-feature').length).toBeGreaterThanOrEqual(1);
       });
+    });
+  });
+
+  describe('repository group order cache', () => {
+    it('uses cached repository order before the DB-backed order request resolves', async () => {
+      const groupedWorktrees: Worktree[] = [
+        {
+          id: 'mywebdata-main',
+          name: 'main',
+          path: '/path/to/mywebdata',
+          repositoryPath: '/path/to/mywebdata',
+          repositoryName: 'myWebData',
+          updatedAt: new Date('2025-01-01T00:00:00Z'),
+        },
+        {
+          id: 'onecompression-main',
+          name: 'main',
+          path: '/path/to/onecompression',
+          repositoryPath: '/path/to/onecompression',
+          repositoryName: 'OneCompression',
+          updatedAt: new Date('2025-01-01T00:00:00Z'),
+        },
+        {
+          id: 'photon-mlx-main',
+          name: 'main',
+          path: '/path/to/photon-mlx',
+          repositoryPath: '/path/to/photon-mlx',
+          repositoryName: 'photon-mlx',
+          updatedAt: new Date('2025-01-01T00:00:00Z'),
+        },
+        {
+          id: 'self-hosted-runner-main',
+          name: 'main',
+          path: '/path/to/self-hosted-runner',
+          repositoryPath: '/path/to/self-hosted-runner',
+          repositoryName: 'self-hosted-runner',
+          updatedAt: new Date('2025-01-01T00:00:00Z'),
+        },
+      ];
+
+      localStorage.setItem(
+        'mcbd-sidebar-group-order-cache',
+        JSON.stringify(['photon-mlx', 'self-hosted-runner', 'myWebData', 'OneCompression'])
+      );
+
+      (worktreeApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        worktrees: groupedWorktrees,
+        repositories: [],
+      });
+      global.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('photon-mlx')).toBeInTheDocument();
+      });
+
+      const groupNames = screen
+        .getAllByTestId('group-header')
+        .map((button) => button.textContent ?? '');
+
+      expect(groupNames[0]).toContain('photon-mlx');
+      expect(groupNames[1]).toContain('self-hosted-runner');
+      expect(groupNames[2]).toContain('myWebData');
+      expect(groupNames[3]).toContain('OneCompression');
     });
   });
 

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -363,6 +363,9 @@ describe('Sidebar', () => {
       const branchList = await screen.findByTestId('branch-list');
       branchList.scrollTop = 180;
 
+      await waitFor(() => {
+        expect(screen.getAllByText('feature/test-2').length).toBeGreaterThanOrEqual(1);
+      });
       const branchItem = screen.getAllByText('feature/test-2')[0].closest('[data-testid="branch-list-item"]');
       expect(branchItem).not.toBeNull();
 

--- a/tests/unit/components/sidebar/BranchListItem.test.tsx
+++ b/tests/unit/components/sidebar/BranchListItem.test.tsx
@@ -6,9 +6,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
-import { BranchListItem } from '@/components/sidebar/BranchListItem';
+import { BranchListItem, __resetMouseEnterSuppression } from '@/components/sidebar/BranchListItem';
 import type { SidebarBranchItem } from '@/types/sidebar';
 
 describe('BranchListItem', () => {
@@ -22,6 +22,7 @@ describe('BranchListItem', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetMouseEnterSuppression();
   });
 
   afterEach(() => {
@@ -376,7 +377,7 @@ describe('BranchListItem', () => {
   });
 
   describe('Tooltip (Issue #651)', () => {
-    it('should render a tooltip with role="tooltip" on mouseEnter', () => {
+    it('should render a tooltip with role="tooltip" on mouseEnter', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -386,10 +387,10 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
     });
 
-    it('should have tooltip id matching aria-describedby on button when tooltip is visible', () => {
+    it('should have tooltip id matching aria-describedby on button when tooltip is visible', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -400,6 +401,7 @@ describe('BranchListItem', () => {
 
       const button = screen.getByTestId('branch-list-item');
       fireEvent.mouseEnter(button);
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
 
       const tooltipId = `tooltip-${defaultBranch.id}`;
       expect(button).toHaveAttribute('aria-describedby', tooltipId);
@@ -408,7 +410,7 @@ describe('BranchListItem', () => {
       expect(tooltip).toHaveAttribute('id', tooltipId);
     });
 
-    it('should display branch name in tooltip', () => {
+    it('should display branch name in tooltip', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -418,11 +420,11 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      const tooltip = screen.getByRole('tooltip');
+      const tooltip = await screen.findByRole('tooltip');
       expect(tooltip.textContent).toContain('feature/test');
     });
 
-    it('should display repository name in tooltip', () => {
+    it('should display repository name in tooltip', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -432,11 +434,11 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      const tooltip = screen.getByRole('tooltip');
+      const tooltip = await screen.findByRole('tooltip');
       expect(tooltip.textContent).toContain('MyRepo');
     });
 
-    it('should display status in tooltip', () => {
+    it('should display status in tooltip', async () => {
       render(
         <BranchListItem
           branch={{ ...defaultBranch, status: 'running' }}
@@ -446,11 +448,11 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      const tooltip = screen.getByRole('tooltip');
+      const tooltip = await screen.findByRole('tooltip');
       expect(tooltip.textContent).toContain('running');
     });
 
-    it('should display worktreePath in tooltip when provided', () => {
+    it('should display worktreePath in tooltip when provided', async () => {
       render(
         <BranchListItem
           branch={{ ...defaultBranch, worktreePath: '/path/to/worktree' }}
@@ -460,11 +462,11 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      const tooltip = screen.getByRole('tooltip');
+      const tooltip = await screen.findByRole('tooltip');
       expect(tooltip.textContent).toContain('/path/to/worktree');
     });
 
-    it('should not crash when worktreePath is undefined', () => {
+    it('should not crash when worktreePath is undefined', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -474,7 +476,7 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      const tooltip = screen.getByRole('tooltip');
+      const tooltip = await screen.findByRole('tooltip');
       expect(tooltip).toBeInTheDocument();
     });
 
@@ -518,7 +520,7 @@ describe('BranchListItem', () => {
       expect(button).not.toHaveAttribute('aria-describedby');
     });
 
-    it('should show tooltip on mouseEnter', () => {
+    it('should show tooltip on mouseEnter', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -528,10 +530,10 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
-      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
     });
 
-    it('should hide tooltip on mouseLeave', () => {
+    it('should hide tooltip on mouseLeave', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -542,13 +544,13 @@ describe('BranchListItem', () => {
 
       const button = screen.getByRole('button');
       fireEvent.mouseEnter(button);
-      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
 
       fireEvent.mouseLeave(button);
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('should hide tooltip on click (B)', () => {
+    it('should hide tooltip on click (B)', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -559,13 +561,13 @@ describe('BranchListItem', () => {
 
       const button = screen.getByRole('button');
       fireEvent.mouseEnter(button);
-      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
 
       fireEvent.click(button);
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('should still invoke onClick when click hides the tooltip (B)', () => {
+    it('should still invoke onClick when click hides the tooltip (B)', async () => {
       const onClick = vi.fn();
       render(
         <BranchListItem
@@ -577,12 +579,13 @@ describe('BranchListItem', () => {
 
       const button = screen.getByRole('button');
       fireEvent.mouseEnter(button);
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
       fireEvent.click(button);
 
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should not render tooltip when isSelected=true even on mouseEnter (A + C)', () => {
+    it('should not render tooltip when isSelected=true even on mouseEnter (A + C)', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -592,6 +595,8 @@ describe('BranchListItem', () => {
       );
 
       fireEvent.mouseEnter(screen.getByRole('button'));
+      // Wait long enough to confirm tooltip does NOT appear (isSelected suppresses it)
+      await new Promise((r) => setTimeout(r, 300));
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
@@ -609,7 +614,7 @@ describe('BranchListItem', () => {
       expect(button).not.toHaveAttribute('aria-describedby');
     });
 
-    it('should show tooltip on focus and hide on blur', () => {
+    it('should show tooltip on focus and hide on blur', async () => {
       render(
         <BranchListItem
           branch={defaultBranch}
@@ -619,8 +624,19 @@ describe('BranchListItem', () => {
       );
 
       const button = screen.getByRole('button');
+      // jsdom programmatic focus doesn't set :focus-visible (spec requires keyboard
+      // interaction), so mock matches() to simulate keyboard-focused state.
+      const realMatches = HTMLElement.prototype.matches;
+      vi.spyOn(HTMLElement.prototype, 'matches').mockImplementation(function (
+        this: Element,
+        selector: string
+      ) {
+        if (selector === ':focus-visible') return true;
+        return realMatches.call(this, selector);
+      });
+
       fireEvent.focus(button);
-      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByRole('tooltip')).toBeInTheDocument());
 
       fireEvent.blur(button);
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- **Sidebar reorder flash fix**: Eliminated the visible list reorder flash when clicking a branch. Three-layer defense: `useDeferredValue` to defer poll-driven updates, ref-only hover-freeze that snapshots the list order on cursor entry, and localStorage-based repository group order cache to keep sorting stable across polls.
- **Repository visibility toggle** (#690): Added per-repository show/hide control in the Repositories screen. Hidden repositories are excluded from the sidebar branch list.
- **Collapsible left pane** (#688): PC worktree detail view now supports collapsing/expanding the left pane (History/Files/CMATE tabs) for more terminal/chat space.
- **MessageHistory timestamp improvements** (#687): Timestamps now show full date+time instead of relative time only.
- **Slash command list update** (#689): `STANDARD_COMMANDS` updated with the latest Claude Code and Codex built-in commands.
- **HtmlPreview dead prop removal** (#681) and **useFileTabs refactor** (#683).
- **Test reliability**: Fixed 3 BranchListItem tooltip tests that timed out due to module-level cross-test contamination (`suppressMouseEnterUntil`) and missing `:focus-visible` support in jsdom.

## Test plan

- [x] `npm run lint` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npm run test:unit` — 6468 tests pass (7 skipped)
- [x] `npm run build` — pass
- [x] GitHub Actions CI — green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)