### PR TITLE
release: v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-05-11
+
+### Added
+- Worktree: PC版Worktree詳細ビューに左パネル折りたたみ機能を追加 (Issue #688)
+- Repository: サイドバー表示制御用のリポジトリ可視性トグルを追加 (Issue #690)
+- MessageHistory: メッセージタイムスタンプに日付+時刻を表示 (Issue #687)
+- CLI: STANDARD_COMMANDSを最新のClaude CodeおよびCodexコマンドに更新 (Issue #689)
+
+### Fixed
+- Sidebar: ブランチホバー時のリスト並び替えフラッシュを解消（useDeferredValue + ref-only freeze方式） (Issue #699)
+- Sidebar: リポジトリグループ順序をキャッシュしてホバー時の並び替えを防止 (Issue #699)
+- Sidebar: ブランチクリック後のツールチップ表示によるリスト再描画チラつきを抑制 (Issue #699)
+- Sidebar: startTransitionでポーリング更新をラップしフラッシュを防止 (Issue #699)
+- Sidebar: ドキュメントクリック時に古いツールチップを閉じるよう修正 (Issue #699)
+- Sidebar: 選択済みブランチのスタックしたツールチップをリセット (Issue #699)
+- Worktree: 狭い幅でのパネルトグルUXを改善しファイルパネル折りたたみを追加 (Issue #698)
+- HtmlPreview: 未使用のonDirtyChange propを除去しリグレッションテストを追加 (Issue #681)
+- Tests: クロステスト汚染によるBranchListItemツールチップテスト失敗を修正
+
+### Refactored
+- FileTab: useFileTabsの戻り値を[state, actions]タプル形式に変更 (Issue #683)
+- Sidebar: サイドバー可視性ヘルパーを抽出しact()警告を修正 (Issue #690)
+
 ## [0.5.6] - 2026-04-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

v0.5.7 リリース PR。`/release patch` スキルから生成。

### 変更
- `package.json` / `package-lock.json` を v0.5.7 に更新
- `CHANGELOG.md` に v0.5.7 セクションを追加（Issue #681, #683, #687, #688, #689, #690, #698, #699 を反映）

### 品質チェック
- npm run lint
- npx tsc --noEmit
- npm run test:unit (6468 tests)
- npm run build

すべてパス済み。マージ後にタグ `v0.5.7` を打ち、GitHub Releases を作成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)