### PR TITLE
Release: 履歴(History)表示件数選択機能 (#701)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ tests/
 | `src/config/copilot-constants.ts` | Copilot CLIタイミング定数（COPILOT_SEND_ENTER_DELAY_MS, COPILOT_TEXT_INPUT_DELAY_MS）（Issue #565）、MODEL_NAME_PATTERN/MAX_MODEL_NAME_LENGTH追加（Issue #588） |
 | `src/config/memo-config.ts` | メモ共有定数（MAX_MEMOS）（Issue #652） |
 | `src/config/repository-config.ts` | リポジトリ共有定数（MAX_DISPLAY_NAME_LENGTH）（Issue #644） |
+| `src/config/history-display-config.ts` | History表示件数定数（HISTORY_DISPLAY_LIMIT_OPTIONS, MAX_MESSAGES_LIMIT派生, DEFAULT_MESSAGES_LIMIT, HISTORY_DISPLAY_LIMIT_STORAGE_KEY, HistoryDisplayLimit型, isHistoryDisplayLimit型ガード）（Issue #701） |
 | `src/config/editable-extensions.ts` | 編集可能拡張子定義・バリデーション（EDITABLE_EXTENSIONS, EXTENSION_VALIDATORS, isEditableExtension, validateContent）。.yaml/.yml 追加・YAML危険タグバリデーション（Issue #646） |
 | `src/config/pdf-extensions.ts` | PDF拡張子・サイズ(20MB)・magic bytes(`%PDF-`)・iframe sandbox定数、isPdfExtension / validatePdfMagicBytes / validatePdfContent（Issue #673） |
 | `src/lib/detection/prompt-key.ts` | promptKey重複排除ユーティリティ |

--- a/src/app/api/worktrees/[id]/messages/route.ts
+++ b/src/app/api/worktrees/[id]/messages/route.ts
@@ -8,6 +8,7 @@ import { getDbInstance } from '@/lib/db/db-instance';
 import { getWorktreeById, getMessages } from '@/lib/db';
 import { CLI_TOOL_IDS, type CLIToolType } from '@/lib/cli-tools/types';
 import { createLogger } from '@/lib/logger';
+import { MAX_MESSAGES_LIMIT, DEFAULT_MESSAGES_LIMIT } from '@/config/history-display-config';
 
 const logger = createLogger('api/messages');
 
@@ -34,7 +35,7 @@ export async function GET(
     const cliToolParam = searchParams.get('cliTool');
 
     const before = beforeParam ? new Date(beforeParam) : undefined;
-    const limit = limitParam ? parseInt(limitParam, 10) : 50;
+    const limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_MESSAGES_LIMIT;
     const cliToolId = cliToolParam as CLIToolType | undefined;
     const includeArchivedParam = searchParams.get('includeArchived');
     const includeArchived = includeArchivedParam === 'true';
@@ -47,10 +48,10 @@ export async function GET(
       );
     }
 
-    // Validate limit
-    if (isNaN(limit) || limit < 1 || limit > 100) {
+    // Validate limit. Upper bound is MAX_MESSAGES_LIMIT (Issue #701).
+    if (isNaN(limit) || limit < 1 || limit > MAX_MESSAGES_LIMIT) {
       return NextResponse.json(
-        { error: 'Invalid limit parameter (must be 1-100)' },
+        { error: `Invalid limit parameter (must be 1-${MAX_MESSAGES_LIMIT})` },
         { status: 400 }
       );
     }

--- a/src/components/worktree/HistoryPane.tsx
+++ b/src/components/worktree/HistoryPane.tsx
@@ -13,6 +13,11 @@ import type { ChatMessage } from '@/types/models';
 import { useConversationHistory } from '@/hooks/useConversationHistory';
 import { ConversationPairCard } from './ConversationPairCard';
 import { copyToClipboard } from '@/lib/clipboard-utils';
+import {
+  HISTORY_DISPLAY_LIMIT_OPTIONS,
+  isHistoryDisplayLimit,
+  type HistoryDisplayLimit,
+} from '@/config/history-display-config';
 
 // ============================================================================
 // Constants
@@ -51,6 +56,10 @@ export interface HistoryPaneProps {
   showArchived?: boolean;
   /** Issue #168: Callback when showArchived toggle changes */
   onShowArchivedChange?: (show: boolean) => void;
+  /** Issue #701: Current history display limit (50/100/150/200/250) */
+  historyDisplayLimit?: HistoryDisplayLimit;
+  /** Issue #701: Callback when the history display limit selector changes */
+  onHistoryDisplayLimitChange?: (limit: HistoryDisplayLimit) => void;
 }
 
 // ============================================================================
@@ -157,6 +166,8 @@ export const HistoryPane = memo(function HistoryPane({
   onInsertToMessage,
   showArchived = false,
   onShowArchivedChange,
+  historyDisplayLimit,
+  onHistoryDisplayLimitChange,
 }: HistoryPaneProps) {
   // worktreeId is kept in props for future use (e.g., filtering, fetching)
   // Using underscore prefix to indicate intentionally unused parameter
@@ -259,6 +270,17 @@ export const HistoryPane = memo(function HistoryPane({
     });
   };
 
+  // Issue #701: history display limit select handler
+  const handleHistoryDisplayLimitSelectChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const parsed = parseInt(e.target.value, 10);
+      if (isHistoryDisplayLimit(parsed)) {
+        onHistoryDisplayLimitChange?.(parsed);
+      }
+    },
+    [onHistoryDisplayLimitChange]
+  );
+
   return (
     <div
       ref={scrollContainerRef}
@@ -267,19 +289,38 @@ export const HistoryPane = memo(function HistoryPane({
       className={containerClasses}
     >
       {/* Header */}
-      <div className="sticky top-0 bg-gray-900 border-b border-gray-700 px-4 py-2 z-10 flex items-center justify-between">
+      <div className="sticky top-0 bg-gray-900 border-b border-gray-700 px-4 py-2 z-10 flex items-center justify-between flex-wrap gap-1">
         <h3 className="text-sm font-medium text-gray-300">Message History</h3>
-        {onShowArchivedChange && (
-          <label className="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={showArchived}
-              onChange={(e) => onShowArchivedChange(e.target.checked)}
-              className="rounded border-gray-600 bg-gray-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 h-3.5 w-3.5"
-            />
-            Show archived
-          </label>
-        )}
+        <div className="flex items-center gap-2 flex-wrap">
+          {onHistoryDisplayLimitChange && historyDisplayLimit !== undefined && (
+            <label className="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer">
+              <span>Show</span>
+              <select
+                value={historyDisplayLimit}
+                onChange={handleHistoryDisplayLimitSelectChange}
+                aria-label="History display limit"
+                className="rounded border border-gray-600 bg-gray-800 text-gray-200 text-xs px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+              >
+                {HISTORY_DISPLAY_LIMIT_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          {onShowArchivedChange && (
+            <label className="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showArchived}
+                onChange={(e) => onShowArchivedChange(e.target.checked)}
+                className="rounded border-gray-600 bg-gray-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 h-3.5 w-3.5"
+              />
+              Show archived
+            </label>
+          )}
+        </div>
       </div>
 
       {/* Content */}

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -95,6 +95,12 @@ import { MoveDialog } from '@/components/worktree/MoveDialog';
 import { NewFileDialog } from '@/components/worktree/NewFileDialog';
 import { encodePathForUrl } from '@/lib/url-path-encoder';
 import { parseCmateContent, validateScheduleHeaders, validateSchedulesSection, CMATE_TEMPLATE_CONTENT } from '@/lib/cmate-validator';
+import {
+  HISTORY_DISPLAY_LIMIT_STORAGE_KEY,
+  DEFAULT_MESSAGES_LIMIT,
+  isHistoryDisplayLimit,
+  type HistoryDisplayLimit,
+} from '@/config/history-display-config';
 
 // ============================================================================
 // Constants
@@ -294,6 +300,32 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     showArchivedRef.current = showArchived;
   }, [showArchived]);
 
+  // Issue #701: history display limit state with localStorage persistence
+  const [historyDisplayLimit, setHistoryDisplayLimit] = useState<HistoryDisplayLimit>(() => {
+    if (typeof window === 'undefined') return DEFAULT_MESSAGES_LIMIT;
+    try {
+      const stored = localStorage.getItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY);
+      if (stored === null) return DEFAULT_MESSAGES_LIMIT;
+      const parsed = parseInt(stored, 10);
+      return isHistoryDisplayLimit(parsed) ? parsed : DEFAULT_MESSAGES_LIMIT;
+    } catch {
+      return DEFAULT_MESSAGES_LIMIT;
+    }
+  });
+  const handleHistoryDisplayLimitChange = useCallback((limit: HistoryDisplayLimit) => {
+    setHistoryDisplayLimit(limit);
+    try {
+      localStorage.setItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY, String(limit));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, []);
+  // Ref for historyDisplayLimit to avoid fetchMessages callback recreation
+  const historyDisplayLimitRef = useRef(historyDisplayLimit);
+  useEffect(() => {
+    historyDisplayLimitRef.current = historyDisplayLimit;
+  }, [historyDisplayLimit]);
+
   // TODO: [D1-001] pendingInsertText の状態管理を useTextInsertion カスタムフックに抽出する（技術的負債）
   // [Issue #485] State for inserting text from history/memo into message input
   const [pendingInsertText, setPendingInsertText] = useState<string | null>(null);
@@ -380,6 +412,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
       if (showArchivedRef.current) {
         params.set('includeArchived', 'true');
       }
+      // Issue #701: include user-selected history display limit
+      params.set('limit', String(historyDisplayLimitRef.current));
       const response = await fetch(`/api/worktrees/${worktreeId}/messages?${params.toString()}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch messages: ${response.status}`);
@@ -523,6 +557,11 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   useEffect(() => {
     void fetchMessages();
   }, [showArchived, fetchMessages]);
+
+  // Issue #701: Re-fetch messages when historyDisplayLimit changes
+  useEffect(() => {
+    void fetchMessages();
+  }, [historyDisplayLimit, fetchMessages]);
 
   // Toast state for notifications (moved before event handlers that reference showToast)
   const { toasts, showToast, removeToast } = useToast();
@@ -1484,6 +1523,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
                   onInsertToMessage={handleInsertToMessage}
                   showArchived={showArchived}
                   onShowArchivedChange={handleShowArchivedChange}
+                  historyDisplayLimit={historyDisplayLimit}
+                  onHistoryDisplayLimitChange={handleHistoryDisplayLimitChange}
                 />
               )}
               {historySubTab === 'git' && (
@@ -1549,7 +1590,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         </div>
       </div>
     ),
-    [leftPaneTab, handleLeftPaneTabChange, historySubTab, state.messages, worktreeId, handleFilePathClick, showToast, fileSearch.query, fileSearch.mode, fileSearch.isSearching, fileSearch.error, fileSearch.setQuery, fileSearch.setMode, fileSearch.clearSearch, fileSearch.results?.results, handleFileSelect, handleNewFile, handleNewDirectory, handleRename, handleDelete, handleUpload, handleMove, handleCmateSetup, fileTreeRefresh, selectedAgents, handleSelectedAgentsChange, vibeLocalModel, handleVibeLocalModelChange, vibeLocalContextWindow, handleVibeLocalContextWindowChange, handleDiffSelect, handleInsertToMessage, showArchived, handleShowArchivedChange, actions.toggleLeftPane]
+    [leftPaneTab, handleLeftPaneTabChange, historySubTab, state.messages, worktreeId, handleFilePathClick, showToast, fileSearch.query, fileSearch.mode, fileSearch.isSearching, fileSearch.error, fileSearch.setQuery, fileSearch.setMode, fileSearch.clearSearch, fileSearch.results?.results, handleFileSelect, handleNewFile, handleNewDirectory, handleRename, handleDelete, handleUpload, handleMove, handleCmateSetup, fileTreeRefresh, selectedAgents, handleSelectedAgentsChange, vibeLocalModel, handleVibeLocalModelChange, vibeLocalContextWindow, handleVibeLocalContextWindowChange, handleDiffSelect, handleInsertToMessage, showArchived, handleShowArchivedChange, historyDisplayLimit, handleHistoryDisplayLimitChange, actions.toggleLeftPane]
   );
 
   // ========================================================================
@@ -1870,6 +1911,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
             onInsertToMessage={handleInsertToMessage}
             showArchived={showArchived}
             onShowArchivedChange={handleShowArchivedChange}
+            historyDisplayLimit={historyDisplayLimit}
+            onHistoryDisplayLimitChange={handleHistoryDisplayLimitChange}
           />
         </main>
 

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -34,6 +34,7 @@ import { GitPane } from '@/components/worktree/GitPane';
 import type { Worktree, ChatMessage, GitStatus } from '@/types/models';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import type { UseFileSearchReturn } from '@/hooks/useFileSearch';
+import type { HistoryDisplayLimit } from '@/config/history-display-config';
 
 // ============================================================================
 // Constants
@@ -878,6 +879,10 @@ interface MobileContentProps {
   showArchived?: boolean;
   /** [Issue #168] Callback when showArchived toggle changes */
   onShowArchivedChange?: (show: boolean) => void;
+  /** [Issue #701] Current history display limit */
+  historyDisplayLimit?: HistoryDisplayLimit;
+  /** [Issue #701] Callback when history display limit changes */
+  onHistoryDisplayLimitChange?: (limit: HistoryDisplayLimit) => void;
 }
 
 /** Renders content based on active mobile tab */
@@ -917,6 +922,8 @@ export const MobileContent = memo(function MobileContent({
   onInsertToMessage,
   showArchived,
   onShowArchivedChange,
+  historyDisplayLimit,
+  onHistoryDisplayLimitChange,
 }: MobileContentProps) {
   switch (activeTab) {
     case 'terminal':
@@ -972,6 +979,8 @@ export const MobileContent = memo(function MobileContent({
                 onInsertToMessage={onInsertToMessage}
                 showArchived={showArchived}
                 onShowArchivedChange={onShowArchivedChange}
+                historyDisplayLimit={historyDisplayLimit}
+                onHistoryDisplayLimitChange={onHistoryDisplayLimitChange}
               />
             </ErrorBoundary>
           ) : (

--- a/src/config/history-display-config.ts
+++ b/src/config/history-display-config.ts
@@ -1,0 +1,57 @@
+/**
+ * History Display Configuration (Issue #701)
+ *
+ * Single Source of Truth for the history display limit options used by:
+ * - GET /api/worktrees/:id/messages (upper-bound validation)
+ * - HistoryPane selector UI (selectable options)
+ * - WorktreeDetailRefactored state (persisted to localStorage)
+ * - useInfiniteMessages default page size
+ *
+ * Design decisions:
+ * - MAX_MESSAGES_LIMIT is derived from HISTORY_DISPLAY_LIMIT_OPTIONS (no duplication).
+ * - DEFAULT_MESSAGES_LIMIT (50) matches the historical default before this issue.
+ * - Storage key uses the `commandmate:` namespace, matching other keys
+ *   (e.g. `commandmate:showArchived`).
+ */
+
+/**
+ * Selectable history display limit options (ascending).
+ * The first entry is the historical default; the last entry is the maximum.
+ */
+export const HISTORY_DISPLAY_LIMIT_OPTIONS = [50, 100, 150, 200, 250] as const;
+
+/**
+ * Union type representing any selectable history display limit.
+ */
+export type HistoryDisplayLimit = (typeof HISTORY_DISPLAY_LIMIT_OPTIONS)[number];
+
+/**
+ * Upper bound enforced by the API, derived from the maximum option.
+ *
+ * Typed as `HistoryDisplayLimit` (not a brittle `as 250` literal) so that
+ * extending `HISTORY_DISPLAY_LIMIT_OPTIONS` does not require touching this line.
+ */
+export const MAX_MESSAGES_LIMIT: HistoryDisplayLimit = Math.max(
+  ...HISTORY_DISPLAY_LIMIT_OPTIONS,
+) as HistoryDisplayLimit;
+
+/**
+ * Default history display limit (used when no localStorage value is present
+ * and as the default `pageSize` for `useInfiniteMessages`).
+ */
+export const DEFAULT_MESSAGES_LIMIT: HistoryDisplayLimit = 50;
+
+/**
+ * localStorage key used to persist the user-selected history display limit.
+ */
+export const HISTORY_DISPLAY_LIMIT_STORAGE_KEY = 'commandmate:historyDisplayLimit';
+
+/**
+ * Type guard: returns true if `value` is one of the allowed limit options.
+ *
+ * Used when reading from localStorage (which may contain stale/corrupted data)
+ * to safely narrow `number` to `HistoryDisplayLimit`.
+ */
+export function isHistoryDisplayLimit(value: number): value is HistoryDisplayLimit {
+  return (HISTORY_DISPLAY_LIMIT_OPTIONS as readonly number[]).includes(value);
+}

--- a/src/hooks/useInfiniteMessages.ts
+++ b/src/hooks/useInfiniteMessages.ts
@@ -21,6 +21,7 @@ import {
   createInfiniteMessagesError,
 } from '@/types/infinite-messages';
 import { groupMessagesIntoPairs } from '@/lib/conversation-grouper';
+import { DEFAULT_MESSAGES_LIMIT } from '@/config/history-display-config';
 
 /**
  * Options for useInfiniteMessages hook
@@ -113,7 +114,7 @@ function parseMessageTimestamps(messages: ChatMessage[]): ChatMessage[] {
 export function useInfiniteMessages(
   options: UseInfiniteMessagesOptions
 ): UseInfiniteMessagesReturn {
-  const { worktreeId, cliToolId, pageSize = 50 } = options;
+  const { worktreeId, cliToolId, pageSize = DEFAULT_MESSAGES_LIMIT } = options;
 
   // State
   const [messages, setMessages] = useState<ChatMessage[]>([]);

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -216,14 +216,23 @@ export const worktreeApi = {
   /**
    * Get messages for a worktree, optionally filtered by CLI tool
    * Issue #168: Added includeArchived parameter for session history retention
+   * Issue #701: Added limit parameter for user-selectable display count (50-250)
    */
-  async getMessages(id: string, cliTool?: CLIToolType, includeArchived?: boolean): Promise<ChatMessage[]> {
+  async getMessages(
+    id: string,
+    cliTool?: CLIToolType,
+    includeArchived?: boolean,
+    limit?: number,
+  ): Promise<ChatMessage[]> {
     const params = new URLSearchParams();
     if (cliTool) {
       params.append('cliTool', cliTool);
     }
     if (includeArchived) {
       params.append('includeArchived', 'true');
+    }
+    if (typeof limit === 'number' && Number.isFinite(limit)) {
+      params.append('limit', String(limit));
     }
     const url = `/api/worktrees/${id}/messages${params.toString() ? `?${params.toString()}` : ''}`;
     return fetchApi<ChatMessage[]>(url);

--- a/tests/integration/api-messages.test.ts
+++ b/tests/integration/api-messages.test.ts
@@ -185,6 +185,76 @@ describe('GET /api/worktrees/:id/messages', () => {
     expect(data.error).toContain('not found');
   });
 
+  // Issue #701: Limit boundary tests
+  describe('limit parameter boundary (Issue #701)', () => {
+    it('should accept limit=250 (upper bound) and return 200', async () => {
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=250'
+      );
+      const params = { params: { id: 'test-worktree' } };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject limit=251 (above upper bound) with 400', async () => {
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=251'
+      );
+      const params = { params: { id: 'test-worktree' } };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data).toHaveProperty('error');
+      expect(data.error).toContain('250');
+    });
+
+    it('should reject limit=0 (below lower bound) with 400', async () => {
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=0'
+      );
+      const params = { params: { id: 'test-worktree' } };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data).toHaveProperty('error');
+    });
+
+    it('should reject limit=abc (non-numeric) with 400', async () => {
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=abc'
+      );
+      const params = { params: { id: 'test-worktree' } };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data).toHaveProperty('error');
+    });
+
+    it('should accept limit=1 (lower bound) and return 200', async () => {
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=1'
+      );
+      const params = { params: { id: 'test-worktree' } };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(200);
+    });
+  });
+
   it('should return 500 on database error', async () => {
     db.close();
 

--- a/tests/unit/config/history-display-config.test.ts
+++ b/tests/unit/config/history-display-config.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for history-display-config (Issue #701)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  HISTORY_DISPLAY_LIMIT_OPTIONS,
+  MAX_MESSAGES_LIMIT,
+  DEFAULT_MESSAGES_LIMIT,
+  HISTORY_DISPLAY_LIMIT_STORAGE_KEY,
+  isHistoryDisplayLimit,
+} from '@/config/history-display-config';
+
+describe('history-display-config (Issue #701)', () => {
+  describe('HISTORY_DISPLAY_LIMIT_OPTIONS', () => {
+    it('should expose [50, 100, 150, 200, 250] in ascending order', () => {
+      expect([...HISTORY_DISPLAY_LIMIT_OPTIONS]).toEqual([50, 100, 150, 200, 250]);
+    });
+
+    it('should not be empty', () => {
+      expect(HISTORY_DISPLAY_LIMIT_OPTIONS.length).toBeGreaterThan(0);
+    });
+
+    it('should contain only positive integers', () => {
+      for (const opt of HISTORY_DISPLAY_LIMIT_OPTIONS) {
+        expect(Number.isInteger(opt)).toBe(true);
+        expect(opt).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('MAX_MESSAGES_LIMIT', () => {
+    it('should be the maximum of HISTORY_DISPLAY_LIMIT_OPTIONS', () => {
+      expect(MAX_MESSAGES_LIMIT).toBe(Math.max(...HISTORY_DISPLAY_LIMIT_OPTIONS));
+    });
+
+    it('should equal 250', () => {
+      expect(MAX_MESSAGES_LIMIT).toBe(250);
+    });
+  });
+
+  describe('DEFAULT_MESSAGES_LIMIT', () => {
+    it('should be 50 (historical default)', () => {
+      expect(DEFAULT_MESSAGES_LIMIT).toBe(50);
+    });
+
+    it('should be one of HISTORY_DISPLAY_LIMIT_OPTIONS', () => {
+      expect(HISTORY_DISPLAY_LIMIT_OPTIONS).toContain(DEFAULT_MESSAGES_LIMIT);
+    });
+  });
+
+  describe('HISTORY_DISPLAY_LIMIT_STORAGE_KEY', () => {
+    it('should use the commandmate: namespace', () => {
+      expect(HISTORY_DISPLAY_LIMIT_STORAGE_KEY).toBe('commandmate:historyDisplayLimit');
+    });
+  });
+
+  describe('isHistoryDisplayLimit', () => {
+    it('should return true for valid options', () => {
+      for (const opt of HISTORY_DISPLAY_LIMIT_OPTIONS) {
+        expect(isHistoryDisplayLimit(opt)).toBe(true);
+      }
+    });
+
+    it('should return false for non-option values', () => {
+      expect(isHistoryDisplayLimit(0)).toBe(false);
+      expect(isHistoryDisplayLimit(49)).toBe(false);
+      expect(isHistoryDisplayLimit(75)).toBe(false);
+      expect(isHistoryDisplayLimit(251)).toBe(false);
+      expect(isHistoryDisplayLimit(-50)).toBe(false);
+      expect(isHistoryDisplayLimit(NaN)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -353,6 +353,23 @@ describe('Database Operations', () => {
         expect(messages).toHaveLength(5);
       });
 
+      // Issue #701: Verify DB layer handles upper bound limit (250)
+      it('should support limit=250 (Issue #701 upper bound)', () => {
+        for (let i = 0; i < 260; i++) {
+          createMessage(testDb, {
+            worktreeId: 'main',
+            role: 'user',
+            content: `Message ${i}`,
+            messageType: 'normal',
+            timestamp: new Date(2025, 0, 1, 0, 0, 0, i),
+          });
+        }
+
+        const messages = getMessages(testDb, 'main', { limit: 250 });
+
+        expect(messages).toHaveLength(250);
+      });
+
       it('should return empty array for worktree with no messages', () => {
         upsertWorktree(testDb, {
           id: 'empty',

--- a/tests/unit/hooks/useInfiniteMessages.test.ts
+++ b/tests/unit/hooks/useInfiniteMessages.test.ts
@@ -146,6 +146,52 @@ describe('useInfiniteMessages', () => {
 
       expect(result.current.hasMore).toBe(false);
     });
+
+    // Issue #701: Verify hasMore detection works at the new upper-bound pageSize (250)
+    it('should set hasMore to true when fetched count equals pageSize=250 (Issue #701)', async () => {
+      const mockMessages = createMockMessages(250);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockMessages),
+      });
+
+      const { result } = renderHook(() =>
+        useInfiniteMessages({
+          worktreeId: 'wt-1',
+          cliToolId: 'claude',
+          pageSize: 250,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasMore).toBe(true);
+      expect(result.current.messages).toHaveLength(250);
+    });
+
+    it('should set hasMore to false when fetched count is less than pageSize=250 (Issue #701)', async () => {
+      const mockMessages = createMockMessages(249);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockMessages),
+      });
+
+      const { result } = renderHook(() =>
+        useInfiniteMessages({
+          worktreeId: 'wt-1',
+          cliToolId: 'claude',
+          pageSize: 250,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasMore).toBe(false);
+    });
   });
 
   describe('loadMore', () => {


### PR DESCRIPTION
## Summary

develop ブランチを main へマージするリリースPRです。Issue #701 の実装を本番ブランチに反映します。

## Included PRs

- #702: feat: 履歴(History)表示件数を50〜250件で選択可能にする (#701) — squash merged to develop (`51d8811a`)

## Closes

- Closes #701

## 主要変更

- 新規: `src/config/history-display-config.ts` (Single Source of Truth)
  - `HISTORY_DISPLAY_LIMIT_OPTIONS = [50, 100, 150, 200, 250]`
  - `DEFAULT_MESSAGES_LIMIT = 50`, `MAX_MESSAGES_LIMIT` (OPTIONS最大値から派生)
  - localStorage key: `commandmate:historyDisplayLimit`
- API: `GET /api/worktrees/[id]/messages` の `limit` 上限 100 → 250
- UI: `HistoryPane` ヘッダーに件数セレクタ（Show archived と同列）
- WorktreeDetailRefactored で `historyDisplayLimit` state 追加・localStorage 永続化
- api-client / useInfiniteMessages を `DEFAULT_MESSAGES_LIMIT` 参照に DRY 化

## Test Results

- ESLint: 0 errors
- TypeScript: 0 errors
- Unit Tests: 6481 passed / 7 skipped (343 files)
- Build: ✓ Compiled successfully (32/32 static pages)
- Integration Tests (新規境界値): 5/5 PASS
- UAT: 15/15 PASS

## Test Plan

- [ ] PC: HistoryPane のセレクタで 50 / 100 / 150 / 200 / 250 を切り替えて表示件数が反映されることを確認
- [ ] PC: ページリロード後にセレクタ選択値が復元されることを確認
- [ ] Mobile: モバイル View でもセレクタが動作することを確認
- [ ] CLIタブ切替 / Show archived 切替後も件数選択が維持されることを確認
- [ ] API: `?limit=250` で 200、`?limit=251` で 400 が返ることを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)