### PR TITLE
fix: Files タブの refetch でスクロール位置がリセットされる問題を修正 (#706)

### DIFF
--- a/dev-reports/bug-fix/706_20260515_185650/acceptance-context.json
+++ b/dev-reports/bug-fix/706_20260515_185650/acceptance-context.json
@@ -1,0 +1,84 @@
+{
+  "bug_id": "706_20260515_185650",
+  "issue_number": 706,
+  "bug_description": "Files タブのツリー再描画でスクロール位置がリセットされる（refetch 時の loading 表示を全置換から控えめインジケーター方式へ変更）",
+  "fix_summary": "1) FileTreeView の loading/error 早期 return を初回マウント時 (rootItems 未取得時) に限定、2) refetch 中は既存ツリー DOM を保持しツールバー右端に小型 spinner (file-tree-refetch-indicator) と非破壊エラーバナー (file-tree-refetch-error + 再試行ボタン) を表示、3) WorktreeDetailRefactored の prevTreeHashRef を初回ポーリング時はベースライン記録のみとし偽陽性 refresh 発火を回避。",
+  "files_modified": [
+    "src/components/worktree/FileTreeView.tsx",
+    "src/components/worktree/WorktreeDetailRefactored.tsx",
+    "tests/unit/components/worktree/FileTreeView.test.tsx"
+  ],
+  "acceptance_criteria": [
+    "Files タブ初回表示後 5 秒経過時にスクロール位置がリセットされない",
+    "実際にファイルが追加／削除された際もスクロール位置・フォーカスが維持される",
+    "refetch 中はパネル内に控えめな更新インジケーターが表示される",
+    "初回マウント時（rootItems 未取得時）は従来通り全画面 loading が表示される",
+    "refetch 失敗時は既存ツリーを保持しつつエラーを非破壊的に通知する",
+    "既存の npm run test:unit で 0 件の回帰",
+    "FileTreeView の refetch 動作に関する新規テストが追加されている",
+    "ESLint / TypeScript チェックがパスする"
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "title": "初回マウント時の loading 表示",
+      "given": "FileTreeView が初めてレンダリングされる (rootItems 未取得)",
+      "when": "loading=true の状態",
+      "then": "data-testid='file-tree-loading' が表示される"
+    },
+    {
+      "id": "TS-2",
+      "title": "refetch 時の loading 非表示",
+      "given": "rootItems が既に取得されツリーが表示されている",
+      "when": "refreshTrigger が変化し loading=true になる",
+      "then": "data-testid='file-tree-loading' は表示されず、既存ツリーが保持される"
+    },
+    {
+      "id": "TS-3",
+      "title": "refetch 中の控えめインジケーター表示",
+      "given": "rootItems が既にある状態",
+      "when": "refreshTrigger が変化し refetch 中",
+      "then": "data-testid='file-tree-refetch-indicator' が表示される (role=status, aria-live=polite)"
+    },
+    {
+      "id": "TS-4",
+      "title": "refetch エラーの非破壊表示",
+      "given": "rootItems が既にある状態",
+      "when": "refetch が失敗",
+      "then": "既存ツリーは保持され、data-testid='file-tree-refetch-error' バナーと再試行ボタンが表示される"
+    },
+    {
+      "id": "TS-5",
+      "title": "初回ロード失敗時の全画面エラー表示",
+      "given": "FileTreeView が初めてレンダリングされる",
+      "when": "fetchDirectory が失敗 (rootItems が取れない)",
+      "then": "data-testid='file-tree-error' が全画面で表示される"
+    },
+    {
+      "id": "TS-6",
+      "title": "再試行ボタンの動作",
+      "given": "refetch エラーバナーが表示されている",
+      "when": "data-testid='file-tree-refetch-retry-button' をクリック",
+      "then": "fetchDirectory が再呼び出しされる"
+    },
+    {
+      "id": "TS-7",
+      "title": "prevTreeHashRef 初回スキップ",
+      "given": "WorktreeDetailRefactored がマウントされ Files タブが表示されている",
+      "when": "初回ツリーポーリング (5秒後) が発火",
+      "then": "setFileTreeRefresh は呼ばれず、prevTreeHashRef のみ更新される。実際のツリー変更時 (2回目以降) は refresh が発火する"
+    },
+    {
+      "id": "TS-8",
+      "title": "既存 Issue #164 テスト互換",
+      "given": "Issue #164 の refreshTrigger expand state preservation シリーズ",
+      "when": "全テストを実行",
+      "then": "全件 pass (回帰なし)"
+    }
+  ],
+  "validation_commands": [
+    "npm run lint",
+    "npx tsc --noEmit",
+    "npm run test:unit"
+  ]
+}

--- a/dev-reports/bug-fix/706_20260515_185650/acceptance-result.json
+++ b/dev-reports/bug-fix/706_20260515_185650/acceptance-result.json
@@ -1,0 +1,115 @@
+{
+  "status": "pass",
+  "summary": "Issue #706 (Files タブツリー再描画でスクロール位置リセット) の修正は全 8 項目の受入条件・全 8 件のテストシナリオを満たし、ESLint / TypeScript / Vitest (6491 tests) の検証も全てパスした。FileTreeView.tsx で初回マウント時のみ全画面 loading/error を表示し、refetch 中は既存ツリー DOM を保持しつつ控えめなインジケーター・非破壊エラーバナー・再試行ボタンを表示する実装が正しく動作する。WorktreeDetailRefactored.tsx の prevTreeHashRef 初回スキップロジックも正しく実装され、偽陽性 refresh 発火を回避している。",
+  "acceptance_criteria_results": [
+    {
+      "criterion": "Files タブ初回表示後 5 秒経過時にスクロール位置がリセットされない",
+      "result": "pass",
+      "evidence": "WorktreeDetailRefactored.tsx:279-284 で prevTreeHashRef.current === null の初回ポーリング時はベースラインのみ記録し setFileTreeRefresh を呼ばない。さらに FileTreeView.tsx:383 で rootItems.length === 0 が偽の場合は loading 早期 return せず既存ツリー DOM を保持するため、スクロール位置はリセットされない。"
+    },
+    {
+      "criterion": "実際にファイルが追加／削除された際もスクロール位置・フォーカスが維持される",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:171-234 の reloadTreeWithExpandedDirs では setRootItems/setCache のみ更新し、ツリーコンテナ DOM は同一インスタンスを保持する。loading 早期 return は rootItems.length === 0 のみで限定されているため、refetch 中もスクロール状態は維持される。"
+    },
+    {
+      "criterion": "refetch 中はパネル内に控えめな更新インジケーターが表示される",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:412 で isRefetching = loading && rootItems.length > 0 を判定し、:512-525 でツールバー右端に data-testid='file-tree-refetch-indicator' (role='status', aria-live='polite') を表示。テスト (FileTreeView.test.tsx:1589-1635) で 'should show file-tree-refetch-indicator while refetching' 動作を確認済み。"
+    },
+    {
+      "criterion": "初回マウント時（rootItems 未取得時）は従来通り全画面 loading が表示される",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:383-394 で isInitialLoading = loading && rootItems.length === 0 のとき従来通り data-testid='file-tree-loading' を表示。テスト (FileTreeView.test.tsx:63-66) で 'should render loading state initially' が pass。"
+    },
+    {
+      "criterion": "refetch 失敗時は既存ツリーを保持しつつエラーを非破壊的に通知する",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:413 で isRefetchError = !!error && rootItems.length > 0 を判定し、:531-549 で data-testid='file-tree-refetch-error' バナー + 再試行ボタンを表示。テスト (FileTreeView.test.tsx:1637-1662) で既存ツリー保持と file-tree-error 非表示を確認済み。"
+    },
+    {
+      "criterion": "既存の npm run test:unit で 0 件の回帰",
+      "result": "pass",
+      "evidence": "npm run test:unit で Test Files 343 passed (343), Tests 6491 passed | 7 skipped (6498)。FileTreeView.test.tsx 単独実行でも 69 tests passed。"
+    },
+    {
+      "criterion": "FileTreeView の refetch 動作に関する新規テストが追加されている",
+      "result": "pass",
+      "evidence": "FileTreeView.test.tsx:1562-1720 に describe('refetch indicator (Issue #706)') が追加され、5 件の新規テスト (loading 非表示・indicator 表示・error 非破壊・全画面 error 維持・retry 動作) が pass。"
+    },
+    {
+      "criterion": "ESLint / TypeScript チェックがパスする",
+      "result": "pass",
+      "evidence": "npm run lint: 'No ESLint warnings or errors'。npx tsc --noEmit: エラー出力なし (exit 0)。"
+    }
+  ],
+  "test_scenario_results": [
+    {
+      "id": "TS-1",
+      "title": "初回マウント時の loading 表示",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:383-394 isInitialLoading 分岐で data-testid='file-tree-loading' を返す。FileTreeView.test.tsx:63 'should render loading state initially' が pass。"
+    },
+    {
+      "id": "TS-2",
+      "title": "refetch 時の loading 非表示",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:383 isInitialLoading = loading && rootItems.length === 0 で限定されており、rootItems がある状態では loading=true でも早期 return せず既存ツリー DOM が保持される。FileTreeView.test.tsx:1563 'should not show file-tree-loading on refetch' で rerender 後も file-tree-loading が出ないことを確認済み。"
+    },
+    {
+      "id": "TS-3",
+      "title": "refetch 中の控えめインジケーター表示",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:512-525 で isRefetching && の条件下、data-testid='file-tree-refetch-indicator' (role='status', aria-live='polite') を表示。FileTreeView.test.tsx:1589 'should show file-tree-refetch-indicator while refetching' が pass (deferred fetch で in-flight 状態をシミュレート)。"
+    },
+    {
+      "id": "TS-4",
+      "title": "refetch エラーの非破壊表示",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:413, :531-549 で isRefetchError 時に data-testid='file-tree-refetch-error' バナーと再試行ボタンを表示し、ツリー DOM は :550-568 で引き続きレンダリングされる。FileTreeView.test.tsx:1637 'should preserve existing tree and show file-tree-refetch-error on refetch failure' が pass。"
+    },
+    {
+      "id": "TS-5",
+      "title": "初回ロード失敗時の全画面エラー表示",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:399-409 で isInitialError = !!error && rootItems.length === 0 のとき data-testid='file-tree-error' を全画面表示。FileTreeView.test.tsx:1664 'should still show full-screen file-tree-error on initial load failure' が pass。"
+    },
+    {
+      "id": "TS-6",
+      "title": "再試行ボタンの動作",
+      "result": "pass",
+      "evidence": "FileTreeView.tsx:539-546 で data-testid='file-tree-refetch-retry-button' の onClick が reloadTreeWithExpandedDirs を呼び出す。FileTreeView.test.tsx:1677 'should retry refetch when file-tree-refetch-retry-button is clicked' でクリック後にエラーバナー消失と src 表示を確認済み。"
+    },
+    {
+      "id": "TS-7",
+      "title": "prevTreeHashRef 初回スキップ",
+      "result": "pass",
+      "evidence": "WorktreeDetailRefactored.tsx:265 で prevTreeHashRef = useRef<string | null>(null) 初期化。:279-284 で prevTreeHashRef.current === null の初回ポーリング時は newHash 記録のみ (setFileTreeRefresh 呼ばず)、2 回目以降は newHash !== prev で setFileTreeRefresh(prev => prev + 1) を発火する分岐ロジックが正しく実装されている。"
+    },
+    {
+      "id": "TS-8",
+      "title": "既存 Issue #164 テスト互換",
+      "result": "pass",
+      "evidence": "FileTreeView.test.tsx:1021 describe('refreshTrigger - expand state preservation (Issue #164)') 全件 (maintain expanded directory contents, CONCURRENT_LIMIT, remove deleted directories, no infinite loop, birthtime visibility, cancel previous reload) が pass。FileTreeView.test.tsx 全 69 tests passed。"
+    }
+  ],
+  "validation_command_results": {
+    "lint": {
+      "result": "pass",
+      "details": "npm run lint → 'No ESLint warnings or errors'"
+    },
+    "typecheck": {
+      "result": "pass",
+      "details": "npx tsc --noEmit → エラー出力なし (exit 0)"
+    },
+    "unit_test": {
+      "result": "pass",
+      "details": "npm run test:unit → Test Files 343 passed (343), Tests 6491 passed | 7 skipped (6498)。FileTreeView.test.tsx 単独実行で 69 tests passed (Issue #706 新規 5 件 + Issue #164 既存テスト含む)。"
+    }
+  },
+  "issues_found": [],
+  "recommendations": [
+    "受入テスト観点では問題なし。手動 (Playwright E2E または実機) でも長時間スクロール後の 5 秒ポーリングでスクロール位置が維持されることを最終確認することを推奨 (今回コードレベル + Unit テストで合理的に保証済み)。",
+    "再試行ボタンのラベル '再試行' は日本語ハードコードのため、将来的に i18n 対応する場合は next-intl メッセージへ移行することを検討 (今回の修正スコープ外)。"
+  ]
+}

--- a/dev-reports/bug-fix/706_20260515_185650/investigation-context.json
+++ b/dev-reports/bug-fix/706_20260515_185650/investigation-context.json
@@ -1,0 +1,42 @@
+{
+  "issue_id": 706,
+  "issue_title": "fix(files): Files タブのツリー再描画でスクロール位置がリセットされる（refetch 時の loading 表示を見直し）",
+  "issue_description": "Files タブのツリー表示で、約5秒経過時や実ファイル変更検知時にツリーが「Loading files...」スピナーへ一瞬切り替わり、スクロール位置・フォーカス・選択強調などのDOMステートが初期化される。",
+  "error_logs": [],
+  "affected_files": [
+    "src/components/worktree/FileTreeView.tsx",
+    "src/components/worktree/WorktreeDetailRefactored.tsx",
+    "tests/unit/components/worktree/FileTreeView.test.tsx"
+  ],
+  "reproduction_steps": [
+    "1. CommandMateを起動し、任意のworktree詳細画面を開く",
+    "2. 左ペインでFilesタブに切り替え、ツリー表示を確認",
+    "3. 大きなツリーで深いノードまでスクロール",
+    "4. 約5秒待機する",
+    "5. 実際: ツリーが「Loading files...」スピナーで全置換され、戻った後スクロール位置が先頭にリセット",
+    "6. 期待: スクロール位置・フォーカス・選択状態が維持される"
+  ],
+  "environment": {
+    "os": "macOS",
+    "node_version": "18.x",
+    "browser": "Chrome"
+  },
+  "severity_hint": "high",
+  "known_root_causes": {
+    "structural_issue": {
+      "file": "src/components/worktree/FileTreeView.tsx",
+      "lines": "367-378",
+      "description": "loading 分岐が初回マウント時もrefetch時も区別なくツリーDOM全体をspinnerで全置換するため、refresh毎にDOMがunmount→remountされる"
+    },
+    "polling_trigger": {
+      "file": "src/components/worktree/WorktreeDetailRefactored.tsx",
+      "lines": "265-283",
+      "description": "prevTreeHashRef の初期値 null のせいで初回ポーリング（5秒後）で常に差分検知→setFileTreeRefresh偽陽性発火"
+    },
+    "polling_interval": {
+      "file": "src/config/file-polling-config.ts",
+      "lines": "8",
+      "description": "FILE_TREE_POLL_INTERVAL_MS = 5000ms"
+    }
+  }
+}

--- a/dev-reports/bug-fix/706_20260515_185650/investigation-result.json
+++ b/dev-reports/bug-fix/706_20260515_185650/investigation-result.json
@@ -1,0 +1,80 @@
+{
+  "investigation_summary": "Files タブのツリーが refetch 時に全画面 Loading スピナーで置換されるため、スクロール位置・フォーカス・選択強調などの DOM ステートがリセットされる。原因は (1) FileTreeView の loading 分岐が初回マウント/refetch を区別せず全置換していること、(2) WorktreeDetailRefactored の prevTreeHashRef が null 初期化のため初回ポーリングで偽陽性発火していることの 2 点。",
+  "root_cause": {
+    "primary": {
+      "type": "structural",
+      "description": "FileTreeView.tsx の `if (loading) return <Loading>` 分岐が初回・refetch を区別せず DOM 全置換する",
+      "evidence": [
+        "src/components/worktree/FileTreeView.tsx:367-378 で loading=true 時に常に file-tree-loading を返す",
+        "src/components/worktree/FileTreeView.tsx:161 で reloadTreeWithExpandedDirs() が refreshTrigger 変化時にも setLoading(true) を呼ぶ",
+        "結果として refetch のたびに rootItems を持つ DOM がアンマウントされ、スクロール位置・選択状態が失われる"
+      ]
+    },
+    "secondary": {
+      "type": "false_positive_polling",
+      "description": "WorktreeDetailRefactored のツリーポーリングが初回ポーリング時に偽陽性で refresh を発火する",
+      "evidence": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx:265 で `const prevTreeHashRef = useRef<string | null>(null)`",
+        "src/components/worktree/WorktreeDetailRefactored.tsx:275 の `if (newHash !== prevTreeHashRef.current)` が初回必ず true になる",
+        "FILE_TREE_POLL_INTERVAL_MS=5000ms（src/config/file-polling-config.ts:8）のため、初回マウント約5秒後に発火"
+      ]
+    }
+  },
+  "affected_scope": {
+    "user_facing": [
+      "Files タブを開いている全 worktree 詳細画面",
+      "初回マウント後 5 秒の偽陽性発火 + 2 回目以降の実ファイル変更検知時",
+      "スクロール位置、選択中ファイルの強調、キーボードフォーカス、hover 状態が瞬間的に失われる"
+    ],
+    "platforms": ["PC", "モバイル"]
+  },
+  "severity": "high",
+  "recommended_actions": [
+    {
+      "id": "action-1",
+      "priority": "high",
+      "title": "FileTreeView の loading 分岐を初回限定に変更（Option 3: 既存ツリー保持）",
+      "description": "loading=true かつ rootItems.length===0 のときだけ全画面 Loading を表示し、refetch 中は既存ツリー DOM を保持する。パネル内に控えめな更新インジケーターを表示。",
+      "files_to_modify": [
+        "src/components/worktree/FileTreeView.tsx"
+      ],
+      "rationale": "本質的なスクロール位置リセット問題を根本解決する。実ファイル変更検知時のリセットも同時に解消できる。"
+    },
+    {
+      "id": "action-2",
+      "priority": "high",
+      "title": "refetch 失敗時の非破壊エラー表示",
+      "description": "refetch エラー時は既存ツリーを保持しつつエラーを非破壊的に通知。初回ロードエラーのみ既存の全画面エラー表示を維持。",
+      "files_to_modify": [
+        "src/components/worktree/FileTreeView.tsx"
+      ],
+      "rationale": "refetch 失敗で既存ツリーが消失する二次的な体験悪化を防ぐ。Issue 受入条件に含まれる。"
+    },
+    {
+      "id": "action-3",
+      "priority": "medium",
+      "title": "prevTreeHashRef 初回スキップで偽陽性ポーリングを抑止",
+      "description": "WorktreeDetailRefactored.tsx の `if (newHash !== prevTreeHashRef.current)` を初回 null のときは比較スキップして代入のみに変更。",
+      "files_to_modify": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx"
+      ],
+      "rationale": "Option 3 単独でもスクロール維持は実現できるが、無駄な refetch を避ける観点で同時対応推奨。Issue で『同時対応推奨』と記載あり。"
+    },
+    {
+      "id": "action-4",
+      "priority": "high",
+      "title": "テスト追加・既存テスト更新",
+      "description": "data-testid=file-tree-loading の期待値を『rootItems 未取得時に限定』に更新。refetch 中も既存ツリーが保持されることの新規テスト追加。",
+      "files_to_modify": [
+        "tests/unit/components/worktree/FileTreeView.test.tsx"
+      ],
+      "rationale": "受入条件: 既存 `npm run test:unit` で 0 件の回帰、refetch 動作の新規テスト追加が必須。"
+    }
+  ],
+  "risks_and_considerations": [
+    "TreeNode の key（key={item.name}）が安定していることに依存する（React reconciliation での再利用）",
+    "expandedRef.current は既存実装で保持されているため、ロジック変更不要",
+    "data-testid=file-tree-loading を期待する既存テストは初回マウント時シナリオに限定する必要あり",
+    "アクセシビリティ: 更新インジケーターに aria-live を検討"
+  ]
+}

--- a/dev-reports/bug-fix/706_20260515_185650/progress-context.json
+++ b/dev-reports/bug-fix/706_20260515_185650/progress-context.json
@@ -1,0 +1,69 @@
+{
+  "bug_id": "706_20260515_185650",
+  "issue_number": 706,
+  "issue_title": "fix(files): Files タブのツリー再描画でスクロール位置がリセットされる（refetch 時の loading 表示を見直し）",
+  "branch": "feature/706-worktree",
+  "severity": "high",
+  "user_selection": "フル対応（推奨）— Action 1+2+3+4 を全て実施",
+  "phases": {
+    "phase_1_investigation": {
+      "status": "completed",
+      "result_file": "dev-reports/bug-fix/706_20260515_185650/investigation-result.json",
+      "root_cause_primary": "FileTreeView.tsx:367-378 の loading 早期 return が初回マウント/refetch を区別せず DOM 全置換",
+      "root_cause_secondary": "WorktreeDetailRefactored.tsx:265 の prevTreeHashRef 初期値 null による初回ポーリング偽陽性発火"
+    },
+    "phase_2_user_feedback": {
+      "status": "completed",
+      "decision": "フル対応"
+    },
+    "phase_3_work_plan": {
+      "status": "completed",
+      "plan_file": "dev-reports/bug-fix/706_20260515_185650/work-plan-context.json",
+      "actions": [
+        "Action 1: FileTreeView loading 分岐を初回限定化（Option 3: 既存ツリー保持）",
+        "Action 2: refetch エラー時の非破壊表示・再試行ボタン",
+        "Action 3: WorktreeDetailRefactored prevTreeHashRef 初回スキップ",
+        "Action 4: テスト追加・既存テスト整合"
+      ]
+    },
+    "phase_4_tdd_implementation": {
+      "status": "success",
+      "result_file": "dev-reports/bug-fix/706_20260515_185650/tdd-fix-result.json",
+      "files_modified": [
+        "src/components/worktree/FileTreeView.tsx",
+        "src/components/worktree/WorktreeDetailRefactored.tsx",
+        "tests/unit/components/worktree/FileTreeView.test.tsx"
+      ],
+      "tests_added": 5,
+      "lint": "pass",
+      "typecheck": "pass",
+      "unit_test": "pass (6491 / 7 skipped)",
+      "coverage": "76.81% (Issue 範囲のコードはカバー済み、pre-existing 検索系コードが範囲外)"
+    },
+    "phase_5_acceptance_test": {
+      "status": "pass",
+      "result_file": "dev-reports/bug-fix/706_20260515_185650/acceptance-result.json",
+      "acceptance_criteria": "8/8 pass",
+      "test_scenarios": "8/8 pass (TS-1〜TS-8)",
+      "regressions": 0
+    }
+  },
+  "key_changes": [
+    "FileTreeView: isInitialLoading / isInitialError フラグで全画面表示を rootItems 未取得時に限定",
+    "FileTreeView: refetch 中の控えめインジケーター (file-tree-refetch-indicator, role=status, aria-live=polite)",
+    "FileTreeView: refetch エラーの非破壊バナー (file-tree-refetch-error) と再試行ボタン (file-tree-refetch-retry-button)",
+    "FileTreeView: reloadTreeWithExpandedDirs を useCallback 抽出、mountedRef でアンマウント後の setState を抑止",
+    "WorktreeDetailRefactored: prevTreeHashRef.current === null 時はベースライン記録のみ（偽陽性 refresh 抑止）"
+  ],
+  "user_facing_improvements": [
+    "Files タブのツリー表示後、約 5 秒経過してもスクロール位置がリセットされない",
+    "実ファイル変更検知時もスクロール位置・フォーカス・選択強調が維持される",
+    "refetch 中・エラー時もツリーが消えず連続性が保たれる",
+    "アクセシビリティ: 更新状態が aria-live で控えめに通知される"
+  ],
+  "next_steps": [
+    "PR 作成 (feature/706-worktree → develop)",
+    "(任意) 実機 UAT で PC/モバイル両ビューポートでのスクロール維持を最終確認",
+    "(任意) WorktreeDetailRefactored の prevTreeHashRef 初回スキップに対する単体テスト追加"
+  ]
+}

--- a/dev-reports/bug-fix/706_20260515_185650/progress-report.md
+++ b/dev-reports/bug-fix/706_20260515_185650/progress-report.md
@@ -1,0 +1,134 @@
+# Progress Report — Issue #706 バグ修正
+
+## 1. サマリー
+
+| 項目 | 内容 |
+|------|------|
+| Issue 番号 | #706 |
+| タイトル | fix(files): Files タブのツリー再描画でスクロール位置がリセットされる（refetch 時の loading 表示を見直し） |
+| 重大度 | high |
+| 修正対象範囲 | フル対応（Action 1+2+3+4 全実施） |
+| ブランチ | `feature/706-worktree` |
+| Bug ID | `706_20260515_185650` |
+| 最終ステータス | **pass**（受入条件 8/8、テストシナリオ 8/8、回帰 0 件） |
+
+ユーザー影響: Files タブ表示後 5 秒経過時の偽陽性 refresh と、refetch のたびに発生していたツリー DOM 全置換が解消され、スクロール位置・選択強調・キーボードフォーカスが維持される。
+
+---
+
+## 2. 根本原因
+
+### 主因（structural）
+**FileTreeView.tsx の `if (loading) return <Loading>` 早期 return が初回マウント／refetch を区別せず DOM を全置換していた。**
+
+- `src/components/worktree/FileTreeView.tsx:367-378` — `loading=true` で常に `data-testid="file-tree-loading"` を返す
+- `src/components/worktree/FileTreeView.tsx:161` — `reloadTreeWithExpandedDirs()` が `refreshTrigger` 変化時にも `setLoading(true)` を呼ぶ
+- 結果: refetch のたびに `rootItems` を持つツリー DOM がアンマウントされ、スクロール位置・選択状態が失われる
+
+### 副因（false_positive_polling）
+**WorktreeDetailRefactored のツリーポーリングが初回ポーリングで偽陽性 refresh を発火していた。**
+
+- `src/components/worktree/WorktreeDetailRefactored.tsx:265` — `const prevTreeHashRef = useRef<string | null>(null)`
+- `src/components/worktree/WorktreeDetailRefactored.tsx:275` — `if (newHash !== prevTreeHashRef.current)` が初回必ず true になる
+- `FILE_TREE_POLL_INTERVAL_MS = 5000ms`（`src/config/file-polling-config.ts:8`）のため、Files タブを開いた約 5 秒後に必ず発火していた
+
+---
+
+## 3. 実施内容（Action 1〜4）
+
+### Action 1: FileTreeView の loading 分岐を初回限定化（Option 3: 既存ツリー保持）
+- 対象: `src/components/worktree/FileTreeView.tsx`
+- 変更:
+  - `isInitialLoading = loading && rootItems.length === 0` を導入し、全画面 `file-tree-loading` を初回マウント時のみに限定
+  - `isRefetching = loading && rootItems.length > 0` のとき、ツールバー右端 (`ml-auto`) に小型インジケーターを描画
+  - 新規 `data-testid="file-tree-refetch-indicator"` (`role="status"`, `aria-live="polite"`, sr-only `Refreshing files`)
+  - ツールバー表示条件に `isRefetching` を追加し、コールバック未提供でも描画されるよう調整
+
+### Action 2: refetch エラー時の非破壊表示・再試行ボタン
+- 対象: `src/components/worktree/FileTreeView.tsx`
+- 変更:
+  - `isInitialError = !!error && rootItems.length === 0` を導入し、全画面 `file-tree-error` を初回ロード失敗時のみに限定
+  - `isRefetchError = !!error && rootItems.length > 0` のとき、ツリー直前に非破壊バナーを描画
+  - 新規 `data-testid="file-tree-refetch-error"` (`role="alert"`, AlertCircle アイコン)
+  - 新規 `data-testid="file-tree-refetch-retry-button"` — クリックで `reloadTreeWithExpandedDirs` を再呼び出し
+  - `reloadTreeWithExpandedDirs` を `useCallback` で外出し、`mountedRef` (`useRef` + `useEffect` cleanup) でアンマウント後の `setState` を抑止
+
+### Action 3: WorktreeDetailRefactored の prevTreeHashRef 初回スキップ
+- 対象: `src/components/worktree/WorktreeDetailRefactored.tsx`
+- 変更:
+  - `prevTreeHashRef.current === null` の初回ポーリング時はベースラインだけ記録し、`setFileTreeRefresh` を呼ばない分岐を追加（行 279-284 付近）
+  - Issue #706 番号・意図のコメント明記
+
+### Action 4: テスト追加・既存テスト整合
+- 対象: `tests/unit/components/worktree/FileTreeView.test.tsx`
+- 変更: `describe('refetch indicator (Issue #706)')` を追加し、5 件の新規テストを集約
+- 既存 Issue #164 / #300 のテストブロックには未介入（互換維持）
+
+---
+
+## 4. テスト結果
+
+### 検証コマンド
+
+| コマンド | 結果 | 詳細 |
+|----------|------|------|
+| `npm run lint` | **pass** | No ESLint warnings or errors |
+| `npx tsc --noEmit` | **pass** | エラー出力なし（exit 0） |
+| `npm run test:unit` | **pass** | Test Files 343 passed (343), Tests 6491 passed \| 7 skipped (6498) |
+| `FileTreeView.test.tsx` 単独 | **pass** | 69 tests passed（Issue #706 新規 5 件 + Issue #164 既存含む） |
+
+### 新規追加テスト（5 件）
+
+`FileTreeView > refetch indicator (Issue #706)` 配下:
+
+1. `should not show file-tree-loading on refetch (refreshTrigger change)`
+2. `should show file-tree-refetch-indicator while refetching`
+3. `should preserve existing tree and show file-tree-refetch-error on refetch failure`
+4. `should still show full-screen file-tree-error on initial load failure`
+5. `should retry refetch when file-tree-refetch-retry-button is clicked`
+
+### カバレッジ
+- **76.81%**（Issue #706 関連経路: lines 152-156, 171-231, 383-499 は全てカバー済み）
+- 未到達分は pre-existing な Issue #21 検索/フィルタ系コード（lines 305-376）および `loadChildren` error path（line 266）— 本 Issue 範囲外
+
+---
+
+## 5. 受入条件チェック（8/8 pass）
+
+| # | 受入条件 | 結果 | 主要エビデンス |
+|---|----------|------|----------------|
+| 1 | Files タブ初回表示後 5 秒経過時にスクロール位置がリセットされない | pass | `WorktreeDetailRefactored.tsx:279-284` 初回スキップ + `FileTreeView.tsx:383` `isInitialLoading` 限定 |
+| 2 | 実ファイル追加/削除時もスクロール位置・フォーカスが維持される | pass | `FileTreeView.tsx:171-234` `setRootItems/setCache` のみ更新でツリーコンテナ DOM 同一 |
+| 3 | refetch 中はパネル内に控えめな更新インジケーターが表示される | pass | `FileTreeView.tsx:512-525` `data-testid="file-tree-refetch-indicator"` (`role="status"`, `aria-live="polite"`) |
+| 4 | 初回マウント時は従来通り全画面 loading が表示される | pass | `FileTreeView.tsx:383-394` `isInitialLoading` 分岐、既存テスト互換 |
+| 5 | refetch 失敗時は既存ツリーを保持しつつ非破壊通知 | pass | `FileTreeView.tsx:413, 531-549` `data-testid="file-tree-refetch-error"` + 再試行ボタン |
+| 6 | 既存 `npm run test:unit` で 0 件の回帰 | pass | 6491 passed \| 7 skipped |
+| 7 | FileTreeView の refetch 動作に関する新規テストが追加されている | pass | `FileTreeView.test.tsx:1562-1720` describe 配下 5 件 |
+| 8 | ESLint / TypeScript チェックがパスする | pass | lint・tsc ともにエラーなし |
+
+---
+
+## 6. 次のステップ
+
+### 推奨
+- **PR 作成**: `feature/706-worktree` → `develop`
+  - PR タイトル例: `fix: Filesタブのツリー再描画でスクロール位置がリセットされる問題を修正 (#706)`
+  - PR ラベル: `bug`
+  - 主要変更ファイル 3 件（`FileTreeView.tsx`, `WorktreeDetailRefactored.tsx`, `FileTreeView.test.tsx`）
+
+### 任意
+- 実機 UAT で PC/モバイル両ビューポートでのスクロール維持を最終確認（Playwright E2E でも可）
+- `WorktreeDetailRefactored` の `prevTreeHashRef` 初回スキップに対する単体テスト追加（現状はコードレビューでロジック妥当性を確認済み）
+- 再試行ボタン「再試行」ラベルの i18n 対応（next-intl への移行、本 Issue スコープ外）
+
+---
+
+## 主要 testid 一覧（新規）
+
+| testid | 役割 | aria 属性 |
+|--------|------|-----------|
+| `file-tree-refetch-indicator` | refetch 中の控えめインジケーター | `role="status"`, `aria-live="polite"`, sr-only `Refreshing files` |
+| `file-tree-refetch-error` | refetch エラー時の非破壊バナー | `role="alert"` |
+| `file-tree-refetch-retry-button` | エラーバナー内の再試行ボタン | — |
+
+既存 testid（`file-tree-loading`, `file-tree-error`）は不変。

--- a/dev-reports/bug-fix/706_20260515_185650/tdd-fix-context.json
+++ b/dev-reports/bug-fix/706_20260515_185650/tdd-fix-context.json
@@ -1,0 +1,47 @@
+{
+  "bug_id": "706_20260515_185650",
+  "issue_number": 706,
+  "bug_description": "Files タブのツリー再描画でスクロール位置がリセットされる。refetch 中の loading 表示を全置換から控えめインジケーター方式へ変更し、既存ツリー DOM を保持する。",
+  "selected_actions": [
+    {
+      "action_id": "1",
+      "title": "FileTreeView の loading 分岐を初回限定に変更",
+      "description": "isInitialLoading = loading && rootItems.length === 0 のときのみ全画面 Loading を表示。refetch 中は既存ツリー DOM を保持し、ツールバー右側に小型 spinner（data-testid='file-tree-refetch-indicator', aria-live='polite'）を表示。",
+      "files_to_modify": ["src/components/worktree/FileTreeView.tsx"]
+    },
+    {
+      "action_id": "2",
+      "title": "refetch エラー時の非破壊表示",
+      "description": "isInitialError = !!error && rootItems.length === 0 のときのみ全画面 Error 表示。それ以外は既存ツリー上部にエラーバナー（data-testid='file-tree-refetch-error'）。",
+      "files_to_modify": ["src/components/worktree/FileTreeView.tsx"]
+    },
+    {
+      "action_id": "3",
+      "title": "prevTreeHashRef の初回スキップ",
+      "description": "WorktreeDetailRefactored.tsx の `if (newHash !== prevTreeHashRef.current)` を、初回 null のときは比較スキップして代入のみに変更。",
+      "files_to_modify": ["src/components/worktree/WorktreeDetailRefactored.tsx"]
+    },
+    {
+      "action_id": "4",
+      "title": "テスト追加・既存テスト更新",
+      "description": "refetch 時の loading 非表示、refetch インジケーター表示、refetch エラー時の既存ツリー保持に関するテストを追加。data-testid='file-tree-loading' を期待する既存テストは初回マウント時に限定して整合性を確保。",
+      "files_to_modify": ["tests/unit/components/worktree/FileTreeView.test.tsx"]
+    }
+  ],
+  "target_coverage": 80,
+  "test_command": "npm run test:unit -- tests/unit/components/worktree/FileTreeView.test.tsx",
+  "lint_command": "npm run lint",
+  "typecheck_command": "npx tsc --noEmit",
+  "constraints": {
+    "tdd_cycle": "Red-Green-Refactor を厳守。新規テストを先に追加して失敗を確認してから実装する。",
+    "preserve_behavior": "既存の Issue #164 の refreshTrigger expand 状態保持テスト・既存スナップショットテストは破壊しない",
+    "no_unused_changes": "Issue 範囲外のリファクタリングは行わない（コードベース既存規約に準拠）",
+    "accessibility": "更新インジケーターには aria-live='polite' を付与"
+  },
+  "notes": [
+    "FileTreeView は memo() ラップされた関数コンポーネントで、useState/useEffect で状態管理",
+    "loading は useState で管理（初期値 true）、reloadTreeWithExpandedDirs() 内で setLoading(true/false)",
+    "data-testid='file-tree-loading' を期待する既存テストは file_path:tests/unit/components/worktree/FileTreeView.test.tsx:65 にあり、初回マウント時のみのテストに限定する形で整合させる",
+    "TreeNode は key={item.name} で再利用される（FileTreeView.tsx:490）。React reconciliation で DOM が保持される設計に既になっているので、loading 分岐の早期 return を削除すれば既存ツリーが保持される"
+  ]
+}

--- a/dev-reports/bug-fix/706_20260515_185650/tdd-fix-result.json
+++ b/dev-reports/bug-fix/706_20260515_185650/tdd-fix-result.json
@@ -1,0 +1,60 @@
+{
+  "status": "success",
+  "summary": "Issue #706 修正完了。FileTreeView の loading/error 早期 return を初回マウント時に限定し、refetch 中は既存ツリー DOM を保持したまま小型インジケーター (file-tree-refetch-indicator) と非破壊エラーバナー (file-tree-refetch-error + 再試行ボタン) を表示するように変更。WorktreeDetailRefactored の prevTreeHashRef は初回ポーリング時に偽陽性 refresh を発火しないようベースライン記録のみに変更。Red-Green-Refactor サイクルで 5 件の新規テストを追加し、既存 69 テスト全て pass、unit suite 全体 6491 テストも pass。lint/typecheck も pass。",
+  "files_modified": [
+    "src/components/worktree/FileTreeView.tsx",
+    "src/components/worktree/WorktreeDetailRefactored.tsx",
+    "tests/unit/components/worktree/FileTreeView.test.tsx"
+  ],
+  "tests_added": [
+    "FileTreeView > refetch indicator (Issue #706) > should not show file-tree-loading on refetch (refreshTrigger change)",
+    "FileTreeView > refetch indicator (Issue #706) > should show file-tree-refetch-indicator while refetching",
+    "FileTreeView > refetch indicator (Issue #706) > should preserve existing tree and show file-tree-refetch-error on refetch failure",
+    "FileTreeView > refetch indicator (Issue #706) > should still show full-screen file-tree-error on initial load failure",
+    "FileTreeView > refetch indicator (Issue #706) > should retry refetch when file-tree-refetch-retry-button is clicked"
+  ],
+  "test_results": {
+    "lint": "pass",
+    "typecheck": "pass",
+    "unit": "pass",
+    "coverage_percent": 76.81
+  },
+  "tdd_cycles": [
+    {
+      "action_id": "1",
+      "red": "「refetch 時に file-tree-loading が出ない」「refetch 中に file-tree-refetch-indicator が出る」「refetch 完了後に消える」の 3 テストを追加し、当初の loading early-return では tree が unmount されることを fail 確認。",
+      "green": "isInitialLoading = loading && rootItems.length === 0 で初回限定の早期 return に変更。refetch 中は既存ツールバー右端 (ml-auto) に小型 spinner を data-testid=file-tree-refetch-indicator + role=status + aria-live=polite + sr-only ラベルで描画。ツールバー表示条件に isRefetching を追加し、コールバック未提供でも描画されるよう調整。",
+      "refactor": "ロジック簡潔のためフラグ (isInitialLoading / isRefetching) を抽出。コメントで Issue 番号と意図を明記。"
+    },
+    {
+      "action_id": "2",
+      "red": "「refetch エラー時に既存ツリー保持」「初回失敗時のみ full-screen file-tree-error 表示」「再試行ボタンで refetch」の 3 テストを追加し、当初の error early-return で tree が unmount されることを fail 確認。",
+      "green": "isInitialError = !!error && rootItems.length === 0 で初回限定の早期 return に変更。それ以外は ml-auto エラーバナー (data-testid=file-tree-refetch-error, role=alert, AlertCircle アイコン, 「再試行」ボタン data-testid=file-tree-refetch-retry-button) を tree 直前に描画。再試行ボタンは抽出した reloadTreeWithExpandedDirs (useCallback) を呼び直す。",
+      "refactor": "useEffect 内の reload 関数を useCallback で外出しし、mountedRef (useRef + useEffect cleanup) でアンマウント後の state 更新を抑止。retry でも同じ関数を再利用するため重複排除。"
+    },
+    {
+      "action_id": "3",
+      "red": "FileTreeView の Issue #706 テストが pass した段階で WorktreeDetailRefactored の初回ポーリング動作にも同様の偽陽性問題があることをコードレビューで確認 (prevTreeHashRef.current === null のとき null !== '[...]' で必ず初回 refresh が発火する)。",
+      "green": "prevTreeHashRef.current === null のとき比較せずベースラインだけ記録する分岐を追加。コメントで Issue #706 と意図を明記。",
+      "refactor": "コメント追加のみ。挙動本質を変えるリファクタリングは Issue 範囲外のため実施せず。"
+    },
+    {
+      "action_id": "4",
+      "red": "上記 Action 1-2 の RED 確認時に既存テスト 'should render loading state initially' が初回マウント時の rootItems 未取得状態に該当することを確認 (loading=true && rootItems.length===0 のため引き続き file-tree-loading が出る)。",
+      "green": "既存テストは無修正のまま pass。新規 5 件のテストを Issue #706 の describe ブロック配下に集約。",
+      "refactor": "新規 describe を Issue #706 ヘッダコメント付きで追加し、既存 Issue #164/#300 のテストブロックには手を入れない方針を維持。"
+    }
+  ],
+  "notes": [
+    "新規 data-testid: file-tree-refetch-indicator / file-tree-refetch-error / file-tree-refetch-retry-button。既存 data-testid は変更なし。",
+    "アクセシビリティ: indicator は role=status + aria-live=polite + sr-only 'Refreshing files'、エラーバナーは role=alert。",
+    "TreeNode の key={item.name} と React reconciliation により、refetch 中も既存 DOM サブツリーが保持されるためスクロール位置・選択状態が失われない。",
+    "reloadTreeWithExpandedDirs を useCallback で抽出し、再試行ボタンから再呼び出し可能にした。mountedRef でアンマウント後の setState を抑止。",
+    "WorktreeDetailRefactored の prevTreeHashRef 初回スキップにより、Files タブを開いた直後の 5 秒ポーリング第1回目で必ず発火していた偽陽性 refresh が解消。実際にツリーが変わった 2 回目以降のみ refresh が発火する。",
+    "coverage_percent (76.81%) は既存の Issue #21 検索/フィルタ系コード (lines 305-376) と loadChildren error path (line 266) などの未テスト経路に起因する pre-existing な値。新規追加した Issue #706 関連の経路 (lines 152-156, 171-231, 383-499) はすべてカバー済み。issue 範囲外の検索コードへのテスト追加は constraints.no_unused_changes に従い実施せず。"
+  ],
+  "remaining_work": [
+    "(任意) 既存 Issue #21 検索/フィルタコードに対するテストを追加してカバレッジ 80% を目指す (本 Issue 範囲外)。",
+    "(任意) WorktreeDetailRefactored の prevTreeHashRef 初回スキップに対する単体テストを tests/unit/components/WorktreeDetailRefactored.test.tsx に追加する (現状コードレビューでロジック妥当性を確認)。"
+  ]
+}

--- a/dev-reports/bug-fix/706_20260515_185650/work-plan-context.json
+++ b/dev-reports/bug-fix/706_20260515_185650/work-plan-context.json
@@ -1,0 +1,88 @@
+{
+  "bug_id": "706_20260515_185650",
+  "issue_number": 706,
+  "bug_description": "Files タブのツリー再描画でスクロール位置がリセットされる（refetch 時の loading 表示を全置換から控えめインジケーター方式へ変更）",
+  "selected_actions": [
+    {
+      "action_id": "1",
+      "title": "FileTreeView の loading 分岐を初回限定に変更（Option 3）",
+      "description": "loading=true かつ rootItems.length===0 のときだけ全画面 Loading を表示する。refetch 中は既存ツリー DOM を保持し、ツールバー右側に小型 spinner を表示。aria-live 付きの控えめインジケーター。",
+      "files_to_modify": [
+        "src/components/worktree/FileTreeView.tsx"
+      ],
+      "implementation_details": [
+        "isInitialLoading = loading && rootItems.length === 0 を導入",
+        "isInitialLoading 時のみ file-tree-loading の早期 return",
+        "それ以外（refetch 時）は既存ツリーをレンダリングしつつ、ツールバー右端に loading インジケーターを追加",
+        "data-testid='file-tree-refetch-indicator' を付与（テストで参照）",
+        "aria-live='polite' で更新を控えめにアナウンス"
+      ]
+    },
+    {
+      "action_id": "2",
+      "title": "refetch 失敗時の非破壊エラー表示",
+      "description": "rootItems が既にある状態で refetch が失敗した場合、既存ツリーは保持しつつ、ツールバー直下にエラーバナーを表示。初回ロード時のみ既存の全画面エラー表示を維持。",
+      "files_to_modify": [
+        "src/components/worktree/FileTreeView.tsx"
+      ],
+      "implementation_details": [
+        "isInitialError = !!error && rootItems.length === 0 を導入",
+        "isInitialError 時のみ file-tree-error の早期 return",
+        "それ以外（refetch エラー）はツリー上部にエラーバナー表示。data-testid='file-tree-refetch-error'",
+        "エラーバナーには『再試行』ボタン（refetch を再実行）"
+      ]
+    },
+    {
+      "action_id": "3",
+      "title": "prevTreeHashRef 初回スキップで偽陽性ポーリングを抑止",
+      "description": "WorktreeDetailRefactored.tsx の `if (newHash !== prevTreeHashRef.current)` を、初回 null のときは比較スキップして代入のみに変更。",
+      "files_to_modify": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx"
+      ],
+      "implementation_details": [
+        "src/components/worktree/WorktreeDetailRefactored.tsx:275 周辺を修正",
+        "`if (prevTreeHashRef.current !== null && newHash !== prevTreeHashRef.current)` に変更",
+        "初回ポーリング時は `prevTreeHashRef.current = newHash` のみ"
+      ]
+    },
+    {
+      "action_id": "4",
+      "title": "テスト追加・既存テスト更新",
+      "description": "FileTreeView の loading/refetch シナリオに関する新規テストを追加し、既存テストを Option 3 仕様に整合させる。",
+      "files_to_modify": [
+        "tests/unit/components/worktree/FileTreeView.test.tsx"
+      ],
+      "implementation_details": [
+        "新規: refreshTrigger 変化時に file-tree-loading が表示されないこと",
+        "新規: refreshTrigger 変化時に file-tree-refetch-indicator が表示されること",
+        "新規: refetch エラー時に既存ツリーが保持され file-tree-refetch-error が表示されること",
+        "既存: 初回ロード時の file-tree-loading 表示は維持（rootItems 取得前）",
+        "既存: refreshTrigger 既存テストの整合性確認"
+      ]
+    }
+  ],
+  "deliverables": [
+    "src/components/worktree/FileTreeView.tsx の修正",
+    "src/components/worktree/WorktreeDetailRefactored.tsx の修正",
+    "tests/unit/components/worktree/FileTreeView.test.tsx の追加・更新"
+  ],
+  "definition_of_done": [
+    "Files タブ初回表示後 5 秒経過時にスクロール位置がリセットされない",
+    "実際にファイルが追加/削除された際もスクロール位置・フォーカスが維持される",
+    "refetch 中はパネル内に控えめな更新インジケーターが表示される",
+    "初回マウント時（rootItems 未取得時）は従来通り全画面 loading が表示される",
+    "refetch 失敗時は既存ツリーを保持しつつエラーを非破壊的に通知する",
+    "既存の npm run test:unit で 0 件の回帰",
+    "FileTreeView の refetch 動作に関する新規テストが追加されている",
+    "ESLint / TypeScript チェックがパスする"
+  ],
+  "target_coverage": 80,
+  "test_targets": [
+    "tests/unit/components/worktree/FileTreeView.test.tsx"
+  ],
+  "tdd_strategy": {
+    "red": "新規テスト（refetch 中の file-tree-loading 非表示、refetch インジケーター表示、refetch エラー時の既存ツリー保持）を追加し、現実装で失敗することを確認",
+    "green": "FileTreeView の loading/error 分岐を Option 3 仕様に変更し、prevTreeHashRef 初回スキップを実装。テストが通ることを確認",
+    "refactor": "重複ロジック整理、型・命名の最適化、既存テストの整合性確保"
+  }
+}

--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -25,7 +25,7 @@ import { ContextMenu } from '@/components/worktree/ContextMenu';
 import { TreeNode } from '@/components/worktree/TreeNode';
 import { computeMatchedPaths } from '@/lib/utils';
 import { useLocale } from 'next-intl';
-import { FilePlus, FolderPlus, FileText } from 'lucide-react';
+import { FilePlus, FolderPlus, FileText, AlertCircle } from 'lucide-react';
 
 // ============================================================================
 // Types
@@ -146,6 +146,17 @@ export const FileTreeView = memo(function FileTreeView({
     [worktreeId]
   );
 
+  // [Issue #706] Mounted ref for the reload function. The ref tracks
+  // whether the component is currently mounted so that the retry button
+  // (which can fire after unmount) can short-circuit state updates safely.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   /**
    * [Issue #164] Load root directory and re-fetch all expanded directories
    * on mount or when refreshTrigger changes.
@@ -153,80 +164,81 @@ export const FileTreeView = memo(function FileTreeView({
    * Instead of clearing cache and only reloading root (which caused expanded
    * directories to lose their contents), this re-fetches all expanded
    * directories in parallel chunks of CONCURRENT_LIMIT.
+   *
+   * [Issue #706] Extracted to a useCallback so the refetch error retry
+   * button can re-trigger the same loader.
    */
-  useEffect(() => {
-    let mounted = true;
+  const reloadTreeWithExpandedDirs = useCallback(async () => {
+    if (!mountedRef.current) return;
+    setLoading(true);
+    setError(null);
 
-    const reloadTreeWithExpandedDirs = async () => {
-      setLoading(true);
-      setError(null);
+    try {
+      // Step 1: Re-fetch root directory
+      const rootData = await fetchDirectory();
+      if (!mountedRef.current || !rootData) return;
 
-      try {
-        // Step 1: Re-fetch root directory
-        const rootData = await fetchDirectory();
-        if (!mounted || !rootData) return;
+      // Step 2: Get currently expanded paths from ref (avoids dependency on expanded)
+      const expandedPaths = Array.from(expandedRef.current);
 
-        // Step 2: Get currently expanded paths from ref (avoids dependency on expanded)
-        const expandedPaths = Array.from(expandedRef.current);
+      // Step 3: Re-fetch expanded directories in parallel chunks
+      const newCache = new Map<string, TreeItem[]>();
+      const stalePaths: string[] = [];
 
-        // Step 3: Re-fetch expanded directories in parallel chunks
-        const newCache = new Map<string, TreeItem[]>();
-        const stalePaths: string[] = [];
+      for (let i = 0; i < expandedPaths.length; i += CONCURRENT_LIMIT) {
+        if (!mountedRef.current) return;
 
-        for (let i = 0; i < expandedPaths.length; i += CONCURRENT_LIMIT) {
-          if (!mounted) return;
+        const chunk = expandedPaths.slice(i, i + CONCURRENT_LIMIT);
+        const results = await Promise.allSettled(
+          chunk.map(async (dirPath) => {
+            const data = await fetchDirectory(dirPath);
+            return { dirPath, data };
+          })
+        );
 
-          const chunk = expandedPaths.slice(i, i + CONCURRENT_LIMIT);
-          const results = await Promise.allSettled(
-            chunk.map(async (dirPath) => {
-              const data = await fetchDirectory(dirPath);
-              return { dirPath, data };
-            })
-          );
-
-          for (const [j, result] of results.entries()) {
-            if (result.status === 'fulfilled' && result.value.data) {
-              newCache.set(result.value.dirPath, result.value.data.items);
-            } else {
-              // Directory may have been deleted or become inaccessible
-              stalePaths.push(chunk[j]);
-            }
+        for (const [j, result] of results.entries()) {
+          if (result.status === 'fulfilled' && result.value.data) {
+            newCache.set(result.value.dirPath, result.value.data.items);
+          } else {
+            // Directory may have been deleted or become inaccessible
+            stalePaths.push(chunk[j]);
           }
         }
-
-        if (!mounted) return;
-
-        // Step 4: Update state in batch
-        setRootItems(rootData.items);
-        setCache(newCache);
-
-        // Remove stale paths (deleted/inaccessible directories) from expanded set
-        if (stalePaths.length > 0) {
-          setExpanded((prev) => {
-            const next = new Set(prev);
-            for (const path of stalePaths) {
-              if (path) next.delete(path);
-            }
-            return next;
-          });
-        }
-      } catch (err) {
-        if (mounted) {
-          setError(err instanceof Error ? err.message : 'Failed to load files');
-        }
-      } finally {
-        if (mounted) {
-          setLoading(false);
-        }
       }
-    };
 
-    reloadTreeWithExpandedDirs();
+      if (!mountedRef.current) return;
 
-    return () => {
-      mounted = false;
-    };
-  }, [fetchDirectory, refreshTrigger]);
+      // Step 4: Update state in batch
+      setRootItems(rootData.items);
+      setCache(newCache);
+
+      // Remove stale paths (deleted/inaccessible directories) from expanded set
+      if (stalePaths.length > 0) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          for (const path of stalePaths) {
+            if (path) next.delete(path);
+          }
+          return next;
+        });
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load files');
+      }
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [fetchDirectory]);
+
+  useEffect(() => {
+    void reloadTreeWithExpandedDirs();
+    // Re-run when refreshTrigger changes; reloadTreeWithExpandedDirs
+    // is stable as long as fetchDirectory (= worktreeId) is unchanged.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reloadTreeWithExpandedDirs, refreshTrigger]);
 
   /**
    * Load children for a directory
@@ -364,8 +376,12 @@ export const FileTreeView = memo(function FileTreeView({
     return rootItems;
   }, [rootItems, searchQuery, searchMode, matchedPaths, cache]);
 
-  // Loading state
-  if (loading) {
+  // [Issue #706] Only show the full-screen loading indicator on the
+  // initial load. Subsequent refetches keep the existing tree visible to
+  // preserve scroll position / selection, and a compact spinner is
+  // rendered in the toolbar area instead (see below).
+  const isInitialLoading = loading && rootItems.length === 0;
+  if (isInitialLoading) {
     return (
       <div
         data-testid="file-tree-loading"
@@ -377,8 +393,11 @@ export const FileTreeView = memo(function FileTreeView({
     );
   }
 
-  // Error state
-  if (error) {
+  // [Issue #706] Only show the full-screen error state if we never managed
+  // to load any items. Otherwise the tree stays mounted and a refetch
+  // error banner is rendered above it (see below).
+  const isInitialError = !!error && rootItems.length === 0;
+  if (isInitialError) {
     return (
       <div
         data-testid="file-tree-error"
@@ -388,6 +407,10 @@ export const FileTreeView = memo(function FileTreeView({
       </div>
     );
   }
+
+  // [Issue #706] Compact, non-destructive refetch indicator state.
+  const isRefetching = loading && rootItems.length > 0;
+  const isRefetchError = !!error && rootItems.length > 0;
 
   // Empty state
   if (rootItems.length === 0) {
@@ -448,7 +471,7 @@ export const FileTreeView = memo(function FileTreeView({
       className={`overflow-auto bg-white dark:bg-gray-900 ${className}`}
     >
       {/* [Issue #300] Toolbar for root-level file/directory creation */}
-      {(onNewFile || onNewDirectory || onCmateSetup) && (
+      {(onNewFile || onNewDirectory || onCmateSetup || isRefetching) && (
         <div
           data-testid="file-tree-toolbar"
           className="flex items-center gap-1 p-1 border-b border-gray-200 dark:border-gray-700"
@@ -483,6 +506,45 @@ export const FileTreeView = memo(function FileTreeView({
               <span>CMATE</span>
             </button>
           )}
+          {/* [Issue #706] Compact refetch indicator. Anchored to the right
+              edge of the existing toolbar so the tree DOM (and its scroll
+              position) is preserved while a background refresh is running. */}
+          {isRefetching && (
+            <div
+              data-testid="file-tree-refetch-indicator"
+              role="status"
+              aria-live="polite"
+              className="ml-auto flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+            >
+              <span
+                aria-hidden="true"
+                className="w-3 h-3 border-2 border-gray-300 dark:border-gray-600 border-t-cyan-500 rounded-full animate-spin"
+              />
+              <span className="sr-only">Refreshing files</span>
+            </div>
+          )}
+        </div>
+      )}
+      {/* [Issue #706] Non-destructive refetch error banner. The previous
+          tree DOM remains mounted, so we surface the error inline with a
+          retry action instead of replacing the whole view. */}
+      {isRefetchError && (
+        <div
+          data-testid="file-tree-refetch-error"
+          role="alert"
+          className="flex items-center gap-2 px-2 py-1 text-xs bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800 text-red-700 dark:text-red-300"
+        >
+          <AlertCircle className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+          <span className="flex-1 truncate">{error}</span>
+          <button
+            data-testid="file-tree-refetch-retry-button"
+            onClick={() => {
+              void reloadTreeWithExpandedDirs();
+            }}
+            className="px-2 py-0.5 text-xs rounded border border-red-300 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
+          >
+            再試行
+          </button>
         </div>
       )}
       {filteredRootItems.map((item) => (

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -272,7 +272,13 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         if (!response.ok) return; // Ignore errors in polling
         const data = await response.json();
         const newHash = JSON.stringify(data?.items);
-        if (newHash !== prevTreeHashRef.current) {
+        // [Issue #706] On the very first poll we have no baseline to
+        // compare against, so just record the hash. Firing a refresh here
+        // would be a false positive that resets the user's scroll/selection
+        // state in FileTreeView for no actual change.
+        if (prevTreeHashRef.current === null) {
+          prevTreeHashRef.current = newHash;
+        } else if (newHash !== prevTreeHashRef.current) {
           prevTreeHashRef.current = newHash;
           setFileTreeRefresh(prev => prev + 1);
         }

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -1550,4 +1550,172 @@ describe('FileTreeView', () => {
       expect(screen.getByTestId('empty-new-directory-button')).toBeInTheDocument();
     });
   });
+
+  /**
+   * Issue #706: Files タブのツリー再描画でスクロール位置がリセットされる問題の修正
+   *
+   * refetch (refreshTrigger 変化) のたびに「Loading files...」全画面スピナーへ
+   * 置換していたためスクロール位置・選択状態が失われていた。
+   * 全画面 Loading は初回マウント時のみに限定し、refetch 中は既存ツリーを
+   * 保持したまま小型インジケーターを表示するように変更する。
+   */
+  describe('refetch indicator (Issue #706)', () => {
+    it('should not show file-tree-loading on refetch (refreshTrigger change)', async () => {
+      const { rerender } = render(
+        <FileTreeView worktreeId="test-worktree" refreshTrigger={0} />
+      );
+
+      // Wait for initial load to finish (existing tree visible)
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      // Trigger refetch
+      rerender(
+        <FileTreeView worktreeId="test-worktree" refreshTrigger={1} />
+      );
+
+      // Existing tree should still be in the DOM
+      expect(screen.getByText('src')).toBeInTheDocument();
+      // Full-screen loading indicator must NOT replace the tree on refetch
+      expect(screen.queryByTestId('file-tree-loading')).not.toBeInTheDocument();
+
+      // Wait for refetch to complete
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+    });
+
+    it('should show file-tree-refetch-indicator while refetching', async () => {
+      // Use a deferred fetch implementation to keep the refetch "in-flight"
+      let resolveRefetch: ((value: unknown) => void) | null = null;
+
+      const { rerender } = render(
+        <FileTreeView worktreeId="test-worktree" refreshTrigger={0} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      // Switch to a fetch implementation that defers the response
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/tree')) {
+          return new Promise((resolve) => {
+            resolveRefetch = resolve;
+          });
+        }
+        return Promise.reject(new Error('Not found'));
+      });
+
+      rerender(<FileTreeView worktreeId="test-worktree" refreshTrigger={1} />);
+
+      // Indicator should appear while the refetch is in-flight
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-refetch-indicator')).toBeInTheDocument();
+      });
+
+      // Existing tree must still be visible
+      expect(screen.getByText('src')).toBeInTheDocument();
+
+      // Resolve the deferred refetch
+      await act(async () => {
+        if (resolveRefetch) {
+          resolveRefetch({
+            ok: true,
+            json: () => Promise.resolve(mockRootData),
+          });
+        }
+      });
+
+      // After completion, the indicator should be gone
+      await waitFor(() => {
+        expect(screen.queryByTestId('file-tree-refetch-indicator')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should preserve existing tree and show file-tree-refetch-error on refetch failure', async () => {
+      const { rerender } = render(
+        <FileTreeView worktreeId="test-worktree" refreshTrigger={0} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      // Switch to a fetch implementation that fails
+      mockFetch.mockImplementation(() => Promise.reject(new Error('Network error')));
+
+      rerender(<FileTreeView worktreeId="test-worktree" refreshTrigger={1} />);
+
+      // Wait for refetch error to surface
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-refetch-error')).toBeInTheDocument();
+      });
+
+      // Existing tree must still be visible (non-destructive error display)
+      expect(screen.getByText('src')).toBeInTheDocument();
+      // The full-screen error state must NOT be shown when we already had a tree
+      expect(screen.queryByTestId('file-tree-error')).not.toBeInTheDocument();
+      // Retry button must be available
+      expect(screen.getByTestId('file-tree-refetch-retry-button')).toBeInTheDocument();
+    });
+
+    it('should still show full-screen file-tree-error on initial load failure', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-error')).toBeInTheDocument();
+      });
+
+      // No refetch error banner on initial failure
+      expect(screen.queryByTestId('file-tree-refetch-error')).not.toBeInTheDocument();
+    });
+
+    it('should retry refetch when file-tree-refetch-retry-button is clicked', async () => {
+      const { rerender } = render(
+        <FileTreeView worktreeId="test-worktree" refreshTrigger={0} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      // Trigger refetch that fails
+      mockFetch.mockImplementation(() => Promise.reject(new Error('Network error')));
+      rerender(<FileTreeView worktreeId="test-worktree" refreshTrigger={1} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-refetch-error')).toBeInTheDocument();
+      });
+
+      // Switch the fetch back to a successful response
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/tree/src')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockSrcData),
+          });
+        }
+        if (url.includes('/tree')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockRootData),
+          });
+        }
+        return Promise.reject(new Error('Not found'));
+      });
+
+      // Click retry
+      fireEvent.click(screen.getByTestId('file-tree-refetch-retry-button'));
+
+      // Error banner should disappear after successful retry
+      await waitFor(() => {
+        expect(screen.queryByTestId('file-tree-refetch-error')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('src')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Files タブのファイルツリーが約 5 秒ポーリングや実ファイル変更検知のたびに「Loading files...」スピナーで全置換され、スクロール位置・フォーカス・選択強調などがリセットされる問題を修正
- `FileTreeView` の loading/error 早期 return を初回マウント時 (`rootItems` 未取得時) に限定し、refetch 中は既存ツリー DOM を保持したまま控えめインジケーター・非破壊エラーバナーを表示
- `WorktreeDetailRefactored` の `prevTreeHashRef` を初回ポーリング時はベースライン記録のみとし、偽陽性 refresh 発火を抑止

## 主な変更

| ファイル | 変更概要 |
|---------|---------|
| `src/components/worktree/FileTreeView.tsx` | `isInitialLoading` / `isInitialError` フラグで全画面表示を初回限定化。refetch 中はツールバー右端に `data-testid="file-tree-refetch-indicator"`（`role="status"`, `aria-live="polite"`）を表示。refetch エラー時は既存ツリー上部に非破壊バナー `data-testid="file-tree-refetch-error"` と再試行ボタン `data-testid="file-tree-refetch-retry-button"`。`reloadTreeWithExpandedDirs` を `useCallback` で抽出、`mountedRef` でアンマウント後の setState を抑止 |
| `src/components/worktree/WorktreeDetailRefactored.tsx` | `prevTreeHashRef.current === null` のときはベースライン記録のみとし、初回ポーリングでの偽陽性 refresh を回避 |
| `tests/unit/components/worktree/FileTreeView.test.tsx` | Issue #706 describe ブロックに 5 件追加（refetch 時 loading 非表示／refetch インジケーター表示／refetch 失敗時のツリー保持・全画面エラー非表示／再試行ボタン動作） |

## 検証結果

- `npm run lint`: ✅ pass
- `npx tsc --noEmit`: ✅ pass
- `npm run test:unit`: ✅ 6491 passed / 7 skipped（343 ファイル全て pass、回帰 0 件）
- `FileTreeView.test.tsx` 単体: ✅ 69 tests pass（新規 5 件 + 既存 Issue #164/#300 含む）

## 受入条件チェック

- [x] Files タブ初回表示後 5 秒経過時にスクロール位置がリセットされない
- [x] 実際にファイルが追加／削除された際もスクロール位置・フォーカスが維持される
- [x] refetch 中はパネル内に控えめな更新インジケーターが表示される
- [x] 初回マウント時（rootItems 未取得時）は従来通り全画面 loading が表示される
- [x] refetch 失敗時は既存ツリーを保持しつつエラーを非破壊的に通知する
- [x] 既存の `npm run test:unit` で 0 件の回帰
- [x] FileTreeView の refetch 動作に関する新規テストが追加されている

## Test plan

- [ ] PC ビューポートで Files タブを開き、深いノードまでスクロール → 5 秒以上待機してもスクロール位置が維持されることを確認
- [ ] エディタや他ツールでファイルを追加／削除 → ツリーが更新されてもスクロール位置・選択状態が維持されることを確認
- [ ] モバイルビューポートで同様の挙動を確認
- [ ] refetch 中にツールバー右端の小型 spinner が表示されることを目視確認
- [ ] ネットワークエラーをシミュレートし、refetch 失敗時に既存ツリーが残ったまま再試行バナーが表示されることを確認

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)