### PR TITLE
perf: scanMultipleRepositories の git worktree list を並列実行 (#711)

### DIFF
--- a/dev-reports/bug-fix/20260515_211238/acceptance-result.json
+++ b/dev-reports/bug-fix/20260515_211238/acceptance-result.json
@@ -1,0 +1,38 @@
+{
+  "bug_id": "20260515_211238",
+  "related_issue": 711,
+  "criteria": [
+    {
+      "criterion": "scanMultipleRepositories を Promise.allSettled で並列化",
+      "passed": true,
+      "evidence": "src/lib/git/worktrees.ts:246 で Promise.allSettled に書き換え済み"
+    },
+    {
+      "criterion": "個別リポジトリで失敗しても全体は失敗させない（既存挙動維持）",
+      "passed": true,
+      "evidence": "unit test 'should continue when one repository scan rejects' が PASS"
+    },
+    {
+      "criterion": "ログ出力に repoPath を付与（並列で順序が不定なため）",
+      "passed": true,
+      "evidence": "src/lib/git/worktrees.ts:248,250,262 で repoPath を含むログを継続出力"
+    },
+    {
+      "criterion": "npm run test:unit 回帰 0 件",
+      "passed": true,
+      "evidence": "baseline 6491 passed → 6495 passed (+4 new tests, 0 regressions)"
+    },
+    {
+      "criterion": "scanMultipleRepositories の単体テストが並列化後も通る",
+      "passed": true,
+      "evidence": "4 件の新規ユニットテストが PASS。tests/unit/worktrees.test.ts に並列実行検証テストを追加"
+    },
+    {
+      "criterion": "npx tsc --noEmit / npm run lint がパス",
+      "passed": true,
+      "evidence": "両方ともエラー 0"
+    }
+  ],
+  "all_passed": true,
+  "notes": "並列実行の検証では deferred-callback パターンを使い、最初の `await setImmediate` 後に全 3 件の exec 呼び出しが完了していることを確認している。逐次実行であれば 1 件目の呼び出ししか観測されない。"
+}

--- a/dev-reports/bug-fix/20260515_211238/investigation-result.json
+++ b/dev-reports/bug-fix/20260515_211238/investigation-result.json
@@ -1,0 +1,19 @@
+{
+  "bug_id": "20260515_211238",
+  "related_issue": 711,
+  "issue_title": "perf(sync): scanMultipleRepositories の git worktree list を並列実行",
+  "root_cause": {
+    "summary": "scanMultipleRepositories は for-await でリポジトリを逐次スキャンしているため、リポジトリ数 N に対して合計時間が N × 単一スキャン時間となる。リポジトリ間は独立なので並列化可能。",
+    "location": "src/lib/git/worktrees.ts:239-257"
+  },
+  "impact": {
+    "estimated_latency": "12 repos × 50-100ms = 600-1200ms (現状) → 並列化後は最遅 1 件分 (100-200ms)",
+    "affected_endpoint": "POST /api/repositories/sync",
+    "affected_ux": "新規ブランチ追加・リポジトリ同期のたびに遅延を体感"
+  },
+  "severity": "medium",
+  "callers": [
+    "server.ts:240",
+    "src/app/api/repositories/sync/route.ts:46"
+  ]
+}

--- a/dev-reports/bug-fix/20260515_211238/progress-report.md
+++ b/dev-reports/bug-fix/20260515_211238/progress-report.md
@@ -1,0 +1,53 @@
+# Issue #711 修正報告書
+
+## 概要
+`scanMultipleRepositories` の逐次スキャン (`for ... await`) を `Promise.allSettled` で並列化し、`POST /api/repositories/sync` の体感遅延を改善。
+
+- **Issue**: [#711 perf(sync): scanMultipleRepositories の git worktree list を並列実行](https://github.com/Kewton/CommandMate/issues/711)
+- **ブランチ**: `feature/711-worktree`
+
+## 根本原因
+`src/lib/git/worktrees.ts:239-257` で `for (const repoPath of repositoryPaths) { await scanWorktrees(...) }` の逐次ループになっており、リポジトリ数 N に比例して合計時間が増えていた。リポジトリ間は独立で並列化可能。
+
+## 修正内容
+
+### `src/lib/git/worktrees.ts`
+- `for ... await` → `Promise.allSettled(repositoryPaths.map(...))` に変更
+- 個別失敗時はログ出力のみ行い、全体は成功させる挙動を維持
+- ログには `repoPath` を付与（並列実行で順序が不定になるため、後追いで紐付け可能にする）
+
+### `tests/unit/worktrees.test.ts`
+- `vi.mock('child_process')` を auto-mock から factory mock へ変更。
+  これは vitest の auto-mock が `child_process.exec` から `util.promisify.custom` シンボルを引き継いでしまい、`promisify(exec)` がモックではなく実装をバイパスして呼び出すための回避策。
+- `scanMultipleRepositories` の単体テスト4件を追加：
+  - 各リポジトリで `git worktree list` が1回ずつ呼ばれる
+  - 1件失敗時も他のリポジトリの結果は返る
+  - 空配列で `[]` を返す
+  - **並列実行の検証**: deferred-callback パターンで、最初の `await setImmediate` 後に全リポジトリの exec が起動していることを確認（逐次なら1件のみ）
+
+## 検証結果
+
+| 項目 | 結果 |
+|------|------|
+| `npx tsc --noEmit` | エラー 0 |
+| `npm run lint` | エラー 0 |
+| `npm run test:unit` | baseline 6491 → 6495 passed（+4 新規テスト、0 リグレッション） |
+
+## 期待される効果
+Issue 記載の試算では:
+- Before: 12 リポジトリ × 50〜100ms ≒ 600〜1200ms
+- After: 最遅 1 件分 ≒ 100〜200ms
+
+実機ベンチは PR 後にコメントで報告予定。
+
+## 留意点
+- 現状の規模（数十リポジトリ）では FD 上限の懸念はないため chunk 化は未実施。
+- `scanWorktrees` 内 `execAsync` のタイムアウト追加は別 Issue 推奨（Issue 本文の留意点に記載済み）。
+
+## 受入条件チェック
+- [x] `scanMultipleRepositories` を `Promise.allSettled` で並列化
+- [x] 個別リポジトリで失敗しても全体は失敗させない（既存挙動維持）
+- [x] ログ出力に `repoPath` を付与
+- [x] `npm run test:unit` 回帰 0 件
+- [x] 単体テストが並列化後も通る（4件新規追加）
+- [ ] 同期所要時間のベンチ計測（PR 後実機で実施）

--- a/dev-reports/bug-fix/20260515_211238/work-plan.md
+++ b/dev-reports/bug-fix/20260515_211238/work-plan.md
@@ -1,0 +1,20 @@
+# Issue #711 作業計画
+
+## 目的
+`scanMultipleRepositories` の逐次スキャンを `Promise.allSettled` で並列化し、`POST /api/repositories/sync` の体感遅延を改善する。
+
+## 変更ファイル
+- `src/lib/git/worktrees.ts` (本体修正)
+- `tests/unit/worktrees.test.ts` (`scanMultipleRepositories` の並列化を検証するテストを追加)
+
+## 実装内容
+1. `scanMultipleRepositories` を `Promise.allSettled(repositoryPaths.map(...))` で書き換え
+2. 個別失敗時の挙動を維持（rejected の場合は logger.error を出し、全体は失敗させない）
+3. `repoPath` を保持したログ出力（並列実行で順序が不定になるため）
+
+## 受入条件
+- [x] `scanMultipleRepositories` を `Promise.allSettled` で並列化
+- [x] 個別リポジトリで失敗しても全体は失敗させない（既存挙動維持）
+- [x] ログ出力に `repoPath` を付与
+- [x] `npm run test:unit` 回帰 0 件
+- [x] 並列化の動作を確認する単体テストを追加

--- a/src/lib/git/worktrees.ts
+++ b/src/lib/git/worktrees.ts
@@ -239,17 +239,29 @@ export async function scanWorktrees(rootDir: string): Promise<Worktree[]> {
 export async function scanMultipleRepositories(
   repositoryPaths: string[]
 ): Promise<Worktree[]> {
-  const allWorktrees: Worktree[] = [];
-
-  for (const repoPath of repositoryPaths) {
-    try {
+  // Issue #711: Parallelize per-repository scans. Each `git worktree list`
+  // spawns an independent child process, so there is no contention between
+  // repositories. allSettled preserves the prior "one failure does not abort
+  // the rest" semantics.
+  const results = await Promise.allSettled(
+    repositoryPaths.map(async (repoPath) => {
       logger.info('repository:scan-start', { repoPath });
       const worktrees = await scanWorktrees(repoPath);
-      allWorktrees.push(...worktrees);
       logger.info('repository:scan-complete', { repoPath, worktreeCount: worktrees.length });
-    } catch (error) {
-      logger.error('repository:scan-failed', { repoPath, error: error instanceof Error ? error.message : String(error) });
-      // Continue with other repositories even if one fails
+      return worktrees;
+    })
+  );
+
+  const allWorktrees: Worktree[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      allWorktrees.push(...result.value);
+    } else {
+      logger.error('repository:scan-failed', {
+        repoPath: repositoryPaths[i],
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
     }
   }
 

--- a/tests/unit/worktrees.test.ts
+++ b/tests/unit/worktrees.test.ts
@@ -7,14 +7,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { exec } from 'child_process';
 import type { Worktree } from '@/types/models';
 
-// Mock child_process - just auto-mock it
-vi.mock('child_process');
+// Mock child_process - use a factory so the mock function does NOT inherit
+// `util.promisify.custom` from the real exec. With auto-mock, that symbol is
+// preserved and promisify(exec) bypasses mockImplementation entirely.
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
 
 // Import functions after mocking
 import {
   generateWorktreeId,
   parseWorktreeOutput,
   scanWorktrees,
+  scanMultipleRepositories,
   syncWorktreesToDB,
 } from '@/lib/git/worktrees';
 
@@ -265,6 +270,81 @@ invalid line
       // Unit test just verifies the function exists and has correct signature
       expect(syncWorktreesToDB).toBeDefined();
       expect(typeof syncWorktreesToDB).toBe('function');
+    });
+  });
+
+  // Issue #711: scanMultipleRepositories must run repository scans in parallel
+  describe('scanMultipleRepositories', () => {
+    it('should invoke git worktree list once per repository', async () => {
+      const observedCwds: string[] = [];
+      vi.mocked(exec).mockImplementation(
+        ((_cmd: string, opts: { cwd?: string }, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+          observedCwds.push(opts?.cwd ?? '');
+          callback(null, '', '');
+          return {} as never;
+        }) as never
+      );
+
+      const result = await scanMultipleRepositories(['/repo1', '/repo2', '/repo3']);
+
+      expect(observedCwds.sort()).toEqual(['/repo1', '/repo2', '/repo3']);
+      expect(result).toEqual([]);
+    });
+
+    it('should continue when one repository scan rejects', async () => {
+      vi.mocked(exec).mockImplementation(
+        ((_cmd: string, opts: { cwd?: string }, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+          if (opts?.cwd === '/bad-repo') {
+            const error = Object.assign(new Error('permission denied'), { code: 1 });
+            callback(error, '', 'permission denied');
+          } else {
+            callback(null, '', '');
+          }
+          return {} as never;
+        }) as never
+      );
+
+      await expect(
+        scanMultipleRepositories(['/repo1', '/bad-repo', '/repo3'])
+      ).resolves.toEqual([]);
+    });
+
+    it('should return an empty array for an empty repository list', async () => {
+      const result = await scanMultipleRepositories([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should start all repository scans before any of them resolves (parallel)', async () => {
+      const started: string[] = [];
+      const deferred = new Map<string, () => void>();
+
+      vi.mocked(exec).mockImplementation(
+        ((_cmd: string, opts: { cwd?: string }, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+          const cwd = opts?.cwd ?? '';
+          started.push(cwd);
+          // Hold the callback until we explicitly release it. With sequential
+          // execution, only the first exec would fire and the loop would block
+          // waiting for it to resolve; with parallel execution, all three
+          // should be observed in `started` before any callback resolves.
+          deferred.set(cwd, () => callback(null, '', ''));
+          return {} as never;
+        }) as never
+      );
+
+      const promise = scanMultipleRepositories(['/repo1', '/repo2', '/repo3']);
+
+      // Let the synchronous .map(...) issue all three exec calls.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(started.sort()).toEqual(['/repo1', '/repo2', '/repo3']);
+
+      // Release in reverse order to make sure ordering doesn't depend on
+      // resolution order.
+      deferred.get('/repo3')!();
+      deferred.get('/repo2')!();
+      deferred.get('/repo1')!();
+
+      await expect(promise).resolves.toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

`scanMultipleRepositories` の逐次スキャン (`for ... await`) を `Promise.allSettled` で並列化し、`POST /api/repositories/sync` の体感遅延を短縮します。
リポジトリ間の `git worktree list` は独立した子プロセスなので干渉せず、合計時間が「リポジトリ数 × 単一スキャン時間」から「最遅 1 件の時間」に圧縮されます。

Closes #711

## Changes

### Changed
- `src/lib/git/worktrees.ts`: `scanMultipleRepositories` を `Promise.allSettled(repositoryPaths.map(...))` に書き換え。
- 個別失敗は `logger.error` でログ出力するのみとし、全体は失敗させない既存挙動を維持。
- ログには `repoPath` を付与（並列実行で順序が不定になるため後追い相関を可能にする）。

### Tests
- `tests/unit/worktrees.test.ts`: `vi.mock('child_process')` を **auto-mock → factory mock** に変更。
  vitest の auto-mock は `child_process.exec` の `util.promisify.custom` シンボルを引き継いでしまい、`promisify(exec)` が `mockImplementation` をバイパスして実装側を呼んでしまうため、`vi.fn()` 単体を返す factory に変更して回避。
- `scanMultipleRepositories` の単体テストを **4 件追加**:
  - 各リポジトリで `git worktree list` が 1 回ずつ呼ばれる
  - 1 件が reject しても残りの結果は返る
  - 空配列で `[]` を返す
  - **並列実行検証**: deferred-callback パターンで、最初の `await setImmediate` 後に全リポジトリの `exec` が起動済みであることを確認（逐次実行であれば 1 件しか観測されない）

## Test Results

### Unit Tests

```
npm run test:unit
Test Files  343 passed (343)
Tests       6495 passed | 7 skipped (6502)
```
ベースライン (本変更前): `6491 passed | 7 skipped` → **+4 新規テスト、0 リグレッション**。

### Lint & Type Check

- ESLint: 0 errors / 0 warnings
- TypeScript (`npx tsc --noEmit`): 0 errors

### Build

```
npm run build
Build successful (Next.js 14)
```

## Performance Impact (試算)

| | Before (逐次) | After (並列) |
|---|---|---|
| 12 リポジトリ × 50〜100ms/件 | 600〜1200ms | 100〜200ms (最遅 1 件分) |

実機ベンチは PR マージ後にコメントで報告予定です。

## Checklist

- [x] Unit tests pass (+4 new, 0 regressions)
- [x] Lint check passes
- [x] Type check passes
- [x] Build succeeds
- [x] No console.log in production code
- [x] 個別失敗時の既存挙動 (1 件失敗で全体は継続) を維持
- [x] ログ出力に `repoPath` を付与

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>