### PR TITLE
perf: useWorktreesCache の二重インスタンス化を解消（Provider 経由に統一）(#709)

### DIFF
--- a/dev-reports/bug-fix/709-20260515_211219/acceptance-context.json
+++ b/dev-reports/bug-fix/709-20260515_211219/acceptance-context.json
@@ -1,0 +1,78 @@
+{
+  "bug_id": "709-20260515_211219",
+  "issue_number": 709,
+  "bug_description": "useWorktreesCache が Sessions ページで二重インスタンス化され /api/worktrees ポーリングが2系統並行で動く",
+  "fix_summary": "WorktreesCacheProvider に WorktreesCacheContext を新設し useWorktreesCacheContext() を export。Sessions ページは useWorktreesCache 直呼びをやめ Context から取得する形に変更。これにより /api/worktrees ポーリングはアプリ全体で1系統に統一される。",
+  "modified_files": [
+    "src/components/providers/WorktreesCacheProvider.tsx",
+    "src/app/sessions/page.tsx",
+    "tests/unit/SessionsPage.test.tsx",
+    "tests/unit/components/providers/WorktreesCacheProvider.test.tsx (新規)"
+  ],
+  "acceptance_criteria": [
+    "Sessions ページで useWorktreesCache() の直接呼び出しが廃止されている (Provider 経由の Context から取得)",
+    "プロジェクト全体で useWorktreesCache の二重呼び出し箇所が存在しない (Provider のみが呼び出す)",
+    "useWorktreesCacheContext() を Provider 外で呼ぶと適切なエラーが投げられる",
+    "Sessions 画面の既存機能 (フィルタ・ソート・XSS sanitize・loading/error/empty state) に回帰がない",
+    "新規テスト tests/unit/components/providers/WorktreesCacheProvider.test.tsx が全件 PASS",
+    "既存テスト tests/unit/SessionsPage.test.tsx が全件 PASS",
+    "npm run test:unit 全件 PASS、回帰 0 件",
+    "npm run lint クリーン",
+    "npx tsc --noEmit クリーン"
+  ],
+  "test_scenarios": [
+    {
+      "id": "T1",
+      "name": "Sessions ページの直接呼び出し廃止確認",
+      "method": "grep で src/app/sessions/page.tsx を検査し useWorktreesCache が import されていないこと、useWorktreesCacheContext が import されていることを確認",
+      "expected": "useWorktreesCache の import が存在しない / useWorktreesCacheContext の import と呼び出しが存在する"
+    },
+    {
+      "id": "T2",
+      "name": "他箇所での二重呼び出し確認",
+      "method": "grep -rn 'useWorktreesCache(' src/ で呼び出し箇所を列挙し、WorktreesCacheProvider のみであることを確認",
+      "expected": "useWorktreesCache() の呼び出し箇所は src/components/providers/WorktreesCacheProvider.tsx 1箇所のみ"
+    },
+    {
+      "id": "T3",
+      "name": "Provider Context テスト",
+      "method": "npx vitest run tests/unit/components/providers/WorktreesCacheProvider.test.tsx を実行",
+      "expected": "全テスト PASS"
+    },
+    {
+      "id": "T4",
+      "name": "Sessions ページテスト回帰確認",
+      "method": "npx vitest run tests/unit/SessionsPage.test.tsx を実行",
+      "expected": "全テスト PASS"
+    },
+    {
+      "id": "T5",
+      "name": "Lint 検査",
+      "method": "npm run lint",
+      "expected": "エラー 0 件"
+    },
+    {
+      "id": "T6",
+      "name": "型検査",
+      "method": "npx tsc --noEmit",
+      "expected": "エラー 0 件"
+    },
+    {
+      "id": "T7",
+      "name": "Unit Test 全件実行",
+      "method": "npm run test:unit",
+      "expected": "全件 PASS、新規導入による回帰 0 件"
+    },
+    {
+      "id": "T8",
+      "name": "Provider 階層維持確認",
+      "method": "src/components/providers/AppProviders.tsx と src/components/providers/WorktreesCacheProvider.tsx を確認し、WorktreeSelectionProvider への externalWorktrees / externalRepositories 伝播が維持されていることを確認",
+      "expected": "既存の WorktreeSelectionProvider プロパティ伝播が保たれている"
+    }
+  ],
+  "regression_check_areas": [
+    "Sessions 画面 (フィルタ・ソート・XSS sanitize・loading/error/empty state)",
+    "Sidebar の Worktree 表示 (WorktreeSelectionContext 経由)",
+    "リポジトリ visible/enabled フィルタ (Issue #690)"
+  ]
+}

--- a/dev-reports/bug-fix/709-20260515_211219/acceptance-result.json
+++ b/dev-reports/bug-fix/709-20260515_211219/acceptance-result.json
@@ -1,0 +1,197 @@
+{
+  "bug_id": "709-20260515_211219",
+  "issue_number": 709,
+  "executed_at": "2026-05-15T21:30:00+09:00",
+  "overall_result": "pass",
+  "summary": "Issue #709 のバグ修正に対する受入テストは全シナリオ (T1-T8) で合格。useWorktreesCache の二重インスタンス化は構造的に解消され、Sessions ページは WorktreesCacheProvider 経由の Context (useWorktreesCacheContext) のみを使用するように変更されている。src/ 配下で useWorktreesCache() を直接呼び出しているのは src/components/providers/WorktreesCacheProvider.tsx 1箇所のみであることを確認した。新規 Provider テスト (5件) と既存の SessionsPage テスト (18件)、および全 unit テスト (6496件 PASS / 7 skipped、344ファイル) も回帰 0 件で完走している。",
+  "test_scenarios": [
+    {
+      "id": "T1",
+      "name": "Sessions ページの直接呼び出し廃止確認",
+      "result": "pass",
+      "command": "grep -n \"useWorktreesCache\" src/app/sessions/page.tsx",
+      "evidence": [
+        "L6: コメント中の言及のみ (Issue #709 説明)",
+        "L7: コメント中の言及のみ (useWorktreesCache() を直接呼び出していない旨の説明)",
+        "L19: import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';",
+        "L114: const { worktrees, isLoading, error } = useWorktreesCacheContext();"
+      ],
+      "expected": "useWorktreesCache の import が存在せず、useWorktreesCacheContext の import と呼び出しが存在する",
+      "actual": "期待通り。useWorktreesCache の import 文と直接呼び出しは消滅し、useWorktreesCacheContext() のみが使用されている (残るのは説明コメント内の文字列マッチのみ)"
+    },
+    {
+      "id": "T2",
+      "name": "他箇所での二重呼び出し確認",
+      "result": "pass",
+      "command": "grep -rn 'useWorktreesCache(' src/",
+      "evidence": [
+        "src/app/sessions/page.tsx:7  -> コメント内の言及のみ",
+        "src/components/providers/WorktreesCacheProvider.tsx:5  -> コメント内の言及のみ",
+        "src/components/providers/WorktreesCacheProvider.tsx:11 -> コメント内の言及のみ",
+        "src/components/providers/WorktreesCacheProvider.tsx:52 -> 唯一の実呼び出し: const cache = useWorktreesCache();",
+        "src/hooks/useWorktreesCache.ts:47 -> エクスポート宣言 (export function useWorktreesCache(): ...)"
+      ],
+      "expected": "useWorktreesCache() の実呼び出しは WorktreesCacheProvider.tsx の 1 箇所のみ",
+      "actual": "期待通り。実呼び出しは WorktreesCacheProvider.tsx の L52 のみで、他はコメントまたはエクスポート宣言にすぎない。構造的に二重インスタンス化は不可能になっている"
+    },
+    {
+      "id": "T3",
+      "name": "Provider Context テスト (新規)",
+      "result": "pass",
+      "command": "npx vitest run tests/unit/components/providers/WorktreesCacheProvider.test.tsx",
+      "evidence": [
+        "Test Files  1 passed (1)",
+        "Tests       5 passed (5)",
+        "Duration    433ms"
+      ],
+      "expected": "全テスト PASS",
+      "actual": "5 件全て PASS。テスト内容: (1) cached worktrees/repositories/isLoading/error/refresh の context 経由公開、(2) loading state 伝播、(3) error state 伝播、(4) refresh() 関数の forward、(5) Provider 外呼び出し時の Error throw。エラーログは Provider 外呼び出しテストの想定内出力"
+    },
+    {
+      "id": "T4",
+      "name": "Sessions ページテスト回帰確認",
+      "result": "pass",
+      "command": "npx vitest run tests/unit/SessionsPage.test.tsx",
+      "evidence": [
+        "Test Files  1 passed (1)",
+        "Tests       18 passed (18)",
+        "Duration    470ms"
+      ],
+      "expected": "全テスト PASS",
+      "actual": "18 件全て PASS。モック対象が useWorktreesCache から useWorktreesCacheContext に置き換わったが、既存挙動 (フィルタ・ソート・XSS sanitize・loading/error/empty state) すべて維持されている"
+    },
+    {
+      "id": "T5",
+      "name": "Lint 検査",
+      "result": "pass",
+      "command": "npm run lint",
+      "evidence": [
+        "✔ No ESLint warnings or errors"
+      ],
+      "expected": "エラー 0 件",
+      "actual": "ESLint 警告・エラー 0 件"
+    },
+    {
+      "id": "T6",
+      "name": "型検査",
+      "result": "pass",
+      "command": "npx tsc --noEmit",
+      "evidence": [
+        "tsc completed with no output (exit code 0)"
+      ],
+      "expected": "エラー 0 件",
+      "actual": "TypeScript 型エラー 0 件"
+    },
+    {
+      "id": "T7",
+      "name": "Unit Test 全件実行",
+      "result": "pass",
+      "command": "npm run test:unit",
+      "evidence": [
+        "Test Files  344 passed (344)",
+        "Tests       6496 passed | 7 skipped (6503)",
+        "Duration    13.73s",
+        "出力中の Error ログは useSidebarContext / useWorktreesCacheContext / useAuthContext 等の Provider 外呼び出し時の意図的な throw テストの想定内出力"
+      ],
+      "expected": "全件 PASS、新規導入による回帰 0 件",
+      "actual": "344 ファイル / 6496 件 PASS、7 件 skipped、失敗 0 件。回帰なし"
+    },
+    {
+      "id": "T8",
+      "name": "Provider 階層維持確認",
+      "result": "pass",
+      "method": "AppProviders.tsx と WorktreesCacheProvider.tsx の構造確認",
+      "evidence": [
+        "AppProviders.tsx: NextIntlClientProvider > ThemeProvider > AuthProvider > SidebarProvider > WorktreesCacheProvider > children の階層を維持",
+        "WorktreesCacheProvider.tsx: useWorktreesCache() の戻り値から worktrees / repositories を取り出し、WorktreeSelectionProvider に externalWorktrees / externalRepositories として伝播 (L66-71)",
+        "新規追加された WorktreesCacheContext.Provider は WorktreeSelectionProvider の外側を包む形で配置され、Issue #690 の visible/enabled フラグを含む repositories の伝播も維持"
+      ],
+      "expected": "既存の WorktreeSelectionProvider プロパティ伝播が保たれている",
+      "actual": "期待通り。externalWorktrees / externalRepositories の伝播は維持されており、Sidebar の Worktree 表示やリポジトリ visible/enabled フィルタ (Issue #690) に影響しない"
+    }
+  ],
+  "acceptance_criteria_check": [
+    {
+      "criterion": "Sessions ページで useWorktreesCache() の直接呼び出しが廃止されている (Provider 経由の Context から取得)",
+      "achieved": true,
+      "evidence": "src/app/sessions/page.tsx は useWorktreesCacheContext() のみを呼び出している (T1)"
+    },
+    {
+      "criterion": "プロジェクト全体で useWorktreesCache の二重呼び出し箇所が存在しない (Provider のみが呼び出す)",
+      "achieved": true,
+      "evidence": "実呼び出しは src/components/providers/WorktreesCacheProvider.tsx L52 の 1 箇所のみ (T2)"
+    },
+    {
+      "criterion": "useWorktreesCacheContext() を Provider 外で呼ぶと適切なエラーが投げられる",
+      "achieved": true,
+      "evidence": "WorktreesCacheProvider.tsx L92-100 で null チェックし 'useWorktreesCacheContext must be used within a WorktreesCacheProvider' を throw。テスト T3 で確認済み"
+    },
+    {
+      "criterion": "Sessions 画面の既存機能 (フィルタ・ソート・XSS sanitize・loading/error/empty state) に回帰がない",
+      "achieved": true,
+      "evidence": "SessionsPage.test.tsx 18 件全 PASS (T4)"
+    },
+    {
+      "criterion": "新規テスト tests/unit/components/providers/WorktreesCacheProvider.test.tsx が全件 PASS",
+      "achieved": true,
+      "evidence": "5 件全 PASS (T3)"
+    },
+    {
+      "criterion": "既存テスト tests/unit/SessionsPage.test.tsx が全件 PASS",
+      "achieved": true,
+      "evidence": "18 件全 PASS (T4)"
+    },
+    {
+      "criterion": "npm run test:unit 全件 PASS、回帰 0 件",
+      "achieved": true,
+      "evidence": "344 ファイル / 6496 件 PASS、7 件 skipped、失敗 0 件 (T7)"
+    },
+    {
+      "criterion": "npm run lint クリーン",
+      "achieved": true,
+      "evidence": "ESLint 警告・エラー 0 件 (T5)"
+    },
+    {
+      "criterion": "npx tsc --noEmit クリーン",
+      "achieved": true,
+      "evidence": "型エラー 0 件 (T6)"
+    }
+  ],
+  "regression_check_areas": [
+    {
+      "area": "Sessions 画面 (フィルタ・ソート・XSS sanitize・loading/error/empty state)",
+      "result": "no_regression",
+      "evidence": "SessionsPage.test.tsx 18 件全 PASS"
+    },
+    {
+      "area": "Sidebar の Worktree 表示 (WorktreeSelectionContext 経由)",
+      "result": "no_regression",
+      "evidence": "WorktreesCacheProvider は引き続き externalWorktrees / externalRepositories を WorktreeSelectionProvider に伝播 (T8 で構造確認、npm run test:unit 全件 PASS)"
+    },
+    {
+      "area": "リポジトリ visible/enabled フィルタ (Issue #690)",
+      "result": "no_regression",
+      "evidence": "externalRepositories の伝播経路は変更されていない (T8)。useWorktreesCache の戻り値 cache.repositories はそのまま WorktreeSelectionProvider に渡されている"
+    }
+  ],
+  "issues_found": [],
+  "recommendations": [
+    "ネットワーク観点での実機検証 (Chrome DevTools Network パネルで /api/worktrees が単一インスタンス化されることの確認) はサーバ起動が必要で本受入テストの範疇外だが、構造的には useWorktreesCache の実呼び出しが WorktreesCacheProvider 1 箇所に限定されており、これにより setInterval ベースのポーリングが 1 系統に統一されていることがコード上保証される。",
+    "今後 Sessions ページ以外のページ (Repositories, Review, More 等) で worktrees キャッシュを参照したい場合は、必ず useWorktreesCacheContext() を使うこと。useWorktreesCache の export を残しているのは Provider 専用にするべきかどうかは将来の検討課題 (例えば JSDoc で internal API である旨を明示する等)。"
+  ],
+  "test_evidence_summary": {
+    "lint": "PASS (0 warnings, 0 errors)",
+    "type_check": "PASS (tsc --noEmit clean)",
+    "new_provider_test": "PASS (5/5)",
+    "sessions_page_test": "PASS (18/18)",
+    "all_unit_tests": "PASS (6496/6503, 7 skipped, 0 failed across 344 files)",
+    "grep_direct_call_count_in_src": "1 (only in WorktreesCacheProvider.tsx)"
+  },
+  "files_verified": [
+    "/Users/maenokota/share/work/github_kewton/commandmate-issue-709/src/app/sessions/page.tsx",
+    "/Users/maenokota/share/work/github_kewton/commandmate-issue-709/src/components/providers/WorktreesCacheProvider.tsx",
+    "/Users/maenokota/share/work/github_kewton/commandmate-issue-709/src/components/providers/AppProviders.tsx",
+    "/Users/maenokota/share/work/github_kewton/commandmate-issue-709/tests/unit/SessionsPage.test.tsx",
+    "/Users/maenokota/share/work/github_kewton/commandmate-issue-709/tests/unit/components/providers/WorktreesCacheProvider.test.tsx"
+  ]
+}

--- a/dev-reports/bug-fix/709-20260515_211219/investigation-context.json
+++ b/dev-reports/bug-fix/709-20260515_211219/investigation-context.json
@@ -1,0 +1,36 @@
+{
+  "issue_number": 709,
+  "issue_description": "useWorktreesCache フックが Sessions 画面表示中に2回インスタンス化され、同じ /api/worktrees ポーリングが並行で2系統動いている。Provider 経由に統一して1系統に集約する。",
+  "error_logs": [],
+  "affected_files": [
+    "src/components/providers/WorktreesCacheProvider.tsx",
+    "src/app/sessions/page.tsx",
+    "src/hooks/useWorktreesCache.ts",
+    "src/contexts/WorktreeSelectionContext.tsx",
+    "src/components/providers/AppProviders.tsx"
+  ],
+  "reproduction_steps": [
+    "1. ブラウザで /sessions にアクセス",
+    "2. ネットワークタブで /api/worktrees の呼び出し頻度を観察",
+    "3. POLLING_INTERVAL_IDLE=30000ms (アイドル時) または POLLING_INTERVAL_ACTIVE=5000ms (アクティブセッション時) に対し、リクエストが2倍の頻度で発生していることを確認"
+  ],
+  "environment": {
+    "framework": "Next.js 14",
+    "language": "TypeScript",
+    "test_framework": "Vitest"
+  },
+  "severity_hint": "high",
+  "key_findings": {
+    "duplicate_instance_locations": [
+      "src/components/providers/WorktreesCacheProvider.tsx:32 (グローバル Provider 経由)",
+      "src/app/sessions/page.tsx:110 (Sessions ページが独自に呼び出し)"
+    ],
+    "internal_state_not_shared": "useWorktreesCache の名前は 'cache' だが React Context を使っていないため、複数箇所で呼ぶと各々独立した useState/useRef/useEffect/setInterval を保有する",
+    "polling_interval_logic": {
+      "POLLING_INTERVAL_ACTIVE": "5000ms",
+      "POLLING_INTERVAL_IDLE": "30000ms",
+      "adaptive": "アクティブセッション有無で切替"
+    },
+    "test_mocking_pattern": "tests/unit/SessionsPage.test.tsx は useWorktreesCache を vi.mock しているため、Context 移行に伴いテストも変更が必要"
+  }
+}

--- a/dev-reports/bug-fix/709-20260515_211219/investigation-result.json
+++ b/dev-reports/bug-fix/709-20260515_211219/investigation-result.json
@@ -1,0 +1,81 @@
+{
+  "issue_number": 709,
+  "investigation_summary": "useWorktreesCache フックは React Context を使わず内部に useState/useRef/setInterval を保有するため、複数コンポーネントで呼び出すたびに独立したインスタンスとポーリングタイマーが作られる。現在 WorktreesCacheProvider と Sessions ページの2箇所で呼ばれており、/api/worktrees が2倍の頻度で叩かれている。",
+  "root_cause": {
+    "description": "useWorktreesCache が Context API ではなくフック単独で setInterval ベースのポーリングを行っているため、複数の呼び出し箇所がそれぞれ独立した状態とポーリングタイマーを保有する。命名は 'cache' だが実体は単なるカスタムフックである。",
+    "key_locations": [
+      {
+        "file": "src/hooks/useWorktreesCache.ts",
+        "line": "47-140",
+        "issue": "Context を使わないフック実装。useState/useRef/setInterval を内部保有するため呼び出すたびにインスタンスが生成される"
+      },
+      {
+        "file": "src/components/providers/WorktreesCacheProvider.tsx",
+        "line": "32",
+        "issue": "正規の呼び出し箇所 (AppProviders 経由でアプリ全体に1個生成される想定)"
+      },
+      {
+        "file": "src/app/sessions/page.tsx",
+        "line": "110",
+        "issue": "Provider と独立に直接呼び出してしまっており、2つ目のインスタンスが生成される"
+      }
+    ]
+  },
+  "impact_analysis": {
+    "scope": "Sessions ページ表示中の全ユーザー",
+    "user_impact": "サイドバー遅延、ネットワーク帯域・サーバ負荷の倍増",
+    "server_impact": "/api/worktrees の N×M ステータス検出処理 (scanMultipleRepositories) が2倍の頻度で発生",
+    "severity": "high"
+  },
+  "fix_approaches": [
+    {
+      "id": "1",
+      "title": "WorktreesCacheProvider に Context を導入し Sessions ページから消費",
+      "description": "useWorktreesCache の戻り値 (worktrees / repositories / isLoading / error / refresh) を React Context で公開する WorktreesCacheContext を新設。WorktreesCacheProvider が単一の useWorktreesCache インスタンスを保持し、Sessions ページは useContext で取得する。useWorktreesCache フック自体は他で再利用される可能性を考慮し、テスト用にエクスポートを残す。",
+      "priority": "High",
+      "files_to_modify": [
+        "src/components/providers/WorktreesCacheProvider.tsx",
+        "src/app/sessions/page.tsx",
+        "tests/unit/SessionsPage.test.tsx"
+      ],
+      "files_to_create": [],
+      "pros": [
+        "Issue の実装方針案に完全準拠",
+        "Sessions ページ以外の場所でも今後同じ Context から取得可能",
+        "React 標準パターン (Provider + useContext)",
+        "useWorktreesCache フック実装は変更不要 (テスト/単体利用は維持)"
+      ],
+      "cons": [
+        "Sessions ページの useWorktreesCache モックを Context モックに変更する必要"
+      ]
+    },
+    {
+      "id": "2",
+      "title": "重複呼び出し検知の警告を useWorktreesCache に追加",
+      "description": "useWorktreesCache 自身に dev-mode の重複検知を入れて将来の再発を防ぐ。グローバル使用カウンタ (mount/unmount) と StrictMode 配慮で実装。",
+      "priority": "Medium",
+      "files_to_modify": [
+        "src/hooks/useWorktreesCache.ts"
+      ],
+      "files_to_create": [],
+      "pros": [
+        "将来の re-introduction を早期検出",
+        "実装コストは低い"
+      ],
+      "cons": [
+        "StrictMode の double-invoke で誤検知のリスク",
+        "リファクタリング用途で意図的に複数 instance を作る場合に邪魔になる"
+      ]
+    }
+  ],
+  "recommended_approach": "1",
+  "definition_of_done": [
+    "Sessions ページが useWorktreesCache を直接呼ばず Context から取得する",
+    "他に二重呼び出し箇所が無い (grep で確認済み)",
+    "/api/worktrees のリクエストがアプリ全体で常に1系統のみ",
+    "Sessions 画面の表示・フィルタ・ソート機能に回帰なし",
+    "npm run test:unit 全件 PASS",
+    "npm run lint クリーン",
+    "npx tsc --noEmit クリーン"
+  ]
+}

--- a/dev-reports/bug-fix/709-20260515_211219/progress-context.json
+++ b/dev-reports/bug-fix/709-20260515_211219/progress-context.json
@@ -1,0 +1,48 @@
+{
+  "bug_id": "709-20260515_211219",
+  "issue_number": 709,
+  "issue_title": "perf(sidebar): useWorktreesCache の二重インスタンス化を解消（Provider 経由に統一）",
+  "issue_url": "https://github.com/Kewton/CommandMate/issues/709",
+  "branch": "feature/709-worktree",
+  "phase_results": {
+    "phase_1_investigation": {
+      "result_file": "dev-reports/bug-fix/709-20260515_211219/investigation-result.json",
+      "summary": "useWorktreesCache フックは Context を使わないため複数呼び出しで独立インスタンスが生成される。Sessions ページが Provider と独立に直接呼び出していることが二重ポーリングの原因。",
+      "severity": "high"
+    },
+    "phase_2_proposal": {
+      "selected_action": "対策案1: Provider に Context を導入し Sessions ページから消費"
+    },
+    "phase_3_work_plan": {
+      "context_file": "dev-reports/bug-fix/709-20260515_211219/work-plan-context.json"
+    },
+    "phase_4_tdd_fix": {
+      "result_file": "dev-reports/bug-fix/709-20260515_211219/tdd-fix-result.json",
+      "summary": "TDD Red-Green-Refactor サイクルを2回実施。WorktreesCacheProvider に Context を実装し、Sessions ページを useWorktreesCacheContext 化。",
+      "coverage": {
+        "WorktreesCacheProvider.tsx": "100%"
+      }
+    },
+    "phase_5_acceptance": {
+      "result_file": "dev-reports/bug-fix/709-20260515_211219/acceptance-result.json",
+      "summary": "T1〜T8 全シナリオ合格。Issue 受入条件 4 件全て達成。",
+      "verdict": "合格"
+    }
+  },
+  "modified_files": [
+    "src/components/providers/WorktreesCacheProvider.tsx",
+    "src/app/sessions/page.tsx",
+    "tests/unit/SessionsPage.test.tsx",
+    "tests/unit/components/providers/WorktreesCacheProvider.test.tsx (新規)"
+  ],
+  "verification_results": {
+    "lint": "0 errors",
+    "tsc": "0 errors",
+    "test_unit": "6496 passed / 7 skipped / 0 failed (344 files)"
+  },
+  "next_steps": [
+    "PR 作成 (feature/709-worktree → develop)",
+    "コードレビュー依頼",
+    "develop マージ後の動作確認 (ブラウザ DevTools Network で /api/worktrees ポーリング回数を実機検証)"
+  ]
+}

--- a/dev-reports/bug-fix/709-20260515_211219/progress-report.md
+++ b/dev-reports/bug-fix/709-20260515_211219/progress-report.md
@@ -1,0 +1,270 @@
+# Bug Fix 進捗レポート - Issue #709
+
+## 1. 概要
+
+| 項目 | 内容 |
+|------|------|
+| Issue 番号 | [#709](https://github.com/Kewton/CommandMate/issues/709) |
+| Issue タイトル | perf(sidebar): useWorktreesCache の二重インスタンス化を解消（Provider 経由に統一） |
+| Bug ID | `709-20260515_211219` |
+| ブランチ | `feature/709-worktree` |
+| 重要度 | high |
+| ステータス | 合格（受入テスト T1〜T8 全 PASS / Issue 受入条件 9 件全達成） |
+| 作業ディレクトリ | `/Users/maenokota/share/work/github_kewton/commandmate-issue-709` |
+
+---
+
+## 2. 不具合の概要と根本原因
+
+### 2.1 不具合の概要
+
+`src/hooks/useWorktreesCache.ts` は名前こそ「cache」だが実体は **React Context を使わないカスタムフック** で、内部に `useState` / `useRef` / `setInterval` を保有している。そのため複数コンポーネントで呼び出されると、その都度独立したインスタンスとポーリングタイマーが生成される。
+
+現状アプリ内で `useWorktreesCache()` を実際に呼び出していたのは以下の 2 箇所:
+
+1. `src/components/providers/WorktreesCacheProvider.tsx` L32（正規・想定通り）
+2. `src/app/sessions/page.tsx` L110（Provider と独立に直接呼び出していた）
+
+この結果、Sessions ページ表示中は `/api/worktrees` への HTTP ポーリングが **2 系統並走** し、サーバ側の `scanMultipleRepositories`（N×M ステータス検出）が二重に走っていた。
+
+### 2.2 根本原因
+
+| 観点 | 内容 |
+|------|------|
+| 直接原因 | `useWorktreesCache` が Context API ではなく単なるフックとして実装されており、複数呼び出しがそれぞれ独立した状態とポーリングタイマーを持つ |
+| 構造的原因 | 「Cache」という命名から共有インスタンスを連想させるが、実装は共有機構を持たない |
+| 検出機構の欠如 | 二重呼び出しを警告する仕組みが無く、re-introduction が容易 |
+
+### 2.3 影響範囲
+
+| スコープ | 影響 |
+|---------|------|
+| ユーザー影響 | サイドバー表示遅延、ネットワーク帯域・サーバ負荷の倍増 |
+| サーバ影響 | `/api/worktrees` の N×M ステータス検出処理が 2 倍の頻度で発生 |
+| 影響ユーザー | Sessions ページ表示中の全ユーザー |
+
+---
+
+## 3. 採択した対策案
+
+**対策案 1: WorktreesCacheProvider に Context を導入し Sessions ページから消費**
+
+### 3.1 設計方針
+
+- `useWorktreesCache` の戻り値（`worktrees` / `repositories` / `isLoading` / `error` / `refresh`）を `React.createContext<UseWorktreesCacheReturn | null>(null)` で公開する **`WorktreesCacheContext`** を新設
+- `WorktreesCacheProvider` が単一の `useWorktreesCache()` インスタンスを保持し、`useMemo` でラップした context value を配信
+- Sessions ページは `useContext` を `useWorktreesCacheContext()` フック経由で取得（Provider 外呼び出し時は明示的に throw）
+- `useWorktreesCache` フック自体の実装は **一切変更しない**（テスト/単体利用の互換性維持）
+- 既存の `WorktreeSelectionProvider` への `externalWorktrees` / `externalRepositories` 伝播は維持
+
+### 3.2 採用理由
+
+- Issue の実装方針案に完全準拠
+- React 標準パターン（Provider + useContext）で実装コストが低い
+- Sessions ページ以外（Repositories / Review / More 等）でも将来同じ Context から取得可能
+- `useWorktreesCache` フック実装は変更不要のため副作用が最小
+
+### 3.3 不採用案
+
+- **対策案 2（重複呼び出し検知の警告追加）**: StrictMode の double-invoke で誤検知のリスクがあり、また再発防止策であって根本解決ではないため不採用
+
+---
+
+## 4. TDD サイクル
+
+Red → Green → Refactor を 2 サイクル実施。
+
+### 4.1 サイクル 1: Provider Context 実装
+
+| Step | 内容 | 検証 |
+|------|------|------|
+| **Red 1** | `tests/unit/components/providers/WorktreesCacheProvider.test.tsx` 新規作成。5 失敗テスト（cached fields 公開 / loading 伝播 / error 伝播 / refresh forward / Provider 外呼び出し時 throw） | `5 failed (useWorktreesCacheContext is not a function)` |
+| **Green 1** | `WorktreesCacheProvider.tsx` に `createContext<UseWorktreesCacheReturn \| null>(null)` と `useMemo` ラップ context value、`useWorktreesCacheContext()` フックを実装。Provider 外呼び出し時は明示的 Error throw | `5 passed` |
+
+### 4.2 サイクル 2: Sessions ページ移行
+
+| Step | 内容 | 検証 |
+|------|------|------|
+| **Red 2** | `tests/unit/SessionsPage.test.tsx` のモック対象を `@/hooks/useWorktreesCache` から `@/components/providers/WorktreesCacheProvider`（`useWorktreesCacheContext`）に置換。`mockRepositories` を追加し `beforeEach` でリセット。既存 18 ケース維持 | `15 failed / 3 passed`（実装側未対応のため fall back で fetch → loading で停止） |
+| **Green 2** | `src/app/sessions/page.tsx` の `import { useWorktreesCache } from '@/hooks/useWorktreesCache'` を `import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider'` に変更。呼び出しも `useWorktreesCacheContext()` に切替 | `23 passed`（18 Sessions + 5 Provider） |
+
+### 4.3 Refactor
+
+- `WorktreesCacheProvider` ヘッダー、`useWorktreesCacheContext` JSDoc、Sessions ページヘッダーに Issue #709 の rationale コメントを追記
+- Context value を `useMemo` でラップして参照安定性を確保
+- `src/hooks/useWorktreesCache.ts` は制約通り無改修
+
+| 検証コマンド | 結果 |
+|-------------|------|
+| `npm run lint` | 0 errors |
+| `npx tsc --noEmit` | 0 errors |
+| `npm run test:unit` | 344 ファイル / 6496 PASS / 7 skipped / 0 failed |
+
+---
+
+## 5. 変更ファイル一覧
+
+| ファイル | 種別 | 変更概要 |
+|---------|------|---------|
+| `src/components/providers/WorktreesCacheProvider.tsx` | 修正 | `createContext` + `useMemo` + `useWorktreesCacheContext()` を追加。`WorktreeSelectionProvider` への `externalWorktrees` / `externalRepositories` 伝播は維持。ヘッダー JSDoc に Issue #709 rationale 追記 |
+| `src/app/sessions/page.tsx` | 修正 | `useWorktreesCache` 直接呼び出しを `useWorktreesCacheContext` 呼び出しに置換。ヘッダー JSDoc に Issue #709 説明追記。レンダーツリー / フィルタ / ソート / sanitize 変更なし |
+| `tests/unit/SessionsPage.test.tsx` | 修正 | モック対象を `@/hooks/useWorktreesCache` → `@/components/providers/WorktreesCacheProvider`（`useWorktreesCacheContext`）に変更。`mockRepositories` フィールド追加・`beforeEach` リセット追加。既存 18 アサーションは intact |
+| `tests/unit/components/providers/WorktreesCacheProvider.test.tsx` | **新規** | Context の契約を担保する 5 テスト：cached fields 公開 / loading 伝播 / error 伝播 / refresh forward / Provider 外呼び出し時 throw。`WorktreeSelectionProvider` をモック化して Context 契約に集中 |
+
+**git status による現在の差分:**
+
+```
+modified:   src/app/sessions/page.tsx
+modified:   src/components/providers/WorktreesCacheProvider.tsx
+modified:   tests/unit/SessionsPage.test.tsx
+Untracked:  tests/unit/components/providers/WorktreesCacheProvider.test.tsx
+```
+
+`src/hooks/useWorktreesCache.ts` は **不変**（制約遵守を `git diff` スコープで確認済み）。
+
+---
+
+## 6. 検証結果
+
+### 6.1 総合品質メトリクス
+
+| 項目 | 結果 | 詳細 |
+|------|------|------|
+| **ESLint** | PASS | 0 warnings / 0 errors |
+| **TypeScript (`tsc --noEmit`)** | PASS | 0 errors |
+| **Unit Test** | PASS | 344 ファイル / 6503 中 **6496 PASS** / 7 skipped / **0 failed** / Duration 13.73s |
+| **新規 Provider テスト** | PASS | 5/5 PASS（Duration 433ms） |
+| **Sessions ページ既存テスト** | PASS | 18/18 PASS（Duration 470ms） |
+
+### 6.2 カバレッジ
+
+| ファイル | Statements | Branches | Functions | Lines | 備考 |
+|---------|-----------|----------|-----------|-------|------|
+| `WorktreesCacheProvider.tsx` | **100%** | 100% | 100% | 100% | 新規追加 Context API 部分は完全カバー |
+| `sessions/page.tsx` | 69.56% | 53.01% | 88.88% | 70.76% | 未カバー行 (76, 96-97, 149-170) は本 fix 以前から存在するレンダリング分岐であり、修正範囲外 |
+
+**目標カバレッジ 80%**: 新規コードについては 100% 達成 ✅
+
+### 6.3 受入テスト（T1〜T8）
+
+| ID | テスト名 | 結果 | エビデンス |
+|----|---------|------|----------|
+| T1 | Sessions ページの直接呼び出し廃止確認 | ✅ pass | `grep "useWorktreesCache" src/app/sessions/page.tsx` → 実呼び出し消滅、`useWorktreesCacheContext()` のみ |
+| T2 | 他箇所での二重呼び出し確認 | ✅ pass | `grep -rn 'useWorktreesCache(' src/` → 実呼び出しは `WorktreesCacheProvider.tsx:52` 1 箇所のみ |
+| T3 | Provider Context テスト（新規） | ✅ pass | 5/5 PASS |
+| T4 | Sessions ページテスト回帰確認 | ✅ pass | 18/18 PASS |
+| T5 | Lint 検査 | ✅ pass | 0 warnings / 0 errors |
+| T6 | 型検査 | ✅ pass | tsc clean |
+| T7 | Unit Test 全件実行 | ✅ pass | 6496/6503 PASS / 0 failed |
+| T8 | Provider 階層維持確認 | ✅ pass | `WorktreeSelectionProvider` への `externalWorktrees` / `externalRepositories` 伝播維持 |
+
+### 6.4 回帰チェック
+
+| 領域 | 結果 |
+|------|------|
+| Sessions 画面（フィルタ・ソート・XSS sanitize・loading/error/empty state） | 回帰なし（18/18 PASS） |
+| Sidebar の Worktree 表示（WorktreeSelectionContext 経由） | 回帰なし（伝播経路維持） |
+| リポジトリ visible/enabled フィルタ（Issue #690） | 回帰なし（`externalRepositories` 伝播経路維持） |
+
+---
+
+## 7. Issue 受入条件チェックリスト
+
+| # | 受入条件 | 達成 | エビデンス |
+|---|---------|:----:|----------|
+| 1 | Sessions ページで `useWorktreesCache()` の直接呼び出しが廃止されている（Provider 経由 Context から取得） | ✅ | `src/app/sessions/page.tsx` は `useWorktreesCacheContext()` のみを呼び出し（T1） |
+| 2 | プロジェクト全体で `useWorktreesCache` の二重呼び出し箇所が存在しない（Provider のみ呼び出す） | ✅ | 実呼び出しは `WorktreesCacheProvider.tsx` L52 の 1 箇所のみ（T2） |
+| 3 | `useWorktreesCacheContext()` を Provider 外で呼ぶと適切なエラーが投げられる | ✅ | `'useWorktreesCacheContext must be used within a WorktreesCacheProvider'` を throw（T3） |
+| 4 | Sessions 画面の既存機能（フィルタ・ソート・XSS sanitize・loading/error/empty state）に回帰がない | ✅ | SessionsPage.test.tsx 18 件全 PASS（T4） |
+| 5 | 新規テスト `tests/unit/components/providers/WorktreesCacheProvider.test.tsx` が全件 PASS | ✅ | 5 件全 PASS（T3） |
+| 6 | 既存テスト `tests/unit/SessionsPage.test.tsx` が全件 PASS | ✅ | 18 件全 PASS（T4） |
+| 7 | `npm run test:unit` 全件 PASS、回帰 0 件 | ✅ | 344 ファイル / 6496 PASS / 0 failed（T7） |
+| 8 | `npm run lint` クリーン | ✅ | 0 warnings / 0 errors（T5） |
+| 9 | `npx tsc --noEmit` クリーン | ✅ | 型エラー 0 件（T6） |
+
+**達成率: 9/9 (100%)**
+
+### 制約遵守
+
+| 制約 | 遵守 | 根拠 |
+|------|:----:|------|
+| `useWorktreesCache` フック自体の実装は変更しない | ✅ | `git diff` スコープで `src/hooks/useWorktreesCache.ts` 不変を確認 |
+| 既存の Sessions ページ振る舞いに回帰を発生させない | ✅ | 既存 18 テスト全 PASS |
+| `WorktreeSelectionProvider` への `externalWorktrees` / `externalRepositories` 伝播維持 | ✅ | T8 構造確認済 |
+
+---
+
+## 8. ブロッカー・残課題
+
+### 8.1 ブロッカー
+
+**なし**。受入テスト・品質ゲート（lint/tsc/test）全合格、Issue 受入条件 9 件全達成。
+
+### 8.2 残課題・推奨事項
+
+| 項目 | 内容 |
+|------|------|
+| 実機検証 | Chrome DevTools Network パネルで `/api/worktrees` が単一インスタンス化されることの確認は本受入テストの範疇外。構造的には `useWorktreesCache` 実呼び出しが 1 箇所に限定されており、setInterval ポーリングが 1 系統に統一されていることがコード上保証されているが、develop マージ後に実機検証推奨 |
+| 将来の検討課題 | `useWorktreesCache` の export を Provider 専用 internal API として JSDoc に明示するかは将来の検討事項。今後 Sessions ページ以外のページ（Repositories / Review / More 等）で worktrees キャッシュを参照する場合は必ず `useWorktreesCacheContext()` を使うこと |
+
+---
+
+## 9. 次のアクション
+
+### 9.1 PR 作成手順
+
+1. **コミット作成**
+
+   ```bash
+   git add src/components/providers/WorktreesCacheProvider.tsx \
+           src/app/sessions/page.tsx \
+           tests/unit/SessionsPage.test.tsx \
+           tests/unit/components/providers/WorktreesCacheProvider.test.tsx
+   ```
+
+   コミットメッセージ案:
+
+   ```
+   perf(sidebar): expose useWorktreesCache via Context to dedupe polling (#709)
+
+   - Add WorktreesCacheContext / useWorktreesCacheContext in WorktreesCacheProvider
+   - Switch sessions page from direct useWorktreesCache() to useWorktreesCacheContext()
+   - Add 5 unit tests covering context contract (cached fields / loading / error / refresh / out-of-provider throw)
+   - Migrate SessionsPage mock target from useWorktreesCache to useWorktreesCacheContext
+
+   Eliminates duplicate /api/worktrees polling caused by two independent useWorktreesCache
+   instances. Direct call site is now limited to WorktreesCacheProvider only.
+
+   Refs: #709
+   ```
+
+2. **PR 作成（feature/709-worktree → develop）**
+
+   ```bash
+   gh pr create --base develop --title "perf(sidebar): useWorktreesCache の二重インスタンス化を解消（Provider 経由に統一） (#709)" --body "..."
+   ```
+
+   PR 本文に含めるべき内容:
+   - Summary: 二重ポーリング解消の背景と Context 化方針
+   - Test plan: lint / tsc / test:unit の結果、新規 5 テスト・既存 18 テスト PASS
+   - 実機検証 TODO: Chrome DevTools Network パネルで `/api/worktrees` ポーリング 1 系統化を確認
+
+3. **ラベル付与**: `bug`, `performance`, `refactor`
+
+### 9.2 マージ後アクション
+
+| アクション | 内容 |
+|-----------|------|
+| 実機検証 | develop マージ後、ブラウザ DevTools Network パネルで Sessions ページ表示時の `/api/worktrees` ポーリング回数を実測（修正前: 2 系統 → 修正後: 1 系統） |
+| ドキュメント反映 | 必要に応じて [モジュールリファレンス](../../../docs/module-reference.md) の `WorktreesCacheProvider` 項目に Issue #709 注記追加 |
+| フォローアップ Issue（任意） | `useWorktreesCache` の export を internal API としてマーキングするか、もしくは hooks ディレクトリから providers ディレクトリへ移設するかの方針決定 |
+
+---
+
+## 10. 参考リンク
+
+- Issue: https://github.com/Kewton/CommandMate/issues/709
+- 調査結果: `dev-reports/bug-fix/709-20260515_211219/investigation-result.json`
+- TDD 修正結果: `dev-reports/bug-fix/709-20260515_211219/tdd-fix-result.json`
+- 受入テスト結果: `dev-reports/bug-fix/709-20260515_211219/acceptance-result.json`
+- 作業計画コンテキスト: `dev-reports/bug-fix/709-20260515_211219/work-plan-context.json`

--- a/dev-reports/bug-fix/709-20260515_211219/tdd-fix-context.json
+++ b/dev-reports/bug-fix/709-20260515_211219/tdd-fix-context.json
@@ -1,0 +1,45 @@
+{
+  "bug_id": "709-20260515_211219",
+  "issue_number": 709,
+  "bug_description": "useWorktreesCache が Sessions ページで二重インスタンス化され /api/worktrees ポーリングが2系統並行で動く",
+  "selected_actions": [
+    {
+      "action_id": "1",
+      "title": "WorktreesCacheProvider に Context を導入し Sessions ページから消費",
+      "files_to_modify": [
+        "src/components/providers/WorktreesCacheProvider.tsx",
+        "src/app/sessions/page.tsx",
+        "tests/unit/SessionsPage.test.tsx"
+      ],
+      "implementation_steps": [
+        "Step 1 (Red): WorktreesCacheProvider に Context を期待する単体テストを書く (tests/unit/components/providers/WorktreesCacheProvider.test.tsx 新規)",
+        "Step 2 (Green): WorktreesCacheProvider に WorktreesCacheContext / useWorktreesCacheContext を実装",
+        "Step 3 (Red): Sessions ページが Context 経由で値を取得するテストへ変更 (tests/unit/SessionsPage.test.tsx を Context モックに移行)",
+        "Step 4 (Green): src/app/sessions/page.tsx の useWorktreesCache 呼び出しを useWorktreesCacheContext() に置換",
+        "Step 5 (Refactor): JSDoc 整備、未使用 import 削除"
+      ]
+    }
+  ],
+  "target_coverage": 80,
+  "test_files_to_modify_or_create": [
+    "tests/unit/components/providers/WorktreesCacheProvider.test.tsx (新規)",
+    "tests/unit/SessionsPage.test.tsx (Context モック方式に変更)"
+  ],
+  "acceptance_criteria": [
+    "Sessions ページで useWorktreesCache を直接呼ばず Context から取得する",
+    "useWorktreesCacheContext を Provider 外で呼ぶと適切なエラーが投げられる",
+    "Provider 経由で worktrees/isLoading/error/refresh が正しく配信される",
+    "既存の Sessions ページ単体テストが Context 経由で動作し全件 PASS",
+    "npm run lint, npx tsc --noEmit, npm run test:unit が全て成功"
+  ],
+  "verification_commands": [
+    "npm run lint",
+    "npx tsc --noEmit",
+    "npm run test:unit"
+  ],
+  "constraints": [
+    "useWorktreesCache フック自体の実装は変更しない (テスト/単体利用は維持)",
+    "既存の Sessions ページ振る舞いに回帰を発生させない",
+    "WorktreeSelectionProvider への externalWorktrees / externalRepositories 伝播は維持する"
+  ]
+}

--- a/dev-reports/bug-fix/709-20260515_211219/tdd-fix-result.json
+++ b/dev-reports/bug-fix/709-20260515_211219/tdd-fix-result.json
@@ -1,0 +1,143 @@
+{
+  "status": "success",
+  "bug_id": "709-20260515_211219",
+  "issue_number": 709,
+  "tdd_cycles": [
+    {
+      "step": "Red 1",
+      "description": "Created tests/unit/components/providers/WorktreesCacheProvider.test.tsx with 5 failing tests: exposes cached fields via context, propagates loading state, propagates error state, forwards refresh() to underlying hook, throws when useWorktreesCacheContext is called outside the Provider.",
+      "verification": "npx vitest run tests/unit/components/providers/WorktreesCacheProvider.test.tsx -> 5 failed (useWorktreesCacheContext is not a function)"
+    },
+    {
+      "step": "Green 1",
+      "description": "Updated src/components/providers/WorktreesCacheProvider.tsx to add createContext<UseWorktreesCacheReturn | null>(null) (WorktreesCacheContext), a useMemo-wrapped context value, and the useWorktreesCacheContext() hook with explicit Provider-out-of-scope error. Existing WorktreeSelectionProvider wrapping with externalWorktrees / externalRepositories is preserved.",
+      "verification": "npx vitest run tests/unit/components/providers/WorktreesCacheProvider.test.tsx -> 5 passed"
+    },
+    {
+      "step": "Red 2",
+      "description": "Migrated tests/unit/SessionsPage.test.tsx from vi.mock('@/hooks/useWorktreesCache', ...) to vi.mock('@/components/providers/WorktreesCacheProvider', ...) exporting useWorktreesCacheContext, added mockRepositories field, and reset it in beforeEach. All 18 existing test cases retained.",
+      "verification": "npx vitest run tests/unit/SessionsPage.test.tsx -> 15 failed | 3 passed (Sessions page still imported useWorktreesCache directly, so the new mock had no effect and tests fell back to real fetch -> stuck in loading)"
+    },
+    {
+      "step": "Green 2",
+      "description": "Updated src/app/sessions/page.tsx to replace `import { useWorktreesCache } from '@/hooks/useWorktreesCache'` with `import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider'` and the corresponding call site. Added Issue #709 explanation to the file header JSDoc.",
+      "verification": "npx vitest run tests/unit/SessionsPage.test.tsx tests/unit/components/providers/WorktreesCacheProvider.test.tsx -> 23 passed (18 Sessions + 5 Provider)"
+    },
+    {
+      "step": "Refactor",
+      "description": "Added Issue #709 rationale comments to WorktreesCacheProvider header, useWorktreesCacheContext JSDoc, and the Sessions page header. Context value wrapped in useMemo for referential stability. No behaviour changes; src/hooks/useWorktreesCache.ts itself is unchanged per constraint.",
+      "verification": "npm run lint -> 0 errors; npx tsc --noEmit -> 0 errors; npm run test:unit -> 344 files / 6496 passed / 7 skipped"
+    }
+  ],
+  "files_changed": [
+    "src/components/providers/WorktreesCacheProvider.tsx",
+    "src/app/sessions/page.tsx",
+    "tests/unit/SessionsPage.test.tsx",
+    "tests/unit/components/providers/WorktreesCacheProvider.test.tsx"
+  ],
+  "diff_summary": {
+    "src/components/providers/WorktreesCacheProvider.tsx": "Added createContext + useContext + useMemo. Added WorktreesCacheContext (null-initialised) and useWorktreesCacheContext() with explicit Provider-out-of-scope error. WorktreeSelectionProvider externalWorktrees / externalRepositories propagation preserved. Header JSDoc updated with Issue #709 rationale.",
+    "src/app/sessions/page.tsx": "Replaced direct useWorktreesCache() call with useWorktreesCacheContext(). Updated header JSDoc with Issue #709 explanation. No render-tree / filter / sort / sanitize changes.",
+    "tests/unit/SessionsPage.test.tsx": "Switched mock target from @/hooks/useWorktreesCache to @/components/providers/WorktreesCacheProvider (useWorktreesCacheContext). Added mockRepositories field reset in beforeEach. All 18 existing assertions intact.",
+    "tests/unit/components/providers/WorktreesCacheProvider.test.tsx": "NEW. 5 tests covering: cache fields are surfaced via context, loading propagation, error propagation, refresh forwarding, and the throws-outside-Provider invariant. WorktreeSelectionProvider is mocked to keep the suite focused on the Context contract."
+  },
+  "verification_results": {
+    "lint": {
+      "command": "npm run lint",
+      "exit_code": 0,
+      "result": "No ESLint warnings or errors"
+    },
+    "typecheck": {
+      "command": "npx tsc --noEmit",
+      "exit_code": 0,
+      "result": "0 TypeScript errors"
+    },
+    "unit_tests": {
+      "command": "npm run test:unit",
+      "exit_code": 0,
+      "test_files_total": 344,
+      "test_files_passed": 344,
+      "test_files_failed": 0,
+      "tests_total": 6503,
+      "tests_passed": 6496,
+      "tests_failed": 0,
+      "tests_skipped": 7,
+      "notes": "Stack traces visible in the test output are the expected throw from the 'outside Provider' test case (asserted via toThrowError)."
+    }
+  },
+  "unit_tests": {
+    "total": 6503,
+    "passed": 6496,
+    "failed": 0,
+    "skipped": 7
+  },
+  "static_analysis": {
+    "eslint_errors": 0,
+    "typescript_errors": 0
+  },
+  "coverage": {
+    "scope": "Coverage measured for the changed targets (provider + sessions page) via the focused suite tests/unit/components/providers/WorktreesCacheProvider.test.tsx + tests/unit/SessionsPage.test.tsx",
+    "WorktreesCacheProvider.tsx": {
+      "statements": 100,
+      "branches": 100,
+      "functions": 100,
+      "lines": 100
+    },
+    "sessions/page.tsx": {
+      "statements": 69.56,
+      "branches": 53.01,
+      "functions": 88.88,
+      "lines": 70.76,
+      "uncovered_lines": "76,96-97,149-170 (pre-existing rendering branches, unchanged by this fix)"
+    },
+    "target_coverage": 80,
+    "target_coverage_met_for_new_code": true,
+    "target_coverage_notes": "All net-new code (WorktreesCacheProvider Context API) is at 100% coverage. The Sessions page percentage reflects pre-existing rendering branches not exercised by the existing suite; this fix neither adds nor removes those branches."
+  },
+  "acceptance_criteria_status": [
+    {
+      "criterion": "Sessions ページで useWorktreesCache を直接呼ばず Context から取得する",
+      "met": true,
+      "evidence": "src/app/sessions/page.tsx now imports useWorktreesCacheContext from @/components/providers/WorktreesCacheProvider; useWorktreesCache is no longer imported."
+    },
+    {
+      "criterion": "useWorktreesCacheContext を Provider 外で呼ぶと適切なエラーが投げられる",
+      "met": true,
+      "evidence": "Test 'throws a descriptive error when useWorktreesCacheContext is called outside the Provider' passes; the hook throws Error('useWorktreesCacheContext must be used within a WorktreesCacheProvider')."
+    },
+    {
+      "criterion": "Provider 経由で worktrees/isLoading/error/refresh が正しく配信される",
+      "met": true,
+      "evidence": "Tests 'exposes the cached worktrees / repositories / isLoading / error / refresh via context', 'propagates loading state', 'propagates error state', and 'forwards refresh() invocations' all pass."
+    },
+    {
+      "criterion": "既存の Sessions ページ単体テストが Context 経由で動作し全件 PASS",
+      "met": true,
+      "evidence": "tests/unit/SessionsPage.test.tsx: 18/18 PASS after migrating mock from useWorktreesCache to useWorktreesCacheContext."
+    },
+    {
+      "criterion": "npm run lint, npx tsc --noEmit, npm run test:unit が全て成功",
+      "met": true,
+      "evidence": "All three commands exit 0 with zero errors."
+    }
+  ],
+  "constraints_respected": [
+    {
+      "constraint": "useWorktreesCache フック自体の実装は変更しない",
+      "respected": true,
+      "evidence": "src/hooks/useWorktreesCache.ts not touched (verified via git diff scope)."
+    },
+    {
+      "constraint": "既存の Sessions ページ振る舞いに回帰を発生させない",
+      "respected": true,
+      "evidence": "All 18 pre-existing Sessions page tests (filter, sort, sanitize/XSS, loading/error/empty, message preview) pass unchanged."
+    },
+    {
+      "constraint": "WorktreeSelectionProvider への externalWorktrees / externalRepositories 伝播は維持する",
+      "respected": true,
+      "evidence": "WorktreesCacheProvider still wraps children with WorktreeSelectionProvider passing externalWorktrees={worktrees} externalRepositories={repositories}."
+    }
+  ],
+  "commits": [],
+  "message": "Issue #709 fix complete. WorktreesCacheProvider now publishes its cache via React Context (useWorktreesCacheContext). Sessions page consumes the Context instead of instantiating a second useWorktreesCache hook, eliminating the duplicate /api/worktrees polling loop. lint / tsc / test:unit all green (344 test files / 6496 tests passed). No commits created (per orchestration policy: the parent agent handles commit/PR)."
+}

--- a/dev-reports/bug-fix/709-20260515_211219/work-plan-context.json
+++ b/dev-reports/bug-fix/709-20260515_211219/work-plan-context.json
@@ -1,0 +1,52 @@
+{
+  "bug_id": "709-20260515_211219",
+  "issue_number": 709,
+  "bug_description": "useWorktreesCache が Sessions ページで二重インスタンス化され /api/worktrees ポーリングが2系統並行で動く",
+  "selected_actions": [
+    {
+      "action_id": "1",
+      "title": "WorktreesCacheProvider に Context を導入し Sessions ページから消費",
+      "description": "useWorktreesCache の戻り値を React Context (WorktreesCacheContext) で公開し、Sessions ページは useContext から取得する",
+      "files_to_modify": [
+        "src/components/providers/WorktreesCacheProvider.tsx",
+        "src/app/sessions/page.tsx",
+        "tests/unit/SessionsPage.test.tsx"
+      ],
+      "implementation_details": {
+        "step_1": "WorktreesCacheProvider.tsx に WorktreesCacheContext を作成し、useWorktreesCache の戻り値 (worktrees, repositories, isLoading, error, refresh) を Context.Provider 経由で配信",
+        "step_2": "useWorktreesCacheContext() フックを export して、Provider 外で使うと例外を投げる安全装置を組み込む",
+        "step_3": "Sessions ページの useWorktreesCache 直接呼び出しを useWorktreesCacheContext() に置き換え",
+        "step_4": "tests/unit/SessionsPage.test.tsx の vi.mock 対象を @/hooks/useWorktreesCache から @/components/providers/WorktreesCacheProvider に変更",
+        "step_5": "Provider 経由の単一インスタンスを検証する単体テストを追加"
+      }
+    }
+  ],
+  "deliverables": [
+    "WorktreesCacheProvider に WorktreesCacheContext を実装",
+    "useWorktreesCacheContext フックを export",
+    "Sessions ページが Context から worktrees / isLoading / error を取得",
+    "Sessions ページの単体テストが Context モック方式に更新され全件 PASS",
+    "WorktreesCacheProvider の単体テストで Context 経由の値配信を検証"
+  ],
+  "definition_of_done": [
+    "Sessions ページで useWorktreesCache の直接呼び出しが消えている",
+    "grep で他に直接呼び出しが無いことを確認",
+    "WorktreesCacheProvider 配下では /api/worktrees ポーリングが1系統のみ",
+    "Sessions 画面の表示・フィルタ・ソート機能に回帰なし (既存テスト PASS)",
+    "新規追加した Context 配信テストが PASS",
+    "npm run test:unit が全件 PASS",
+    "npm run lint クリーン",
+    "npx tsc --noEmit クリーン"
+  ],
+  "test_strategy": {
+    "tdd_cycle": "Red → Green → Refactor",
+    "red_tests": [
+      "WorktreesCacheProvider が Context 経由で worktrees/isLoading/error を配信することを検証",
+      "useWorktreesCacheContext が Provider 外で例外を投げることを検証",
+      "Sessions ページが Context モック経由で worktrees を取得することを検証 (既存テストを Context モックに移行)"
+    ],
+    "green_implementation": "Context 作成 → Provider に value 注入 → Sessions ページを useContext 化",
+    "refactor": "型定義整理・JSDoc 整備"
+  },
+  "rollback_plan": "Sessions ページを useWorktreesCache 直呼びに戻し、Provider の Context export を削除"
+}

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -3,7 +3,11 @@
  *
  * Issue #600: UX refresh - Worktree exploration, search, and filtering.
  * Issue #606: Sessions enhancement - sort options and last sent message display.
- * Uses useWorktreesCache() for shared logic [DR1-005].
+ * Issue #709: Reads cached worktrees through `useWorktreesCacheContext()`
+ * instead of `useWorktreesCache()` directly so the page shares a single
+ * polling loop with `WorktreesCacheProvider` (otherwise `/api/worktrees`
+ * is polled twice while this page is mounted).
+ *
  * Sidebar auto-collapses on this page (via useLayoutConfig).
  */
 
@@ -12,7 +16,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import Link from 'next/link';
 import { AppShell } from '@/components/layout';
-import { useWorktreesCache } from '@/hooks/useWorktreesCache';
+import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { deriveCliStatus } from '@/types/sidebar';
 import { getCliToolDisplayName } from '@/lib/cli-tools/types';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
@@ -107,7 +111,7 @@ const DEFAULT_BADGE_CLASS = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:tex
 // ============================================================================
 
 export default function SessionsPage() {
-  const { worktrees, isLoading, error } = useWorktreesCache();
+  const { worktrees, isLoading, error } = useWorktreesCacheContext();
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('lastSent');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');

--- a/src/components/providers/WorktreesCacheProvider.tsx
+++ b/src/components/providers/WorktreesCacheProvider.tsx
@@ -1,19 +1,26 @@
 /**
- * WorktreesCacheProvider - Bridges useWorktreesCache with WorktreeSelectionProvider.
+ * WorktreesCacheProvider - Bridges useWorktreesCache with React Context.
  *
- * Issue #600: UX refresh - Task 3.7
- * Provides a single source of truth for worktree list data by feeding
- * useWorktreesCache() results into WorktreeSelectionProvider via
- * the externalWorktrees prop.
+ * Issue #600: UX refresh - Task 3.7. Provides a single source of truth for
+ * worktree list data by feeding useWorktreesCache() results into
+ * WorktreeSelectionProvider via the externalWorktrees prop.
  *
- * This replaces the duplicate polling that previously existed in
- * WorktreeSelectionContext.
+ * Issue #709: The cached values (worktrees / repositories / isLoading /
+ * error / refresh) are also published through `WorktreesCacheContext` so
+ * that pages such as `/sessions` can consume the same cache instead of
+ * calling `useWorktreesCache()` again. Calling `useWorktreesCache()` twice
+ * spawns two independent `setInterval` pollers and doubles the load on
+ * `/api/worktrees`, which is the root cause behind the sidebar latency
+ * tracked in Issue #709.
  */
 
 'use client';
 
-import { type ReactNode } from 'react';
-import { useWorktreesCache } from '@/hooks/useWorktreesCache';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import {
+  useWorktreesCache,
+  type UseWorktreesCacheReturn,
+} from '@/hooks/useWorktreesCache';
 import { WorktreeSelectionProvider } from '@/contexts/WorktreeSelectionContext';
 
 interface WorktreesCacheProviderProps {
@@ -21,22 +28,73 @@ interface WorktreesCacheProviderProps {
 }
 
 /**
- * Provider that wires useWorktreesCache into WorktreeSelectionProvider.
+ * React Context that mirrors the return value of `useWorktreesCache`.
  *
- * Usage: Place inside SidebarProvider, wraps children with WorktreeSelectionProvider.
+ * Initial value is `null` so that calling `useWorktreesCacheContext()`
+ * outside the Provider can be detected and reported as an explicit error.
+ */
+const WorktreesCacheContext = createContext<UseWorktreesCacheReturn | null>(null);
+
+/**
+ * Provider that wires `useWorktreesCache` into both `WorktreeSelectionProvider`
+ * and the new `WorktreesCacheContext`.
  *
- * Issue #690: Also propagates the cached `repositories` payload (with
- * `visible` / `enabled`) so the Sidebar can filter hidden repositories.
+ * Usage: Place inside `SidebarProvider`; wraps children with
+ * `WorktreeSelectionProvider` so that the existing
+ * `externalWorktrees` / `externalRepositories` propagation keeps working
+ * (Issue #600, Issue #690).
+ *
+ * Consumers that need the raw cache values (worktrees, repositories,
+ * isLoading, error, refresh) should call `useWorktreesCacheContext()` —
+ * see Issue #709 for the rationale.
  */
 export function WorktreesCacheProvider({ children }: WorktreesCacheProviderProps) {
-  const { worktrees, repositories } = useWorktreesCache();
+  const cache = useWorktreesCache();
+  const { worktrees, repositories, isLoading, error, refresh } = cache;
+
+  // Stable context value — only changes when one of the cache fields changes.
+  // This prevents unnecessary re-renders of context consumers when the
+  // hook itself recreates its return object but the underlying data is
+  // the same reference.
+  const contextValue = useMemo<UseWorktreesCacheReturn>(
+    () => ({ worktrees, repositories, isLoading, error, refresh }),
+    [worktrees, repositories, isLoading, error, refresh]
+  );
 
   return (
-    <WorktreeSelectionProvider
-      externalWorktrees={worktrees}
-      externalRepositories={repositories}
-    >
-      {children}
-    </WorktreeSelectionProvider>
+    <WorktreesCacheContext.Provider value={contextValue}>
+      <WorktreeSelectionProvider
+        externalWorktrees={worktrees}
+        externalRepositories={repositories}
+      >
+        {children}
+      </WorktreeSelectionProvider>
+    </WorktreesCacheContext.Provider>
   );
+}
+
+/**
+ * Access the cached worktrees data published by `WorktreesCacheProvider`.
+ *
+ * @throws Error when called outside a `WorktreesCacheProvider`.
+ *
+ * Issue #709: prefer this hook over calling `useWorktreesCache` directly
+ * to avoid creating a second polling loop against `/api/worktrees`.
+ *
+ * @example
+ * ```tsx
+ * function MyPage() {
+ *   const { worktrees, isLoading, error, refresh } = useWorktreesCacheContext();
+ *   // ...
+ * }
+ * ```
+ */
+export function useWorktreesCacheContext(): UseWorktreesCacheReturn {
+  const ctx = useContext(WorktreesCacheContext);
+  if (ctx === null) {
+    throw new Error(
+      'useWorktreesCacheContext must be used within a WorktreesCacheProvider'
+    );
+  }
+  return ctx;
 }

--- a/tests/unit/SessionsPage.test.tsx
+++ b/tests/unit/SessionsPage.test.tsx
@@ -48,15 +48,21 @@ vi.mock('@/lib/date-utils', () => ({
   },
 }));
 
-// --- useWorktreesCache mock ---
+// --- WorktreesCacheProvider context mock (Issue #709) ---
+// Sessions page now reads cached worktrees via useWorktreesCacheContext()
+// instead of calling useWorktreesCache() directly, so we mock the Context
+// hook here. The underlying useWorktreesCache hook is exercised by its
+// own unit tests.
 const mockRefresh = vi.fn();
 let mockWorktrees: Array<Record<string, unknown>> = [];
+let mockRepositories: Array<Record<string, unknown>> = [];
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-vi.mock('@/hooks/useWorktreesCache', () => ({
-  useWorktreesCache: () => ({
+vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
+  useWorktreesCacheContext: () => ({
     worktrees: mockWorktrees,
+    repositories: mockRepositories,
     isLoading: mockIsLoading,
     error: mockError,
     refresh: mockRefresh,
@@ -85,6 +91,7 @@ function createWorktree(overrides: Record<string, unknown> = {}) {
 describe('SessionsPage', () => {
   beforeEach(() => {
     mockWorktrees = [];
+    mockRepositories = [];
     mockIsLoading = false;
     mockError = null;
     vi.clearAllMocks();

--- a/tests/unit/components/providers/WorktreesCacheProvider.test.tsx
+++ b/tests/unit/components/providers/WorktreesCacheProvider.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for WorktreesCacheProvider Context API.
+ *
+ * Issue #709: Eliminate duplicate `useWorktreesCache` instances by exposing
+ * the cache via React Context. The Sessions page (and any future consumer)
+ * must consume the cache through `useWorktreesCacheContext()` instead of
+ * calling `useWorktreesCache()` directly, ensuring a single polling source.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import type { Worktree } from '@/types/models';
+import type { RepositorySummary } from '@/lib/api-client';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable mock object returned by useWorktreesCache. Tests mutate the fields
+ * on this object so the Provider receives the latest values on each render.
+ */
+const mockRefresh = vi.fn().mockResolvedValue(undefined);
+const mockCacheState: {
+  worktrees: Worktree[];
+  repositories: RepositorySummary[];
+  isLoading: boolean;
+  error: Error | null;
+  refresh: typeof mockRefresh;
+} = {
+  worktrees: [],
+  repositories: [],
+  isLoading: false,
+  error: null,
+  refresh: mockRefresh,
+};
+
+vi.mock('@/hooks/useWorktreesCache', () => ({
+  useWorktreesCache: () => mockCacheState,
+}));
+
+// Avoid pulling the full WorktreeSelectionProvider chain into the test —
+// it is exercised by its own suite. The provider just needs to render
+// children.
+vi.mock('@/contexts/WorktreeSelectionContext', () => ({
+  WorktreeSelectionProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'worktree-selection-provider' },
+      children
+    ),
+}));
+
+// Import after mocks are registered.
+import {
+  WorktreesCacheProvider,
+  useWorktreesCacheContext,
+} from '@/components/providers/WorktreesCacheProvider';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    name: 'feature/test',
+    path: '/path/to/wt',
+    repositoryPath: '/path/to/repo',
+    repositoryName: 'MyRepo',
+    ...overrides,
+  } as Worktree;
+}
+
+function makeRepository(overrides: Partial<RepositorySummary> = {}): RepositorySummary {
+  return {
+    id: 'repo-1',
+    path: '/path/to/repo',
+    name: 'MyRepo',
+    worktreeCount: 1,
+    visible: true,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+/** Consumer that surfaces the context values via data-testids. */
+function ContextConsumer() {
+  const ctx = useWorktreesCacheContext();
+  return (
+    <div>
+      <span data-testid="cache-worktree-count">{ctx.worktrees.length}</span>
+      <span data-testid="cache-repository-count">{ctx.repositories.length}</span>
+      <span data-testid="cache-is-loading">{String(ctx.isLoading)}</span>
+      <span data-testid="cache-error">{ctx.error ? ctx.error.message : 'null'}</span>
+      <button
+        type="button"
+        data-testid="cache-refresh"
+        onClick={() => {
+          void ctx.refresh();
+        }}
+      >
+        refresh
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorktreesCacheProvider', () => {
+  beforeEach(() => {
+    mockCacheState.worktrees = [];
+    mockCacheState.repositories = [];
+    mockCacheState.isLoading = false;
+    mockCacheState.error = null;
+    mockCacheState.refresh = mockRefresh;
+    mockRefresh.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes the cached worktrees / repositories / isLoading / error / refresh via context', () => {
+    mockCacheState.worktrees = [
+      makeWorktree({ id: 'wt-a' }),
+      makeWorktree({ id: 'wt-b', name: 'feature/b' }),
+    ];
+    mockCacheState.repositories = [makeRepository({ id: 'repo-a' })];
+    mockCacheState.isLoading = false;
+    mockCacheState.error = null;
+
+    render(
+      <WorktreesCacheProvider>
+        <ContextConsumer />
+      </WorktreesCacheProvider>
+    );
+
+    expect(screen.getByTestId('cache-worktree-count').textContent).toBe('2');
+    expect(screen.getByTestId('cache-repository-count').textContent).toBe('1');
+    expect(screen.getByTestId('cache-is-loading').textContent).toBe('false');
+    expect(screen.getByTestId('cache-error').textContent).toBe('null');
+  });
+
+  it('propagates loading state from useWorktreesCache', () => {
+    mockCacheState.isLoading = true;
+
+    render(
+      <WorktreesCacheProvider>
+        <ContextConsumer />
+      </WorktreesCacheProvider>
+    );
+
+    expect(screen.getByTestId('cache-is-loading').textContent).toBe('true');
+  });
+
+  it('propagates error state from useWorktreesCache', () => {
+    mockCacheState.error = new Error('boom');
+
+    render(
+      <WorktreesCacheProvider>
+        <ContextConsumer />
+      </WorktreesCacheProvider>
+    );
+
+    expect(screen.getByTestId('cache-error').textContent).toBe('boom');
+  });
+
+  it('forwards refresh() invocations from consumers to the underlying hook', () => {
+    render(
+      <WorktreesCacheProvider>
+        <ContextConsumer />
+      </WorktreesCacheProvider>
+    );
+
+    screen.getByTestId('cache-refresh').click();
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a descriptive error when useWorktreesCacheContext is called outside the Provider', () => {
+    // Silence the expected React error boundary console output for this case.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() => render(<ContextConsumer />)).toThrowError(
+      /useWorktreesCacheContext must be used within a WorktreesCacheProvider/
+    );
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

`useWorktreesCache` フックが Sessions 画面表示中に2回インスタンス化され、同じ `/api/worktrees` ポーリングが並行で2系統動いていた問題を解消。`WorktreesCacheProvider` に React Context を新設し、Sessions ページが Provider 経由で同一インスタンスを参照するようにすることで、アプリ全体で **1系統のポーリング** に統一しました。

Closes #709

## Changes

### Added
- `src/components/providers/WorktreesCacheProvider.tsx` に `WorktreesCacheContext` および `useWorktreesCacheContext()` フックを追加
  - Context 初期値は `null`、Provider 外で呼ぶと明示的にエラーを投げる
  - `useMemo` で context value を安定化させ不要な再レンダリングを抑止
- `tests/unit/components/providers/WorktreesCacheProvider.test.tsx` を新規作成（5 テスト）

### Changed
- `src/app/sessions/page.tsx`: `useWorktreesCache()` 直接呼び出しを `useWorktreesCacheContext()` に置換
- `tests/unit/SessionsPage.test.tsx`: モック対象を `@/hooks/useWorktreesCache` から `@/components/providers/WorktreesCacheProvider` に変更

### Constraint
- `src/hooks/useWorktreesCache.ts` 自体は変更せず、テスト・将来の単体利用を維持
- `WorktreeSelectionProvider` への `externalWorktrees` / `externalRepositories` 伝播（Issue #600 / #690）は維持

## Acceptance Criteria

- [x] Sessions ページで `useWorktreesCache()` の直接呼び出しを廃止し、Provider 経由 Context から取得する
- [x] 同様の二重呼び出し箇所が他に無いか grep で確認・統一する（`useWorktreesCache()` の実呼び出しは Provider 1 箇所のみ）
- [x] Sessions 画面の表示内容に回帰がない
- [x] `npm run test:unit` 回帰 0 件

## Test Results

### Unit Tests

```
npm run test:unit
Test Files  344 passed
Tests       6496 passed | 7 skipped
```

### Lint & Type Check

- ESLint: 0 errors
- TypeScript (`tsc --noEmit`): 0 errors

### Coverage

- `WorktreesCacheProvider.tsx`: 100% statements / 100% branches / 100% functions / 100% lines

## Test Plan

- [ ] PR画面でCIが全て通ることを確認
- [ ] develop マージ後にブラウザ DevTools Network で `/api/worktrees` のポーリングが Sessions 画面表示中も1系統のみであることを実機検証
- [ ] サイドバー・Sessions ページの表示に回帰がないことを確認

## Checklist

- [x] Unit tests pass
- [x] Lint check passes
- [x] Type check passes
- [x] No console.log in production code
- [x] `src/hooks/useWorktreesCache.ts` は変更せず制約遵守

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)