### PR TITLE
perf: chat_messages の role 列を含む複合インデックスを追加 (#708)

### DIFF
--- a/src/lib/db/init-db.ts
+++ b/src/lib/db/init-db.ts
@@ -70,8 +70,8 @@ export function initDatabase(db: Database.Database): void {
   `);
 
   db.exec(`
-    CREATE INDEX IF NOT EXISTS idx_messages_archived
-    ON chat_messages(worktree_id, archived, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS idx_messages_worktree_role_archived_time
+    ON chat_messages(worktree_id, role, archived, timestamp DESC);
   `);
 
   // Create session_states table

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -14,6 +14,7 @@ import { v28_migrations } from './v28-assistant-conversations';
 import { v29_migrations } from './v29-assistant-non-interactive';
 import { v30_migrations } from './v30-assistant-context-snapshot';
 import { v31_migrations } from './v31-repository-visible';
+import { v32_migrations } from './v32-add-messages-role-composite-index';
 
 /**
  * Complete ordered list of all migrations.
@@ -33,4 +34,5 @@ export const migrations: Migration[] = [
   ...v29_migrations,
   ...v30_migrations,
   ...v31_migrations,
+  ...v32_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 31;
+export const CURRENT_SCHEMA_VERSION = 32;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v32-add-messages-role-composite-index.ts
+++ b/src/lib/db/migrations/v32-add-messages-role-composite-index.ts
@@ -1,0 +1,43 @@
+/** Migration v32: Add composite index on chat_messages including role column (Issue #708).
+ *
+ * Existing idx_messages_archived (worktree_id, archived, timestamp DESC) does NOT
+ * include the `role` column, causing SQLite to row-scan role='assistant'/'user'
+ * filters in correlated subqueries (getWorktrees, getLastAssistantMessageAt, etc.).
+ * This results in O(N * M) cost as chat_messages grows.
+ *
+ * Replaces idx_messages_archived with a composite index that includes role:
+ *   (worktree_id, role, archived, timestamp DESC)
+ *
+ * Column order rationale:
+ *   - worktree_id: highest selectivity, always equality-filtered
+ *   - role: 2-value CHECK constraint, always equality-fixed in target queries
+ *   - archived: equality-filtered (default 0)
+ *   - timestamp DESC: suffix scan satisfies MAX(timestamp) and ORDER BY DESC LIMIT 1
+ *
+ * The old idx_messages_archived is dropped to avoid redundant write costs;
+ * existing role-free queries (getMessages, getLastMessage, deleteAllMessages)
+ * are covered by idx_messages_worktree_time(worktree_id, timestamp DESC).
+ */
+
+import type { Migration } from './runner';
+
+export const v32_migrations: Migration[] = [
+  {
+    version: 32,
+    name: 'add-messages-role-composite-index',
+    up: (db) => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_messages_worktree_role_archived_time
+          ON chat_messages(worktree_id, role, archived, timestamp DESC);
+      `);
+      db.exec('DROP INDEX IF EXISTS idx_messages_archived;');
+    },
+    down: (db) => {
+      db.exec('DROP INDEX IF EXISTS idx_messages_worktree_role_archived_time;');
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_messages_archived
+          ON chat_messages(worktree_id, archived, timestamp DESC);
+      `);
+    },
+  },
+];

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,55 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 31 after Migration #31', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(31);
+    it('should be 32 after Migration #32', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(32);
+    });
+  });
+
+  describe('Migration #32: add-messages-role-composite-index (Issue #708)', () => {
+    beforeEach(() => {
+      runMigrations(db);
+    });
+
+    it('should create idx_messages_worktree_role_archived_time index', () => {
+      const indexes = db.prepare(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND name='idx_messages_worktree_role_archived_time'"
+      ).all() as Array<{ name: string; sql: string }>;
+
+      expect(indexes).toHaveLength(1);
+      expect(indexes[0].sql).toContain('chat_messages');
+      expect(indexes[0].sql).toContain('worktree_id');
+      expect(indexes[0].sql).toContain('role');
+      expect(indexes[0].sql).toContain('archived');
+      expect(indexes[0].sql).toContain('timestamp DESC');
+    });
+
+    it('should drop the old idx_messages_archived index', () => {
+      const indexes = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_archived'"
+      ).all() as Array<{ name: string }>;
+
+      expect(indexes).toHaveLength(0);
+    });
+
+    it('should record migration in schema_version table', () => {
+      const history = getMigrationHistory(db);
+      expect(history.find(m => m.version === 32)?.name).toBe('add-messages-role-composite-index');
+    });
+
+    it('should rollback by dropping the new index and restoring idx_messages_archived', () => {
+      rollbackMigrations(db, 31);
+      expect(getCurrentVersion(db)).toBe(31);
+
+      const newIndex = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_worktree_role_archived_time'"
+      ).all() as Array<{ name: string }>;
+      expect(newIndex).toHaveLength(0);
+
+      const oldIndex = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_archived'"
+      ).all() as Array<{ name: string }>;
+      expect(oldIndex).toHaveLength(1);
     });
   });
 
@@ -442,7 +489,12 @@ describe('db-migrations', () => {
       expect(archivedColumn?.dflt_value).toBe('0');
     });
 
-    it('should create composite index idx_messages_archived', () => {
+    it('should create composite index idx_messages_archived (at v22; superseded by Migration #32)', () => {
+      // Migration #22 created idx_messages_archived. Migration #32 (Issue #708) drops it
+      // and replaces it with idx_messages_worktree_role_archived_time. Rolling back to v31
+      // restores the v22-era idx_messages_archived index so we can assert its presence here.
+      rollbackMigrations(db, 31);
+
       const indexes = db.prepare(
         "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='chat_messages'"
       ).all() as Array<{ name: string }>;

--- a/tests/unit/lib/db/chat-db-explain-plan.test.ts
+++ b/tests/unit/lib/db/chat-db-explain-plan.test.ts
@@ -1,0 +1,94 @@
+/**
+ * EXPLAIN QUERY PLAN tests for chat-db queries (Issue #708)
+ *
+ * Verifies that role/archived/timestamp queries use the new composite index
+ * idx_messages_worktree_role_archived_time after Migration #32.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../../../src/lib/db/db-migrations';
+
+interface ExplainRow {
+  id: number;
+  parent: number;
+  notused: number;
+  detail: string;
+}
+
+const TARGET_INDEX = 'idx_messages_worktree_role_archived_time';
+
+function explainContainsIndex(rows: ExplainRow[], indexName: string): boolean {
+  return rows.map((r) => r.detail).join('\n').includes(indexName);
+}
+
+describe('chat-db EXPLAIN QUERY PLAN (Issue #708)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    if (db) {
+      db.close();
+    }
+  });
+
+  it('getWorktrees correlated subquery uses idx_messages_worktree_role_archived_time', () => {
+    const sql = `
+      SELECT MAX(timestamp)
+      FROM chat_messages
+      WHERE worktree_id = ? AND role = 'assistant' AND archived = 0
+    `;
+    const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all('test-id') as ExplainRow[];
+    expect(explainContainsIndex(rows, TARGET_INDEX)).toBe(true);
+  });
+
+  it('getLastAssistantMessageAt uses idx_messages_worktree_role_archived_time', () => {
+    const sql = `
+      SELECT MAX(timestamp) as last_assistant_message_at
+      FROM chat_messages
+      WHERE worktree_id = ? AND role = 'assistant' AND archived = 0
+    `;
+    const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all('test-id') as ExplainRow[];
+    expect(explainContainsIndex(rows, TARGET_INDEX)).toBe(true);
+  });
+
+  it('getLastUserMessage uses idx_messages_worktree_role_archived_time', () => {
+    const sql = `
+      SELECT id, worktree_id, role, content, summary, timestamp, log_file_name, request_id, message_type, prompt_data, cli_tool_id, archived
+      FROM chat_messages
+      WHERE worktree_id = ? AND role = 'user' AND archived = 0
+      ORDER BY timestamp DESC
+      LIMIT 1
+    `;
+    const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all('test-id') as ExplainRow[];
+    expect(explainContainsIndex(rows, TARGET_INDEX)).toBe(true);
+  });
+
+  it('getLastMessagesByCliBatch ROW_NUMBER subquery uses idx_messages_worktree_role_archived_time', () => {
+    const sql = `
+      WITH ranked_messages AS (
+        SELECT
+          worktree_id,
+          cli_tool_id,
+          content,
+          ROW_NUMBER() OVER (
+            PARTITION BY worktree_id, cli_tool_id
+            ORDER BY timestamp DESC
+          ) as rn
+        FROM chat_messages
+        WHERE worktree_id IN (?)
+          AND role = 'user'
+          AND archived = 0
+      )
+      SELECT worktree_id, cli_tool_id, content
+      FROM ranked_messages
+      WHERE rn = 1
+    `;
+    const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all('test-id') as ExplainRow[];
+    expect(explainContainsIndex(rows, TARGET_INDEX)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- chat_messages テーブルに `role` 列を含む複合インデックス `idx_messages_worktree_role_archived_time(worktree_id, role, archived, timestamp DESC)` を追加 (Migration v32)
- 既存の `idx_messages_archived` を DROP し重複インデックスを整理
- `getWorktrees()` の相関サブクエリ等で role 列を行スキャンしていた線形劣化を解消

## Root Cause

既存インデックス `idx_messages_archived(worktree_id, archived, timestamp DESC)` は `role` 列を含まないため、SQLite は `(worktree_id, archived)` までしかインデックスサーチできず、`role='assistant'` / `role='user'` フィルタは行スキャンになっていた。`getWorktrees()` で N+1 相関サブクエリとして実行されるため、chat_messages 件数 × worktree 件数で線形劣化していた。

## Changes

### 新規
- `src/lib/db/migrations/v32-add-messages-role-composite-index.ts` — v32 マイグレーション (up: 新インデックス追加 + 旧インデックス DROP / down: 逆動作)
- `tests/unit/lib/db/chat-db-explain-plan.test.ts` — EXPLAIN QUERY PLAN 検証テスト (4 クエリ)

### 修正
- `src/lib/db/migrations/index.ts` — v32_migrations を配列に追加
- `src/lib/db/migrations/runner.ts` — `CURRENT_SCHEMA_VERSION = 32`
- `src/lib/db/init-db.ts` — `idx_messages_archived` の CREATE 文を新インデックスに置換
- `tests/unit/lib/db-migrations.test.ts` — Migration #32 describe ブロック追加、CURRENT_SCHEMA_VERSION テスト更新

## Performance Impact

| 項目 | Before | After |
|------|--------|-------|
| getWorktrees サブクエリ | role を行スキャン | `idx_messages_worktree_role_archived_time` でサフィックススキャン |
| MAX(timestamp) / LIMIT 1 | 残候補全件走査 | B-tree 右端 1 行で完結 |
| 影響クエリ | 5 箇所 | 全て新インデックス利用に切り替え |

## Verification

- ✅ Unit Test: **6499 passed / 0 failed / 7 skipped**
- ✅ ESLint: clean
- ✅ TypeScript (`tsc --noEmit`): clean
- ✅ EXPLAIN QUERY PLAN で対象 4 クエリ全てが新インデックスを選択することを実測確認

## Acceptance Criteria

- [x] `chat_messages(worktree_id, role, archived, timestamp DESC)` の複合インデックスを追加 (v32 マイグレーション)
- [x] `EXPLAIN QUERY PLAN` で role 列までインデックス利用が確認できる
- [x] `getLastMessagesByCli` 系 (role='user') も同インデックスで高速化
- [x] 既存の `idx_messages_archived` を DROP (重複・冗長を整理)
- [x] マイグレーションのロールバック手順あり (down)
- [x] `npm run test:unit` 回帰 0 件

## Test plan

- [ ] develop 環境にマージ後、長期運用 DB で `EXPLAIN QUERY PLAN` を実行し、新インデックス利用を再確認
- [ ] サイドバーポーリング (5秒間隔) のレイテンシ計測 (任意)
- [ ] ロールバック手順動作確認: `rollbackMigrations(db, 31)` で旧インデックスが復元されること

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)