### PR TITLE
fix(scheduler): diagnose execFile maxBuffer errors and bump limit to 10MB (#719)

### DIFF
--- a/src/lib/session/claude-executor.ts
+++ b/src/lib/session/claude-executor.ts
@@ -23,8 +23,15 @@ import { COPILOT_PERMISSIONS, type CopilotPermission } from '@/config/schedule-c
 // Constants
 // =============================================================================
 
-/** Maximum output buffer size for execFile (1MB) */
-export const MAX_OUTPUT_SIZE = 1 * 1024 * 1024;
+/**
+ * Maximum output buffer size for execFile (10MB).
+ *
+ * Issue #719: 暫定緩和（1MB → 10MB）。
+ * execFile はバッファリング方式であり、CLI 出力が膨らむ運用ケースで
+ * `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` を頻発させていたため一時的に拡張。
+ * 根本対策（spawn + rolling buffer 化）は別Issueで対応する。
+ */
+export const MAX_OUTPUT_SIZE = 10 * 1024 * 1024;
 
 /** Maximum output size stored in DB (100KB) */
 export const MAX_STORED_OUTPUT_SIZE = 100 * 1024;
@@ -202,13 +209,34 @@ export async function executeClaudeCommand(
       },
       (error, stdout, stderr) => {
         if (error) {
-          const isTimeout = error.killed || (error as NodeJS.ErrnoException).code === 'ETIMEDOUT';
-          const rawOutput = stripAnsi(stdout || stderr || error.message);
+          // Issue #719: 診断情報（Error / Code / Signal / Reason）を必ず出力先頭に残し、
+          // exitCode は数値の場合のみ保存（文字列コードは null とする）。
+          const errCode = (error as NodeJS.ErrnoException).code;
+          const isMaxBuffer = errCode === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+          // maxBuffer 超過は時間切れではなく「出力過多」なので timeout 扱いにしない。
+          const isTimeout = error.killed || errCode === 'ETIMEDOUT';
+
+          const errorSummary = [
+            `Error: ${error.message}`,
+            `Code: ${errCode ?? 'unknown'}`,
+            `Signal: ${error.signal ?? 'none'}`,
+            isMaxBuffer ? 'Reason: stdout exceeded execFile maxBuffer (output_limit)' : null,
+          ]
+            .filter((line): line is string => line !== null)
+            .join('\n');
+
+          const rawOutput = stripAnsi(
+            [
+              errorSummary,
+              stdout ? `\n--- stdout ---\n${stdout}` : '',
+              stderr ? `\n--- stderr ---\n${stderr}` : '',
+            ].join('\n')
+          );
           const output = truncateOutput(rawOutput);
 
           resolve({
             output,
-            exitCode: error.code ? parseInt(String(error.code), 10) || null : null,
+            exitCode: typeof errCode === 'number' ? errCode : null,
             status: isTimeout ? 'timeout' : 'failed',
             error: error.message,
           });

--- a/tests/unit/lib/claude-executor.test.ts
+++ b/tests/unit/lib/claude-executor.test.ts
@@ -1,9 +1,18 @@
 /**
  * Tests for claude-executor.ts
  * Issue #294: Claude CLI executor for scheduled executions
+ * Issue #719: Add execFile error handling tests (maxBuffer, ETIMEDOUT, signal, exit code)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ChildProcess } from 'child_process';
+
+// Mock child_process before importing the module under test
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from 'child_process';
 import {
   truncateOutput,
   buildCliArgs,
@@ -17,9 +26,50 @@ import {
 } from '../../../src/lib/session/claude-executor';
 import { SENSITIVE_ENV_KEYS } from '../../../src/lib/security/env-sanitizer';
 
+const mockedExecFile = vi.mocked(execFile);
+
+/**
+ * Create a minimal mock ChildProcess for execFile return value.
+ */
+function makeMockChild(): ChildProcess {
+  return {
+    stdin: { end: vi.fn() },
+    on: vi.fn(),
+    pid: undefined,
+  } as unknown as ChildProcess;
+}
+
+/**
+ * Configure mocked execFile to invoke its callback with the given (error, stdout, stderr).
+ * Returns the mock child for further assertion if needed.
+ */
+function setupExecFileMock(
+  error: (Error & { code?: string | number; signal?: string; killed?: boolean }) | null,
+  stdout: string,
+  stderr: string
+): ChildProcess {
+  const child = makeMockChild();
+  mockedExecFile.mockImplementationOnce(((
+    _cmd: string,
+    _args: readonly string[],
+    _options: unknown,
+    cb: (
+      err: (Error & { code?: string | number; signal?: string; killed?: boolean }) | null,
+      out: string,
+      err2: string
+    ) => void
+  ) => {
+    // Invoke callback asynchronously to match real Node behavior
+    queueMicrotask(() => cb(error, stdout, stderr));
+    return child;
+  }) as unknown as typeof execFile);
+  return child;
+}
+
 describe('claude-executor', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockedExecFile.mockReset();
     // Clear active processes
     globalThis.__scheduleActiveProcesses = undefined;
   });
@@ -29,8 +79,8 @@ describe('claude-executor', () => {
   });
 
   describe('constants', () => {
-    it('should have MAX_OUTPUT_SIZE = 1MB', () => {
-      expect(MAX_OUTPUT_SIZE).toBe(1 * 1024 * 1024);
+    it('should have MAX_OUTPUT_SIZE = 10MB (Issue #719: bumped from 1MB)', () => {
+      expect(MAX_OUTPUT_SIZE).toBe(10 * 1024 * 1024);
     });
 
     it('should have MAX_STORED_OUTPUT_SIZE = 100KB', () => {
@@ -197,6 +247,122 @@ describe('claude-executor', () => {
       expect(SENSITIVE_ENV_KEYS).toContain('CLAUDECODE');
       expect(SENSITIVE_ENV_KEYS).toContain('CM_AUTH_TOKEN_HASH');
       expect(SENSITIVE_ENV_KEYS).toContain('CM_DB_PATH');
+    });
+  });
+
+  // ===========================================================================
+  // Issue #719: execFile error handling
+  // ===========================================================================
+  describe('executeClaudeCommand - execFile error handling (Issue #719)', () => {
+    it('should handle ERR_CHILD_PROCESS_STDIO_MAXBUFFER as failed with diagnostic output', async () => {
+      const hugeStdout = 'x'.repeat(2 * 1024 * 1024); // 2MB to simulate overflow
+      const err = Object.assign(new Error('stdout maxBuffer length exceeded'), {
+        code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
+      });
+      setupExecFileMock(err, hugeStdout, '');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('failed');
+      expect(result.exitCode).toBeNull();
+      expect(result.output).toContain('Code: ERR_CHILD_PROCESS_STDIO_MAXBUFFER');
+      expect(result.output).toContain('Reason: stdout exceeded execFile maxBuffer (output_limit)');
+      expect(result.output).toContain('Error: stdout maxBuffer length exceeded');
+      expect(result.error).toBe('stdout maxBuffer length exceeded');
+    });
+
+    it('should handle ETIMEDOUT as timeout status', async () => {
+      const err = Object.assign(new Error('command timed out'), {
+        code: 'ETIMEDOUT',
+      });
+      setupExecFileMock(err, '', '');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('timeout');
+      expect(result.exitCode).toBeNull();
+      expect(result.output).toContain('Code: ETIMEDOUT');
+    });
+
+    it('should handle killed=true as timeout status', async () => {
+      const err = Object.assign(new Error('killed'), {
+        killed: true,
+      });
+      setupExecFileMock(err, '', '');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('timeout');
+    });
+
+    it('should handle numeric exit code 1 as failed with exitCode=1', async () => {
+      const err = Object.assign(new Error('command failed'), {
+        code: 1,
+      });
+      setupExecFileMock(err, '', 'something went wrong');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('failed');
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Error: command failed');
+      expect(result.output).toContain('Code: 1');
+      expect(result.output).toContain('--- stderr ---');
+      expect(result.output).toContain('something went wrong');
+    });
+
+    it('should handle SIGTERM signal as failed with exitCode=null', async () => {
+      const err = Object.assign(new Error('killed by signal'), {
+        signal: 'SIGTERM',
+      });
+      setupExecFileMock(err, '', '');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('failed');
+      expect(result.exitCode).toBeNull();
+      expect(result.output).toContain('Signal: SIGTERM');
+    });
+
+    it('should not include errorSummary in output on success path', async () => {
+      setupExecFileMock(null, 'hello', '');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('completed');
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toBe('hello');
+      expect(result.output).not.toContain('Error:');
+      expect(result.output).not.toContain('Code:');
+      expect(result.output).not.toContain('Signal:');
+    });
+
+    it('should include both stdout and stderr sections when both present on error', async () => {
+      const err = Object.assign(new Error('exit 2'), {
+        code: 2,
+      });
+      setupExecFileMock(err, 'partial output', 'error detail');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('failed');
+      expect(result.exitCode).toBe(2);
+      expect(result.output).toContain('--- stdout ---');
+      expect(result.output).toContain('partial output');
+      expect(result.output).toContain('--- stderr ---');
+      expect(result.output).toContain('error detail');
+    });
+
+    it('should report Signal: none and Code: unknown when neither is set on a generic error', async () => {
+      const err = new Error('mystery failure');
+      setupExecFileMock(err, '', '');
+
+      const result = await executeClaudeCommand('hello', '/tmp', 'claude');
+
+      expect(result.status).toBe('failed');
+      expect(result.exitCode).toBeNull();
+      expect(result.output).toContain('Code: unknown');
+      expect(result.output).toContain('Signal: none');
     });
   });
 });


### PR DESCRIPTION
## Summary
- `src/lib/session/claude-executor.ts` の `execFile` エラーハンドリングを改修し、`ERR_CHILD_PROCESS_STDIO_MAXBUFFER` を含む全エラーで `Error` / `Code` / `Signal` / `Reason` を必ず `result` 先頭に残すよう変更
- `exitCode` を `typeof errCode === 'number'` で型ガードし、文字列コードは `null` を保存（従来は `parseInt` で NaN → `null`、原因不明化）
- maxBuffer 超過は時間切れではなく「出力過多」なので `timeout` 扱いにせず `failed` のままにする（Codex 助言反映）
- `MAX_OUTPUT_SIZE` を 1MB → 10MB に暫定緩和（根本対策の `spawn` + rolling buffer 化は別Issueへ）

Closes #719

## 変更内容

### 修正前の問題
Node v24.1.0 で `execFile` の stdout が `maxBuffer=1MB` を超えると、コールバックには `{code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER', signal: undefined, killed: undefined}` が渡される。現行コードでは：
- `isTimeout = error.killed (undefined) || code === 'ETIMEDOUT'` → false → status='failed'
- `parseInt('ERR_CHILD_PROCESS_STDIO_MAXBUFFER', 10) || null` → null → exit_code=NULL
- `stdout || stderr || error.message` の優先順で、巨大 stdout に押されて `error.message` が消失

その結果、DB の `execution_logs` には原因不明な \`status=failed / exit_code=NULL / result=切り詰めた stdout\` だけが残り、運用で原因特定不能だった。

### 修正後
\`\`\`ts
const errCode = (error as NodeJS.ErrnoException).code;
const isMaxBuffer = errCode === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
const isTimeout = error.killed || errCode === 'ETIMEDOUT';

const errorSummary = [
  \`Error: \${error.message}\`,
  \`Code: \${errCode ?? 'unknown'}\`,
  \`Signal: \${error.signal ?? 'none'}\`,
  isMaxBuffer ? 'Reason: stdout exceeded execFile maxBuffer (output_limit)' : null,
].filter(Boolean).join('\n');

const rawOutput = stripAnsi([
  errorSummary,
  stdout ? \`\n--- stdout ---\n\${stdout}\` : '',
  stderr ? \`\n--- stderr ---\n\${stderr}\` : '',
].join('\n'));

resolve({
  output: truncateOutput(rawOutput),
  exitCode: typeof errCode === 'number' ? errCode : null,
  status: isTimeout ? 'timeout' : 'failed',
  error: error.message,
});
\`\`\`

## Test plan
- [x] `npm run lint` → ✅ No ESLint warnings or errors
- [x] `npx tsc --noEmit` → ✅ クリーン
- [x] `npx vitest run tests/unit/lib/claude-executor.test.ts` → ✅ 37 tests passed
- [x] 新規テスト追加：maxBuffer 超過時に `result` 先頭へ `Code: ERR_CHILD_PROCESS_STDIO_MAXBUFFER` と `Reason: stdout exceeded execFile maxBuffer` が記録される
- [x] 新規テスト追加：外部 SIGTERM kill 時に `Signal: SIGTERM` が記録される
- [x] 新規テスト追加：exit code 1 終了時に `Code: 1` が記録され `exit_code=1` で保存される
- [x] 既存テスト：timeout / 正常終了は従来通り

## 影響範囲
- `src/lib/session/claude-executor.ts`（38 行追加 / 5 行変更）
- `tests/unit/lib/claude-executor.test.ts`（テストケース追加）
- スキーマ変更なし（既存 `execution_logs.result` に診断情報を入れる）
- UI 表示は非破壊（Schedules タブの実行ログ表示の冒頭に診断行が出る）

## 残課題（別Issueへ）
- P3: `execFile` → `spawn` + tail-rolling buffer 化（10MB ですら超える可能性のあるケースの根本対策）
- 運用：codex プロンプト指針（広範囲 `rg` 抑制 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)