### PR TITLE
refactor(cli): consolidate CLI_TOOL_IDS to single source of truth (#757)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,7 @@ tests/
 | `src/cli/utils/command-helpers.ts` | CLI共通ヘルパー（TOKEN_WARNING定数・handleCommandError統一エラーハンドラ）（Issue #518） |
 | `src/cli/types/api-responses.ts` | CLI側APIレスポンス型定義（WorktreeListResponse, CurrentOutputResponse, PromptResponseResult等）（Issue #518） |
 | `src/cli/config/duration-constants.ts` | CLI側duration定数（DURATION_MAP, parseDurationToMs）（Issue #518） |
-| `src/cli/config/cli-tool-ids.ts` | CLI側ツールID定義（CLI_TOOL_IDS, isCliToolId、copilot含む6ツール）（Issue #518, #545） |
+| `src/cli/config/cli-tool-ids.ts` | CLI側ツールID定義（CLI_TOOL_IDS, isCliToolId、copilot含む6ツール）（Issue #518, #545）。Issue #757で literal copy を撤廃し `src/lib/cli-tools/types.ts`（単一ソース）からの**相対パス re-export**（`@/` 不可、`isCliToolType as isCliToolId`/`CLIToolType as CLIToolId` エイリアス）に変更。cross-validation test は参照同一性で単一ソース契約を保証 |
 | `src/cli/config/model-validation.ts` | CLI側model名バリデーション（validateCopilotModelName、MODEL_NAME_PATTERN、クロスバリデーション対象）（Issue #588） |
 | `src/config/review-config.ts` | Review設定定数・テンプレート定数（STALLED_THRESHOLD_MS, REVIEW_POLL_INTERVAL_MS, MAX_TEMPLATES, MAX_TEMPLATE_NAME_LENGTH, MAX_TEMPLATE_CONTENT_LENGTH）（Issue #600, #618）、MAX_COMMIT_LOG_LENGTH/GIT_LOG_TOTAL_TIMEOUT_MS追加（Issue #627） |
 | `src/lib/session/next-action-helper.ts` | 次アクション算出ヘルパー（getNextAction, getReviewStatus, ReviewStatus型）（Issue #600） |

--- a/src/cli/config/cli-tool-ids.ts
+++ b/src/cli/config/cli-tool-ids.ts
@@ -1,21 +1,23 @@
 /**
  * CLI Tool IDs for CLI module
- * Issue #518: [DR2-07] Approach B - Subset copy with cross-validation test
  *
- * Source of truth: src/lib/cli-tools/types.ts CLI_TOOL_IDS
- * Cross-validation test: tests/unit/cli/config/cross-validation.test.ts
+ * Issue #757: Single source of truth.
+ * Re-exports CLI_TOOL_IDS / type / type guard from the server-side source of truth
+ * (src/lib/cli-tools/types.ts) instead of copying the literal array.
+ *
+ * - Uses a RELATIVE path, NOT the `@/` alias: tsconfig.cli.json sets `"paths": {}`,
+ *   so `@/lib/...` does not resolve in the CLI build (`npm run build:cli`). The CLI
+ *   module already imports server code via relative paths (e.g. `../../lib/errors`,
+ *   `../../lib/security/auth`).
+ * - Aliases bridge the historical naming difference between the CLI side
+ *   (`isCliToolId` / `CLIToolId`) and the server side (`isCliToolType` / `CLIToolType`),
+ *   keeping the CLI public API backward compatible.
+ *
+ * Previously (Issue #518 [DR2-07]): Approach B - subset copy guarded by a
+ * cross-validation test. That copy is now eliminated; the cross-validation test
+ * (tests/unit/cli/config/cross-validation.test.ts) additionally asserts reference
+ * identity to lock in the single-source contract.
  */
 
-/** CLI tool IDs available for --agent option */
-export const CLI_TOOL_IDS = ['claude', 'codex', 'gemini', 'vibe-local', 'opencode', 'copilot'] as const;
-
-export type CLIToolId = typeof CLI_TOOL_IDS[number];
-
-/**
- * Check if a string is a valid CLI tool ID
- * @param value - String to check
- * @returns True if value is a valid CLI tool ID
- */
-export function isCliToolId(value: string): value is CLIToolId {
-  return (CLI_TOOL_IDS as readonly string[]).includes(value);
-}
+export { CLI_TOOL_IDS, isCliToolType as isCliToolId } from '../../lib/cli-tools/types';
+export type { CLIToolType as CLIToolId } from '../../lib/cli-tools/types';

--- a/tests/unit/cli/config/cross-validation.test.ts
+++ b/tests/unit/cli/config/cross-validation.test.ts
@@ -43,3 +43,14 @@ describe('[DR2-07] CLI_TOOL_IDS cross-validation', () => {
     expect(CLI_TOOL_IDS.length).toBe(SERVER_CLI_TOOL_IDS.length);
   });
 });
+
+describe('[#757] CLI_TOOL_IDS single source of truth', () => {
+  // After Issue #757, src/cli/config/cli-tool-ids.ts re-exports CLI_TOOL_IDS from
+  // src/lib/cli-tools/types.ts (the single source of truth) instead of copying the
+  // literal. This asserts the *same array reference* is shared, which guarantees
+  // there is no second literal that could silently drift. If anyone reintroduces a
+  // standalone copy, this reference check fails even when the values happen to match.
+  it('CLI CLI_TOOL_IDS is the same reference as the server source of truth', () => {
+    expect(CLI_TOOL_IDS).toBe(SERVER_CLI_TOOL_IDS);
+  });
+});


### PR DESCRIPTION
## Summary

`CLI_TOOL_IDS` 配列が `src/cli/config/cli-tool-ids.ts` と `src/lib/cli-tools/types.ts` の 2 箇所で literal 重複定義されており、CLI ツール追加時の同期漏れリスクがあった。`src/lib/cli-tools/types.ts` を単一ソースとし、CLI 側から re-export することで参照同一性を保証する。

Closes #757 (v0.6.0 リリース準備)

## 主な変更

- `src/cli/config/cli-tool-ids.ts`: literal 削除 → `src/lib/cli-tools/types.ts` から `CLI_TOOL_IDS` / `isCliToolId` / `CLIToolType` を re-export
- `tests/unit/cli/config/cross-validation.test.ts`: 参照同一性 (`toBe` で同一オブジェクト) を検証する RED テスト追加
- `CLAUDE.md`: モジュール表に #757 追記

## 検証

- `npx tsc --noEmit` PASS
- `npm run lint` PASS
- `npm run test:unit` PASS（参照同一性テスト含む）
- `npm run build:cli` PASS（CLI モジュール解決の regression なし）

## レビューで防いだ不具合

- import 方向（CLI → lib）の検証で循環参照リスクなしを確認
- 純粋な re-export のため runtime 動作は完全に不変

## Test plan

- [x] lint / tsc / test:unit / build:cli 全 PASS
- [ ] CI GitHub Actions 全パス

🤖 v0.6.0 リリース準備