### PR TITLE
refactor(fullscreen): extract useFullscreen browser-compat shims (#763)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ tests/
 | `src/lib/version-checker.ts` | バージョンアップ通知 |
 | `src/lib/slash-commands.ts` | スラッシュコマンドローダー（.claude/commands, .claude/skills, .codex/skills対応、getCopilotBuiltinCommands追加）（Issue #166, #547） |
 | `src/lib/link-utils.ts` | リンク種別判定・相対パス解決・hrefサニタイズ（Issue #505） |
+| `src/lib/browser-compat/fullscreen-api.ts` | Fullscreen API vendor-prefix（webkit/moz/ms）互換シム（Issue #763）。isFullscreenSupportedCompat/getFullscreenElementCompat/requestFullscreenCompat/exitFullscreenCompat/addFullscreenChangeListenerCompat を export。ファイルローカル型 FullscreenElementCompat/FullscreenDocumentCompat + 型アサーション（declare global 禁止）、SSRガード維持、@ts-expect-error 0個。useFullscreen.ts から prefix シムを移送し prefix 由来 @ts-expect-error を全削除 |
 | `src/lib/url-path-encoder.ts` | ファイルパスURLエンコード |
 | `src/lib/file-search.ts` | ファイル内容検索 |
 | `src/lib/terminal-highlight.ts` | CSS Custom Highlight API ラッパー（Issue #47）XSS安全なターミナルハイライト。Issue #716で名前空間分離（HighlightNamespace型、HISTORY_SEARCH_NAMESPACE、applyHistoryHighlights/clearHistoryHighlights追加）。Issue #744で `makeHistoryNamespace(splitIndex)` ファクトリ追加（`history-search-${splitIndex}` 等の per-split namespace で `CSS.highlights` グローバルレジストリの上書き衝突を回避）、`applyHistoryHighlights`/`clearHistoryHighlights` に optional `namespace` 引数を additive 追加（default=`HISTORY_SEARCH_NAMESPACE`＝後方互換） |

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -85,7 +85,8 @@
 | `src/hooks/useFileOperations.ts` | ファイル操作フック（Issue #162: move操作の状態管理、MoveTarget型、UIロジック分離） |
 | `src/hooks/useLongPress.ts` | タッチ長押し検出フック（Issue #123、500ms閾値、10px移動キャンセル） |
 | `src/hooks/useSwipeGesture.ts` | スワイプジェスチャー検出フック（Issue #299: isInsideScrollableElement追加でscrollable要素内スワイプを抑制） |
-| `src/hooks/useFullscreen.ts` | Fullscreen API ラッパー（CSSフォールバック対応） |
+| `src/hooks/useFullscreen.ts` | Fullscreen API ラッパー（CSSフォールバック対応）。Issue #763 で browser-compat シム（webkit/moz/ms prefix フォールバック）を `src/lib/browser-compat/fullscreen-api.ts` に抽出し、prefix 由来の `@ts-expect-error` を全削除。`isIOSDevice()`（Issue #104）と公開API（UseFullscreenReturn/UseFullscreenOptions/useFullscreen）は不変 |
+| `src/lib/browser-compat/fullscreen-api.ts` | Fullscreen API の vendor-prefix（webkit/moz/ms）互換シム（Issue #763）。`isFullscreenSupportedCompat`（Boolean正規化）/ `getFullscreenElementCompat`（\|\|null フォールバック）/ `requestFullscreenCompat`（全prefix不在で `throw new Error('Fullscreen API not supported')`）/ `exitFullscreenCompat`（prefix不在で void resolve・throwしない）/ `addFullscreenChangeListenerCompat`（標準+prefix イベント登録・cleanup返却）を export。ファイルローカル型 `FullscreenElementCompat`/`FullscreenDocumentCompat` + 型アサーションで型安全アクセス（`declare global` 禁止）、各関数 SSR ガード（`typeof document==='undefined'`）維持、`@ts-expect-error` 0個 |
 | `src/hooks/useLocalStorageState.ts` | localStorage永続化フック（バリデーション対応） |
 | `src/config/z-index.ts` | z-index値の一元管理（Issue #299: JSDocコメント修正、レイヤー番号繰り上げ MODAL=50, MAXIMIZED_EDITOR=55, TOAST=60, CONTEXT_MENU=70） |
 | `src/config/uploadable-extensions.ts` | アップロード可能拡張子・MIMEタイプ・マジックバイト検証（Issue #302: mp4バリデータ追加、15MB上限、ftypシグネチャ検証） |

--- a/src/hooks/useFullscreen.ts
+++ b/src/hooks/useFullscreen.ts
@@ -12,6 +12,13 @@
 'use client';
 
 import { useState, useCallback, useEffect, RefObject } from 'react';
+import {
+  isFullscreenSupportedCompat,
+  getFullscreenElementCompat,
+  requestFullscreenCompat,
+  exitFullscreenCompat,
+  addFullscreenChangeListenerCompat,
+} from '@/lib/browser-compat/fullscreen-api';
 
 /**
  * Return type for useFullscreen hook
@@ -72,91 +79,6 @@ function isIOSDevice(): boolean {
 }
 
 /**
- * Check if Fullscreen API is available
- */
-function isFullscreenSupported(): boolean {
-  return (
-    typeof document !== 'undefined' &&
-    (document.fullscreenEnabled ||
-      // @ts-expect-error - webkit prefix
-      document.webkitFullscreenEnabled ||
-      // @ts-expect-error - moz prefix
-      document.mozFullScreenEnabled ||
-      // @ts-expect-error - ms prefix
-      document.msFullscreenEnabled)
-  );
-}
-
-/**
- * Get the current fullscreen element
- */
-function getFullscreenElement(): Element | null {
-  if (typeof document === 'undefined') return null;
-
-  return (
-    document.fullscreenElement ||
-    // @ts-expect-error - webkit prefix
-    document.webkitFullscreenElement ||
-    // @ts-expect-error - moz prefix
-    document.mozFullScreenElement ||
-    // @ts-expect-error - ms prefix
-    document.msFullscreenElement ||
-    null
-  );
-}
-
-/**
- * Request fullscreen on an element
- */
-async function requestFullscreen(element: Element): Promise<void> {
-  if (element.requestFullscreen) {
-    return element.requestFullscreen();
-  }
-  // @ts-expect-error - webkit prefix
-  if (element.webkitRequestFullscreen) {
-    // @ts-expect-error - webkit prefix
-    return element.webkitRequestFullscreen();
-  }
-  // @ts-expect-error - moz prefix
-  if (element.mozRequestFullScreen) {
-    // @ts-expect-error - moz prefix
-    return element.mozRequestFullScreen();
-  }
-  // @ts-expect-error - ms prefix
-  if (element.msRequestFullscreen) {
-    // @ts-expect-error - ms prefix
-    return element.msRequestFullscreen();
-  }
-  throw new Error('Fullscreen API not supported');
-}
-
-/**
- * Exit fullscreen mode
- */
-async function exitFullscreenApi(): Promise<void> {
-  if (typeof document === 'undefined') return;
-
-  if (document.exitFullscreen) {
-    return document.exitFullscreen();
-  }
-  // @ts-expect-error - webkit prefix
-  if (document.webkitExitFullscreen) {
-    // @ts-expect-error - webkit prefix
-    return document.webkitExitFullscreen();
-  }
-  // @ts-expect-error - moz prefix
-  if (document.mozCancelFullScreen) {
-    // @ts-expect-error - moz prefix
-    return document.mozCancelFullScreen();
-  }
-  // @ts-expect-error - ms prefix
-  if (document.msExitFullscreen) {
-    // @ts-expect-error - ms prefix
-    return document.msExitFullscreen();
-  }
-}
-
-/**
  * Hook for managing fullscreen state with API support and CSS fallback
  *
  * @param options - Configuration options
@@ -193,7 +115,7 @@ export function useFullscreen(options: UseFullscreenOptions = {}): UseFullscreen
    * Update fullscreen state from API
    */
   const updateFullscreenState = useCallback(() => {
-    const element = getFullscreenElement();
+    const element = getFullscreenElementCompat();
     const isActive = element != null;
     setIsFullscreen(isActive);
 
@@ -224,9 +146,9 @@ export function useFullscreen(options: UseFullscreenOptions = {}): UseFullscreen
     }
 
     // If API is supported, use it
-    if (isFullscreenSupported() && elementRef?.current) {
+    if (isFullscreenSupportedCompat() && elementRef?.current) {
       try {
-        await requestFullscreen(elementRef.current);
+        await requestFullscreenCompat(elementRef.current);
         setIsFullscreen(true);
         setIsFallbackMode(false);
         onEnter?.();
@@ -264,9 +186,9 @@ export function useFullscreen(options: UseFullscreenOptions = {}): UseFullscreen
     }
 
     // If using API, exit via API
-    if (getFullscreenElement()) {
+    if (getFullscreenElementCompat()) {
       try {
-        await exitFullscreenApi();
+        await exitFullscreenCompat();
         setIsFullscreen(false);
         onExit?.();
       } catch (err) {
@@ -302,19 +224,7 @@ export function useFullscreen(options: UseFullscreenOptions = {}): UseFullscreen
    * Listen for fullscreen change events from API
    */
   useEffect(() => {
-    if (typeof document === 'undefined') return;
-
-    document.addEventListener('fullscreenchange', updateFullscreenState);
-    document.addEventListener('webkitfullscreenchange', updateFullscreenState);
-    document.addEventListener('mozfullscreenchange', updateFullscreenState);
-    document.addEventListener('MSFullscreenChange', updateFullscreenState);
-
-    return () => {
-      document.removeEventListener('fullscreenchange', updateFullscreenState);
-      document.removeEventListener('webkitfullscreenchange', updateFullscreenState);
-      document.removeEventListener('mozfullscreenchange', updateFullscreenState);
-      document.removeEventListener('MSFullscreenChange', updateFullscreenState);
-    };
+    return addFullscreenChangeListenerCompat(updateFullscreenState);
   }, [updateFullscreenState]);
 
   return {

--- a/src/lib/browser-compat/fullscreen-api.ts
+++ b/src/lib/browser-compat/fullscreen-api.ts
@@ -1,0 +1,172 @@
+/**
+ * Browser-compat shims for the Fullscreen API.
+ *
+ * Centralizes the vendor-prefix (webkit/moz/ms) fallbacks for the Fullscreen
+ * API so that hooks/components can consume a single, type-safe surface without
+ * scattering type-suppression directives across the codebase.
+ *
+ * Design notes:
+ * - Prefix access uses **file-local** type aliases + assertions
+ *   (`FullscreenElementCompat` / `FullscreenDocumentCompat`). We intentionally
+ *   avoid `declare global` / module augmentation: the main tsconfig resolves
+ *   all of `src` as a single program, so augmenting the global `Document` /
+ *   `Element` interfaces would (a) pollute global types and (b) risk
+ *   `TS2578` unused-directive failures elsewhere.
+ * - Behavior is preserved 1:1 from the original `useFullscreen.ts` helpers:
+ *   `Boolean(...)` normalization, `|| null` fallback, the
+ *   `'Fullscreen API not supported'` throw, and the silent void return on exit.
+ * - Each function keeps the SSR guard (`typeof document === 'undefined'`) of
+ *   the original implementation. `requestFullscreenCompat` receives an
+ *   `Element` argument, so it does not need a document guard (matching the
+ *   original).
+ * - Request/exit return `Promise<void>` (the legacy prefixed APIs may return a
+ *   thenable or nothing, so results are wrapped with `Promise.resolve(...)`).
+ *
+ * Security: the Fullscreen API requires a user gesture (click, keydown, etc.).
+ *
+ * @module lib/browser-compat/fullscreen-api
+ */
+
+/**
+ * Element augmented with the legacy vendor-prefixed `requestFullscreen`
+ * variants. File-local only — never registered as a global augmentation.
+ */
+type FullscreenElementCompat = Element & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullScreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+};
+
+/**
+ * Document augmented with the legacy vendor-prefixed Fullscreen surface.
+ * File-local only — never registered as a global augmentation.
+ */
+type FullscreenDocumentCompat = Document & {
+  webkitFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+  webkitFullscreenEnabled?: boolean;
+  mozFullScreenEnabled?: boolean;
+  msFullscreenEnabled?: boolean;
+};
+
+/**
+ * Whether the Fullscreen API (standard or any vendor prefix) is available.
+ *
+ * SSR-safe: returns `false` when `document` is undefined.
+ * Always returns a normalized `boolean` (never a truthy non-boolean).
+ */
+export function isFullscreenSupportedCompat(): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const doc = document as FullscreenDocumentCompat;
+  return Boolean(
+    doc.fullscreenEnabled ||
+      doc.webkitFullscreenEnabled ||
+      doc.mozFullScreenEnabled ||
+      doc.msFullscreenEnabled
+  );
+}
+
+/**
+ * The current fullscreen element (standard or vendor-prefixed).
+ *
+ * SSR-safe: returns `null` when `document` is undefined, and falls back to
+ * `null` when no prefix reports a fullscreen element.
+ */
+export function getFullscreenElementCompat(): Element | null {
+  if (typeof document === 'undefined') return null;
+
+  const doc = document as FullscreenDocumentCompat;
+  return (
+    doc.fullscreenElement ||
+    doc.webkitFullscreenElement ||
+    doc.mozFullScreenElement ||
+    doc.msFullscreenElement ||
+    null
+  );
+}
+
+/**
+ * Request fullscreen on an element (standard or vendor-prefixed).
+ *
+ * IMPORTANT: must be called from a user gesture (click, keydown, etc.).
+ *
+ * @throws Error('Fullscreen API not supported') when no API variant exists.
+ */
+export function requestFullscreenCompat(element: Element): Promise<void> {
+  const el = element as FullscreenElementCompat;
+
+  if (el.requestFullscreen) {
+    return Promise.resolve(el.requestFullscreen());
+  }
+  if (el.webkitRequestFullscreen) {
+    return Promise.resolve(el.webkitRequestFullscreen());
+  }
+  if (el.mozRequestFullScreen) {
+    return Promise.resolve(el.mozRequestFullScreen());
+  }
+  if (el.msRequestFullscreen) {
+    return Promise.resolve(el.msRequestFullscreen());
+  }
+  return Promise.reject(new Error('Fullscreen API not supported'));
+}
+
+/**
+ * Exit fullscreen mode (standard or vendor-prefixed).
+ *
+ * SSR-safe: resolves to void when `document` is undefined. Unlike
+ * {@link requestFullscreenCompat}, this resolves silently (does NOT throw)
+ * when no exit API variant exists — preserving the original behavior.
+ */
+export function exitFullscreenCompat(): Promise<void> {
+  if (typeof document === 'undefined') return Promise.resolve();
+
+  const doc = document as FullscreenDocumentCompat;
+  if (doc.exitFullscreen) {
+    return Promise.resolve(doc.exitFullscreen());
+  }
+  if (doc.webkitExitFullscreen) {
+    return Promise.resolve(doc.webkitExitFullscreen());
+  }
+  if (doc.mozCancelFullScreen) {
+    return Promise.resolve(doc.mozCancelFullScreen());
+  }
+  if (doc.msExitFullscreen) {
+    return Promise.resolve(doc.msExitFullscreen());
+  }
+  return Promise.resolve();
+}
+
+/**
+ * Register a handler for fullscreen-change events across the standard and all
+ * vendor-prefixed event names.
+ *
+ * SSR-safe: returns a no-op cleanup when `document` is undefined.
+ *
+ * @param handler - invoked on any fullscreen-change event.
+ * @returns a cleanup function that removes all registered listeners.
+ */
+export function addFullscreenChangeListenerCompat(handler: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+
+  const events = [
+    'fullscreenchange',
+    'webkitfullscreenchange',
+    'mozfullscreenchange',
+    'MSFullscreenChange',
+  ];
+
+  for (const event of events) {
+    document.addEventListener(event, handler);
+  }
+
+  return () => {
+    for (const event of events) {
+      document.removeEventListener(event, handler);
+    }
+  };
+}

--- a/tests/unit/lib/browser-compat/fullscreen-api.test.ts
+++ b/tests/unit/lib/browser-compat/fullscreen-api.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for browser-compat fullscreen-api shims
+ *
+ * Verifies the vendor-prefix fallback branches (webkit/moz/ms) of each compat
+ * function. JSDOM does not define the legacy prefixed Fullscreen API surface,
+ * so we mock them with `Object.defineProperty(document/element, ...)` and clean
+ * up (delete) in afterEach to avoid cross-test leakage.
+ *
+ * SSR guard note: `typeof document === 'undefined'` cannot be exercised
+ * directly under JSDOM (document is always defined). The functions are written
+ * defensively for the SSR path; behavior parity with the original
+ * useFullscreen.ts is covered by the hook's existing tests + the branch tests
+ * below.
+ *
+ * @module tests/unit/lib/browser-compat/fullscreen-api
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  isFullscreenSupportedCompat,
+  getFullscreenElementCompat,
+  requestFullscreenCompat,
+  exitFullscreenCompat,
+  addFullscreenChangeListenerCompat,
+} from '@/lib/browser-compat/fullscreen-api';
+
+/**
+ * Define a (possibly prefixed) property on a target, tracking it for cleanup.
+ */
+function defineProp(
+  target: object,
+  key: string,
+  value: unknown,
+  registry: Array<{ target: object; key: string }>
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    configurable: true,
+    writable: true,
+  });
+  registry.push({ target, key });
+}
+
+describe('browser-compat/fullscreen-api', () => {
+  // Track every property we add so afterEach can remove it.
+  const defined: Array<{ target: object; key: string }> = [];
+
+  afterEach(() => {
+    while (defined.length > 0) {
+      const entry = defined.pop();
+      if (entry) {
+        // delete restores JSDOM's "undefined" default for prefixed props.
+        delete (entry.target as Record<string, unknown>)[entry.key];
+      }
+    }
+    vi.clearAllMocks();
+  });
+
+  describe('requestFullscreenCompat', () => {
+    it('calls the standard element.requestFullscreen when available', async () => {
+      const standard = vi.fn().mockResolvedValue(undefined);
+      const element = document.createElement('div');
+      defineProp(element, 'requestFullscreen', standard, defined);
+
+      await requestFullscreenCompat(element);
+
+      expect(standard).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to webkitRequestFullscreen when only webkit prefix exists', async () => {
+      const webkit = vi.fn().mockResolvedValue(undefined);
+      const element = document.createElement('div');
+      // Ensure standard API is absent on this element.
+      defineProp(element, 'requestFullscreen', undefined, defined);
+      defineProp(element, 'webkitRequestFullscreen', webkit, defined);
+
+      await requestFullscreenCompat(element);
+
+      expect(webkit).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to mozRequestFullScreen when only moz prefix exists', async () => {
+      const moz = vi.fn().mockResolvedValue(undefined);
+      const element = document.createElement('div');
+      defineProp(element, 'requestFullscreen', undefined, defined);
+      defineProp(element, 'mozRequestFullScreen', moz, defined);
+
+      await requestFullscreenCompat(element);
+
+      expect(moz).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to msRequestFullscreen when only ms prefix exists', async () => {
+      const ms = vi.fn().mockResolvedValue(undefined);
+      const element = document.createElement('div');
+      defineProp(element, 'requestFullscreen', undefined, defined);
+      defineProp(element, 'msRequestFullscreen', ms, defined);
+
+      await requestFullscreenCompat(element);
+
+      expect(ms).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws "Fullscreen API not supported" when no API is present', async () => {
+      const element = document.createElement('div');
+      defineProp(element, 'requestFullscreen', undefined, defined);
+
+      await expect(requestFullscreenCompat(element)).rejects.toThrow(
+        'Fullscreen API not supported'
+      );
+    });
+  });
+
+  describe('exitFullscreenCompat', () => {
+    it('calls the standard document.exitFullscreen when available', async () => {
+      const standard = vi.fn().mockResolvedValue(undefined);
+      defineProp(document, 'exitFullscreen', standard, defined);
+
+      await exitFullscreenCompat();
+
+      expect(standard).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to webkitExitFullscreen when only webkit prefix exists', async () => {
+      const webkit = vi.fn().mockResolvedValue(undefined);
+      defineProp(document, 'exitFullscreen', undefined, defined);
+      defineProp(document, 'webkitExitFullscreen', webkit, defined);
+
+      await exitFullscreenCompat();
+
+      expect(webkit).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to mozCancelFullScreen when only moz prefix exists', async () => {
+      const moz = vi.fn().mockResolvedValue(undefined);
+      defineProp(document, 'exitFullscreen', undefined, defined);
+      defineProp(document, 'mozCancelFullScreen', moz, defined);
+
+      await exitFullscreenCompat();
+
+      expect(moz).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to msExitFullscreen when only ms prefix exists', async () => {
+      const ms = vi.fn().mockResolvedValue(undefined);
+      defineProp(document, 'exitFullscreen', undefined, defined);
+      defineProp(document, 'msExitFullscreen', ms, defined);
+
+      await exitFullscreenCompat();
+
+      expect(ms).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves to void (does not throw) when no exit API is present', async () => {
+      defineProp(document, 'exitFullscreen', undefined, defined);
+
+      await expect(exitFullscreenCompat()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getFullscreenElementCompat', () => {
+    it('returns the standard document.fullscreenElement when set', () => {
+      const el = document.createElement('div');
+      defineProp(document, 'fullscreenElement', el, defined);
+
+      expect(getFullscreenElementCompat()).toBe(el);
+    });
+
+    it('falls back to a prefixed fullscreen element', () => {
+      const el = document.createElement('section');
+      defineProp(document, 'fullscreenElement', null, defined);
+      defineProp(document, 'webkitFullscreenElement', el, defined);
+
+      expect(getFullscreenElementCompat()).toBe(el);
+    });
+
+    it('returns null when no fullscreen element is present', () => {
+      defineProp(document, 'fullscreenElement', null, defined);
+
+      expect(getFullscreenElementCompat()).toBeNull();
+    });
+  });
+
+  describe('isFullscreenSupportedCompat', () => {
+    it('returns boolean true when webkit prefix flag is set', () => {
+      defineProp(document, 'fullscreenEnabled', false, defined);
+      defineProp(document, 'webkitFullscreenEnabled', true, defined);
+
+      const result = isFullscreenSupportedCompat();
+      expect(result).toBe(true);
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('returns boolean true when moz prefix flag is set', () => {
+      defineProp(document, 'fullscreenEnabled', false, defined);
+      defineProp(document, 'mozFullScreenEnabled', true, defined);
+
+      const result = isFullscreenSupportedCompat();
+      expect(result).toBe(true);
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('returns boolean true when ms prefix flag is set', () => {
+      defineProp(document, 'fullscreenEnabled', false, defined);
+      defineProp(document, 'msFullscreenEnabled', true, defined);
+
+      const result = isFullscreenSupportedCompat();
+      expect(result).toBe(true);
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('returns boolean false (not undefined) when no API flag is set', () => {
+      defineProp(document, 'fullscreenEnabled', false, defined);
+
+      const result = isFullscreenSupportedCompat();
+      expect(result).toBe(false);
+      expect(typeof result).toBe('boolean');
+    });
+  });
+
+  describe('addFullscreenChangeListenerCompat', () => {
+    const PREFIXED_EVENTS = [
+      'fullscreenchange',
+      'webkitfullscreenchange',
+      'mozfullscreenchange',
+      'MSFullscreenChange',
+    ];
+
+    it('registers the handler on standard + all prefixed change events', () => {
+      const addSpy = vi.spyOn(document, 'addEventListener');
+      const handler = vi.fn();
+
+      addFullscreenChangeListenerCompat(handler);
+
+      for (const evt of PREFIXED_EVENTS) {
+        expect(addSpy).toHaveBeenCalledWith(evt, handler);
+      }
+      addSpy.mockRestore();
+    });
+
+    it('removes all listeners via the returned cleanup function', () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener');
+      const handler = vi.fn();
+
+      const cleanup = addFullscreenChangeListenerCompat(handler);
+      expect(typeof cleanup).toBe('function');
+
+      cleanup();
+
+      for (const evt of PREFIXED_EVENTS) {
+        expect(removeSpy).toHaveBeenCalledWith(evt, handler);
+      }
+      removeSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`src/hooks/useFullscreen.ts` L81-154 で **19 個の `@ts-expect-error` がクラスタ**になっていたブラウザ互換コード (webkit/moz/ms prefix) を、互換性ラッパーとして別ファイルに抽出し可読性を改善。挙動完全保存。

Closes #763 (v0.6.0 リリース準備)

## 主な変更

- `src/lib/browser-compat/fullscreen-api.ts` (新規): 4 関数 export
  - `requestFullscreenCompat(elem)` / `exitFullscreenCompat()` / `getFullscreenElementCompat()` / `addFullscreenChangeListenerCompat(handler)`
  - 各関数内に最小限の `@ts-expect-error` のみ残存（1-2 個/関数）
- `src/hooks/useFullscreen.ts`: 上記関数を呼ぶだけにクリーン化、`@ts-expect-error` を撤去

## 挙動保存

- Boolean() 正規化
- `||null` (nullable)
- Promise.reject (同期 throw でない)
- void resolve
- SSR ガード

## 検証

- プロジェクト全体の `@ts-expect-error` 件数: 19→ 削減（受入基準 15 個以下達成）
- 既存 `useFullscreen.test.ts` PASS
- `npm run lint` / `npx tsc --noEmit` / `npm run test:unit` / `npm run build` 全 PASS

## Test plan

- [x] 既存ユニットテスト全 PASS
- [ ] CI GitHub Actions 全パス

🤖 v0.6.0 リリース準備