### PR TITLE
chore(test): triage skipped tests — revive 5, remove 2 obsolete (#764)

### DIFF
--- a/tests/unit/cli/commands/start.test.ts
+++ b/tests/unit/cli/commands/start.test.ts
@@ -247,14 +247,11 @@ describe('startCommand', () => {
     });
   });
 
-  // Note: Foreground mode tests are skipped because they rely on child process
-  // event handlers that trigger process.exit, which causes Vitest worker to exit.
-  // These are tested via integration/e2e tests instead.
-  describe.skip('foreground mode', () => {
-    it('should start in foreground by default', () => {
-      // Covered by integration tests
-    });
-  });
+  // Issue #764: Removed the empty `describe.skip('foreground mode')` placeholder
+  // (it contained only a no-op test). Foreground mode relies on child-process
+  // event handlers that trigger process.exit, which terminates the Vitest worker,
+  // so it cannot be unit-tested here. Foreground startup is covered by
+  // integration/e2e tests instead.
 
   describe('error handling', () => {
     it('should exit with UNEXPECTED_ERROR on unexpected exception', async () => {

--- a/tests/unit/components/WorktreeDetailRefactored.test.tsx
+++ b/tests/unit/components/WorktreeDetailRefactored.test.tsx
@@ -574,18 +574,13 @@ describe('WorktreeDetailRefactored', () => {
   });
 
   describe('Terminal State', () => {
-    // TODO: Fix flaky test - terminal output state update timing issue
-    it.skip('passes terminal output to TerminalDisplay', async () => {
-      render(<WorktreeDetailRefactored worktreeId="test-worktree-123" />);
-
-      await waitFor(
-        () => {
-          expect(screen.getByTestId('terminal-output')).toHaveTextContent('Terminal output');
-        },
-        { timeout: 3000 }
-      );
-    });
-
+    // Issue #764: Removed the obsolete skipped test
+    // 'passes terminal output to TerminalDisplay'. Terminal output is no longer
+    // owned by this parent component: Issue #728/#736 moved it into per-split
+    // useTerminalPanePolling (the parent's terminal reducer slice was deleted),
+    // so the parent never feeds `output` to a parent-controlled TerminalDisplay.
+    // Terminal output rendering is covered by useTerminalPanePolling tests and
+    // TerminalSplitPaneContent tests instead.
     it('renders FilePanelSplit when Claude is thinking (terminal details inside mock)', async () => {
       // Issue #438: TerminalDisplay is now inside FilePanelSplit (mocked).
       // This test verifies the component renders without errors when thinking state is active.

--- a/tests/unit/worktrees.test.ts
+++ b/tests/unit/worktrees.test.ts
@@ -166,15 +166,18 @@ invalid line
   });
 
   describe('scanWorktrees', () => {
-    // Note: The following tests are skipped due to vitest/promisify mocking limitations
-    // These will be covered by integration tests instead
-    it.skip('should execute git worktree list and return parsed worktrees', async () => {
+    // Issue #764: Revived previously-skipped tests. The factory mock for
+    // child_process strips `util.promisify.custom`, so `promisify(exec)` uses
+    // standard promisification and resolves with the FIRST callback value.
+    // The mock must therefore pass `{ stdout, stderr }` as that value so
+    // `const { stdout } = await execAsync(...)` in scanWorktrees works.
+    it('should execute git worktree list and return parsed worktrees', async () => {
       const mockOutput = `/path/to/main abc123 [main]
 /path/to/feature-foo def456 [feature/foo]`;
 
       vi.mocked(exec).mockImplementationOnce(
         ((cmd: string, opts: any, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
-          callback(null, mockOutput, '');
+          callback(null, { stdout: mockOutput, stderr: '' } as any, '');
           return {} as any;
         }) as any
       );
@@ -182,13 +185,14 @@ invalid line
       const result = await scanWorktrees('/path/to/root');
 
       expect(result).toHaveLength(2);
+      // ID is prefixed with the repository name (basename of rootDir, here "root").
       expect(result[0]).toMatchObject({
-        id: 'main',
+        id: 'root-main',
         name: 'main',
         path: '/path/to/main',
       });
       expect(result[1]).toMatchObject({
-        id: 'feature-foo',
+        id: 'root-feature-foo',
         name: 'feature/foo',
         path: '/path/to/feature-foo',
       });
@@ -200,7 +204,7 @@ invalid line
       );
     });
 
-    it.skip('should return empty array for non-git directory', async () => {
+    it('should return empty array for non-git directory', async () => {
       vi.mocked(exec).mockImplementationOnce(
         ((cmd: string, opts: any, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
           const error = new Error('not a git repository') as any;
@@ -215,7 +219,7 @@ invalid line
       expect(result).toEqual([]);
     });
 
-    it.skip('should throw on unexpected git errors', async () => {
+    it('should throw on unexpected git errors', async () => {
       vi.mocked(exec).mockImplementationOnce(
         ((cmd: string, opts: any, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
           const error = new Error('permission denied') as any;
@@ -230,12 +234,12 @@ invalid line
       );
     });
 
-    it.skip('should handle paths with spaces', async () => {
+    it('should handle paths with spaces', async () => {
       const mockOutput = '/path/with spaces/main abc123 [main]';
 
       vi.mocked(exec).mockImplementationOnce(
         ((cmd: string, opts: any, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
-          callback(null, mockOutput, '');
+          callback(null, { stdout: mockOutput, stderr: '' } as any, '');
           return {} as any;
         }) as any
       );
@@ -246,12 +250,12 @@ invalid line
       expect(result[0].path).toBe('/path/with spaces/main');
     });
 
-    it.skip('should resolve paths to absolute', async () => {
+    it('should resolve paths to absolute', async () => {
       const mockOutput = './relative/path abc123 [main]';
 
       vi.mocked(exec).mockImplementationOnce(
         ((cmd: string, opts: any, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
-          callback(null, mockOutput, '');
+          callback(null, { stdout: mockOutput, stderr: '' } as any, '');
           return {} as any;
         }) as any
       );


### PR DESCRIPTION
## Summary

`tests/` 配下に残留していた `.skip` / `.only` の棚卸しを実施し、以下を反映:
- **5 件のスキップテストを復活**: 仕様変更で解消可能だったもの
- **2 件の陳腐化テストを削除**: 仕様変更で不要になったもの
- **残留 skip にコメント追記**: 理由・Issue 番号リンクを付与

Closes #764 (v0.6.0 リリース準備)

## 検証

- `it.only` / `describe.only` の残留: **0 件** (受入基準達成)
- `it.skip` / `describe.skip` の残留: **20 件以下** (受入基準達成)
- `npm run test:unit` PASS、テスト件数が +5 件増加
- `npx tsc --noEmit` PASS / `npm run lint` PASS

## 補足

ESLint は `tests/` をデフォルトの next lint 対象外とするため、mock の `as any`（既存コードと同一スタイル）は CI に影響なし。

## Test plan

- [x] lint / tsc / test:unit 全 PASS
- [ ] CI GitHub Actions 全パス

🤖 v0.6.0 リリース準備