### PR TITLE
fix(slash-commands): open palette on $ trigger for Codex composer (#799)

### DIFF
--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -302,13 +302,22 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
       return;
     }
 
-    // Show command selector when '/' is typed at the start
-    if (newValue === '/' || (newValue.startsWith('/') && !newValue.includes(' '))) {
+    // Show command selector when a trigger character is typed at the start.
+    // Issue #799: Codex skills are surfaced via the `$NAME` trigger (introduced
+    // in #790), so on the Codex tab the selector also opens on a leading '$'.
+    // Other CLI tools (Claude/Copilot/Gemini) treat '$' as a normal character
+    // to avoid false triggers.
+    const isSlashTrigger =
+      newValue === '/' || (newValue.startsWith('/') && !newValue.includes(' '));
+    const isDollarTrigger =
+      cliToolId === 'codex' &&
+      (newValue === '$' || (newValue.startsWith('$') && !newValue.includes(' ')));
+    if (isSlashTrigger || isDollarTrigger) {
       setShowCommandSelector(true);
     } else {
       setShowCommandSelector(false);
     }
-  }, [isFreeInputMode]);
+  }, [isFreeInputMode, cliToolId]);
 
   /**
    * Handle keyboard shortcuts

--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -525,6 +525,71 @@ describe('MessageInput', () => {
     });
   });
 
+  // ===== Dollar trigger for Codex skills (Issue #799) =====
+
+  describe('Dollar trigger for Codex skills (Issue #799)', () => {
+    beforeEach(() => {
+      setMobileMode(false);
+    });
+
+    it('opens the command selector when "$" is typed on the Codex tab', () => {
+      render(<MessageInput {...defaultProps} cliToolId="codex" />);
+
+      expect(queryDesktopSelector()).not.toBeInTheDocument();
+
+      typeMessage('$');
+
+      expect(queryDesktopSelector()).toBeInTheDocument();
+    });
+
+    it('keeps the selector open while typing a "$name" command on the Codex tab', () => {
+      render(<MessageInput {...defaultProps} cliToolId="codex" />);
+
+      typeMessage('$orchestrate');
+
+      expect(queryDesktopSelector()).toBeInTheDocument();
+    });
+
+    it('closes the selector when a space follows the "$" trigger on the Codex tab', () => {
+      render(<MessageInput {...defaultProps} cliToolId="codex" />);
+
+      typeMessage('$');
+      expect(queryDesktopSelector()).toBeInTheDocument();
+
+      typeMessage('$orchestrate now');
+      expect(queryDesktopSelector()).not.toBeInTheDocument();
+    });
+
+    it('does NOT open the selector on "$" for non-Codex tabs (claude)', () => {
+      render(<MessageInput {...defaultProps} cliToolId="claude" />);
+
+      typeMessage('$');
+
+      expect(queryDesktopSelector()).not.toBeInTheDocument();
+    });
+
+    it('does NOT open the selector on "$" when cliToolId is omitted (defaults to claude)', () => {
+      const propsWithoutCliTool = {
+        worktreeId: 'test-worktree',
+        onMessageSent: vi.fn(),
+      };
+
+      render(<MessageInput {...propsWithoutCliTool} />);
+
+      typeMessage('$');
+
+      expect(queryDesktopSelector()).not.toBeInTheDocument();
+    });
+
+    it('still opens the selector on "/" on the Codex tab (existing behavior unchanged)', () => {
+      render(<MessageInput {...defaultProps} cliToolId="codex" />);
+
+      openSelector();
+
+      expect(queryDesktopSelector()).toBeInTheDocument();
+    });
+  });
+
   // ===== pendingInsertText behavior (Issue #485) =====
 
   describe('pendingInsertText insertion (Issue #485)', () => {


### PR DESCRIPTION
## Summary

Fixes #799. PC 版 Codex タブで `$` を入力しても slash command palette が開かない問題を修正。

- `MessageInput.tsx` の `handleMessageChange` で trigger 条件を拡張：cliToolId が `codex` のとき先頭 `$` でも palette を開く
- Claude/Copilot/Gemini タブでは `$` を通常文字として扱う（誤発火回避）
- 既存 `/` trigger 動作は不変

## Verification

- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` 7384/7384 ✅
- [x] `npm run build` ✅

## Test plan

- [ ] PC UAT @ `http://localhost:3000/worktrees/anvil-develop`:
  - [ ] Codex タブで `$` 1 文字入力 → palette が開く
  - [ ] `$imagegen` 等の Codex skill エントリ表示
  - [ ] Claude タブで `$` 入力 → palette 開かない
  - [ ] `/` trigger は全タブで不変

関連: #790 (`$NAME` 表記化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)