### PR TITLE
fix(status-detector): detect Claude busy state during /pm-auto-dev + subagent runs (#805)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -36,6 +36,26 @@ export const CLAUDE_THINKING_PATTERN = new RegExp(
 );
 
 /**
+ * Claude status-bar "esc to interrupt" hint (Issue #805)
+ *
+ * Claude Code shows "esc to interrupt" in the bottom status bar ONLY while it is
+ * actively processing. When idle/ready, the status bar shows shortcut hints
+ * (e.g., "? for shortcuts") instead -- so this token is a reliable "running" signal.
+ *
+ * Why this exists separately from CLAUDE_THINKING_PATTERN's "esc to interrupt"
+ * alternative: status detection evaluates the spinner+ellipsis branch of
+ * CLAUDE_THINKING_PATTERN within a narrow 5-line window (THINKING_TAIL_LINE_COUNT)
+ * to avoid mistaking a completed thinking summary in scrollback for active work
+ * (Issue #188). During /pm-auto-dev + subagent runs, the bottom task panel
+ * ("⏺ main" / "◯ general-purpose ..." rows) pushes both the "✶ Running…" spinner
+ * AND the "esc to interrupt" status bar out of that 5-line window, so the session
+ * was misdetected as Ready (Issue #805). Unlike the spinner+ellipsis summary, the
+ * status-bar text is repainted live and never lingers in scrollback, so it can be
+ * matched in a wider footer window without regressing Issue #188.
+ */
+export const CLAUDE_INTERRUPT_HINT_PATTERN = /esc to interrupt/;
+
+/**
  * Codex thinking pattern
  * Matches activity indicators like "• Planning", "• Searching", etc.
  * T1.1: Extended to include "Ran" and "Deciding"

--- a/src/lib/detection/status-detector.ts
+++ b/src/lib/detection/status-detector.ts
@@ -24,7 +24,7 @@
  * coupling via a minimal DTO/projection type.
  */
 
-import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN } from './cli-patterns';
+import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN } from './cli-patterns';
 import { detectPrompt } from './prompt-detector';
 import type { PromptDetectionResult } from './prompt-detector';
 import type { CLIToolType } from '@/lib/cli-tools/types';
@@ -313,6 +313,28 @@ export function detectSessionStatus(
       status: 'running',
       confidence: 'high',
       reason: 'thinking_indicator',
+      hasActivePrompt: false,
+      promptDetection,
+    };
+  }
+
+  // 2.6. Claude status-bar "esc to interrupt" detection — wider STATUS_CHECK_LINE_COUNT window (Issue #805)
+  // When Claude runs a subagent Task (e.g., /pm-auto-dev + general-purpose subagent), the
+  // bottom-of-screen task panel ("⏺ main" / "◯ general-purpose ... 55s" rows) pushes BOTH the
+  // "✶ Running…" spinner (top of the footer) and the "esc to interrupt" status bar above the
+  // narrow THINKING_TAIL_LINE_COUNT (5) window used by step 2. The visible "❯" input box then
+  // matches the input-prompt check at step 3, so the session was misreported as Ready.
+  //
+  // The "esc to interrupt" status bar appears only while Claude is actively processing (idle
+  // sessions show "? for shortcuts" instead) and is repainted live rather than lingering in
+  // scrollback, so matching it in the wider 15-line footer window is a safe running signal and
+  // does not reintroduce the Issue #188 spinner-summary false positive (only the spinner+ellipsis
+  // branch is restricted to the 5-line window).
+  if (cliToolId === 'claude' && CLAUDE_INTERRUPT_HINT_PATTERN.test(lastLines)) {
+    return {
+      status: 'running',
+      confidence: 'high',
+      reason: STATUS_REASON.THINKING_INDICATOR,
       hasActivePrompt: false,
       promptDetection,
     };

--- a/tests/unit/lib/status-detector.test.ts
+++ b/tests/unit/lib/status-detector.test.ts
@@ -543,4 +543,80 @@ describe('status-detector', () => {
       expect(result.promptDetection?.promptData?.type).toBe('multiple_choice');
     });
   });
+
+  describe('Issue #805: Claude busy state during /pm-auto-dev + subagent execution', () => {
+    // During /pm-auto-dev with a general-purpose subagent, Claude's footer is:
+    //   ✶ Running… spinner (top)        <- pushed above the 5-line thinking window
+    //   ⎿ phase task tree
+    //   ❯                               <- visible input box (user can interrupt)
+    //   ─────────── separator
+    //   esc to interrupt · ctrl+t ...   <- live status bar (running indicator)
+    //   ⏺ main                          <- task panel header
+    //   ◯ general-purpose ... 55s       <- subagent rows (bottom)
+    // The subagent panel pushes the spinner AND "esc to interrupt" out of the
+    // narrow 5-line thinking window, so the session was misdetected as Ready.
+
+    it('should return running when subagent task panel pushes "esc to interrupt" past the 5-line window', () => {
+      const output = [
+        'Some prior conversation output here',
+        '',
+        '✶ Running design→dev pipeline… (6m 1s · ↓ 22.5k tokens)',
+        '  ⎿  ✔ Phase 0.5: Hypothesis verification (issue-review)',
+        '     ◼ Phase 2-6: design-policy → design-review → work-plan → pm-auto-dev → report',
+        '',
+        '❯',
+        '───────────',
+        '  esc to interrupt · ctrl+t to hide tasks · ↓ to manage',
+        '  ⏺ main',
+        '  ◯ general-purpose  TDD implement Issue #919   55s',
+        '  ◯ general-purpose  Review architecture #920   40s',
+        '  ◯ general-purpose  Write acceptance tests #921   22s',
+        '  ◯ general-purpose  Refactor module #922   10s',
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'claude');
+
+      expect(result.status).toBe('running');
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBe('thinking_indicator');
+      expect(result.hasActivePrompt).toBe(false);
+    });
+
+    it('should still return running for the single-subagent panel from the issue capture', () => {
+      // Literal capture from the issue body (only one subagent row below the status bar).
+      const output = [
+        '✶ Running design→dev pipeline… (6m 1s · ↓ 22.5k tokens)',
+        '  ⎿  ✔ Phase 0.5: Hypothesis verification (issue-review)',
+        '     ✔ Stages 1-4: opus review + apply (iteration 1)',
+        '     ◼ Phase 2-6: design-policy → design-review → work-plan → pm-auto-dev → report',
+        '',
+        '❯',
+        '───────────',
+        '  esc to interrupt · ctrl+t to hide tasks · ↓ to manage',
+        '  ⏺ main',
+        '  ◯ general-purpose  TDD implement Issue #919   55s',
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'claude');
+
+      expect(result.status).toBe('running');
+      expect(result.reason).toBe('thinking_indicator');
+    });
+
+    it('should still return ready when an idle ❯ prompt has no "esc to interrupt" status bar', () => {
+      // Regression guard: the wider status-bar check must not turn genuinely idle
+      // prompts into running. An idle Claude footer shows shortcut hints, not "esc to interrupt".
+      const output = [
+        'Previous assistant response here',
+        '───────────────────────────────────────────────────',
+        '❯',
+        '  ? for shortcuts',
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'claude');
+
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #805. Claude セッションの \`/pm-auto-dev\` Skill + general-purpose subagent 起動中（\`✶ Running design→dev pipeline…\` + subagent task panel 表示）に、API が `isProcessing: false`（=Ready）を返していた誤検出を修正。

## Root cause

subagent task panel (\`⏺ main\` / \`◯ general-purpose ... 55s\` 行) が footer 末尾にレンダリングされると、

- thinking spinner (\`✶ Running…\`) — footer 上部
- \`esc to interrupt\` ステータスバー

が両方とも step 2 の thinking 検出に使う narrow 5-line `THINKING_TAIL_LINE_COUNT` window より上に押し出される。残った composer prompt (\`❯ \`) が step 3 の input-prompt 判定にヒットし `status='ready'` を返していた。

## Fix

Claude 専用の追加チェックを step 3 の前段に挿入：wider 15-line `STATUS_CHECK_LINE_COUNT` window 内に `esc to interrupt` ステータスバーが出ていれば `status='running'` を返す。

このステータスバーは Claude が実際に処理中のときのみ live で再描画される（idle 時は `? for shortcuts` 表示）ため、Issue #188 で対処した spinner-summary false positive を再導入しない（spinner+ellipsis branch は 5-line window のまま制限維持）。

## Verification

- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` 7390/7390 ✅（+6 vs baseline: subagent + busy fixture テスト追加）
- [x] `npm run build` ✅

## Test plan

- [ ] PC UAT @ \`http://localhost:3000\` で \`/pm-auto-dev\` 等 Skill 実行中の worktree を開く
- [ ] Worktree status indicator が "Running" / processing 表示になることを確認（"Ready" のままにならない）
- [ ] Skill 終了後 "Ready" に戻ることを確認
- [ ] 既存の idle / waiting / 通常 thinking 検出が不変

## 影響ファイル

- \`src/lib/detection/status-detector.ts\`（+24 -1）
- \`src/lib/detection/cli-patterns.ts\`（+20）
- \`tests/unit/lib/status-detector.test.ts\`（+76）

## 関連

- #806: busy 時送信 UX フィードバック（本 PR 後に着手予定 / \`isProcessing\` の正確性に依存）
- #807: AskUserQuestion picker auto-yes 不動作（#806 後に着手予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)