### PR TITLE
feat(message-input): show 'queued (session busy)' toast when sending to a busy session (#806)

### DIFF
--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -15,6 +15,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { useImageAttachment } from '@/hooks/useImageAttachment';
 import type { SlashCommand } from '@/types/slash-commands';
 import { getSlashCommandTrigger } from '@/lib/slash-command-format';
+import type { ShowToast } from '@/types/markdown-editor';
 
 export interface MessageInputProps {
   worktreeId: string;
@@ -36,6 +37,20 @@ export interface MessageInputProps {
    * MemoPane insertions land in the most recently focused split.
    */
   onFocus?: () => void;
+  /**
+   * Issue #806: whether the target session is currently busy (processing
+   * another task). When true, a successful send is queued behind the running
+   * task on the CLI side rather than executed immediately, so we surface a
+   * "queued (session busy)" toast to avoid the send looking like a no-op.
+   * Defaults to false (idle) for backward compatibility — idle sends behave
+   * exactly as before (no extra toast).
+   */
+  isProcessing?: boolean;
+  /**
+   * Issue #806: toast surface used to show the "queued (session busy)" hint.
+   * Optional — when omitted (or when the session is idle) no toast is shown.
+   */
+  showToast?: ShowToast;
 }
 
 /**
@@ -48,6 +63,15 @@ export interface MessageInputProps {
  */
 /** localStorage key prefix for draft message persistence */
 const DRAFT_STORAGE_KEY_PREFIX = 'commandmate:draft-message:';
+
+/**
+ * Issue #806: shown when a message is successfully sent to a session that is
+ * already busy with another task. The send itself succeeds (200) and the CLI
+ * queues the message, so this clarifies it will not be processed until the
+ * current task finishes.
+ */
+const QUEUED_BUSY_TOAST_MESSAGE =
+  'Queued (session busy) — your message will run after the current task finishes.';
 
 /**
  * Issue #728: Per-(worktree, split) draft key. Falls back to the legacy
@@ -78,7 +102,7 @@ function migrateLegacyDraftKey(worktreeId: string): void {
   }
 }
 
-export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus }: MessageInputProps) {
+export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast }: MessageInputProps) {
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -195,13 +219,19 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
       setIsFreeInputMode(false);
       resetAfterSend();
       try { window.localStorage.removeItem(getDraftKey(worktreeId, splitIndex)); } catch { /* ignore */ }
+      // Issue #806: when the session is busy, the CLI queues this message behind
+      // the running task. Surface a toast so the (successful) send doesn't look
+      // like a no-op. Idle sessions are unchanged (no toast).
+      if (isProcessing) {
+        showToast?.(QUEUED_BUSY_TOAST_MESSAGE, 'warning');
+      }
       onMessageSent?.(effectiveCliTool);
     } catch (err) {
       setError(handleApiError(err));
     } finally {
       setSending(false);
     }
-  }, [isComposing, message, attachedImage, sending, worktreeId, cliToolId, onMessageSent, resetAfterSend, splitIndex]);
+  }, [isComposing, message, attachedImage, sending, worktreeId, cliToolId, onMessageSent, resetAfterSend, splitIndex, isProcessing, showToast]);
 
   const handleSubmit = useCallback(async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -419,6 +419,12 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
           onInsertConsumed={onInsertConsumed}
           splitIndex={splitIndex}
           onFocus={onFocus}
+          // Issue #806: surface a "queued (session busy)" toast when sending to
+          // a session that is still processing the previous task. isProcessing
+          // is sourced from this split's own poller (terminal.isRunning), and
+          // showToast reuses the existing history toast surface.
+          isProcessing={terminal.isRunning}
+          showToast={showToast}
         />
       </div>
     ),
@@ -444,6 +450,8 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
       autoYesExpiresAt,
       lastAutoResponse,
       onAutoYesToggle,
+      // Issue #806: toast surface for the "queued (session busy)" hint.
+      showToast,
     ],
   );
 

--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -792,4 +792,101 @@ describe('MessageInput', () => {
       expect(onFocus).toHaveBeenCalled();
     });
   });
+
+  // ===== Issue #806: queued (session busy) toast =====
+
+  describe('Issue #806 — queued (session busy) toast', () => {
+    beforeEach(() => {
+      setMobileMode(false);
+    });
+
+    it('shows a warning toast after a successful send when the session is busy (isProcessing=true)', async () => {
+      const { worktreeApi } = await import('@/lib/api-client');
+      const showToast = vi.fn();
+
+      render(
+        <MessageInput {...defaultProps} isProcessing showToast={showToast} />
+      );
+
+      typeMessage('queued while busy');
+      pressEnter();
+
+      await waitFor(() => {
+        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+      });
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining('Queued (session busy)'),
+        'warning'
+      );
+    });
+
+    it('does NOT show a toast when the session is idle (isProcessing=false)', async () => {
+      const { worktreeApi } = await import('@/lib/api-client');
+      const showToast = vi.fn();
+
+      render(
+        <MessageInput
+          {...defaultProps}
+          isProcessing={false}
+          showToast={showToast}
+        />
+      );
+
+      typeMessage('sent while idle');
+      pressEnter();
+
+      await waitFor(() => {
+        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+      });
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('does NOT show a toast when isProcessing is omitted (default idle behavior unchanged)', async () => {
+      const { worktreeApi } = await import('@/lib/api-client');
+      const showToast = vi.fn();
+
+      render(<MessageInput {...defaultProps} showToast={showToast} />);
+
+      typeMessage('no isProcessing prop');
+      pressEnter();
+
+      await waitFor(() => {
+        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+      });
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('does NOT show a toast when the send fails even if the session is busy', async () => {
+      const { worktreeApi } = await import('@/lib/api-client');
+      vi.mocked(worktreeApi.sendMessage).mockRejectedValueOnce(
+        new Error('Network error')
+      );
+      const showToast = vi.fn();
+
+      render(
+        <MessageInput {...defaultProps} isProcessing showToast={showToast} />
+      );
+
+      typeMessage('busy but fails');
+      pressEnter();
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when busy but no showToast is provided', async () => {
+      const { worktreeApi } = await import('@/lib/api-client');
+
+      render(<MessageInput {...defaultProps} isProcessing />);
+
+      typeMessage('busy without toast surface');
+      pressEnter();
+
+      await waitFor(() => {
+        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #806. busy セッションへのメッセージ送信時、API は 200 を返し Claude/Codex 側 queue に積まれるが、composer がクリアされて見かけ上「送信できなかった」と誤認される問題を改善。

## Changes

- **MessageInput.tsx**: `isProcessing` + `showToast` props 追加。送信成功時に `isProcessing===true` なら **warning toast** "Queued (session busy)" 系で「現タスク完了後に処理される」ことを明示。idle 送信時は従来通り追加 toast なし（バイト不変）。
- **TerminalSplitPaneContent.tsx**: 各 split 自身の poller (`useTerminalPanePolling` の `terminal.isRunning`) から `isProcessing` を解決。InterruptButton 用の `isSessionRunning` とは別 prop として分離（責務分割）。
- **MessageInput.test.tsx**: queue toast 表示 / 非表示の test を追加。

## Verification

- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` 7395/7395 ✅
- [x] `npm run build` ✅

## Test plan

- [ ] PC UAT @ `http://localhost:3000`: heavy thinking 中のセッションに `/rebuild` 後送信 → "Queued (session busy)" toast 表示
- [ ] idle セッションへ送信 → toast 表示なし（既存挙動）

## 関連

- #805 (status-detector 修正): `isProcessing` の正確性は #805 で先行修正済 → 本 PR で UX に反映
- #807 (AskUserQuestion picker auto-yes): 次の Issue で対応予定
- #809 (CLAUDE.md 構造除去): 本 PR 後に着手予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)