### PR TITLE
fix(prompt-detector): handle Claude Code v2.x AskUserQuestion picker for auto-yes (#807)

### DIFF
--- a/src/lib/detection/prompt-detect-multiple-choice.ts
+++ b/src/lib/detection/prompt-detect-multiple-choice.ts
@@ -116,6 +116,35 @@ const SUMMARY_LINE_PATTERN = /^\s*[…]?\s*[+\-↑↓⏵⏷]?\s*\d+\s+(?:pending
 const CLAUDE_PROMPT_FOOTER_PATTERN = /Esc\s+to\s+cancel\s*[·•]\s*Tab\s+to\s+amend/i;
 
 /**
+ * [Issue #807] Pattern for the Claude Code v2.x AskUserQuestion picker footer.
+ * Examples (the `·` separators and arrow glyphs vary by terminal width):
+ *   "Enter to select · ↑/↓ to navigate · Esc to cancel"
+ *   "Enter to select · Tab/Arrow keys to navigate · Esc to cancel"
+ *
+ * The AskUserQuestion picker renders an extra overlay BELOW this footer — most
+ * notably the /pm-auto-dev task panel ("6 tasks (4 done, 2 open)" etc.). That
+ * trailing panel poisons option collection: NORMAL_OPTION_PATTERN matches the
+ * "6 tasks ..." line as option 6, and the reverse scan then stops at this footer
+ * (isQuestionLikeLine matches "select"/"navigate"), so the real 1./2./3. picker
+ * options above are never collected and detection returns no_prompt. As a result
+ * auto-yes goes silent whenever the panel is rendered.
+ *
+ * Used (alongside CLAUDE_PROMPT_FOOTER_PATTERN) to trim effectiveEnd down to the
+ * footer line so the trailing panel falls outside the scan window entirely —
+ * the same defense-in-depth approach introduced for Issue #704. It also flags
+ * the prompt as an AskUserQuestion picker (isAskUserQuestion) so the answer
+ * sender can engage the picker cursor before confirming the default option.
+ *
+ * Distinct from CLAUDE_PROMPT_FOOTER_PATTERN (old Bash-tool confirmation footer,
+ * "Esc to cancel · Tab to amend") which this pattern intentionally does NOT match,
+ * keeping the old-format detection path byte-for-byte unchanged.
+ *
+ * Linear pattern, single unbounded quantifier between literal anchors —
+ * ReDoS safe (S4-001).
+ */
+const CLAUDE_ASK_USER_QUESTION_FOOTER_PATTERN = /Enter\s+to\s+select\b.*\bnavigate\b/i;
+
+/**
  * Codex/OpenAI TUI confirmation footer shown beneath interactive choices.
  * When this footer is present, numbered options form an active prompt even if
  * the default cursor marker is missing from the capture output.
@@ -504,6 +533,7 @@ function extractInstructionText(
  * @param output - Original output text (used for rawContent truncation)
  * @param truncateRawContentFn - Function to truncate raw content
  * @param submitMode - Optional submit mode for the prompt (Issue #616)
+ * @param isAskUserQuestion - Whether this is a Claude Code v2.x AskUserQuestion picker (Issue #807)
  * @returns PromptDetectionResult with isPrompt: true and multiple_choice data
  */
 export function buildMultipleChoiceResult(
@@ -513,6 +543,7 @@ export function buildMultipleChoiceResult(
   output: string,
   truncateRawContentFn: (content: string) => string,
   submitMode?: SubmitMode,
+  isAskUserQuestion?: boolean,
 ): PromptDetectionResult {
   return {
     isPrompt: true,
@@ -533,6 +564,7 @@ export function buildMultipleChoiceResult(
       status: 'pending',
       instructionText,
       ...(submitMode ? { submitMode } : {}),
+      ...(isAskUserQuestion ? { isAskUserQuestion: true } : {}),
     },
     cleanContent: question.trim(),
     rawContent: truncateRawContentFn(output.trim()),  // Issue #235: complete prompt output (truncated) [MF-001]
@@ -595,9 +627,18 @@ export function detectMultipleChoicePrompt(
   // Fallback: if no footer line is found, effectiveEnd is left unchanged —
   // every other CLI tool (Codex, Gemini, OpenCode, Copilot) is therefore
   // untouched by this branch (regression guard).
+  //
+  // [Issue #807] Also trim at the Claude Code v2.x AskUserQuestion picker footer
+  // so a trailing task panel overlay ("N tasks (...)" rows) below it cannot poison
+  // option collection. The bottom-most footer of either kind wins; when the match
+  // is the AskUserQuestion footer, flag the prompt so the answer sender can engage
+  // the picker cursor before confirming.
+  let hasAskUserQuestionFooter = false;
   for (let i = effectiveEnd - 1; i >= scanStart; i--) {
-    if (CLAUDE_PROMPT_FOOTER_PATTERN.test(lines[i])) {
+    const isAskUserQuestionFooter = CLAUDE_ASK_USER_QUESTION_FOOTER_PATTERN.test(lines[i]);
+    if (CLAUDE_PROMPT_FOOTER_PATTERN.test(lines[i]) || isAskUserQuestionFooter) {
       effectiveEnd = i;
+      hasAskUserQuestionFooter = isAskUserQuestionFooter;
       break;
     }
   }
@@ -825,5 +866,5 @@ export function detectMultipleChoicePrompt(
     ? (hasNumberFooter ? 'answer_only' : 'answer_then_enter')
     : undefined;
 
-  return buildMultipleChoiceResult(question, collectedOptions, instructionText, output, truncateRawContentFn, submitMode);
+  return buildMultipleChoiceResult(question, collectedOptions, instructionText, output, truncateRawContentFn, submitMode, hasAskUserQuestionFooter);
 }

--- a/src/lib/prompt-answer-sender.ts
+++ b/src/lib/prompt-answer-sender.ts
@@ -120,10 +120,21 @@ export async function sendPromptAnswer(params: SendPromptAnswerParams): Promise<
       await sendSpecialKeys(sessionName, keys);
     } else {
       // Single-select: navigate and Enter to select
-      const keys: string[] = [
-        ...buildNavigationKeys(offset),
-        'Enter',
-      ];
+      const navigationKeys = buildNavigationKeys(offset);
+
+      // [Issue #807] Claude Code v2.x AskUserQuestion picker: when selecting the
+      // already-highlighted default option (offset === 0), a bare Enter can fail
+      // to advance the picker because its internal cursor index is not committed
+      // until a navigation key is pressed. Send a net-zero Down+Up nudge first to
+      // engage the cursor onto the default option, then Enter. For offset !== 0
+      // the Up/Down navigation already engages the cursor, so no extra nudge is
+      // needed. Old-format numbered prompts (isAskUserQuestion unset) keep their
+      // exact prior key sequence, so their response behavior is unchanged.
+      const isAskUserQuestionPicker = promptData?.type === 'multiple_choice'
+        && promptData.isAskUserQuestion === true;
+      const keys: string[] = (isAskUserQuestionPicker && offset === 0)
+        ? ['Down', 'Up', 'Enter']
+        : [...navigationKeys, 'Enter'];
       await sendSpecialKeys(sessionName, keys);
     }
   } else {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -215,6 +215,15 @@ export interface MultipleChoicePromptData extends BasePromptData {
   options: MultipleChoiceOption[];
   /** How to submit the answer: 'answer_only' (no Enter) or 'answer_then_enter' (default). Issue #616. */
   submitMode?: SubmitMode;
+  /**
+   * Whether this prompt is rendered as a Claude Code v2.x AskUserQuestion picker
+   * (arrow-key navigation, "Enter to select … to navigate" footer). Issue #807.
+   * When true, the answer sender engages the picker cursor with a net-zero
+   * Down+Up nudge before confirming the already-highlighted default option, since
+   * a bare Enter can fail to register on the picker. Absent/false for the legacy
+   * numbered-confirmation format, whose response behavior is therefore unchanged.
+   */
+  isAskUserQuestion?: boolean;
 }
 
 /**

--- a/tests/unit/lib/detection/prompt-detect-multiple-choice.test.ts
+++ b/tests/unit/lib/detection/prompt-detect-multiple-choice.test.ts
@@ -1,0 +1,227 @@
+/**
+ * [Issue #807] Regression tests for the Claude Code v2.x AskUserQuestion picker.
+ *
+ * The new AskUserQuestion picker differs from the legacy numbered confirmation:
+ *   - each option is rendered across TWO lines (title + indented description)
+ *   - it includes meta options ("4. Type something." / "5. Chat about this")
+ *   - a `─` divider separates the meta options
+ *   - it ends with a "Enter to select · ↑/↓ to navigate · Esc to cancel" footer
+ *   - while /pm-auto-dev runs, a task panel ("6 tasks (4 done, 2 open)" etc.) is
+ *     overlaid BELOW that footer.
+ *
+ * Before the fix, the trailing task panel poisoned option collection: the
+ * "6 tasks ..." line was parsed as option 6 and the reverse scan stopped at the
+ * footer, so the real 1./2./3. options were never collected and detection
+ * returned no_prompt. Auto-yes therefore went silent whenever the panel was
+ * rendered (the reported 30+ minute stall). These tests pin the corrected
+ * behavior and guard the legacy format from regressing.
+ *
+ * Captures reproduced from the Issue #807 body (anvil-feature-issue-921 PC UAT).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectMultipleChoicePrompt,
+  buildMultipleChoiceResult,
+} from '@/lib/detection/prompt-detect-multiple-choice';
+import type { DetectPromptOptions } from '@/lib/detection/types';
+import type { MultipleChoicePromptData } from '@/types/models';
+
+/** Identity truncation: the unit under test only needs a passthrough. */
+const truncate = (s: string) => s;
+
+/** Claude is detected with requireDefaultIndicator: false (buildDetectPromptOptions). */
+const CLAUDE_OPTS: DetectPromptOptions = { requireDefaultIndicator: false };
+
+function asMultipleChoice(
+  output: string,
+  opts: DetectPromptOptions = CLAUDE_OPTS,
+): MultipleChoicePromptData | null {
+  const result = detectMultipleChoicePrompt(output, opts, truncate);
+  if (result.promptData?.type === 'multiple_choice') {
+    return result.promptData;
+  }
+  return null;
+}
+
+// The picker exactly as rendered by Claude Code v2.x (no trailing panel yet).
+const PICKER_CLEAN = [
+  'Phase 5 (TDD 実装) に進んでよいですか？設計は opus×2 + Codex×2 でレビュー済み、作業計画も確定しています。',
+  '',
+  '❯ 1. 実装に進む (pm-auto-dev)',
+  '     /pm-auto-dev 921 を起動し、TDD (Red-Green-Refactor) で assess_structured_data SSOT + 両ゲート OR-tolerant 化 + テスト一式を実装。完了後 Phase 6 検証まで自動進行。',
+  '  2. 設計/計画を先に確認したい',
+  '     実装の前に設計方針書(181行)または作業計画をあなたが確認・修正。承認後に Phase 5 へ。',
+  '  3. ここで一旦停止',
+  '     Phase 1-4 の成果物(issue v5・設計方針書・作業計画)で区切り、実装は別途あなたの判断で開始。',
+  '  4. Type something.',
+  '─────────────────────',
+  '  5. Chat about this',
+  '',
+  'Enter to select · ↑/↓ to navigate · Esc to cancel',
+].join('\n');
+
+// The exact failure case: the /pm-auto-dev task panel overlaid below the footer.
+const PICKER_WITH_TASK_PANEL = [
+  PICKER_CLEAN,
+  '',
+  '  6 tasks (4 done, 2 open)',
+  '  ⏺ assess_structured_data SSOT',
+  '  ◯ 両ゲート OR-tolerant 化',
+].join('\n');
+
+describe('detectMultipleChoicePrompt - Issue #807 AskUserQuestion picker', () => {
+  describe('clean picker (no trailing task panel)', () => {
+    it('detects all 5 options including the divider-separated meta options', () => {
+      const promptData = asMultipleChoice(PICKER_CLEAN);
+
+      expect(promptData).not.toBeNull();
+      expect(promptData!.options).toHaveLength(5);
+      expect(promptData!.options.map(o => o.number)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('returns option 1 (the ❯ line) as the default', () => {
+      const promptData = asMultipleChoice(PICKER_CLEAN)!;
+      const defaultOption = promptData.options.find(o => o.isDefault);
+
+      expect(defaultOption?.number).toBe(1);
+      expect(defaultOption?.label).toBe('実装に進む (pm-auto-dev)');
+    });
+
+    it('does not misparse the indented description lines as options', () => {
+      const promptData = asMultipleChoice(PICKER_CLEAN)!;
+
+      // Description lines like "/pm-auto-dev 921 を起動し…" must not be collected.
+      expect(promptData.options.map(o => o.label)).toEqual([
+        '実装に進む (pm-auto-dev)',
+        '設計/計画を先に確認したい',
+        'ここで一旦停止',
+        'Type something.',
+        'Chat about this',
+      ]);
+    });
+
+    it('flags the prompt as an AskUserQuestion picker', () => {
+      const promptData = asMultipleChoice(PICKER_CLEAN)!;
+      expect(promptData.isAskUserQuestion).toBe(true);
+    });
+
+    it('extracts the question text from above the options', () => {
+      const promptData = asMultipleChoice(PICKER_CLEAN)!;
+      expect(promptData.question).toContain('Phase 5 (TDD 実装) に進んでよいですか？');
+    });
+  });
+
+  describe('picker WITH the /pm-auto-dev task panel overlay (the reported bug)', () => {
+    // Before the fix this returned isPrompt: false (the panel poisoned the scan),
+    // so auto-yes never sent a response — the 30+ minute silence in the issue.
+    it('still detects the prompt instead of silently failing', () => {
+      const result = detectMultipleChoicePrompt(PICKER_WITH_TASK_PANEL, CLAUDE_OPTS, truncate);
+      expect(result.isPrompt).toBe(true);
+    });
+
+    it('detects the same 5 options as the clean capture (panel excluded)', () => {
+      const promptData = asMultipleChoice(PICKER_WITH_TASK_PANEL)!;
+
+      expect(promptData.options).toHaveLength(5);
+      expect(promptData.options.map(o => o.number)).toEqual([1, 2, 3, 4, 5]);
+      // The "6 tasks (4 done, 2 open)" panel line must NOT appear as an option.
+      expect(promptData.options.some(o => o.label.includes('tasks'))).toBe(false);
+    });
+
+    it('returns option 1 as the default so auto-yes resolves to "1"', () => {
+      const promptData = asMultipleChoice(PICKER_WITH_TASK_PANEL)!;
+      expect(promptData.options.find(o => o.isDefault)?.number).toBe(1);
+    });
+
+    it('flags the prompt as an AskUserQuestion picker even with the panel present', () => {
+      const promptData = asMultipleChoice(PICKER_WITH_TASK_PANEL)!;
+      expect(promptData.isAskUserQuestion).toBe(true);
+    });
+  });
+
+  describe('alternate footer wording', () => {
+    it('handles "Tab/Arrow keys to navigate" footer wording', () => {
+      const output = [
+        'どの方式でコピーしますか？',
+        '',
+        '❯ 1. ユーザー入力のみ',
+        '  2. レスポンスのみ',
+        '  3. 両方個別に',
+        '',
+        'Enter to select · Tab/Arrow keys to navigate · Esc to cancel',
+        '',
+        '  3 tasks (1 done, 2 open)',
+      ].join('\n');
+
+      const promptData = asMultipleChoice(output);
+      expect(promptData).not.toBeNull();
+      expect(promptData!.options).toHaveLength(3);
+      expect(promptData!.options.find(o => o.isDefault)?.number).toBe(1);
+      expect(promptData!.isAskUserQuestion).toBe(true);
+    });
+  });
+
+  describe('legacy numbered confirmation format is unchanged (no regression)', () => {
+    it('does NOT flag the legacy "Do you want to proceed?" prompt as a picker', () => {
+      const output = [
+        'Do you want to proceed?',
+        '❯ 1. Yes',
+        '  2. No',
+        '  3. Cancel',
+      ].join('\n');
+
+      const promptData = asMultipleChoice(output);
+      expect(promptData).not.toBeNull();
+      expect(promptData!.options).toHaveLength(3);
+      expect(promptData!.options.find(o => o.isDefault)?.number).toBe(1);
+      // Legacy format has no AskUserQuestion footer -> flag stays unset.
+      expect(promptData!.isAskUserQuestion).toBeUndefined();
+    });
+
+    it('legacy prompt with the "Esc to cancel · Tab to amend" footer stays a non-picker', () => {
+      const output = [
+        'Do you want to proceed?',
+        '❯ 1. Yes',
+        '  2. No',
+        'Esc to cancel · Tab to amend · ctrl+e to explain',
+      ].join('\n');
+
+      const promptData = asMultipleChoice(output);
+      expect(promptData).not.toBeNull();
+      expect(promptData!.options).toHaveLength(2);
+      expect(promptData!.isAskUserQuestion).toBeUndefined();
+    });
+  });
+
+  describe('buildMultipleChoiceResult isAskUserQuestion flag', () => {
+    it('omits the flag when isAskUserQuestion is not passed', () => {
+      const result = buildMultipleChoiceResult(
+        'Choose:',
+        [{ number: 1, label: 'A', isDefault: true }, { number: 2, label: 'B', isDefault: false }],
+        undefined,
+        'Choose:',
+        truncate,
+      );
+      expect(result.promptData?.type).toBe('multiple_choice');
+      if (result.promptData?.type === 'multiple_choice') {
+        expect(result.promptData.isAskUserQuestion).toBeUndefined();
+      }
+    });
+
+    it('sets the flag when isAskUserQuestion is true', () => {
+      const result = buildMultipleChoiceResult(
+        'Choose:',
+        [{ number: 1, label: 'A', isDefault: true }, { number: 2, label: 'B', isDefault: false }],
+        undefined,
+        'Choose:',
+        truncate,
+        undefined,
+        true,
+      );
+      if (result.promptData?.type === 'multiple_choice') {
+        expect(result.promptData.isAskUserQuestion).toBe(true);
+      }
+    });
+  });
+});

--- a/tests/unit/lib/prompt-answer-sender.test.ts
+++ b/tests/unit/lib/prompt-answer-sender.test.ts
@@ -277,6 +277,107 @@ describe('sendPromptAnswer', () => {
   });
 
   // =========================================================================
+  // Issue #807: AskUserQuestion picker (isAskUserQuestion) cursor engagement
+  // =========================================================================
+  describe('Issue #807: AskUserQuestion picker cursor engagement', () => {
+    it('engages the cursor with Down+Up before Enter when selecting the default (offset=0)', async () => {
+      const promptData: PromptData = {
+        type: 'multiple_choice',
+        question: 'Phase 5 に進んでよいですか？',
+        options: [
+          { number: 1, label: '実装に進む (pm-auto-dev)', isDefault: true },
+          { number: 2, label: '設計/計画を先に確認したい', isDefault: false },
+          { number: 3, label: 'ここで一旦停止', isDefault: false },
+          { number: 4, label: 'Type something.', isDefault: false },
+          { number: 5, label: 'Chat about this', isDefault: false },
+        ],
+        status: 'pending',
+        isAskUserQuestion: true,
+      };
+
+      await sendPromptAnswer({
+        sessionName: 'claude-test',
+        answer: '1',
+        cliToolId: 'claude',
+        promptData,
+      });
+
+      // Net-zero Down+Up nudge engages the picker cursor, then Enter confirms.
+      expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test', ['Down', 'Up', 'Enter']);
+      expect(sendKeys).not.toHaveBeenCalled();
+    });
+
+    it('does NOT add the nudge for non-default targets (offset != 0 already engages cursor)', async () => {
+      const promptData: PromptData = {
+        type: 'multiple_choice',
+        question: 'Choose:',
+        options: [
+          { number: 1, label: 'A', isDefault: true },
+          { number: 2, label: 'B', isDefault: false },
+          { number: 3, label: 'C', isDefault: false },
+        ],
+        status: 'pending',
+        isAskUserQuestion: true,
+      };
+
+      await sendPromptAnswer({
+        sessionName: 'claude-test',
+        answer: '3',
+        cliToolId: 'claude',
+        promptData,
+      });
+
+      // offset = 3 - 1 = 2 -> the navigation itself engages the cursor.
+      expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test', ['Down', 'Down', 'Enter']);
+    });
+
+    it('keeps bare Enter for the default option when isAskUserQuestion is NOT set (legacy unchanged)', async () => {
+      const promptData: PromptData = {
+        type: 'multiple_choice',
+        question: 'Do you want to proceed?',
+        options: [
+          { number: 1, label: 'Yes', isDefault: true },
+          { number: 2, label: 'No', isDefault: false },
+        ],
+        status: 'pending',
+        // isAskUserQuestion intentionally omitted (legacy numbered confirmation)
+      };
+
+      await sendPromptAnswer({
+        sessionName: 'claude-test',
+        answer: '1',
+        cliToolId: 'claude',
+        promptData,
+      });
+
+      expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test', ['Enter']);
+    });
+
+    it('does not apply the nudge to multi-select pickers (checkbox flow takes priority)', async () => {
+      const promptData: PromptData = {
+        type: 'multiple_choice',
+        question: 'Select tools:',
+        options: [
+          { number: 1, label: '[ ] Option A', isDefault: true },
+          { number: 2, label: '[ ] Option B', isDefault: false },
+        ],
+        status: 'pending',
+        isAskUserQuestion: true,
+      };
+
+      await sendPromptAnswer({
+        sessionName: 'claude-test',
+        answer: '1',
+        cliToolId: 'claude',
+        promptData,
+      });
+
+      // Multi-select: Space toggle + navigate to "Next" + Enter (unchanged path).
+      expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test', ['Space', 'Down', 'Down', 'Enter']);
+    });
+  });
+
+  // =========================================================================
   // 8. Offset > 0 -> Down + Enter
   // =========================================================================
   describe('Offset > 0 (navigate Down)', () => {


### PR DESCRIPTION
## Summary

Fixes #807. Claude Code v2.x の AskUserQuestion picker UI で auto-yes が空振り（30 分以上 silent）する問題を検出側 + 応答側の両方で修正。

## Root cause

AskUserQuestion picker は `Enter to select · ↑/↓ to navigate · Esc to cancel` フッターの**下に** task panel overlay（例: `6 tasks (4 done, 2 open)`）を描画する。この trailing panel が `NORMAL_OPTION_PATTERN` で `6 tasks ...` を option 6 として誤拾い → reverse scan がフッターで止まり実 picker option (1./2./3.) を収集できず → `detectMultipleChoicePrompt` が `no_prompt` を返す → `sendPromptAnswer` 未到達 → auto-yes が silent に。

## Changes

**Detection** (`src/lib/detection/prompt-detect-multiple-choice.ts`):
- `CLAUDE_ASK_USER_QUESTION_FOOTER_PATTERN` を追加し、既存 `effectiveEnd` footer-trim 機構 (#704 mechanism) を拡張して picker フッターでも trim（trailing panel が scan window から外れる）。
- 旧 `Esc to cancel · Tab to amend` footer パターンは**未変更**（旧形式パス byte-for-byte 維持）。
- 検出時 `isAskUserQuestion` フラグを prompt data に付与。

**Answer sender** (`src/lib/prompt-answer-sender.ts`):
- AskUserQuestion picker かつ default (offset===0) を選択する場合、`Enter` 前に net-zero `Down+Up` nudge を送信し picker cursor を確実に engage（bare Enter は selection を commit できないケースあり）。
- offset !== 0 のケースは既存 navigation で cursor engaged 済みで影響なし。
- 旧形式 (`isAskUserQuestion` 未指定) は完全同じ key sequence 維持。

**Tests** (`tests/unit/lib/detection/prompt-detect-multiple-choice.test.ts`):
- 再現 fixture（clean picker + task-panel overlay の 2 ケース）を追加。
- answer-sender の AskUserQuestion 分岐テスト追加。
- 旧形式の detection/response 動作不変を検証。

## Verification

- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` 7413/7413 ✅（+18 vs baseline）
- [x] `npm run build` ✅

## Test plan

- [ ] 実機 UAT @ http://localhost:3000/worktrees/anvil-feature-issue-921-data-capability:
  - [ ] `/rebuild` 後、AskUserQuestion picker が出ている session で auto-yes が default option (1.) を選択して prompt を進めることを確認
  - [ ] 旧 `Do you want to make this edit?` / `Do you want to proceed?` 系の auto-yes 動作不変

## 関連

- #805 (status-detector) / #806 (busy 時 UX) と同系統の Claude Code v2.x 追従。
- 本 PR 後は #809 (CLAUDE.md 構造除去) に進む予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)