### PR TITLE
feat(git-pane): UX Phase 3 — 'Ask AI' buttons pre-populate composer for complex Git ops (#817)

### DIFF
--- a/src/components/worktree/GitPane.tsx
+++ b/src/components/worktree/GitPane.tsx
@@ -29,6 +29,15 @@ import type { GitNetworkOperation } from '@/types/git';
 import { BranchCheckoutDropdown } from '@/components/worktree/git/BranchCheckoutDropdown';
 import { AdvancedSection } from '@/components/worktree/git/AdvancedSection';
 import {
+  branchCreatePrompt,
+  branchDeletePrompt,
+  stashCleanupPrompt,
+  stashConflictPrompt,
+  resetPrompt,
+  revertPrompt,
+  forcePushPrompt,
+} from '@/lib/git-ai-prompt-templates';
+import {
   GIT_STATUS_POLL_INTERVAL_MS,
   RESET_HARD_HISTORY_LOSS_WARNING,
   DANGER_ZONE_RUNNING_SESSION_WARNING,
@@ -51,6 +60,13 @@ interface GitPaneProps {
    * the checkout confirm dialog. When omitted, no session warning is shown.
    */
   worktree?: Pick<Worktree, 'sessionStatusByCli'>;
+  /**
+   * Issue #817: pre-populate the active CLI tab's MessageInput composer with an
+   * "Ask AI" prompt (no auto-send). Wired to the parent's `handleInsertToMessage`
+   * (the same `pendingInsertTextMap` path History / Memo panes use). When
+   * omitted, the "Ask AI" buttons are hidden (graceful degradation).
+   */
+  onInsertToMessage?: (text: string) => void;
   className?: string;
 }
 
@@ -92,6 +108,39 @@ const RefreshIcon = memo(function RefreshIcon() {
         d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
       />
     </svg>
+  );
+});
+
+/**
+ * "Ask AI" button (Issue #817). Drafts a context-rich prompt into the active CLI
+ * tab's MessageInput composer (no auto-send) so the user can review/edit before
+ * sending. Presentational only: the call site owns the `onClick` (it builds the
+ * prompt from a `git-ai-prompt-templates` builder and closes any open dialog),
+ * and gates rendering on whether an `onInsertToMessage` handler is wired.
+ */
+const AskAiButton = memo(function AskAiButton({
+  onClick,
+  disabled = false,
+  testId,
+  className = '',
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  testId?: string;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-violet-300 dark:border-violet-700 text-violet-700 dark:text-violet-300 hover:bg-violet-50 dark:hover:bg-violet-900/30 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      data-testid={testId}
+      title="現在の状況を AI チャットに下書きします（自動送信はされません）"
+    >
+      <span aria-hidden="true">✨</span>
+      Ask AI
+    </button>
   );
 });
 
@@ -834,6 +883,8 @@ interface BranchesSectionProps {
   onRefresh: () => void;
   onCreate: (name: string, from: string | undefined) => void;
   onDelete: (name: string, force: boolean) => void;
+  /** Issue #817: draft an "Ask AI" prompt into the composer (no auto-send). */
+  onAskAi?: (text: string) => void;
 }
 
 /**
@@ -855,6 +906,7 @@ const BranchesSection = memo(function BranchesSection({
   onRefresh,
   onCreate,
   onDelete,
+  onAskAi,
 }: BranchesSectionProps) {
   // Mobile default-collapses the entire section (#780 same approach).
   const [open, setOpen] = useState(!isMobile);
@@ -1039,6 +1091,17 @@ const BranchesSection = memo(function BranchesSection({
               ))}
             </select>
             <div className="flex items-center justify-end gap-2">
+              {onAskAi && (
+                <AskAiButton
+                  className="mr-auto"
+                  testId="branch-create-ask-ai"
+                  disabled={createName.trim().length === 0}
+                  onClick={() => {
+                    onAskAi(branchCreatePrompt(createName, createFrom));
+                    setShowCreate(false);
+                  }}
+                />
+              )}
               <button
                 type="button"
                 onClick={() => setShowCreate(false)}
@@ -1082,6 +1145,17 @@ const BranchesSection = memo(function BranchesSection({
               Force delete (-D) — unmerged commits will be lost
             </label>
             <div className="flex items-center justify-end gap-2">
+              {onAskAi && deleteTarget && (
+                <AskAiButton
+                  className="mr-auto"
+                  testId="branch-delete-ask-ai"
+                  onClick={() => {
+                    onAskAi(branchDeletePrompt(deleteTarget.name, deleteForce));
+                    setDeleteTarget(null);
+                    setDeleteForce(false);
+                  }}
+                />
+              )}
               <button
                 type="button"
                 onClick={() => setDeleteTarget(null)}
@@ -1124,6 +1198,8 @@ interface StashSectionProps {
   onPop: (index: number) => void;
   onApply: (index: number) => void;
   onDrop: (index: number) => void;
+  /** Issue #817: draft an "Ask AI" prompt into the composer (no auto-send). */
+  onAskAi?: (text: string) => void;
 }
 
 /**
@@ -1145,6 +1221,7 @@ const StashSection = memo(function StashSection({
   onPop,
   onApply,
   onDrop,
+  onAskAi,
 }: StashSectionProps) {
   const [open, setOpen] = useState(!isMobile);
   const [pushMessage, setPushMessage] = useState('');
@@ -1165,14 +1242,22 @@ const StashSection = memo(function StashSection({
           <span className="text-xs w-4 text-center">{open ? '▼' : '▶'}</span>
           Stash {stashes.length > 0 && <span className="text-xs text-gray-400">({stashes.length})</span>}
         </button>
-        <button
-          type="button"
-          onClick={onRefresh}
-          className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded"
-          aria-label="Refresh stash list"
-        >
-          <RefreshIcon />
-        </button>
+        <div className="flex items-center gap-1">
+          {open && onAskAi && stashes.length > 0 && (
+            <AskAiButton
+              testId="stash-cleanup-ask-ai"
+              onClick={() => onAskAi(stashCleanupPrompt(stashes))}
+            />
+          )}
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded"
+            aria-label="Refresh stash list"
+          >
+            <RefreshIcon />
+          </button>
+        </div>
       </div>
 
       {open && (
@@ -1188,8 +1273,17 @@ const StashSection = memo(function StashSection({
             </div>
           )}
           {conflictNotice && (
-            <div className="text-xs text-orange-600 dark:text-orange-400" role="status" data-testid="git-stash-conflict">
-              {conflictNotice}
+            <div className="flex items-start justify-between gap-2">
+              <div className="text-xs text-orange-600 dark:text-orange-400" role="status" data-testid="git-stash-conflict">
+                {conflictNotice}
+              </div>
+              {onAskAi && (
+                <AskAiButton
+                  className="shrink-0"
+                  testId="stash-conflict-ask-ai"
+                  onClick={() => onAskAi(stashConflictPrompt(conflictNotice))}
+                />
+              )}
             </div>
           )}
 
@@ -1342,10 +1436,14 @@ interface DangerZoneSectionProps {
   actionError: string | null;
   conflictNotice: string | null;
   currentBranch: string | null;
+  /** Issue #817: commits ahead of upstream, for the force-push Ask AI prompt. */
+  aheadCount?: number | null;
   hasRunningSession: boolean;
   isMobile: boolean;
   onReset: (target: string, mode: GitResetMode, confirmBranch: string | undefined) => void;
   onRevert: (commitHash: string, noCommit: boolean) => void;
+  /** Issue #817: draft an "Ask AI" prompt into the composer (no auto-send). */
+  onAskAi?: (text: string) => void;
   /**
    * Issue #783: force-push the current branch. `--force-with-lease` is the
    * default (forceWithLease=true); the lease check is a second safety net. The
@@ -1368,11 +1466,13 @@ const DangerZoneSection = memo(function DangerZoneSection({
   actionError,
   conflictNotice,
   currentBranch,
+  aheadCount,
   hasRunningSession,
   isMobile,
   onReset,
   onRevert,
   onForcePush,
+  onAskAi,
 }: DangerZoneSectionProps) {
   const [open, setOpen] = useState(false); // default closed
   const [resetMode, setResetMode] = useState<GitResetMode>('mixed');
@@ -1534,6 +1634,19 @@ const DangerZoneSection = memo(function DangerZoneSection({
           )}
 
           <div className="flex items-center gap-2">
+            {onAskAi && (
+              <AskAiButton
+                className="mr-auto"
+                testId="reset-ask-ai"
+                disabled={resetTargetMissing}
+                onClick={() => {
+                  if (!resetTarget) return;
+                  onAskAi(resetPrompt(resetMode, resetTarget));
+                  setShowResetModal(false);
+                  setConfirmBranch('');
+                }}
+              />
+            )}
             <button
               type="button"
               disabled={
@@ -1595,6 +1708,17 @@ const DangerZoneSection = memo(function DangerZoneSection({
             No commit (leave staged)
           </label>
           <div className="flex items-center gap-2">
+            {onAskAi && (
+              <AskAiButton
+                className="mr-auto"
+                testId="revert-ask-ai"
+                onClick={() => {
+                  onAskAi(revertPrompt(selectedCommit));
+                  setShowRevertModal(false);
+                  setRevertNoCommit(false);
+                }}
+              />
+            )}
             <button
               type="button"
               disabled={busy}
@@ -1654,6 +1778,16 @@ const DangerZoneSection = memo(function DangerZoneSection({
             Use --force-with-lease (recommended — refuses if the remote moved)
           </label>
           <div className="flex items-center gap-2">
+            {onAskAi && (
+              <AskAiButton
+                className="mr-auto"
+                testId="force-push-ask-ai"
+                onClick={() => {
+                  onAskAi(forcePushPrompt({ branch: currentBranch, ahead: aheadCount ?? null }));
+                  setShowForcePushModal(false);
+                }}
+              />
+            )}
             <button
               type="button"
               disabled={busy}
@@ -1689,6 +1823,7 @@ export const GitPane = memo(function GitPane({
   onDiffSelect,
   isMobile = false,
   worktree,
+  onInsertToMessage,
   className = '',
 }: GitPaneProps) {
   const [commits, setCommits] = useState<CommitInfo[]>([]);
@@ -2872,6 +3007,7 @@ export const GitPane = memo(function GitPane({
           onRefresh={handleBranchesRefresh}
           onCreate={handleBranchCreate}
           onDelete={handleBranchDelete}
+          onAskAi={onInsertToMessage}
         />
 
         {/* Stash (Issue #782) */}
@@ -2889,6 +3025,7 @@ export const GitPane = memo(function GitPane({
           onPop={handleStashPop}
           onApply={handleStashApply}
           onDrop={handleStashDrop}
+          onAskAi={onInsertToMessage}
         />
 
         {/* Danger Zone (Issue #782) */}
@@ -2898,6 +3035,7 @@ export const GitPane = memo(function GitPane({
           actionError={dangerActionError}
           conflictNotice={dangerConflictNotice}
           currentBranch={gitStatus?.currentBranch ?? null}
+          aheadCount={gitStatus?.aheadBehind?.ahead ?? null}
           hasRunningSession={hasRunningSession}
           isMobile={isMobile}
           onReset={handleReset}
@@ -2905,6 +3043,7 @@ export const GitPane = memo(function GitPane({
           onForcePush={(forceWithLease) =>
             runNetworkPush(forceWithLease ? { forceWithLease: true } : { force: true })
           }
+          onAskAi={onInsertToMessage}
         />
       </AdvancedSection>
     </div>

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -524,6 +524,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
           onDiffSelect={onDiffSelect}
           isMobile={false}
           worktree={worktree ?? undefined}
+          onInsertToMessage={handleInsertToMessage}
           className="h-full"
         />
       ),

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -302,6 +302,7 @@ export const MobileContent = memo(function MobileContent({
                 onDiffSelect={onDiffSelect}
                 isMobile={true}
                 worktree={worktree ?? undefined}
+                onInsertToMessage={onInsertToMessage}
                 className="flex-1 min-h-0"
               />
             </ErrorBoundary>

--- a/src/lib/git-ai-prompt-templates.ts
+++ b/src/lib/git-ai-prompt-templates.ts
@@ -1,0 +1,100 @@
+/**
+ * Git "Ask AI" prompt templates (Issue #817).
+ *
+ * Single source of truth for the Japanese prompts that the GitPane "Ask AI"
+ * buttons pre-populate into the active CLI tab's MessageInput composer (no
+ * auto-send — the user reviews / edits before sending). Pure string builders:
+ * no React / DOM, so they are unit-testable in isolation and reusable from any
+ * GitPane section.
+ *
+ * i18n is a follow-up (this Phase 3 ships ja only); centralizing the wording
+ * here is what makes that follow-up a localized-table swap rather than a hunt
+ * through GitPane.tsx.
+ */
+
+import type { GitResetMode } from '@/types/git';
+
+/** Context for the force-push Ask AI prompt. */
+export interface ForcePushPromptInput {
+  /** Current local branch (null when unknown / detached HEAD). */
+  branch: string | null;
+  /** Commits ahead of upstream (null when unknown / no upstream). */
+  ahead: number | null;
+}
+
+/** A stash entry referenced by the stash-cleanup prompt. */
+export interface StashEntryRef {
+  index: number;
+  message: string;
+}
+
+const RESOLVE_THEN_COMMIT = 'conflict を解決してから commit してください。';
+
+/** Wrap `s` in Markdown inline code (kept literal so callers read naturally). */
+function code(s: string): string {
+  return '`' + s + '`';
+}
+
+/**
+ * Branch create + checkout. Mirrors the create-branch modal inputs; `from`
+ * falls back to the current HEAD when empty.
+ */
+export function branchCreatePrompt(name: string, from: string | undefined): string {
+  const base = from && from.trim().length > 0 ? code(from.trim()) : '現在の HEAD';
+  return `${base} から ${code(name.trim())} ブランチを作成して checkout してください。`;
+}
+
+/** Branch delete (force-aware). */
+export function branchDeletePrompt(name: string, force: boolean): string {
+  const forceNote = force
+    ? '（マージされていないコミットがあっても -D で強制削除してください）'
+    : '';
+  return `${code(name)} ブランチを削除してください。${forceNote}`;
+}
+
+/** Stash list / cleanup ("古い stash entry をリストアップ…"). */
+export function stashCleanupPrompt(stashes: StashEntryRef[]): string {
+  const head = '古い stash entry をリストアップし、不要なものを削除する提案をしてください。';
+  if (stashes.length === 0) return head;
+  const list = stashes.map((s) => `- stash@{${s.index}}: ${s.message}`).join('\n');
+  return `${head}\n\n現在の stash:\n${list}`;
+}
+
+/** Stash pop / apply conflict resolution. Appends the conflict notice if any. */
+export function stashConflictPrompt(conflictNotice: string | null): string {
+  const head = `stash の pop / apply で conflict が発生しました。${RESOLVE_THEN_COMMIT}`;
+  return conflictNotice && conflictNotice.trim().length > 0
+    ? `${head}\n\n${conflictNotice.trim()}`
+    : head;
+}
+
+/**
+ * Reset delegation. Hard mode adds a reflog-recovery note so the same prompt
+ * covers the "直前の hard reset を取り消したい" recovery case.
+ */
+export function resetPrompt(mode: GitResetMode, target: string): string {
+  const head = `${code(target)} に対して ${mode} reset を行いたいです。安全に実行してください。`;
+  if (mode === 'hard') {
+    return (
+      `${head} hard reset は作業内容を失う可能性があります。` +
+      'もし直前の hard reset を取り消したい場合は git reflog から復旧してください。'
+    );
+  }
+  return head;
+}
+
+/** Revert a specific commit. */
+export function revertPrompt(commitHash: string): string {
+  return `コミット ${code(commitHash.slice(0, 7))} を revert してください。`;
+}
+
+/** Force push with --force-with-lease, diff-first. */
+export function forcePushPrompt({ branch, ahead }: ForcePushPromptInput): string {
+  const branchRef = branch ? code(branch) : '現在のブランチ';
+  const aheadNote = typeof ahead === 'number' && ahead > 0 ? `（↑${ahead}）` : '';
+  const upstream = code(`origin/${branch ?? '<branch>'}`);
+  return (
+    `${branchRef}${aheadNote} を force-with-lease で push したいです。` +
+    `事前に upstream（${upstream}）との差分を確認し、安全な場合のみ push してください。`
+  );
+}

--- a/tests/unit/components/GitPane.test.tsx
+++ b/tests/unit/components/GitPane.test.tsx
@@ -14,6 +14,14 @@ import {
   RESET_HARD_HISTORY_LOSS_WARNING,
   PUSH_AUTH_FAILED_GUIDANCE,
 } from '@/config/git-status-config';
+// Issue #817: SSOT prompt builders — imported so the "Ask AI" wiring tests
+// assert the right builder/context without duplicating the ja wording here.
+import {
+  branchCreatePrompt,
+  branchDeletePrompt,
+  resetPrompt,
+  revertPrompt,
+} from '@/lib/git-ai-prompt-templates';
 
 // ----------------------------------------------------------------------------
 // URL-discriminating fetch mock (Issue #779 hard gate)
@@ -2122,6 +2130,249 @@ describe('GitPane', () => {
           expect(onDiffSelect).toHaveBeenCalledWith(PREVIEW_DIFF, 'src/unstaged.ts');
         });
       });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Issue #817: "Ask AI" buttons pre-populate the composer (no auto-send)
+  // --------------------------------------------------------------------------
+  describe("'Ask AI' buttons (Issue #817)", () => {
+    /** True if any fetch call hit `path` (optionally with the given method). */
+    function postedTo(path: string, method = 'POST') {
+      return mockFetch.mock.calls.some(
+        (call) =>
+          typeof call[0] === 'string' &&
+          (call[0] as string).includes(path) &&
+          ((call[1] as { method?: string } | undefined)?.method ?? 'GET') === method
+      );
+    }
+
+    it('drafts a create+checkout prompt into the composer and closes the modal (no POST)', async () => {
+      const onInsertToMessage = vi.fn();
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByTestId('git-advanced-toggle')).toBeInTheDocument());
+      openAdvanced();
+      await waitFor(() => expect(screen.getByTestId('git-branch-create-open')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('git-branch-create-open'));
+      await waitFor(() => expect(screen.getByTestId('branch-create-name-input')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByTestId('branch-create-name-input'), {
+        target: { value: 'feature/created' },
+      });
+      fireEvent.click(screen.getByTestId('branch-create-ask-ai'));
+
+      expect(onInsertToMessage).toHaveBeenCalledTimes(1);
+      expect(onInsertToMessage).toHaveBeenCalledWith(branchCreatePrompt('feature/created', ''));
+      // Modal closed; the create API was NOT called (delegated to the agent).
+      expect(screen.queryByTestId('branch-create-name-input')).not.toBeInTheDocument();
+      expect(postedTo('/git/branch/create')).toBe(false);
+    });
+
+    it('disables the create Ask AI button until a branch name is entered', async () => {
+      const onInsertToMessage = vi.fn();
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByTestId('git-advanced-toggle')).toBeInTheDocument());
+      openAdvanced();
+      fireEvent.click(screen.getByTestId('git-branch-create-open'));
+      await waitFor(() => expect(screen.getByTestId('branch-create-ask-ai')).toBeInTheDocument());
+
+      expect(screen.getByTestId('branch-create-ask-ai')).toBeDisabled();
+      fireEvent.change(screen.getByTestId('branch-create-name-input'), {
+        target: { value: 'feature/y' },
+      });
+      expect(screen.getByTestId('branch-create-ask-ai')).not.toBeDisabled();
+    });
+
+    it('drafts a delete prompt into the composer and closes the modal (no POST)', async () => {
+      const onInsertToMessage = vi.fn();
+      setEndpoints({
+        branches: {
+          ok: true,
+          json: {
+            branches: [
+              {
+                name: 'feature/old',
+                isCurrent: false,
+                isRemote: false,
+                isDefault: false,
+                upstream: null,
+                aheadBehind: null,
+                checkedOutWorktreePath: null,
+              },
+            ],
+          },
+        },
+      });
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByTestId('git-advanced-toggle')).toBeInTheDocument());
+      openAdvanced();
+      await waitFor(() => expect(screen.getByLabelText('Delete feature/old')).toBeInTheDocument());
+      fireEvent.click(screen.getByLabelText('Delete feature/old'));
+      await waitFor(() => expect(screen.getByTestId('branch-delete-ask-ai')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('branch-delete-ask-ai'));
+
+      expect(onInsertToMessage).toHaveBeenCalledWith(branchDeletePrompt('feature/old', false));
+      expect(screen.queryByTestId('branch-delete-ask-ai')).not.toBeInTheDocument();
+      expect(postedTo('/git/branch/delete')).toBe(false);
+    });
+
+    it('drafts a stash cleanup prompt listing the current stashes', async () => {
+      const onInsertToMessage = vi.fn();
+      setEndpoints({
+        stash: {
+          ok: true,
+          json: {
+            stashes: [{ index: 0, message: 'WIP on main: a', branch: 'main', date: '2026-01-01', sha: 'sha0' }],
+          },
+        },
+      });
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByTestId('git-advanced-toggle')).toBeInTheDocument());
+      openAdvanced();
+      await waitFor(() => expect(screen.getByTestId('stash-cleanup-ask-ai')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('stash-cleanup-ask-ai'));
+
+      expect(onInsertToMessage).toHaveBeenCalledTimes(1);
+      const inserted = onInsertToMessage.mock.calls[0][0] as string;
+      expect(inserted).toContain('古い stash entry');
+      expect(inserted).toContain('stash@{0}: WIP on main: a');
+    });
+
+    it('hides the stash cleanup Ask AI button when there are no stashes', async () => {
+      const onInsertToMessage = vi.fn();
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByTestId('git-advanced-toggle')).toBeInTheDocument());
+      openAdvanced();
+      await waitFor(() => expect(screen.getByTestId('git-stash-section')).toBeInTheDocument());
+      expect(screen.queryByTestId('stash-cleanup-ask-ai')).not.toBeInTheDocument();
+    });
+
+    it('offers a conflict-resolution Ask AI prompt after a stash pop conflict', async () => {
+      const onInsertToMessage = vi.fn();
+      setEndpoints({
+        stash: {
+          ok: true,
+          json: {
+            stashes: [{ index: 0, message: 'WIP on main: a', branch: 'main', date: '2026-01-01', sha: 'sha0' }],
+          },
+        },
+        stashPop: {
+          ok: true,
+          json: { success: true, conflict: true, conflictFiles: ['a.ts'], stashRetained: true },
+        },
+      });
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByTestId('git-advanced-toggle')).toBeInTheDocument());
+      openAdvanced();
+      await waitFor(() => expect(screen.getByTestId('stash-pop-button')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('stash-pop-button'));
+      await waitFor(() => expect(screen.getByTestId('stash-conflict-ask-ai')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('stash-conflict-ask-ai'));
+
+      const inserted = onInsertToMessage.mock.calls[0][0] as string;
+      expect(inserted).toContain('conflict を解決してから commit してください。');
+      expect(inserted).toContain('a.ts');
+    });
+
+    it('drafts a reset prompt and closes the Reset modal (no POST)', async () => {
+      const onInsertToMessage = vi.fn();
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await openDangerZone();
+      fireEvent.click(screen.getByTestId('git-danger-zone-reset-open'));
+      await waitFor(() => expect(screen.getByTestId('reset-ask-ai')).toBeInTheDocument());
+
+      // Default target HEAD + mixed mode.
+      fireEvent.click(screen.getByTestId('reset-ask-ai'));
+
+      expect(onInsertToMessage).toHaveBeenCalledWith(resetPrompt('mixed', 'HEAD'));
+      expect(screen.queryByTestId('reset-confirm')).not.toBeInTheDocument();
+      expect(postedTo('/git/reset')).toBe(false);
+    });
+
+    it('includes a git reflog recovery note for a hard reset Ask AI prompt', async () => {
+      const onInsertToMessage = vi.fn();
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await openDangerZone();
+      fireEvent.click(screen.getByTestId('git-danger-zone-reset-open'));
+      await waitFor(() => expect(screen.getByTestId('reset-mode-hard')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('reset-mode-hard'));
+      // Ask AI is not gated by the hard-confirm branch input (only the real Reset is).
+      fireEvent.click(screen.getByTestId('reset-ask-ai'));
+
+      const inserted = onInsertToMessage.mock.calls[0][0] as string;
+      expect(inserted).toContain('git reflog から復旧');
+      expect(postedTo('/git/reset')).toBe(false);
+    });
+
+    it('drafts a revert prompt for the selected commit', async () => {
+      const onInsertToMessage = vi.fn();
+      setEndpoints({
+        log: {
+          ok: true,
+          json: {
+            commits: [
+              { hash: 'abc1234def', shortHash: 'abc1234', message: 'pick me', author: 'a', date: '2026-01-01' },
+            ],
+          },
+        },
+      });
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await waitFor(() => expect(screen.getByText('pick me')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('pick me')); // select the commit
+
+      await openDangerZone();
+      await waitFor(() => expect(screen.getByTestId('git-danger-zone-revert-open')).not.toBeDisabled());
+      fireEvent.click(screen.getByTestId('git-danger-zone-revert-open'));
+      await waitFor(() => expect(screen.getByTestId('revert-ask-ai')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('revert-ask-ai'));
+
+      expect(onInsertToMessage).toHaveBeenCalledWith(revertPrompt('abc1234def'));
+      expect(postedTo('/git/revert')).toBe(false);
+    });
+
+    it('drafts a force-push prompt and closes the modal (no POST)', async () => {
+      const onInsertToMessage = vi.fn();
+      render(<GitPane {...defaultProps} onInsertToMessage={onInsertToMessage} />);
+
+      await openDangerZone();
+      fireEvent.click(screen.getByTestId('git-force-push-open'));
+      await waitFor(() => expect(screen.getByTestId('force-push-ask-ai')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('force-push-ask-ai'));
+
+      const inserted = onInsertToMessage.mock.calls[0][0] as string;
+      expect(inserted).toContain('force-with-lease');
+      // DEFAULT_STATUS.currentBranch is 'feature/test'.
+      expect(inserted).toContain('feature/test');
+      expect(screen.queryByTestId('force-push-confirm')).not.toBeInTheDocument();
+      expect(postedTo('/git/push')).toBe(false);
+    });
+
+    it('hides every Ask AI button when no onInsertToMessage handler is wired', async () => {
+      render(<GitPane {...defaultProps} />);
+
+      await openDangerZone();
+      fireEvent.click(screen.getByTestId('git-danger-zone-reset-open'));
+      await waitFor(() => expect(screen.getByTestId('reset-confirm')).toBeInTheDocument());
+      expect(screen.queryByTestId('reset-ask-ai')).not.toBeInTheDocument();
+
+      // Branch create modal also has no Ask AI affordance.
+      fireEvent.click(screen.getByTestId('git-branch-create-open'));
+      await waitFor(() => expect(screen.getByTestId('branch-create-name-input')).toBeInTheDocument());
+      expect(screen.queryByTestId('branch-create-ask-ai')).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/lib/git-ai-prompt-templates.test.ts
+++ b/tests/unit/lib/git-ai-prompt-templates.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for git-ai-prompt-templates (Issue #817).
+ *
+ * These are the SSOT prompt builders for the GitPane "Ask AI" buttons. They are
+ * pure functions, so we assert the exact ja wording / context interpolation
+ * here and let the component tests assert only that the right builder is wired.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  branchCreatePrompt,
+  branchDeletePrompt,
+  stashCleanupPrompt,
+  stashConflictPrompt,
+  resetPrompt,
+  revertPrompt,
+  forcePushPrompt,
+} from '@/lib/git-ai-prompt-templates';
+
+describe('git-ai-prompt-templates', () => {
+  describe('branchCreatePrompt', () => {
+    it('uses the given base branch when `from` is provided', () => {
+      const out = branchCreatePrompt('feature/123-foo', 'develop');
+      expect(out).toBe('`develop` から `feature/123-foo` ブランチを作成して checkout してください。');
+    });
+
+    it('falls back to the current HEAD when `from` is empty/undefined', () => {
+      expect(branchCreatePrompt('feature/x', undefined)).toBe(
+        '現在の HEAD から `feature/x` ブランチを作成して checkout してください。'
+      );
+      expect(branchCreatePrompt('feature/x', '   ')).toContain('現在の HEAD から');
+    });
+
+    it('trims whitespace around the name and base', () => {
+      expect(branchCreatePrompt('  feature/y  ', '  main  ')).toBe(
+        '`main` から `feature/y` ブランチを作成して checkout してください。'
+      );
+    });
+  });
+
+  describe('branchDeletePrompt', () => {
+    it('builds a plain delete prompt when not forced', () => {
+      expect(branchDeletePrompt('feature/old', false)).toBe(
+        '`feature/old` ブランチを削除してください。'
+      );
+    });
+
+    it('adds a -D force note when forced', () => {
+      const out = branchDeletePrompt('feature/old', true);
+      expect(out).toContain('`feature/old` ブランチを削除してください。');
+      expect(out).toContain('-D で強制削除');
+    });
+  });
+
+  describe('stashCleanupPrompt', () => {
+    it('returns just the head when there are no stashes', () => {
+      expect(stashCleanupPrompt([])).toBe(
+        '古い stash entry をリストアップし、不要なものを削除する提案をしてください。'
+      );
+    });
+
+    it('lists the current stash entries when present', () => {
+      const out = stashCleanupPrompt([
+        { index: 0, message: 'WIP on main: a' },
+        { index: 1, message: 'WIP on dev: b' },
+      ]);
+      expect(out).toContain('現在の stash:');
+      expect(out).toContain('- stash@{0}: WIP on main: a');
+      expect(out).toContain('- stash@{1}: WIP on dev: b');
+    });
+  });
+
+  describe('stashConflictPrompt', () => {
+    it('asks to resolve the conflict before commit', () => {
+      expect(stashConflictPrompt(null)).toContain('conflict を解決してから commit してください。');
+    });
+
+    it('appends the conflict notice when provided', () => {
+      const out = stashConflictPrompt('a.ts でコンフリクト (stash retained)');
+      expect(out).toContain('conflict を解決してから commit してください。');
+      expect(out).toContain('a.ts でコンフリクト (stash retained)');
+    });
+  });
+
+  describe('resetPrompt', () => {
+    it('builds a soft/mixed reset prompt without the reflog note', () => {
+      const soft = resetPrompt('soft', 'HEAD');
+      expect(soft).toBe('`HEAD` に対して soft reset を行いたいです。安全に実行してください。');
+      expect(soft).not.toContain('reflog');
+    });
+
+    it('adds a git reflog recovery note for hard reset', () => {
+      const hard = resetPrompt('hard', 'abc1234');
+      expect(hard).toContain('`abc1234` に対して hard reset を行いたいです。');
+      expect(hard).toContain('git reflog から復旧');
+    });
+  });
+
+  describe('revertPrompt', () => {
+    it('uses the short (7-char) commit hash', () => {
+      expect(revertPrompt('abc1234def5678')).toBe('コミット `abc1234` を revert してください。');
+    });
+  });
+
+  describe('forcePushPrompt', () => {
+    it('references the branch, ahead count, and upstream', () => {
+      const out = forcePushPrompt({ branch: 'feature/x', ahead: 3 });
+      expect(out).toContain('`feature/x`');
+      expect(out).toContain('（↑3）');
+      expect(out).toContain('force-with-lease');
+      expect(out).toContain('`origin/feature/x`');
+    });
+
+    it('omits the ahead note when ahead is null or 0', () => {
+      expect(forcePushPrompt({ branch: 'feature/x', ahead: null })).not.toContain('↑');
+      expect(forcePushPrompt({ branch: 'feature/x', ahead: 0 })).not.toContain('↑');
+    });
+
+    it('falls back gracefully when branch is null', () => {
+      const out = forcePushPrompt({ branch: null, ahead: null });
+      expect(out).toContain('現在のブランチ');
+      expect(out).toContain('origin/<branch>');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #817. **複雑な Git 操作を AI コーディングエージェントに委譲する**ユーザのメンタルモデルを UI で明示。Phase 1 (#815) / Phase 2 (#816) の上に "Ask AI" ボタンを Advanced 配下に配置。

## Changes

### A. SSOT: `src/lib/git-ai-prompt-templates.ts`（新規）

- **Pure builder functions** で日本語 prompt template を SSOT 管理
- 対象:
  - Branch create/delete（with checkout 同時実行案内）
  - Stash cleanup（古い entry 一括整理提案）
  - Stash pop/apply conflict（conflict 解決依頼）
  - Reset（hard reset 時は reflog 復旧案内付き）
  - Revert（指定 commit 取り消し）
  - Force push（事前 diff 確認 + force-with-lease 推奨）
- **i18n は follow-up**、まず ja のみ

### B. GitPane: 再利用可能 `AskAiButton`

- Advanced 配下のセクションに配置（既存 execute ボタンの**横**または下、置換ではない）
- クリックで context 付き prompt を **activeCliTab の composer に pre-populate**（既存 \`pendingInsertTextMap\` → \`handleInsertToMessage\` 経由、#728 / #744 確立済）
- **自動送信なし** — user が確認 / 編集 / 送信
- \`onInsertToMessage\` prop 未配線時は **button 非表示**（オプション機能扱い）

### C. 配線

- \`WorktreeDetailDesktop\` → GitPane に \`handleInsertToMessage\` 配線
- \`WorktreeDetailMobile\` → GitPane に \`onInsertToMessage\` 配線

### D. テスト

- \`git-ai-prompt-templates\` の builder 関数 unit tests（template 文言確定）
- GitPane "Ask AI" 配線 tests（composer drafted / dialog closed / **API POST されない**ことを確認）

## Verification

- [x] CLAUDE.md 14,931 bytes（不変、#809 directive 遵守）✅
- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` **7457/7457** ✅（+26 vs baseline）
- [x] `npm run build` ✅
- [x] docs/module-reference.md に詳細追記

## Test plan

- [ ] PC UAT @ http://localhost:3000/worktrees/* で GitPane を Advanced 展開:
  - [ ] Stash push/pop/apply/drop の各 modal/section に "Ask AI" ボタン表示
  - [ ] クリックで activeCliTab composer に template 挿入（送信されない）
  - [ ] Danger Zone (Reset / Revert / Force Push) modal に同様の "Ask AI" 配置
  - [ ] Branches create/delete dialog にも配置
  - [ ] composer 編集 → 送信で worker が実際に動く（#806 toast 表示 + #807 picker auto-yes と整合）

## 関連

- Phase 1: #815 → #819 マージ済（情報設計 2 階層化）
- Phase 2: #816 → #820 マージ済（compound buttons, inline diff）
- Phase 4: #818（mobile tab UI + visual grouping、次の Issue）
- 関連 directive: #809（CLAUDE.md untouched, detail to docs/module-reference.md）
- 関連 UX 基盤: #806（Queued toast）/ #807（AskUserQuestion picker auto-yes）— composer 送信時に効く

🤖 Generated with [Claude Code](https://claude.com/claude-code)