### PR TITLE
feat(schedules): UX Phase 3 — empty-state CTA + Logs tab separation + inline row actions (#826)

### DIFF
--- a/locales/en/schedule.json
+++ b/locales/en/schedule.json
@@ -1,6 +1,16 @@
 {
   "title": "Schedules",
   "executionLogs": "Execution Logs",
+  "tabs": {
+    "schedules": "Schedules",
+    "logs": "Logs"
+  },
+  "emptyState": {
+    "title": "No schedules yet",
+    "description": "Run an agent automatically on a cron schedule.",
+    "createButton": "Create Schedule",
+    "manualToggle": "Or edit CMATE.md manually"
+  },
   "noSchedules": "No schedules configured. Add a CMATE.md with a Schedules section.",
   "noSchedulesTitle": "No schedules configured",
   "noSchedulesStep1": "Switch to the Files tab",

--- a/locales/ja/schedule.json
+++ b/locales/ja/schedule.json
@@ -1,6 +1,16 @@
 {
   "title": "スケジュール",
   "executionLogs": "実行ログ",
+  "tabs": {
+    "schedules": "スケジュール",
+    "logs": "ログ"
+  },
+  "emptyState": {
+    "title": "スケジュールはまだありません",
+    "description": "cron スケジュールでエージェントを自動実行します。",
+    "createButton": "新規スケジュール作成",
+    "manualToggle": "または CMATE.md を直接編集"
+  },
   "noSchedules": "スケジュールが設定されていません。CMATE.mdにSchedulesセクションを追加してください。",
   "noSchedulesTitle": "スケジュールが設定されていません",
   "noSchedulesStep1": "Files タブに切り替えてください",

--- a/src/components/worktree/ExecutionLogPane.tsx
+++ b/src/components/worktree/ExecutionLogPane.tsx
@@ -1,11 +1,12 @@
 /**
  * ExecutionLogPane Component
  * Issue #294: Execution log list and schedule overview
+ * Issue #826: UX Phase 3 — empty-state CTA, Schedules/Logs tab separation,
+ *             inline row actions (toggle / edit / delete icons).
  *
- * Shows:
- * - Execution log entries (most recent first)
- * - Log detail expansion
- * - Schedule list section
+ * Two tabs:
+ * - Schedules: active schedule overview + configured schedule rows
+ * - Logs: execution log entries (delegated to ExecutionLogsView)
  */
 
 'use client';
@@ -13,34 +14,14 @@
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import { ScheduleEditDialog, type ScheduleFormValues } from '@/components/worktree/schedules/ScheduleEditDialog';
+import { ExecutionLogsView, type ExecutionLog } from '@/components/worktree/schedules/ExecutionLogsView';
+import { formatTimestamp } from '@/components/worktree/schedules/format';
 import { parseCmateContent } from '@/lib/cmate-validator';
 import { parseCliToolColumn } from '@/lib/cmate-cli-tool-parser';
 
 // ============================================================================
 // Types
 // ============================================================================
-
-/** Possible execution log status values */
-type ExecutionLogStatus = 'running' | 'completed' | 'failed' | 'timeout' | 'cancelled';
-
-/** Execution log entry from the list API (excludes result for performance) */
-interface ExecutionLog {
-  id: string;
-  schedule_id: string;
-  worktree_id: string;
-  message: string;
-  exit_code: number | null;
-  status: ExecutionLogStatus;
-  started_at: number;
-  completed_at: number | null;
-  created_at: number;
-  schedule_name: string | null;
-}
-
-/** Execution log detail from the individual API (includes result) */
-interface ExecutionLogDetail extends ExecutionLog {
-  result: string | null;
-}
 
 /** Schedule entry from the schedules API */
 interface Schedule {
@@ -69,44 +50,31 @@ interface ActiveSchedule {
   model?: string;
 }
 
+type ScheduleTab = 'schedules' | 'logs';
+
 export interface ExecutionLogPaneProps {
   worktreeId: string;
   className?: string;
 }
 
 // ============================================================================
-// Helper Functions
+// Icons (inline, so row actions stay icon-sized without an icon dep)
 // ============================================================================
 
-function formatTimestamp(ts: number): string {
-  return new Date(ts).toLocaleString();
+function EditIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+      <path d="M13.586 3.586a2 2 0 112.828 2.828l-8.5 8.5a1 1 0 01-.43.26l-3 .857a.5.5 0 01-.617-.618l.857-3a1 1 0 01.26-.43l8.5-8.5z" />
+    </svg>
+  );
 }
 
-/** Format duration between two timestamps in human-readable form */
-function formatDuration(startedAt: number, completedAt: number | null): string | null {
-  if (completedAt === null) return null;
-  const durationMs = completedAt - startedAt;
-  if (durationMs < 0) return null;
-
-  const totalSeconds = Math.floor(durationMs / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  if (minutes > 0) {
-    return `${minutes}m ${seconds}s`;
-  }
-  return `${seconds}s`;
-}
-
-/** Map execution log status to Tailwind CSS color classes */
-function getStatusColor(status: ExecutionLogStatus): string {
-  switch (status) {
-    case 'completed': return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/30';
-    case 'failed': return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30';
-    case 'timeout': return 'text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/30';
-    case 'running': return 'text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-900/30';
-    case 'cancelled': return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800';
-  }
+function DeleteIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+      <path fillRule="evenodd" d="M8 2a1 1 0 00-.894.553L6.382 4H3a1 1 0 000 2h.293l.668 9.357A2 2 0 005.956 17h8.088a2 2 0 001.995-1.643L16.707 6H17a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0012 2H8zm1 5a1 1 0 012 0v6a1 1 0 11-2 0V7zm-3 0a1 1 0 011 1v5a1 1 0 11-2 0V8a1 1 0 011-1z" clipRule="evenodd" />
+    </svg>
+  );
 }
 
 // ============================================================================
@@ -123,8 +91,10 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
   const [activeSchedules, setActiveSchedules] = useState<ActiveSchedule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
-  const [logDetail, setLogDetail] = useState<ExecutionLogDetail | null>(null);
+
+  // View state (Issue #826)
+  const [activeTab, setActiveTab] = useState<ScheduleTab>('schedules');
+  const [manualStepsOpen, setManualStepsOpen] = useState(false);
 
   // Schedule edit dialog state (Issue #824)
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -168,25 +138,6 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
   useEffect(() => {
     void fetchData();
   }, [fetchData]);
-
-  const handleExpandLog = useCallback(async (logId: string) => {
-    if (expandedLogId === logId) {
-      setExpandedLogId(null);
-      setLogDetail(null);
-      return;
-    }
-
-    try {
-      const res = await fetch(`/api/worktrees/${worktreeId}/execution-logs/${logId}`);
-      if (res.ok) {
-        const data = await res.json();
-        setLogDetail(data.log);
-        setExpandedLogId(logId);
-      }
-    } catch (err) {
-      console.error('Failed to fetch log detail:', err);
-    }
-  }, [worktreeId, expandedLogId]);
 
   // --------------------------------------------------------------------------
   // Schedule edit/create/delete/toggle (Issue #824, CMATE.md write-only sync)
@@ -315,169 +266,209 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
   }
 
   return (
-    <div className={`flex flex-col gap-4 p-4 overflow-y-auto ${className}`}>
-      {/* Schedules Section */}
-      <div>
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">{t('title')} ({schedules.length})</h3>
-          <button
-            type="button"
-            data-testid="schedule-new-button"
-            onClick={handleNewSchedule}
-            className="px-2 py-1 text-xs font-medium text-white bg-cyan-600 hover:bg-cyan-700 rounded transition-colors whitespace-nowrap"
-          >
-            + {t('edit.newSchedule')}
-          </button>
-        </div>
-        <div className="mb-3 rounded border border-cyan-100 bg-cyan-50/60 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
-          <div className="mb-2 flex items-center justify-between">
-            <span className="text-sm font-semibold text-cyan-900 dark:text-cyan-200">
-              {t('activeSchedulesTitle')} ({activeSchedules.length})
-            </span>
-            <span className="text-xs text-cyan-700 dark:text-cyan-300">
-              {t('activeSchedulesDescription')}
-            </span>
-          </div>
-          {activeSchedules.length === 0 ? (
-            <p className="text-xs text-cyan-800 dark:text-cyan-300">{t('noActiveSchedules')}</p>
-          ) : (
-            <div className="space-y-2">
-              {activeSchedules.map((schedule) => (
-                <div key={schedule.scheduleId} className="rounded border border-cyan-200/80 bg-white/80 p-3 dark:border-cyan-900/40 dark:bg-gray-900/60">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium text-sm text-gray-900 dark:text-gray-100">{schedule.name}</span>
-                    <div className="flex items-center gap-2">
-                      <span className={`text-xs px-2 py-0.5 rounded ${schedule.isCronActive ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'}`}>
-                        {schedule.isCronActive ? t('activeState.active') : t('activeState.inactive')}
-                      </span>
-                      {schedule.isExecuting && (
-                        <span className="text-xs px-2 py-0.5 rounded bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300">
-                          {t('activeState.executing')}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <div className="mt-1 text-xs text-gray-600 dark:text-gray-400">
-                    <span>{t('cron')}: {schedule.cronExpression || 'N/A'}</span>
-                    <span className="ml-3">{t('agentLabel')}: {schedule.cliToolId}</span>
-                    {schedule.model && (
-                      <span className="ml-3">model: {schedule.model}</span>
-                    )}
-                    {schedule.nextRunAt && (
-                      <span className="ml-3">{t('nextRun')}: {formatTimestamp(schedule.nextRunAt)}</span>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-        {schedules.length === 0 ? (
-          <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-            <p className="font-medium text-gray-600 dark:text-gray-300 mb-3">{t('noSchedulesTitle')}</p>
-            <ol className="text-sm text-left inline-block space-y-1.5 list-decimal list-inside">
-              <li>{t('noSchedulesStep1')}</li>
-              <li>{t('noSchedulesStep2')}</li>
-              <li>{t('noSchedulesStep3')}</li>
-              <li>{t('noSchedulesStep4')}</li>
-            </ol>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {schedules.map((schedule) => (
-              <div key={schedule.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-900">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium text-sm">{schedule.name}</span>
-                  <span className={`text-xs px-2 py-0.5 rounded ${schedule.enabled ? 'bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400' : 'bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400'}`}>
-                    {schedule.enabled ? t('enabled') : t('disabled')}
-                  </span>
-                </div>
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  <span>{t('cron')}: {schedule.cron_expression || 'N/A'}</span>
-                  {schedule.last_executed_at && (
-                    <span className="ml-3">{t('lastRun')}: {formatTimestamp(schedule.last_executed_at)}</span>
-                  )}
-                </div>
-                <div className="mt-2 flex items-center gap-2">
-                  <button
-                    type="button"
-                    data-testid={`schedule-edit-${schedule.name}`}
-                    onClick={() => void handleEditSchedule(schedule)}
-                    className="px-2 py-1 text-xs text-cyan-600 dark:text-cyan-400 hover:bg-cyan-50 dark:hover:bg-cyan-900/20 rounded transition-colors"
-                  >
-                    {t('edit.edit')}
-                  </button>
-                  <button
-                    type="button"
-                    data-testid={`schedule-toggle-${schedule.name}`}
-                    onClick={() => void handleToggleSchedule(schedule)}
-                    className="px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors"
-                  >
-                    {schedule.enabled ? t('edit.disable') : t('edit.enable')}
-                  </button>
-                  <button
-                    type="button"
-                    data-testid={`schedule-delete-${schedule.name}`}
-                    onClick={() => void handleDeleteSchedule(schedule.name)}
-                    className="px-2 py-1 text-xs text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded transition-colors"
-                  >
-                    {t('edit.delete')}
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+    <div className={`flex flex-col h-full ${className}`}>
+      {/* Tab bar (Issue #826): separate "Schedules" view from "Logs" view */}
+      <div className="flex shrink-0 border-b border-gray-200 dark:border-gray-700 px-4 pt-3">
+        <button
+          type="button"
+          data-testid="schedule-tab-schedules"
+          role="tab"
+          aria-selected={activeTab === 'schedules'}
+          onClick={() => setActiveTab('schedules')}
+          className={`-mb-px px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'schedules'
+              ? 'border-cyan-500 text-cyan-700 dark:text-cyan-300'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+          }`}
+        >
+          {t('tabs.schedules')} ({schedules.length})
+        </button>
+        <button
+          type="button"
+          data-testid="schedule-tab-logs"
+          role="tab"
+          aria-selected={activeTab === 'logs'}
+          onClick={() => setActiveTab('logs')}
+          className={`-mb-px px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'logs'
+              ? 'border-cyan-500 text-cyan-700 dark:text-cyan-300'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+          }`}
+        >
+          {t('tabs.logs')} ({logs.length})
+        </button>
       </div>
 
-      {/* Execution Logs Section */}
-      <div>
-        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">{t('executionLogs')} ({logs.length})</h3>
-        {logs.length === 0 ? (
-          <p className="text-sm text-gray-500 dark:text-gray-400">{t('noLogs')}</p>
-        ) : (
-          <div className="space-y-2">
-            {logs.map((log) => (
-              <div key={log.id} className="border border-gray-200 dark:border-gray-700 rounded bg-white dark:bg-gray-900">
+      <div className="flex-1 overflow-y-auto p-4">
+        {activeTab === 'schedules' ? (
+          <div className="flex flex-col gap-4">
+            {/* Active Schedules overview */}
+            <div className="rounded border border-cyan-100 bg-cyan-50/60 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-sm font-semibold text-cyan-900 dark:text-cyan-200">
+                  {t('activeSchedulesTitle')} ({activeSchedules.length})
+                </span>
+                <span className="text-xs text-cyan-700 dark:text-cyan-300">
+                  {t('activeSchedulesDescription')}
+                </span>
+              </div>
+              {activeSchedules.length === 0 ? (
+                <p className="text-xs text-cyan-800 dark:text-cyan-300">{t('noActiveSchedules')}</p>
+              ) : (
+                <div className="space-y-2">
+                  {activeSchedules.map((schedule) => (
+                    <div key={schedule.scheduleId} className="rounded border border-cyan-200/80 bg-white/80 p-3 dark:border-cyan-900/40 dark:bg-gray-900/60">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium text-sm text-gray-900 dark:text-gray-100">{schedule.name}</span>
+                        <div className="flex items-center gap-2">
+                          <span className={`text-xs px-2 py-0.5 rounded ${schedule.isCronActive ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'}`}>
+                            {schedule.isCronActive ? t('activeState.active') : t('activeState.inactive')}
+                          </span>
+                          {schedule.isExecuting && (
+                            <span className="text-xs px-2 py-0.5 rounded bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300">
+                              {t('activeState.executing')}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                        <span>{t('cron')}: {schedule.cronExpression || 'N/A'}</span>
+                        <span className="ml-3">{t('agentLabel')}: {schedule.cliToolId}</span>
+                        {schedule.model && (
+                          <span className="ml-3">model: {schedule.model}</span>
+                        )}
+                        {schedule.nextRunAt && (
+                          <span className="ml-3">{t('nextRun')}: {formatTimestamp(schedule.nextRunAt)}</span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Configured schedules */}
+            {schedules.length === 0 ? (
+              <div className="flex flex-col items-center text-center py-8 px-4">
+                <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-cyan-50 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-300">
+                  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-7 h-7">
+                    <circle cx="12" cy="12" r="9" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5V12l3 2" />
+                  </svg>
+                </div>
+                <p className="font-semibold text-gray-700 dark:text-gray-200 mb-1">{t('emptyState.title')}</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-xs">{t('emptyState.description')}</p>
                 <button
                   type="button"
-                  onClick={() => void handleExpandLog(log.id)}
-                  className="w-full text-left p-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  data-testid="schedule-empty-cta"
+                  onClick={handleNewSchedule}
+                  className="inline-flex items-center gap-1.5 px-5 py-2.5 text-sm font-semibold text-white bg-cyan-600 hover:bg-cyan-700 rounded-lg shadow-sm transition-colors"
                 >
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm truncate max-w-[60%]">{log.schedule_name || t('unknownSchedule')}</span>
-                    <span className={`text-xs px-2 py-0.5 rounded ${getStatusColor(log.status)}`}>
-                      {t(`status.${log.status}`)}
-                    </span>
-                  </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    {formatTimestamp(log.started_at)}
-                    {formatDuration(log.started_at, log.completed_at) && (
-                      <span className="ml-2">({formatDuration(log.started_at, log.completed_at)})</span>
-                    )}
-                    {log.exit_code !== null && <span className="ml-2">{t('exitCode')}: {log.exit_code}</span>}
-                  </div>
+                  <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                    <path d="M10 4a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V5a1 1 0 011-1z" />
+                  </svg>
+                  {t('emptyState.createButton')}
                 </button>
-
-                {expandedLogId === log.id && logDetail && (
-                  <div className="border-t border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-gray-800 space-y-3">
-                    <div>
-                      <div className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1">{t('message')}</div>
-                      <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200">
-                        {logDetail.message}
-                      </pre>
-                    </div>
-                    <div>
-                      <div className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1">{t('response')}</div>
-                      <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200 max-h-60 overflow-y-auto">
-                        {logDetail.result || t('noOutput')}
-                      </pre>
-                    </div>
-                  </div>
+                <button
+                  type="button"
+                  data-testid="schedule-manual-toggle"
+                  aria-expanded={manualStepsOpen}
+                  onClick={() => setManualStepsOpen((open) => !open)}
+                  className="mt-5 text-xs text-cyan-700 dark:text-cyan-300 hover:underline"
+                >
+                  {t('emptyState.manualToggle')}
+                </button>
+                {manualStepsOpen && (
+                  <ol
+                    data-testid="schedule-manual-steps"
+                    className="mt-3 text-xs text-left inline-block space-y-1.5 list-decimal list-inside text-gray-500 dark:text-gray-400"
+                  >
+                    <li>{t('noSchedulesStep1')}</li>
+                    <li>{t('noSchedulesStep2')}</li>
+                    <li>{t('noSchedulesStep3')}</li>
+                    <li>{t('noSchedulesStep4')}</li>
+                  </ol>
                 )}
               </div>
-            ))}
+            ) : (
+              <div>
+                <div className="mb-2 flex items-center justify-end">
+                  <button
+                    type="button"
+                    data-testid="schedule-new-button"
+                    onClick={handleNewSchedule}
+                    className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-white bg-cyan-600 hover:bg-cyan-700 rounded transition-colors whitespace-nowrap"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                      <path d="M10 4a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V5a1 1 0 011-1z" />
+                    </svg>
+                    {t('edit.newSchedule')}
+                  </button>
+                </div>
+                <div className="space-y-2">
+                  {schedules.map((schedule) => {
+                    const isEnabled = schedule.enabled === 1;
+                    return (
+                      <div key={schedule.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-900">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-medium text-sm truncate">{schedule.name}</span>
+                          <div className="flex items-center gap-1">
+                            {/* Inline enabled toggle (1-click, no modal) */}
+                            <button
+                              type="button"
+                              role="switch"
+                              aria-checked={isEnabled}
+                              aria-label={isEnabled ? t('edit.disable') : t('edit.enable')}
+                              title={isEnabled ? t('edit.disable') : t('edit.enable')}
+                              data-testid={`schedule-toggle-${schedule.name}`}
+                              onClick={() => void handleToggleSchedule(schedule)}
+                              className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+                                isEnabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
+                              }`}
+                            >
+                              <span
+                                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                                  isEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                                }`}
+                              />
+                            </button>
+                            <button
+                              type="button"
+                              data-testid={`schedule-edit-${schedule.name}`}
+                              aria-label={t('edit.edit')}
+                              title={t('edit.edit')}
+                              onClick={() => void handleEditSchedule(schedule)}
+                              className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 hover:bg-cyan-50 dark:hover:bg-cyan-900/20 rounded transition-colors"
+                            >
+                              <EditIcon />
+                            </button>
+                            <button
+                              type="button"
+                              data-testid={`schedule-delete-${schedule.name}`}
+                              aria-label={t('edit.delete')}
+                              title={t('edit.delete')}
+                              onClick={() => void handleDeleteSchedule(schedule.name)}
+                              className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded transition-colors"
+                            >
+                              <DeleteIcon />
+                            </button>
+                          </div>
+                        </div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          <span>{t('cron')}: {schedule.cron_expression || 'N/A'}</span>
+                          {schedule.last_executed_at && (
+                            <span className="ml-3">{t('lastRun')}: {formatTimestamp(schedule.last_executed_at)}</span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
           </div>
+        ) : (
+          <ExecutionLogsView worktreeId={worktreeId} logs={logs} />
         )}
       </div>
 

--- a/src/components/worktree/schedules/ExecutionLogsView.tsx
+++ b/src/components/worktree/schedules/ExecutionLogsView.tsx
@@ -1,0 +1,143 @@
+/**
+ * ExecutionLogsView Component
+ * Issue #826: Execution Logs separated from the Schedules view.
+ *
+ * Renders the execution log list with on-demand detail expansion. Extracted
+ * from ExecutionLogPane so the "Logs" tab owns its own expansion state and
+ * detail fetching, keeping the Schedules view focused.
+ */
+
+'use client';
+
+import React, { useState, useCallback, memo } from 'react';
+import { useTranslations } from 'next-intl';
+import { formatTimestamp, formatDuration } from './format';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Possible execution log status values */
+export type ExecutionLogStatus = 'running' | 'completed' | 'failed' | 'timeout' | 'cancelled';
+
+/** Execution log entry from the list API (excludes result for performance) */
+export interface ExecutionLog {
+  id: string;
+  schedule_id: string;
+  worktree_id: string;
+  message: string;
+  exit_code: number | null;
+  status: ExecutionLogStatus;
+  started_at: number;
+  completed_at: number | null;
+  created_at: number;
+  schedule_name: string | null;
+}
+
+/** Execution log detail from the individual API (includes result) */
+export interface ExecutionLogDetail extends ExecutionLog {
+  result: string | null;
+}
+
+export interface ExecutionLogsViewProps {
+  worktreeId: string;
+  logs: ExecutionLog[];
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Map execution log status to Tailwind CSS color classes */
+function getStatusColor(status: ExecutionLogStatus): string {
+  switch (status) {
+    case 'completed': return 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/30';
+    case 'failed': return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30';
+    case 'timeout': return 'text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/30';
+    case 'running': return 'text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-900/30';
+    case 'cancelled': return 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800';
+  }
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export const ExecutionLogsView = memo(function ExecutionLogsView({
+  worktreeId,
+  logs,
+}: ExecutionLogsViewProps) {
+  const t = useTranslations('schedule');
+  const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
+  const [logDetail, setLogDetail] = useState<ExecutionLogDetail | null>(null);
+
+  const handleExpandLog = useCallback(async (logId: string) => {
+    if (expandedLogId === logId) {
+      setExpandedLogId(null);
+      setLogDetail(null);
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/worktrees/${worktreeId}/execution-logs/${logId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setLogDetail(data.log);
+        setExpandedLogId(logId);
+      }
+    } catch (err) {
+      console.error('Failed to fetch log detail:', err);
+    }
+  }, [worktreeId, expandedLogId]);
+
+  if (logs.length === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">{t('noLogs')}</p>;
+  }
+
+  return (
+    <div className="space-y-2" data-testid="execution-logs-view">
+      {logs.map((log) => (
+        <div key={log.id} className="border border-gray-200 dark:border-gray-700 rounded bg-white dark:bg-gray-900">
+          <button
+            type="button"
+            onClick={() => void handleExpandLog(log.id)}
+            className="w-full text-left p-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm truncate max-w-[60%]">{log.schedule_name || t('unknownSchedule')}</span>
+              <span className={`text-xs px-2 py-0.5 rounded ${getStatusColor(log.status)}`}>
+                {t(`status.${log.status}`)}
+              </span>
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {formatTimestamp(log.started_at)}
+              {formatDuration(log.started_at, log.completed_at) && (
+                <span className="ml-2">({formatDuration(log.started_at, log.completed_at)})</span>
+              )}
+              {log.exit_code !== null && <span className="ml-2">{t('exitCode')}: {log.exit_code}</span>}
+            </div>
+          </button>
+
+          {expandedLogId === log.id && logDetail && (
+            <div className="border-t border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-gray-800 space-y-3">
+              <div>
+                <div className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1">{t('message')}</div>
+                <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200">
+                  {logDetail.message}
+                </pre>
+              </div>
+              <div>
+                <div className="text-xs font-semibold text-gray-600 dark:text-gray-300 mb-1">{t('response')}</div>
+                <pre className="text-xs whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200 max-h-60 overflow-y-auto">
+                  {logDetail.result || t('noOutput')}
+                </pre>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+});
+
+export default ExecutionLogsView;

--- a/src/components/worktree/schedules/format.ts
+++ b/src/components/worktree/schedules/format.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared formatting helpers for the Schedules UI (Issue #826).
+ *
+ * Centralizes timestamp / duration formatting so that the Schedules pane and
+ * the Execution Logs view present "last run" / "next run" / log times in one
+ * consistent format.
+ */
+
+/** Format a unix-millis timestamp using the user's locale. */
+export function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+/** Format the duration between two timestamps in human-readable form. */
+export function formatDuration(startedAt: number, completedAt: number | null): string | null {
+  if (completedAt === null) return null;
+  const durationMs = completedAt - startedAt;
+  if (durationMs < 0) return null;
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}

--- a/tests/unit/components/schedules/ExecutionLogsView.test.tsx
+++ b/tests/unit/components/schedules/ExecutionLogsView.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for ExecutionLogsView (Issue #826)
+ *
+ * Focus: empty message, log rendering, and on-demand detail expansion.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import {
+  ExecutionLogsView,
+  type ExecutionLog,
+} from '@/components/worktree/schedules/ExecutionLogsView';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function makeLog(overrides: Partial<ExecutionLog> = {}): ExecutionLog {
+  return {
+    id: 'log-1',
+    schedule_id: 'sch-1',
+    worktree_id: 'wt-1',
+    message: 'do work',
+    exit_code: 0,
+    status: 'completed',
+    started_at: 1_700_000_000_000,
+    completed_at: 1_700_000_010_000,
+    created_at: 1_700_000_000_000,
+    schedule_name: 'daily-review',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ExecutionLogsView', () => {
+  it('shows the empty message when there are no logs', () => {
+    render(<ExecutionLogsView worktreeId="wt-1" logs={[]} />);
+    expect(screen.getByText('schedule.noLogs')).toBeDefined();
+    expect(screen.queryByTestId('execution-logs-view')).toBeNull();
+  });
+
+  it('renders a row per log with its schedule name and status', () => {
+    render(<ExecutionLogsView worktreeId="wt-1" logs={[makeLog()]} />);
+    expect(screen.getByTestId('execution-logs-view')).toBeDefined();
+    expect(screen.getByText('daily-review')).toBeDefined();
+    expect(screen.getByText('schedule.status.completed')).toBeDefined();
+  });
+
+  it('fetches and shows detail when a log row is expanded', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ log: { ...makeLog(), result: 'the output' } }),
+    });
+    render(<ExecutionLogsView worktreeId="wt-1" logs={[makeLog()]} />);
+
+    fireEvent.click(screen.getByText('daily-review'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/worktrees/wt-1/execution-logs/log-1');
+      expect(screen.getByText('the output')).toBeDefined();
+    });
+  });
+
+  it('falls back to the deleted-schedule label when schedule_name is null', () => {
+    render(<ExecutionLogsView worktreeId="wt-1" logs={[makeLog({ schedule_name: null })]} />);
+    expect(screen.getByText('schedule.unknownSchedule')).toBeDefined();
+  });
+});

--- a/tests/unit/components/worktree/ExecutionLogPane.test.tsx
+++ b/tests/unit/components/worktree/ExecutionLogPane.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for ExecutionLogPane (Issue #826 — UX Phase 3)
+ *
+ * Focus: empty-state CTA + collapsible manual steps, Schedules/Logs tab
+ * separation, and inline row actions (toggle / edit / delete).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import { ExecutionLogPane } from '@/components/worktree/ExecutionLogPane';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+interface RouteData {
+  schedules?: unknown[];
+  logs?: unknown[];
+  active?: unknown[];
+}
+
+/** Route the three mount-time GETs by URL; PATCH/DELETE resolve ok. */
+function setupFetch({ schedules = [], logs = [], active = [] }: RouteData = {}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    if (method !== 'GET') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    }
+    if (url.endsWith('/schedules/active')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ schedules: active }) });
+    }
+    if (url.endsWith('/schedules')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ schedules }) });
+    }
+    if (url.endsWith('/execution-logs')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ logs }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+function makeSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sch-1',
+    worktree_id: 'wt-1',
+    name: 'daily-review',
+    message: 'Summarize README',
+    cron_expression: '0 9 * * *',
+    cli_tool_id: 'claude',
+    enabled: 1,
+    last_executed_at: 1_700_000_000_000,
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ExecutionLogPane (Issue #826)', () => {
+  describe('empty state', () => {
+    it('shows a centered create CTA and hides manual steps by default', async () => {
+      setupFetch({ schedules: [] });
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      const cta = await screen.findByTestId('schedule-empty-cta');
+      expect(cta).toBeDefined();
+      expect(screen.queryByTestId('schedule-manual-steps')).toBeNull();
+    });
+
+    it('reveals the legacy 4-step manual instructions when the toggle is clicked', async () => {
+      setupFetch({ schedules: [] });
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      const toggle = await screen.findByTestId('schedule-manual-toggle');
+      fireEvent.click(toggle);
+
+      const steps = screen.getByTestId('schedule-manual-steps');
+      expect(steps.querySelectorAll('li')).toHaveLength(4);
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('opens the create dialog when the CTA is clicked', async () => {
+      setupFetch({ schedules: [] });
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      const cta = await screen.findByTestId('schedule-empty-cta');
+      fireEvent.click(cta);
+
+      // ScheduleEditDialog renders its name input only when open.
+      expect(await screen.findByTestId('schedule-name-input')).toBeDefined();
+    });
+  });
+
+  describe('tabs', () => {
+    it('defaults to the Schedules tab and switches to Logs on click', async () => {
+      setupFetch({ schedules: [makeSchedule()], logs: [] });
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      // Schedules tab content (the row) is visible first.
+      expect(await screen.findByTestId('schedule-edit-daily-review')).toBeDefined();
+
+      fireEvent.click(screen.getByTestId('schedule-tab-logs'));
+
+      // Logs tab: no logs message; schedule row no longer rendered.
+      expect(screen.queryByTestId('schedule-edit-daily-review')).toBeNull();
+      expect(screen.getByText('schedule.noLogs')).toBeDefined();
+    });
+  });
+
+  describe('inline row actions', () => {
+    it('renders an enabled switch plus edit and delete icon buttons', async () => {
+      setupFetch({ schedules: [makeSchedule({ enabled: 1 })] });
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      const toggle = await screen.findByTestId('schedule-toggle-daily-review');
+      expect(toggle.getAttribute('role')).toBe('switch');
+      expect(toggle.getAttribute('aria-checked')).toBe('true');
+      expect(screen.getByTestId('schedule-edit-daily-review')).toBeDefined();
+      expect(screen.getByTestId('schedule-delete-daily-review')).toBeDefined();
+    });
+
+    it('sends a PATCH with the flipped enabled flag when the toggle is clicked', async () => {
+      setupFetch({ schedules: [makeSchedule({ enabled: 1 })] });
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      const toggle = await screen.findByTestId('schedule-toggle-daily-review');
+      fireEvent.click(toggle);
+
+      await waitFor(() => {
+        const patch = mockFetch.mock.calls.find(
+          ([, init]) => (init as RequestInit | undefined)?.method === 'PATCH',
+        );
+        expect(patch).toBeDefined();
+        expect(patch![0]).toContain('/cmate/schedules');
+        expect(JSON.parse((patch![1] as RequestInit).body as string)).toEqual({
+          name: 'daily-review',
+          enabled: false,
+        });
+      });
+    });
+
+    it('sends a DELETE after confirmation when the delete icon is clicked', async () => {
+      setupFetch({ schedules: [makeSchedule()] });
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      render(<ExecutionLogPane worktreeId="wt-1" />);
+
+      const del = await screen.findByTestId('schedule-delete-daily-review');
+      fireEvent.click(del);
+
+      await waitFor(() => {
+        const call = mockFetch.mock.calls.find(
+          ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE',
+        );
+        expect(call).toBeDefined();
+        expect(JSON.parse((call![1] as RequestInit).body as string)).toEqual({ name: 'daily-review' });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #826. Schedules UX Phase 3: ExecutionLogPane を再構成（empty state CTA / Logs 分離 / inline row actions）。CRUD と data-testids は不変。

## Changes

### A. Empty state CTA リデザイン

- 中央に **icon + 簡潔コピー + "+ 新規スケジュール作成" CTA ボタン**
- 既存の 4 ステップ CMATE.md 手動手順は **折り畳み**（"または CMATE.md を直接編集" toggle、default 閉）へ移動

### B. Execution Logs を別タブに分離

- pane 内 **タブ切替**（"Schedules" / "Logs"）
- 新規 `src/components/worktree/schedules/ExecutionLogsView.tsx` (143 行) — Logs view 抽出
- expansion / detail-fetch state は ExecutionLogsView が所有

### C. Schedule row inline actions

- **enabled toggle**（role=switch、1-click、modal を開かない）
- **edit icon button** / **delete icon button**（aria-labelled、コンパクト）
- 新規 `src/components/worktree/schedules/format.ts` (28 行) — last-run / next-run / log timestamp の format ヘルパー共有

### D. 不変性

- CRUD 動作・data-testids 完全不変
- Phase 1 で配線した modal 経由の create/edit/delete/toggle はそのまま

### E. テスト

新規 unit tests:
- empty-state CTA 表示
- manual-steps 折り畳み toggle
- Schedules / Logs タブ切替
- inline toggle / delete row actions
- ExecutionLogsView

## Verification

- [x] CLAUDE.md 14,931 bytes（不変、#809 directive 遵守）✅
- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` **7550/7550** ✅（+11 vs Phase 2 baseline）
- [x] `npm run build` ✅
- [x] docs/module-reference.md に新規 ExecutionLogsView/format.ts を追記

## Test plan

- [ ] PC UAT @ http://localhost:3000/worktrees/* Schedules activity:
  - [ ] schedules 0 件時に "Create Schedule" CTA 中央表示、4-step 手順は折り畳み内
  - [ ] "Schedules" / "Logs" タブ切替が動作
  - [ ] row 内 enabled toggle が 1-click で動作（modal 開かず）
  - [ ] edit/delete icon button が動作
  - [ ] Phase 1 modal 動作不変、Phase 2 mobile full-screen 動作不変
- [ ] Mobile UAT で同様確認

## 関連

- 前提: Phase 1 (#824 / PR #828) / Phase 2 (#825 / PR #829) マージ済
- 後続: Phase 4 (#827) "Ask AI" buttons in modal
- 既存 directive 遵守: #809 (CLAUDE.md untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)