### PR TITLE
fix(schedules): show disabled schedules so #824 modal can manage them

### DIFF
--- a/src/app/api/worktrees/[id]/schedules/route.ts
+++ b/src/app/api/worktrees/[id]/schedules/route.ts
@@ -42,7 +42,7 @@ export async function GET(
     }
 
     const schedules = db.prepare(
-      'SELECT * FROM scheduled_executions WHERE worktree_id = ? AND enabled = 1 ORDER BY created_at DESC'
+      'SELECT * FROM scheduled_executions WHERE worktree_id = ? ORDER BY created_at DESC'
     ).all(params.id);
 
     return NextResponse.json({ schedules }, { status: 200 });

--- a/tests/unit/schedules-route.test.ts
+++ b/tests/unit/schedules-route.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for schedules/route.ts
+ * Regression test for: GET should return both enabled and disabled schedules
+ * so the UI (introduced in #824) can edit/toggle/delete disabled rows.
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+interface Row {
+  id: string;
+  worktree_id: string;
+  name: string;
+  enabled: 0 | 1;
+}
+
+const allMock = vi.fn<(...args: unknown[]) => Row[]>();
+const prepareMock = vi.fn((_sql: string) => ({ all: allMock }));
+
+vi.mock('@/lib/db/db-instance', () => ({
+  getDbInstance: vi.fn(() => ({ prepare: prepareMock })),
+}));
+
+vi.mock('@/lib/db', () => ({
+  getWorktreeById: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { GET } from '@/app/api/worktrees/[id]/schedules/route';
+import { getWorktreeById } from '@/lib/db';
+
+function makeReq(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/worktrees/wt-1/schedules', { method: 'GET' });
+}
+
+describe('GET /api/worktrees/[id]/schedules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getWorktreeById).mockReturnValue({ id: 'wt-1', path: '/wt-1' } as never);
+  });
+
+  it('returns both enabled (1) and disabled (0) rows so the UI can manage every CMATE.md entry', async () => {
+    allMock.mockReturnValue([
+      { id: 'a', worktree_id: 'wt-1', name: 'enabled-one', enabled: 1 },
+      { id: 'b', worktree_id: 'wt-1', name: 'disabled-one', enabled: 0 },
+      { id: 'c', worktree_id: 'wt-1', name: 'disabled-two', enabled: 0 },
+    ]);
+
+    const res = await GET(makeReq(), { params: { id: 'wt-1' } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.schedules).toHaveLength(3);
+    expect(body.schedules.map((s: Row) => s.name)).toEqual([
+      'enabled-one',
+      'disabled-one',
+      'disabled-two',
+    ]);
+  });
+
+  it('SQL must not filter by enabled (regression: pre-fix query was AND enabled = 1)', () => {
+    allMock.mockReturnValue([]);
+    void GET(makeReq(), { params: { id: 'wt-1' } });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const sql = prepareMock.mock.calls[0][0];
+    expect(sql).not.toMatch(/enabled\s*=\s*1/);
+    expect(sql).toMatch(/WHERE\s+worktree_id\s*=\s*\?/);
+  });
+});


### PR DESCRIPTION
## Summary

`GET /api/worktrees/[id]/schedules` の SQL に **`AND enabled = 1` がハードコード**されており、CMATE.md で `enabled=false` のレコードが UI に表示されない不具合を修正。

## Root cause

`src/app/api/worktrees/[id]/schedules/route.ts:45`:

```sql
-- Before
SELECT * FROM scheduled_executions WHERE worktree_id = ? AND enabled = 1 ORDER BY created_at DESC

-- After
SELECT * FROM scheduled_executions WHERE worktree_id = ? ORDER BY created_at DESC
```

- pane が read-only だった時代 (#294 era) は disabled を「どうせ動かない」として除外していて問題なかった
- #824 (PR #828) で create/edit/delete/toggle UI を追加した結果、disabled schedule が **UI から見えず管理不可** になっていた

## 実機再現

http://localhost:3000/worktrees/commandmate-marketing-main の CMATE.md には 8 件の schedule（うち 7 件が `enabled=false`）が定義されているが、API は `enabled=true` の 1 件 (`githubInsights`) しか返さない。

## Changes

- `src/app/api/worktrees/[id]/schedules/route.ts`: SQL から `AND enabled = 1` を削除
- `tests/unit/schedules-route.test.ts` (新規): regression test
  - enabled + disabled 両方のレコードが返却されることを確認
  - SQL が `enabled = 1` を含まないことを確認（再発防止 pin）

## 不変

- Active Schedules セクション（`/schedules/active` 別 endpoint）— actually-running cron job のみ取得、本修正の影響なし
- cron-parser の CMATE.md sync + soft-delete (`enabled=0` when removed) 動作不変
- UI 側 (`ExecutionLogPane.tsx`) は既に `schedule.enabled` で表示分岐済 — 緑/グレー badge + toggle 表示が正しく動く（Phase 3 で配線済）

## Verification

- [x] CLAUDE.md 14,931 bytes（不変、#809 directive 遵守）✅
- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] `npm run test:unit` **7563/7563** ✅（+2 新規 regression cases）
- [x] `npm run build` ✅

## Test plan

- [ ] `/rebuild` 後 http://localhost:3000/worktrees/commandmate-marketing-main を開く:
  - [ ] Schedules pane に **8 件すべて表示**される（disabled の 7 件含む）
  - [ ] disabled row が **グレー badge** で表示、toggle で enable に切替可能
  - [ ] enable 後、CMATE.md が **enabled=true** に書き換わる（#824 動線）
  - [ ] Active Schedules section は `githubInsights` 1 件のまま（変化なし）
- [ ] 別 worktree で従来通り表示動作確認

## 関連

- 設計上の遠因: #824 (Phase 1) で UI editable 化 — pane が read-only だった前提が崩れた
- 既存 directive 遵守: #809 (CLAUDE.md untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)