### PR TITLE
fix(terminal-pane): clear residual PC terminal output after agent close + add ended placeholder

### DIFF
--- a/src/components/worktree/TerminalDisplay.tsx
+++ b/src/components/worktree/TerminalDisplay.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import React, { useEffect, useRef, useMemo, memo, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useMemo, memo, useCallback } from 'react';
 import { sanitizeTerminalOutput } from '@/lib/security/sanitize';
 import { useTerminalScroll } from '@/hooks/useTerminalScroll';
 import { useTerminalSearch } from '@/hooks/useTerminalSearch';
@@ -21,6 +21,12 @@ export interface TerminalDisplayProps {
   output: string;
   /** Whether the terminal session is currently active */
   isActive: boolean;
+  /**
+   * Issue #842: true while the pane is performing its initial attach (before the
+   * first /current-output response). Used to render a "loading" placeholder and
+   * to suppress the "session ended" placeholder during load / not-started states.
+   */
+  attaching?: boolean;
   /** Whether Claude is currently thinking/processing */
   isThinking?: boolean;
   /** Initial auto-scroll state (default: true) */
@@ -68,6 +74,7 @@ function ThinkingIndicator() {
 export const TerminalDisplay = memo(function TerminalDisplay({
   output,
   isActive,
+  attaching = false,
   isThinking = false,
   autoScroll: initialAutoScroll = true,
   onScrollChange,
@@ -114,6 +121,26 @@ export const TerminalDisplay = memo(function TerminalDisplay({
 
   // Sanitize the output for safe rendering
   const sanitizedOutput = sanitizeTerminalOutput(output || '');
+
+  // Issue #842: distinguish "loading (attaching)" / "not-started" / "ended" so an
+  // empty terminal does not ambiguously read as a dead session. We only show the
+  // "session ended" placeholder once a session that was actually active becomes
+  // inactive with no output — never during initial attach or for a never-started
+  // pane (which would otherwise read as a spurious "ended" state).
+  const [hasBeenActive, setHasBeenActive] = useState(false);
+  useEffect(() => {
+    if (attaching) {
+      // A fresh attach (mount or worktree/CLI switch) resets the lifecycle.
+      setHasBeenActive(false);
+    } else if (isActive) {
+      setHasBeenActive(true);
+    }
+  }, [attaching, isActive]);
+
+  const isEmptyOutput = !output;
+  const showLoadingPlaceholder = isEmptyOutput && attaching;
+  const showEndedPlaceholder =
+    isEmptyOutput && !attaching && !isActive && hasBeenActive;
 
   // Issue #379: Track when we need to scroll to top on next content arrival.
   // When switching to a disableAutoFollow tab (OpenCode), the content is cleared then
@@ -212,6 +239,24 @@ export const TerminalDisplay = memo(function TerminalDisplay({
           className="whitespace-pre-wrap break-words"
           dangerouslySetInnerHTML={{ __html: sanitizedOutput }}
         />
+
+        {/* Issue #842: empty-state placeholders clarify loading vs. ended. */}
+        {showLoadingPlaceholder && (
+          <div
+            data-testid="terminal-loading-placeholder"
+            className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-500 select-none"
+          >
+            読込中...
+          </div>
+        )}
+        {showEndedPlaceholder && (
+          <div
+            data-testid="terminal-ended-placeholder"
+            className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-500 select-none"
+          >
+            セッションは終了しました（メッセージ送信で再開できます）
+          </div>
+        )}
 
         {/* Thinking indicator */}
         {isActive && isThinking && <ThinkingIndicator />}

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -293,6 +293,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
       <TerminalDisplay
         output={terminal.output}
         isActive={terminal.isRunning}
+        attaching={terminal.attaching}
         isThinking={terminal.isThinking}
         autoScroll={terminal.autoScroll}
         onScrollChange={handleAutoScrollChange}
@@ -302,6 +303,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
     [
       terminal.output,
       terminal.isRunning,
+      terminal.attaching,
       terminal.isThinking,
       terminal.autoScroll,
       handleAutoScrollChange,

--- a/src/hooks/useTerminalPanePolling.ts
+++ b/src/hooks/useTerminalPanePolling.ts
@@ -141,10 +141,14 @@ export function useTerminalPanePolling({
       const nextOutput = data.fullOutput ?? data.realtimeSnippet ?? '';
 
       setTerminal(prev => {
-        // Only overwrite output if we actually have content or the session is
-        // still running. Mirrors WorktreeDetailRefactored's behavior to avoid
-        // clearing during session transitions.
-        const writeOutput = !!nextOutput || !!data.isRunning;
+        // Overwrite output if we have content or the session is still running.
+        // Issue #842: also overwrite (i.e. clear) once the session has stopped,
+        // so kill / natural-termination residue does not linger. The prior guard
+        // only kept stale output in the "empty + stopped" case, which is exactly
+        // the kill case we need to clear. Running sessions are unaffected, so no
+        // meaningful flicker is introduced.
+        const sessionStopped = data.isRunning === false;
+        const writeOutput = !!nextOutput || !!data.isRunning || sessionStopped;
         return {
           ...prev,
           output: writeOutput ? nextOutput : prev.output,

--- a/tests/unit/components/TerminalDisplay.test.tsx
+++ b/tests/unit/components/TerminalDisplay.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import { TerminalDisplay } from '@/components/worktree/TerminalDisplay';
 
 describe('TerminalDisplay', () => {
@@ -304,6 +304,50 @@ describe('TerminalDisplay', () => {
         window.dispatchEvent(new CustomEvent('terminal-search-open'));
       });
       expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+  });
+
+  // ============================================================================
+  // [Issue #842] Session-ended placeholder (distinguish loading / not-started / ended)
+  // ============================================================================
+
+  describe('[Issue #842] Session-ended placeholder', () => {
+    afterEach(() => {
+      cleanup();
+    });
+
+    it('shows the ended placeholder after an active session goes inactive with empty output', () => {
+      const { rerender } = render(
+        <TerminalDisplay output="running output" isActive={true} attaching={false} />,
+      );
+      // Kill / natural termination: session becomes inactive and output is cleared.
+      rerender(<TerminalDisplay output="" isActive={false} attaching={false} />);
+      expect(screen.getByTestId('terminal-ended-placeholder')).toBeInTheDocument();
+    });
+
+    it('does NOT show the ended placeholder while attaching (loading)', () => {
+      render(<TerminalDisplay output="" isActive={false} attaching={true} />);
+      expect(screen.queryByTestId('terminal-ended-placeholder')).not.toBeInTheDocument();
+    });
+
+    it('does NOT show the ended placeholder for a never-started session', () => {
+      render(<TerminalDisplay output="" isActive={false} attaching={false} />);
+      expect(screen.queryByTestId('terminal-ended-placeholder')).not.toBeInTheDocument();
+    });
+
+    it('does NOT show the ended placeholder while output is present', () => {
+      render(<TerminalDisplay output="still has content" isActive={false} attaching={false} />);
+      expect(screen.queryByTestId('terminal-ended-placeholder')).not.toBeInTheDocument();
+    });
+
+    it('shows a loading placeholder while attaching with no output', () => {
+      render(<TerminalDisplay output="" isActive={false} attaching={true} />);
+      expect(screen.getByTestId('terminal-loading-placeholder')).toBeInTheDocument();
+    });
+
+    it('does NOT show the loading placeholder once output has arrived', () => {
+      render(<TerminalDisplay output="arrived" isActive={true} attaching={false} />);
+      expect(screen.queryByTestId('terminal-loading-placeholder')).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/hooks/useTerminalPanePolling.test.ts
+++ b/tests/unit/hooks/useTerminalPanePolling.test.ts
@@ -156,6 +156,44 @@ describe('useTerminalPanePolling', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  // Issue #842: kill / natural-termination must clear residual output.
+  it('clears output when the session stops (isRunning:false + empty content)', async () => {
+    let phase: 'running' | 'stopped' = 'running';
+    mockFetch.mockImplementation(() => {
+      if (phase === 'running') {
+        return okJson({ isRunning: true, fullOutput: 'live output', thinking: false });
+      }
+      // Mirrors current-output route's stopped response: no fullOutput / realtimeSnippet.
+      return okJson({ isRunning: false, content: '', thinking: false });
+    });
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude' }),
+    );
+    await waitFor(() => expect(result.current.terminal.output).toBe('live output'));
+    phase = 'stopped';
+    await act(async () => {
+      await result.current.refresh();
+    });
+    await waitFor(() => expect(result.current.terminal.output).toBe(''));
+    expect(result.current.terminal.isRunning).toBe(false);
+  });
+
+  // Issue #842: a running session that keeps returning content must NOT flicker to empty.
+  it('keeps output across polls while the session stays running (no flicker)', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({ isRunning: true, fullOutput: 'steady output', thinking: false }),
+    );
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude' }),
+    );
+    await waitFor(() => expect(result.current.terminal.output).toBe('steady output'));
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.terminal.output).toBe('steady output');
+    expect(result.current.terminal.isRunning).toBe(true);
+  });
+
   it('resets output/attaching/prompt when (worktreeId, cliToolId) changes', async () => {
     mockFetch.mockImplementation((input) => {
       const url = new URL(getUrlString(input), 'http://localhost');


### PR DESCRIPTION
## 概要
Issue #842 の対応。PCでヘッダー「End」からエージェントをクローズ後にターミナルの古い表示が残る不具合を修正。

## 主な変更
- A: `useTerminalPanePolling.ts` 停止確定時(isRunning=false)に output をクリア（実行中はフリッカーなし）
- C: `TerminalDisplay.tsx` に終了プレースホルダ追加（attaching/isRunning で読込中/未開始/終了を区別）
- `TerminalSplitPaneContent.tsx` に attaching を配線
- ユニットテスト追加（kill時クリア / 実行中no-flicker / プレースホルダ条件）

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)