### PR TITLE
feat(mobile): rename 'CMATE' tab to 'Notes' for clarity

### DIFF
--- a/src/components/mobile/MobileTabBar.tsx
+++ b/src/components/mobile/MobileTabBar.tsx
@@ -102,7 +102,7 @@ const TABS: TabConfig[] = [
   { id: 'terminal', label: 'Terminal', icon: <Icon path={ICON_PATHS.terminal} /> },
   { id: 'history', label: 'History', icon: <Icon path={ICON_PATHS.history} /> },
   { id: 'files', label: 'Files', icon: <Icon path={ICON_PATHS.files} /> },
-  { id: 'memo', label: 'CMATE', icon: <Icon path={ICON_PATHS.memo} /> },
+  { id: 'memo', label: 'Notes', icon: <Icon path={ICON_PATHS.memo} /> },
   { id: 'info', label: 'Info', icon: <Icon path={ICON_PATHS.info} /> },
 ];
 

--- a/tests/unit/components/mobile/MobileTabBar.test.tsx
+++ b/tests/unit/components/mobile/MobileTabBar.test.tsx
@@ -37,7 +37,7 @@ describe('MobileTabBar', () => {
       expect(screen.getByRole('tab', { name: /terminal/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /history/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /files/i })).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: /cmate/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /notes/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /info/i })).toBeInTheDocument();
     });
 
@@ -242,7 +242,7 @@ describe('MobileTabBar', () => {
       expect(screen.getByRole('tab', { name: /terminal/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /history/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /files/i })).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: /cmate/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /notes/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /info/i })).toBeInTheDocument();
     });
   });
@@ -251,7 +251,7 @@ describe('MobileTabBar', () => {
     it('should highlight memo tab when activeTab is memo', () => {
       render(<MobileTabBar {...defaultProps} activeTab="memo" />);
 
-      const memoTab = screen.getByRole('tab', { name: /cmate/i });
+      const memoTab = screen.getByRole('tab', { name: /notes/i });
       expect(memoTab).toHaveAttribute('aria-selected', 'true');
     });
 
@@ -259,7 +259,7 @@ describe('MobileTabBar', () => {
       const onTabChange = vi.fn();
       render(<MobileTabBar {...defaultProps} onTabChange={onTabChange} />);
 
-      fireEvent.click(screen.getByRole('tab', { name: /cmate/i }));
+      fireEvent.click(screen.getByRole('tab', { name: /notes/i }));
 
       expect(onTabChange).toHaveBeenCalledWith('memo');
     });
@@ -270,11 +270,11 @@ describe('MobileTabBar', () => {
       const tabs = screen.getAllByRole('tab');
       const tabLabels = tabs.map(tab => tab.textContent?.toLowerCase().trim());
 
-      // Order: terminal, history, files, cmate, info
+      // Order: terminal, history, files, notes, info
       expect(tabLabels[0]).toContain('terminal');
       expect(tabLabels[1]).toContain('history');
       expect(tabLabels[2]).toContain('files');
-      expect(tabLabels[3]).toContain('cmate');
+      expect(tabLabels[3]).toContain('notes');
       expect(tabLabels[4]).toContain('info');
     });
   });
@@ -335,7 +335,7 @@ describe('MobileTabBar', () => {
         />
       );
 
-      fireEvent.click(screen.getByRole('tab', { name: /cmate/i }));
+      fireEvent.click(screen.getByRole('tab', { name: /notes/i }));
 
       expect(onSearchParamsChange).toHaveBeenCalledWith('notes');
     });


### PR DESCRIPTION
## 概要
Issue #838 の対応。モバイルタブの label を 'CMATE' → 'Notes' に変更（label のみ、ID は不変）。

## 主な変更
- `MobileTabBar.tsx` label 変更
- テストの label アサーション更新

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)