### PR TITLE
fix(file-panel): persist collapsed state + vertical labels + unified Show/Hide wording (#840)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -47,5 +47,13 @@
     "version": "Version",
     "installTypeGlobal": "npm (global)",
     "installTypeLocal": "Local (git pull)"
+  },
+  "terminal": {
+    "historyLabel": "History",
+    "filesLabel": "Files",
+    "showHistory": "Show history",
+    "hideHistory": "Hide history",
+    "showFiles": "Show files",
+    "hideFiles": "Hide files"
   }
 }

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -47,5 +47,13 @@
     "version": "バージョン",
     "installTypeGlobal": "npm（グローバル）",
     "installTypeLocal": "ローカル（git pull）"
+  },
+  "terminal": {
+    "historyLabel": "履歴",
+    "filesLabel": "ファイル",
+    "showHistory": "履歴を表示",
+    "hideHistory": "履歴を非表示",
+    "showFiles": "ファイルを表示",
+    "hideFiles": "ファイルを非表示"
   }
 }

--- a/src/components/worktree/FilePanelSplit.tsx
+++ b/src/components/worktree/FilePanelSplit.tsx
@@ -10,9 +10,11 @@
 'use client';
 
 import React, { memo, useState, useCallback, useRef, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
 import { PaneResizer } from './PaneResizer';
 import { FilePanelTabs } from './FilePanelTabs';
 import { DiffViewer } from './DiffViewer';
+import { useFilePanelState } from '@/hooks/useFilePanelState';
 import type { FileTabsState } from '@/hooks/useFileTabs';
 import type { FileContent } from '@/types/models';
 
@@ -68,8 +70,11 @@ const MIN_TERMINAL_WIDTH = 20;
 /** Maximum terminal width as percentage */
 const MAX_TERMINAL_WIDTH = 80;
 
-/** Width of the collapse/expand bar for the file panel (px) */
-const FILE_PANEL_BAR_WIDTH_PX = 24;
+/**
+ * Width of the collapsed file-panel bar (px). Issue #840: widened 24 → 36 so
+ * the vertical "Files" label is legible and the bar is easier to notice/hit.
+ */
+const FILE_PANEL_BAR_WIDTH_PX = 36;
 
 // ============================================================================
 // Main Component
@@ -99,11 +104,13 @@ export const FilePanelSplit = memo(function FilePanelSplit({
   onMoveToFront,
   onOpenFile,
 }: FilePanelSplitProps) {
+  const t = useTranslations('worktree');
   const containerRef = useRef<HTMLDivElement>(null);
   const [terminalWidth, setTerminalWidth] = useState(INITIAL_TERMINAL_WIDTH);
-  const [filePanelCollapsed, setFilePanelCollapsed] = useState(false);
-
-  const toggleFilePanel = useCallback(() => setFilePanelCollapsed((v) => !v), []);
+  // Issue #840: collapsed state is persisted to localStorage so it survives
+  // reload / re-mount (previously a local useState that reset to default).
+  const { collapsed: filePanelCollapsed, toggle: toggleFilePanel } =
+    useFilePanelState();
 
   const handleResize = useCallback((delta: number) => {
     const container = containerRef.current;
@@ -158,17 +165,25 @@ export const FilePanelSplit = memo(function FilePanelSplit({
         <div
           data-testid="file-panel-expand-bar"
           style={{ width: `${FILE_PANEL_BAR_WIDTH_PX}px` }}
-          className="flex-shrink-0 flex items-center justify-center bg-gray-100 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700"
+          className="flex-shrink-0 flex items-start justify-center bg-gray-100 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700"
         >
           <button
             type="button"
-            aria-label="Show file panel"
+            aria-label={t('terminal.showFiles')}
+            title={t('terminal.showFiles')}
             onClick={toggleFilePanel}
-            className="flex items-center justify-center w-full h-10 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+            className="flex flex-col items-center gap-2 w-full pt-2 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
+            <span
+              className="text-xs font-medium tracking-wide select-none"
+              style={{ writingMode: 'vertical-rl' }}
+              aria-hidden="true"
+            >
+              {t('terminal.filesLabel')}
+            </span>
           </button>
         </div>
       </div>
@@ -202,7 +217,8 @@ export const FilePanelSplit = memo(function FilePanelSplit({
         {/* Collapse button strip — always visible at the left edge of the file panel */}
         <button
           type="button"
-          aria-label="Hide file panel"
+          aria-label={t('terminal.hideFiles')}
+          title={t('terminal.hideFiles')}
           onClick={toggleFilePanel}
           className="flex-shrink-0 flex items-center justify-center w-5 h-full bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
         >

--- a/src/components/worktree/HistoryPane.tsx
+++ b/src/components/worktree/HistoryPane.tsx
@@ -11,6 +11,7 @@
 'use client';
 
 import React, { useMemo, useCallback, memo, useRef, useLayoutEffect, useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { Search, User, UserCheck, ChevronRight } from 'lucide-react';
 import type { ChatMessage } from '@/types/models';
 import { useConversationHistory } from '@/hooks/useConversationHistory';
@@ -232,6 +233,7 @@ export const HistoryPane = memo(function HistoryPane({
   splitIndex,
   cliToolId: _cliToolId,
 }: HistoryPaneProps) {
+  const t = useTranslations('worktree');
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // Issue #744: per-split CSS highlight namespace. When this pane is inside a
@@ -560,11 +562,11 @@ export const HistoryPane = memo(function HistoryPane({
             <button
               type="button"
               onClick={onCollapse}
-              aria-label="Collapse history panel"
+              aria-label={t('terminal.hideHistory')}
               aria-expanded="true"
               aria-controls={collapseAriaControls}
               className="p-1 text-gray-400 hover:text-gray-200 rounded transition-colors"
-              title="Collapse history panel"
+              title={t('terminal.hideHistory')}
               data-testid={collapseTestId}
             >
               <ChevronRight size={14} aria-hidden="true" />

--- a/src/components/worktree/TerminalContainer.tsx
+++ b/src/components/worktree/TerminalContainer.tsx
@@ -23,6 +23,7 @@
 'use client';
 
 import React, { memo, useCallback, useRef, type ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
 import { useHistoryPaneState } from '@/hooks/useHistoryPaneState';
 import { PaneResizer } from './PaneResizer';
@@ -37,7 +38,11 @@ import { PaneResizer } from './PaneResizer';
  */
 export const HISTORY_PANE_ID = 'worktree-history-pane';
 
-const EXPAND_BAR_WIDTH_PX = 24;
+/**
+ * Width of the collapsed History bar (px). Issue #840: widened 24 → 36 so the
+ * vertical "History" label is legible and the bar is easier to notice/hit.
+ */
+const EXPAND_BAR_WIDTH_PX = 36;
 
 export interface TerminalContainerProps {
   /**
@@ -57,23 +62,25 @@ const HistoryExpandBar = memo(function HistoryExpandBar({
 }: {
   onToggle: () => void;
 }) {
+  const t = useTranslations('worktree');
   return (
     <div
       data-testid="terminal-container-expand-bar"
       style={{ width: `${EXPAND_BAR_WIDTH_PX}px` }}
-      className="flex-shrink-0 flex items-center justify-center bg-gray-100 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700"
+      className="flex-shrink-0 flex items-start justify-center bg-gray-100 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700"
     >
       <button
         type="button"
         data-testid="history-pane-expand"
-        aria-label="Expand history panel"
+        aria-label={t('terminal.showHistory')}
+        title={t('terminal.showHistory')}
         aria-expanded="false"
         aria-controls={HISTORY_PANE_ID}
         onClick={onToggle}
-        className="flex items-center justify-center w-full h-10 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+        className="flex flex-col items-center gap-2 w-full pt-2 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
       >
         <svg
-          className="w-4 h-4"
+          className="w-4 h-4 flex-shrink-0"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -86,6 +93,13 @@ const HistoryExpandBar = memo(function HistoryExpandBar({
             d="M9 5l7 7-7 7"
           />
         </svg>
+        <span
+          className="text-xs font-medium tracking-wide select-none"
+          style={{ writingMode: 'vertical-rl' }}
+          aria-hidden="true"
+        >
+          {t('terminal.historyLabel')}
+        </span>
       </button>
     </div>
   );

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -23,6 +23,7 @@
 'use client';
 
 import React, { memo, useCallback, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import { TerminalSplitPane } from '@/components/worktree/TerminalSplitPane';
 import { TerminalDisplay } from '@/components/worktree/TerminalDisplay';
@@ -118,6 +119,8 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   const onHistoryInsertToMessage = history?.onInsertToMessage;
   const onFilePathClick = history?.onFilePathClick;
   const showToast = history?.showToast;
+
+  const t = useTranslations('worktree');
 
   const {
     terminal,
@@ -337,18 +340,19 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
         ) : (
           <div
             data-testid={`split-history-expand-bar-${splitIndex}`}
-            className="flex-shrink-0 flex items-start justify-center w-6 bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700"
+            className="flex-shrink-0 flex items-start justify-center w-9 bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700"
           >
             <button
               type="button"
               data-testid={`split-history-expand-${splitIndex}`}
-              aria-label="Expand history panel"
+              aria-label={t('terminal.showHistory')}
+              title={t('terminal.showHistory')}
               aria-expanded="false"
               onClick={toggleHistory}
-              className="flex items-center justify-center w-full h-10 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+              className="flex flex-col items-center gap-2 w-full pt-2 text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500"
             >
               <svg
-                className="w-4 h-4"
+                className="w-4 h-4 flex-shrink-0"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -361,6 +365,13 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
                   d="M9 5l7 7-7 7"
                 />
               </svg>
+              <span
+                className="text-xs font-medium tracking-wide select-none"
+                style={{ writingMode: 'vertical-rl' }}
+                aria-hidden="true"
+              >
+                {t('terminal.historyLabel')}
+              </span>
             </button>
           </div>
         )}
@@ -377,6 +388,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
       toggleHistory,
       terminalDisplaySlot,
       splitIndex,
+      t,
     ],
   );
 

--- a/src/hooks/useFilePanelState.ts
+++ b/src/hooks/useFilePanelState.ts
@@ -1,0 +1,126 @@
+/**
+ * useFilePanelState Hook (Issue #840)
+ *
+ * Manages the PC file panel collapsed state with localStorage persistence.
+ * Mirrors `useHistoryPaneState` (Issue #727/#730) so the two panes behave
+ * consistently. The file panel only needs a collapsed boolean (its width is
+ * handled by `FilePanelSplit`'s own resizer), so this hook is the
+ * visibility-only subset of the History pattern.
+ *
+ * Persistence:
+ *   - `commandmate.worktree.filePanelCollapsed` (boolean)
+ *
+ * Default:
+ *   - collapsed: false (file panel visible)
+ *
+ * SSR / hydration:
+ *   - SSR returns the default. An effect on mount syncs from localStorage.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const FILE_PANEL_COLLAPSED_STORAGE_KEY =
+  'commandmate.worktree.filePanelCollapsed';
+
+export const DEFAULT_FILE_PANEL_COLLAPSED = false;
+
+export interface UseFilePanelStateReturn {
+  /** Whether the file panel is collapsed (true = hidden). */
+  collapsed: boolean;
+  /** Toggle collapsed state (also persists). */
+  toggle: () => void;
+  /** Set collapsed state explicitly (also persists). */
+  setCollapsed: (next: boolean) => void;
+}
+
+function readStoredCollapsed(): boolean {
+  if (typeof window === 'undefined') return DEFAULT_FILE_PANEL_COLLAPSED;
+  try {
+    const raw = window.localStorage.getItem(FILE_PANEL_COLLAPSED_STORAGE_KEY);
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+  } catch {
+    /* unavailable */
+  }
+  return DEFAULT_FILE_PANEL_COLLAPSED;
+}
+
+function writeStoredCollapsed(v: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(FILE_PANEL_COLLAPSED_STORAGE_KEY, String(v));
+  } catch {
+    /* unavailable */
+  }
+}
+
+/**
+ * Custom event used to broadcast hook state changes across multiple
+ * `useFilePanelState` instances on the same page (same rationale as
+ * `useHistoryPaneState` — Issue #730): same-window localStorage writes do not
+ * fire the native `storage` event, so a second consumer (e.g. the Phase 2
+ * toolbar toggle) would otherwise desync. We emit a lightweight CustomEvent on
+ * every write and listen for it on every mount.
+ */
+const FILE_PANEL_STATE_EVENT = 'commandmate:filePanelStateChange';
+
+interface FilePanelStateEventDetail {
+  collapsed: boolean;
+}
+
+function emitChange(detail: FilePanelStateEventDetail): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent<FilePanelStateEventDetail>(FILE_PANEL_STATE_EVENT, {
+        detail,
+      })
+    );
+  } catch {
+    /* CustomEvent may be unavailable in very old environments */
+  }
+}
+
+export function useFilePanelState(): UseFilePanelStateReturn {
+  const [collapsed, setCollapsedState] = useState<boolean>(
+    DEFAULT_FILE_PANEL_COLLAPSED
+  );
+
+  const collapsedRef = useRef(collapsed);
+  collapsedRef.current = collapsed;
+
+  // Hydrate once on mount.
+  useEffect(() => {
+    setCollapsedState(readStoredCollapsed());
+  }, []);
+
+  // Sync state across hook instances on the same page.
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const onChange = (event: Event): void => {
+      const ce = event as CustomEvent<FilePanelStateEventDetail>;
+      if (!ce.detail) return;
+      if (ce.detail.collapsed !== collapsedRef.current) {
+        setCollapsedState(ce.detail.collapsed);
+      }
+    };
+    window.addEventListener(FILE_PANEL_STATE_EVENT, onChange);
+    return () => window.removeEventListener(FILE_PANEL_STATE_EVENT, onChange);
+  }, []);
+
+  const setCollapsed = useCallback((next: boolean): void => {
+    setCollapsedState(next);
+    writeStoredCollapsed(next);
+    emitChange({ collapsed: next });
+  }, []);
+
+  const toggle = useCallback((): void => {
+    setCollapsed(!collapsedRef.current);
+  }, [setCollapsed]);
+
+  return { collapsed, toggle, setCollapsed };
+}
+
+export default useFilePanelState;

--- a/tests/unit/components/FilePanelSplit.test.tsx
+++ b/tests/unit/components/FilePanelSplit.test.tsx
@@ -7,8 +7,9 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { FilePanelSplit } from '@/components/worktree/FilePanelSplit';
+import { FILE_PANEL_COLLAPSED_STORAGE_KEY } from '@/hooks/useFilePanelState';
 import type { FileTabsState } from '@/hooks/useFileTabs';
 
 // Mock PaneResizer
@@ -38,7 +39,13 @@ describe('FilePanelSplit', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
   });
+
+  const openTabs: FileTabsState = {
+    tabs: [{ path: 'a.ts', name: 'a.ts', content: null, loading: false, error: null, isDirty: false }],
+    activeIndex: 0,
+  };
 
   it('should render terminal at full width when no tabs are open', () => {
     const fileTabs: FileTabsState = { tabs: [], activeIndex: null };
@@ -73,5 +80,40 @@ describe('FilePanelSplit', () => {
     // Should have terminal-pane and file-panel-pane
     expect(container.querySelector('[data-testid="terminal-pane"]')).toBeInTheDocument();
     expect(container.querySelector('[data-testid="file-panel-pane"]')).toBeInTheDocument();
+  });
+
+  // Issue #840: collapsed-state persistence + vertical label + Show/Hide wording.
+  describe('collapse persistence and labels (Issue #840)', () => {
+    it('uses the persisted collapsed=true state on mount (expand bar shown)', () => {
+      window.localStorage.setItem(FILE_PANEL_COLLAPSED_STORAGE_KEY, 'true');
+      render(<FilePanelSplit fileTabs={openTabs} {...defaultProps} />);
+
+      expect(screen.getByTestId('file-panel-expand-bar')).toBeInTheDocument();
+      expect(screen.queryByTestId('file-panel-tabs')).not.toBeInTheDocument();
+    });
+
+    it('renders the vertical "Files" label and Show/Hide wording from i18n', () => {
+      window.localStorage.setItem(FILE_PANEL_COLLAPSED_STORAGE_KEY, 'true');
+      render(<FilePanelSplit fileTabs={openTabs} {...defaultProps} />);
+
+      // i18n mock returns the namespaced key as the rendered string.
+      expect(screen.getByText('worktree.terminal.filesLabel')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'worktree.terminal.showFiles' }),
+      ).toBeInTheDocument();
+    });
+
+    it('toggling the hide button collapses the panel and persists the state', () => {
+      render(<FilePanelSplit fileTabs={openTabs} {...defaultProps} />);
+
+      // Expanded by default: file tabs visible, hide button present.
+      expect(screen.getByTestId('file-panel-tabs')).toBeInTheDocument();
+      fireEvent.click(
+        screen.getByRole('button', { name: 'worktree.terminal.hideFiles' }),
+      );
+
+      expect(window.localStorage.getItem(FILE_PANEL_COLLAPSED_STORAGE_KEY)).toBe('true');
+      expect(screen.getByTestId('file-panel-expand-bar')).toBeInTheDocument();
+    });
   });
 });

--- a/tests/unit/components/worktree/TerminalContainer.test.tsx
+++ b/tests/unit/components/worktree/TerminalContainer.test.tsx
@@ -108,7 +108,8 @@ describe('TerminalContainer (Issue #730)', () => {
     expect(screen.queryByTestId('history-content')).not.toBeInTheDocument();
     const expandBar = screen.getByTestId('terminal-container-expand-bar');
     expect(expandBar).toBeInTheDocument();
-    const btn = screen.getByRole('button', { name: /expand history panel/i });
+    // Issue #840: aria-label is now driven by i18n (worktree.terminal.showHistory).
+    const btn = screen.getByTestId('history-pane-expand');
     expect(btn).toHaveAttribute('aria-controls', 'worktree-history-pane');
     expect(btn).toHaveAttribute('aria-expanded', 'false');
   });
@@ -121,7 +122,7 @@ describe('TerminalContainer (Issue #730)', () => {
         terminal={<div data-testid="terminal-content">T</div>}
       />
     );
-    fireEvent.click(screen.getByRole('button', { name: /expand history panel/i }));
+    fireEvent.click(screen.getByTestId('history-pane-expand'));
     expect(mockToggle).toHaveBeenCalledTimes(1);
   });
 
@@ -215,9 +216,7 @@ describe('TerminalContainer (Issue #730)', () => {
 
     it('does not render the history-pane-expand button when history is omitted', () => {
       render(<TerminalContainer terminal={<div data-testid="terminal-content">T</div>} />);
-      expect(
-        screen.queryByRole('button', { name: /expand history panel/i })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('history-pane-expand')).not.toBeInTheDocument();
     });
 
     it('still wraps the terminal area in its ErrorBoundary', () => {

--- a/tests/unit/hooks/useFilePanelState.test.ts
+++ b/tests/unit/hooks/useFilePanelState.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for useFilePanelState (Issue #840)
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useFilePanelState,
+  FILE_PANEL_COLLAPSED_STORAGE_KEY,
+  DEFAULT_FILE_PANEL_COLLAPSED,
+} from '@/hooks/useFilePanelState';
+
+describe('useFilePanelState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to collapsed=false (file panel visible)', () => {
+    const { result } = renderHook(() => useFilePanelState());
+    expect(result.current.collapsed).toBe(DEFAULT_FILE_PANEL_COLLAPSED);
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it('toggle() flips collapsed and persists', () => {
+    const { result } = renderHook(() => useFilePanelState());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.collapsed).toBe(true);
+    expect(window.localStorage.getItem(FILE_PANEL_COLLAPSED_STORAGE_KEY)).toBe('true');
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.collapsed).toBe(false);
+    expect(window.localStorage.getItem(FILE_PANEL_COLLAPSED_STORAGE_KEY)).toBe('false');
+  });
+
+  it('setCollapsed(true) persists', () => {
+    const { result } = renderHook(() => useFilePanelState());
+    act(() => {
+      result.current.setCollapsed(true);
+    });
+    expect(result.current.collapsed).toBe(true);
+    expect(window.localStorage.getItem(FILE_PANEL_COLLAPSED_STORAGE_KEY)).toBe('true');
+  });
+
+  it('restores stored collapsed=true on mount', () => {
+    window.localStorage.setItem(FILE_PANEL_COLLAPSED_STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useFilePanelState());
+    expect(result.current.collapsed).toBe(true);
+  });
+
+  it('restores stored collapsed=false on mount', () => {
+    window.localStorage.setItem(FILE_PANEL_COLLAPSED_STORAGE_KEY, 'false');
+    const { result } = renderHook(() => useFilePanelState());
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it('falls back to default when stored value is invalid', () => {
+    window.localStorage.setItem(FILE_PANEL_COLLAPSED_STORAGE_KEY, 'garbage');
+    const { result } = renderHook(() => useFilePanelState());
+    expect(result.current.collapsed).toBe(DEFAULT_FILE_PANEL_COLLAPSED);
+  });
+
+  it('syncs state across hook instances on the same page', () => {
+    const a = renderHook(() => useFilePanelState());
+    const b = renderHook(() => useFilePanelState());
+
+    act(() => {
+      a.result.current.toggle();
+    });
+
+    expect(a.result.current.collapsed).toBe(true);
+    expect(b.result.current.collapsed).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #840 (Phase 1) の対応。File panel の collapse 永続化 + 折り畳み中バーの縦書きラベル + 用語統一。

## 主な変更
- 新規 `useFilePanelState.ts`（localStorage 永続化, #841 が参照する SSOT）
- `FilePanelSplit/HistoryPane/TerminalContainer/TerminalSplitPaneContent` 縦書きラベル+幅拡大+用語統一
- i18n キー `worktree.terminal.*`(en/ja) 追加
- ユニットテスト追加

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)