### PR TITLE
perf(worktree-detail): prime worktree state from cache (Issue #839)

### DIFF
--- a/src/components/providers/WorktreesCacheProvider.tsx
+++ b/src/components/providers/WorktreesCacheProvider.tsx
@@ -98,3 +98,22 @@ export function useWorktreesCacheContext(): UseWorktreesCacheReturn {
   }
   return ctx;
 }
+
+/**
+ * Non-throwing variant of {@link useWorktreesCacheContext}.
+ *
+ * Returns the cached worktrees data when called inside a
+ * `WorktreesCacheProvider`, or `null` when no provider is present.
+ *
+ * Issue #839: the worktree detail controller reads this purely as an
+ * optimization (priming `worktree` state from the already-loaded list cache to
+ * eliminate the "Loading worktree info..." flash). Cache priming is therefore a
+ * best-effort enhancement, not a hard dependency — when the provider is absent
+ * (e.g. isolated unit tests) the consumer must degrade gracefully to the
+ * cache-miss path instead of throwing. Reading the shared context (rather than
+ * calling `useWorktreesCache()` directly) keeps the single-poller guarantee from
+ * Issue #709 intact.
+ */
+export function useOptionalWorktreesCacheContext(): UseWorktreesCacheReturn | null {
+  return useContext(WorktreesCacheContext);
+}

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -24,6 +24,7 @@ import { useRouter } from 'next/navigation';
 import { useWorktreeUIState } from '@/hooks/useWorktreeUIState';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useSidebarContext } from '@/contexts/SidebarContext';
+import { useOptionalWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { type WorktreeStatus } from '@/components/mobile/MobileHeader';
 import { type MobileTab } from '@/components/mobile/MobileTabBar';
 import { useFileSearch } from '@/hooks/useFileSearch';
@@ -146,10 +147,31 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   const tAutoYes = useTranslations('autoYes');
   const tSchedule = useTranslations('schedule');
 
+  // Issue #839: Stale-while-revalidate priming. The worktree *list* is already
+  // cached by useWorktreesCache (exposed via WorktreesCacheProvider). When the
+  // user opens a detail screen for a worktree that is already in that cache, we
+  // seed the local `worktree` state from the cached list item so the screen
+  // renders immediately with real data instead of flashing "Loading worktree
+  // info...". The background fetchWorktree() below still runs and overwrites the
+  // seeded value with the authoritative (full) detail payload (fresh > cached).
+  //
+  // Read through the *context* (non-throwing variant) rather than calling
+  // useWorktreesCache() directly: a second direct call would spawn an extra
+  // /api/worktrees poller, the regression Issue #709 fixed. When the provider is
+  // absent (isolated unit tests) this degrades to the cache-miss path.
+  const cache = useOptionalWorktreesCacheContext();
+  const initialFromCache = cache?.worktrees.find((w) => w.id === worktreeId) ?? null;
+
   // Local state for worktree data and loading status
-  const [worktree, setWorktree] = useState<Worktree | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [worktree, setWorktree] = useState<Worktree | null>(initialFromCache);
+  // On a cache hit we already have data to show, so skip the full-screen loading
+  // gate; on a cache miss fall back to the previous loading-first behavior.
+  const [loading, setLoading] = useState(initialFromCache === null);
   const [error, setError] = useState<string | null>(null);
+  // Captured once at mount: whether the initial render was primed from cache.
+  // Drives the loadInitialData loading guard so the background refresh on a
+  // cache hit never flips the screen back to the loading indicator.
+  const primedFromCacheRef = useRef(initialFromCache !== null);
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
   // Issue #438: File tabs state (replaces fileViewerPath for desktop)
   // Issue #683: B案 - [tabsState, tabsActions] tuple; tabsActions is stable across renders
@@ -1246,7 +1268,12 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     let isMounted = true;
 
     const loadInitialData = async () => {
-      setLoading(true);
+      // Issue #839: Only show the full-screen loading indicator when there was no
+      // cached worktree to display at mount. On a cache hit we keep rendering the
+      // seeded data and revalidate silently in the background (SWR).
+      if (!primedFromCacheRef.current) {
+        setLoading(true);
+      }
       // Parallel: fetch worktree, messages, and current output simultaneously.
       // fetchMessages/fetchCurrentOutput handle missing worktree gracefully.
       await Promise.all([

--- a/tests/unit/components/providers/WorktreesCacheProvider.test.tsx
+++ b/tests/unit/components/providers/WorktreesCacheProvider.test.tsx
@@ -58,6 +58,7 @@ vi.mock('@/contexts/WorktreeSelectionContext', () => ({
 import {
   WorktreesCacheProvider,
   useWorktreesCacheContext,
+  useOptionalWorktreesCacheContext,
 } from '@/components/providers/WorktreesCacheProvider';
 
 // ---------------------------------------------------------------------------
@@ -106,6 +107,16 @@ function ContextConsumer() {
         refresh
       </button>
     </div>
+  );
+}
+
+/** Consumer for the non-throwing optional context reader (Issue #839). */
+function OptionalContextConsumer() {
+  const ctx = useOptionalWorktreesCacheContext();
+  return (
+    <span data-testid="optional-ctx">
+      {ctx === null ? 'null' : `count:${ctx.worktrees.length}`}
+    </span>
   );
 }
 
@@ -193,5 +204,25 @@ describe('WorktreesCacheProvider', () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  // Issue #839: the optional reader must degrade gracefully instead of throwing
+  // so the worktree detail controller can use it as a best-effort optimization.
+  it('useOptionalWorktreesCacheContext returns null outside the Provider (no throw)', () => {
+    render(<OptionalContextConsumer />);
+
+    expect(screen.getByTestId('optional-ctx').textContent).toBe('null');
+  });
+
+  it('useOptionalWorktreesCacheContext exposes the cache when inside the Provider', () => {
+    mockCacheState.worktrees = [makeWorktree({ id: 'wt-a' })];
+
+    render(
+      <WorktreesCacheProvider>
+        <OptionalContextConsumer />
+      </WorktreesCacheProvider>
+    );
+
+    expect(screen.getByTestId('optional-ctx').textContent).toBe('count:1');
   });
 });

--- a/tests/unit/hooks/useWorktreeDetailController.test.tsx
+++ b/tests/unit/hooks/useWorktreeDetailController.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for useWorktreeDetailController cache-priming (Issue #839).
+ *
+ * Verifies the stale-while-revalidate behavior that eliminates the
+ * "Loading worktree info..." flash:
+ *  - cache hit  -> `worktree` is seeded from the list cache and `loading`
+ *                  starts false (screen renders immediately, no flash)
+ *  - cache miss -> `worktree` stays null and `loading` starts true
+ *                  (previous loading-first behavior preserved, no regression)
+ *  - background fetch overwrites the seeded value with the fresh detail payload
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { Worktree } from '@/types/models';
+import type { UseWorktreesCacheReturn } from '@/hooks/useWorktreesCache';
+
+// ---------------------------------------------------------------------------
+// Mocks for provider-dependent hooks so the controller can run under
+// renderHook without the full app provider tree. next-intl is mocked globally
+// in tests/setup.ts.
+// ---------------------------------------------------------------------------
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/worktrees/wt-1',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+  MOBILE_BREAKPOINT: 768,
+}));
+
+vi.mock('@/contexts/SidebarContext', () => ({
+  useSidebarContext: () => ({
+    isOpen: true,
+    width: 288,
+    isMobileDrawerOpen: false,
+    toggle: vi.fn(),
+    setWidth: vi.fn(),
+    openMobileDrawer: vi.fn(),
+    closeMobileDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useUpdateCheck', () => ({
+  useUpdateCheck: () => ({ data: null, loading: false, error: null }),
+}));
+
+// Controllable cache context: each test assigns the desired snapshot (or null).
+const mockCache: { current: UseWorktreesCacheReturn | null } = { current: null };
+vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
+  useOptionalWorktreesCacheContext: () => mockCache.current,
+}));
+
+import { useWorktreeDetailController } from '@/hooks/useWorktreeDetailController';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    name: 'feature/cached',
+    path: '/path/to/wt',
+    repositoryPath: '/path/to/repo',
+    repositoryName: 'MyRepo',
+    ...overrides,
+  } as Worktree;
+}
+
+function makeCache(worktrees: Worktree[]): UseWorktreesCacheReturn {
+  return {
+    worktrees,
+    repositories: [],
+    isLoading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const mockFetch = vi.fn();
+
+/** Build a fetch implementation whose detail endpoint returns `detail`. */
+function fetchReturning(detail: Worktree) {
+  return (url: string) => {
+    if (url.includes('/messages')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (url.includes('/current-output')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ isRunning: false }),
+      });
+    }
+    if (url.includes('/api/worktrees/')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(detail) });
+    }
+    return Promise.resolve({ ok: false, status: 404 });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useWorktreeDetailController — cache priming (Issue #839)', () => {
+  beforeEach(() => {
+    mockCache.current = null;
+    mockFetch.mockReset();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cache hit: seeds worktree from cache and starts with loading=false (no flash)', () => {
+    const cached = makeWorktree({ id: 'wt-1', name: 'feature/cached' });
+    mockCache.current = makeCache([cached]);
+    // Detail fetch never resolves during this synchronous assertion window.
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useWorktreeDetailController({ worktreeId: 'wt-1' })
+    );
+
+    // Seeded synchronously from cache — the detail screen has real data to show
+    // immediately, so neither the full-screen loader nor "Loading worktree
+    // info..." (gated on !worktree) ever appears.
+    expect(result.current.worktree).toEqual(cached);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('cache miss (worktree not in cached list): worktree=null, loading=true', () => {
+    mockCache.current = makeCache([makeWorktree({ id: 'other' })]);
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useWorktreeDetailController({ worktreeId: 'wt-1' })
+    );
+
+    expect(result.current.worktree).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('no provider (cache=null): falls back to cache-miss path', () => {
+    mockCache.current = null;
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useWorktreeDetailController({ worktreeId: 'wt-1' })
+    );
+
+    expect(result.current.worktree).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('background fetch overwrites the cached value with fresh detail data', async () => {
+    const cached = makeWorktree({ id: 'wt-1', name: 'feature/cached' });
+    const fresh = makeWorktree({ id: 'wt-1', name: 'feature/fresh', description: 'full' });
+    mockCache.current = makeCache([cached]);
+    mockFetch.mockImplementation(fetchReturning(fresh));
+
+    const { result } = renderHook(() =>
+      useWorktreeDetailController({ worktreeId: 'wt-1' })
+    );
+
+    // Initially the cached (stale) value.
+    expect(result.current.worktree?.name).toBe('feature/cached');
+
+    // After the background revalidation resolves, fresh > cached.
+    await waitFor(() => {
+      expect(result.current.worktree?.name).toBe('feature/fresh');
+    });
+    expect(result.current.worktree?.description).toBe('full');
+    expect(result.current.loading).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #839 の対応。初期表示の 'Loading worktree info...' フラッシュを cache 状態の prime で解消。

## 主な変更
- `WorktreesCacheProvider.tsx` に非throwの useOptionalWorktreesCacheContext() 追加
- `useWorktreeDetailController.ts` cache hit 時に worktree を seed し loading=false で開始（cache miss は従来通り）
- ユニットテスト追加

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)