### PR TITLE
feat(terminal-split-action-bar): add History/Files toggle buttons (#841)

### DIFF
--- a/src/components/worktree/TerminalSplitContainer.tsx
+++ b/src/components/worktree/TerminalSplitContainer.tsx
@@ -5,6 +5,9 @@
  *  - split configuration via `useTerminalSplits` (worktreeId-scoped)
  *  - add / remove buttons (disabled at the MIN / MAX boundary and while
  *    a PaneResizer drag is in progress)
+ *  - History / Files visibility toggles in the Action bar (Issue #841): a
+ *    second entry point alongside the existing vertical collapse strips, both
+ *    reading the same persisted state (useHistoryPaneState / useFilePanelState)
  *  - PaneResizer widget(s) between splits, with width persistence
  *  - delegating each split's body to a parent-supplied `renderPane`
  *
@@ -26,10 +29,14 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
+import { useTranslations } from 'next-intl';
+import { History, Files } from 'lucide-react';
 import { getCliToolDisplayName, type CLIToolType } from '@/lib/cli-tools/types';
 import type { ShowToast } from '@/types/markdown-editor';
 import { MAX_SPLITS, MIN_SPLITS } from '@/config/terminal-split-config';
 import { useTerminalSplits } from '@/hooks/useTerminalSplits';
+import { useHistoryPaneState } from '@/hooks/useHistoryPaneState';
+import { useFilePanelState } from '@/hooks/useFilePanelState';
 import { PaneResizer } from './PaneResizer';
 
 /** Render-prop signature: each pane is supplied externally so the
@@ -89,6 +96,19 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
     focusedSplitIndex,
     setFocusedSplitIndex,
   } = useTerminalSplits(worktreeId);
+
+  const t = useTranslations('worktree');
+
+  // Issue #841 (Phase 2): the Action bar hosts History / Files visibility
+  // toggles. These hooks broadcast across instances (useHistoryPaneState /
+  // useFilePanelState), so toggling here is the single source of truth shared
+  // with the existing vertical collapse strips — both stay in sync.
+  const { visible: historyVisible, toggle: toggleHistory } =
+    useHistoryPaneState();
+  const { collapsed: filePanelCollapsed, toggle: toggleFilePanel } =
+    useFilePanelState();
+  // The file panel hook stores `collapsed`; "Files visible" is its inverse.
+  const filesVisible = !filePanelCollapsed;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
@@ -219,6 +239,58 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
         <span className="text-xs text-gray-500 dark:text-gray-400">
           {splits.length} / {MAX_SPLITS} splits
         </span>
+
+        {/*
+          Issue #841 (Phase 2): History / Files visibility toggles. Always
+          shown (split-count independent). Active = cyan accent, inactive =
+          gray. `aria-pressed` reflects current visibility. The existing
+          vertical collapse strips remain and share this state (SSOT).
+        */}
+        <button
+          type="button"
+          onClick={toggleHistory}
+          aria-pressed={historyVisible}
+          aria-label={
+            historyVisible
+              ? t('terminal.hideHistory')
+              : t('terminal.showHistory')
+          }
+          title={
+            historyVisible
+              ? t('terminal.hideHistory')
+              : t('terminal.showHistory')
+          }
+          data-testid="toggle-history-pane"
+          className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded border transition-colors ${
+            historyVisible
+              ? 'border-cyan-300 dark:border-cyan-700 bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300'
+              : 'border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
+          }`}
+        >
+          <History className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+          <span>{t('terminal.historyLabel')}</span>
+        </button>
+        <button
+          type="button"
+          onClick={toggleFilePanel}
+          aria-pressed={filesVisible}
+          aria-label={
+            filesVisible ? t('terminal.hideFiles') : t('terminal.showFiles')
+          }
+          title={
+            filesVisible ? t('terminal.hideFiles') : t('terminal.showFiles')
+          }
+          data-testid="toggle-file-panel"
+          className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded border transition-colors ${
+            filesVisible
+              ? 'border-cyan-300 dark:border-cyan-700 bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300'
+              : 'border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
+          }`}
+        >
+          <Files className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+          <span>{t('terminal.filesLabel')}</span>
+        </button>
+
         <button
           type="button"
           onClick={addSplit}

--- a/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
@@ -108,6 +108,110 @@ describe('TerminalSplitContainer', () => {
 });
 
 // ===========================================================================
+// Issue #841 (Phase 2): the existing +Split/-Split Action bar also hosts
+// "History" and "Files" toggle buttons. They are the single source of truth
+// shared with the vertical collapse strips (useHistoryPaneState /
+// useFilePanelState broadcast across instances), so toggling here flips the
+// persisted state and aria-pressed reflects current visibility.
+// ===========================================================================
+describe('TerminalSplitContainer History/Files toggles (Issue #841)', () => {
+  const HISTORY_KEY = 'commandmate.worktree.historyVisible';
+  const FILE_PANEL_KEY = 'commandmate.worktree.filePanelCollapsed';
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders History and Files toggle buttons (always visible at 1 split)', () => {
+    setup();
+    expect(screen.getByTestId('toggle-history-pane')).toBeInTheDocument();
+    expect(screen.getByTestId('toggle-file-panel')).toBeInTheDocument();
+  });
+
+  it('keeps the toggles visible at MAX splits (split-count independent)', () => {
+    setup();
+    fireEvent.click(screen.getByTestId('add-terminal-split'));
+    fireEvent.click(screen.getByTestId('add-terminal-split'));
+    expect(screen.getByTestId('add-terminal-split')).toBeDisabled(); // at MAX
+    expect(screen.getByTestId('toggle-history-pane')).toBeInTheDocument();
+    expect(screen.getByTestId('toggle-file-panel')).toBeInTheDocument();
+  });
+
+  it('History toggle defaults to pressed (visible) and flips on click', () => {
+    setup();
+    const btn = screen.getByTestId('toggle-history-pane');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('Files toggle defaults to pressed (visible) and flips on click', () => {
+    setup();
+    const btn = screen.getByTestId('toggle-file-panel');
+    // collapsed=false → visible → pressed
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('History toggle persists visibility to localStorage', () => {
+    setup();
+    fireEvent.click(screen.getByTestId('toggle-history-pane'));
+    expect(window.localStorage.getItem(HISTORY_KEY)).toBe('false');
+  });
+
+  it('Files toggle persists collapsed state to localStorage', () => {
+    setup();
+    fireEvent.click(screen.getByTestId('toggle-file-panel'));
+    // Files hidden → file panel collapsed=true
+    expect(window.localStorage.getItem(FILE_PANEL_KEY)).toBe('true');
+  });
+
+  it('aria-label / title reflect show vs hide depending on state', () => {
+    setup();
+    const history = screen.getByTestId('toggle-history-pane');
+    // default visible → "hide" wording
+    expect(history).toHaveAttribute('aria-label', 'worktree.terminal.hideHistory');
+    expect(history).toHaveAttribute('title', 'worktree.terminal.hideHistory');
+    fireEvent.click(history);
+    expect(history).toHaveAttribute('aria-label', 'worktree.terminal.showHistory');
+
+    const files = screen.getByTestId('toggle-file-panel');
+    expect(files).toHaveAttribute('aria-label', 'worktree.terminal.hideFiles');
+    fireEvent.click(files);
+    expect(files).toHaveAttribute('aria-label', 'worktree.terminal.showFiles');
+  });
+
+  it('applies cyan accent when active and gray when inactive', () => {
+    setup();
+    const history = screen.getByTestId('toggle-history-pane');
+    // active (visible) → cyan accent classes
+    expect(history.className).toMatch(/cyan/);
+    fireEvent.click(history);
+    // inactive (hidden) → gray text, no cyan accent
+    expect(history.className).not.toMatch(/cyan/);
+    expect(history.className).toMatch(/text-gray-500/);
+  });
+
+  it('does not affect the existing +Split / -Split controls', () => {
+    setup();
+    // +Split still adds; -Split still disabled at MIN=1
+    expect(screen.getByTestId('add-terminal-split')).not.toBeDisabled();
+    expect(screen.getByTestId('remove-terminal-split')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('add-terminal-split'));
+    expect(screen.getByTestId('pane-cli-1')).toBeInTheDocument();
+    expect(screen.getByTestId('remove-terminal-split')).not.toBeDisabled();
+  });
+});
+
+// ===========================================================================
 // Issue #786: drag-drop validation owner. The container holds the `splits`
 // array, so it classifies a drop as no-op / reject / apply and owns the toast
 // messaging + activeCliTab sync. Each pane receives `onDropCliTool` via the


### PR DESCRIPTION
## 概要
Issue #841 (Phase 2) の対応。既存の +Split/-Split Action bar に History/Files toggle を統合（#840の useFilePanelState を SSOT として参照）。

## 主な変更
- `TerminalSplitContainer.tsx` Action bar に History/Files toggle 追加（useHistoryPaneState + useFilePanelState）
- toggle は split数に依存せず常時表示、cyan/gray状態・aria-pressed 対応
- ユニットテスト追加（rendering / aria-pressed / click ハンドラ）

依存: #840 (useFilePanelState) — develop マージ済
Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)