### PR TITLE
feat(file-tree): show full filename on hover via title tooltip (#852)

### DIFF
--- a/src/components/worktree/FilePanelContent.tsx
+++ b/src/components/worktree/FilePanelContent.tsx
@@ -199,7 +199,8 @@ function FileToolbar({ filePath, isMaximized, onToggleMaximize, copyableContent,
         >
           {pathCopied ? <Check className="w-3.5 h-3.5 text-green-600" /> : <ClipboardCopy className="w-3.5 h-3.5" />}
         </button>
-        <span className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate">{filePath}</span>
+        {/* [Issue #852] title shows full path on hover when truncated */}
+        <span className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate" title={filePath}>{filePath}</span>
       </div>
       <div className="flex items-center gap-1 flex-shrink-0">
         {/* [Issue #47] File content search button */}

--- a/src/components/worktree/TreeNode.tsx
+++ b/src/components/worktree/TreeNode.tsx
@@ -366,7 +366,11 @@ export const TreeNode = memo(function TreeNode({
         )}
 
         {/* Name - with highlight for name search */}
-        <span className="flex-1 truncate text-sm text-gray-700 dark:text-gray-300">
+        {/* [Issue #852] title shows full name on hover when truncated */}
+        <span
+          className="flex-1 truncate text-sm text-gray-700 dark:text-gray-300"
+          title={item.name}
+        >
           {searchMode === 'name' && searchQuery ? (
             <HighlightedText text={item.name} query={searchQuery} />
           ) : (

--- a/tests/unit/components/FilePanelContent.test.tsx
+++ b/tests/unit/components/FilePanelContent.test.tsx
@@ -163,6 +163,18 @@ describe('FilePanelContent', () => {
       expect(codeElement).toBeInTheDocument();
     });
 
+    // [Issue #852] Full file path on hover via native title tooltip for truncated path
+    it('should set title attribute with full path on toolbar path span', () => {
+      const content = createContent({
+        content: 'const x = 1;',
+        extension: 'ts',
+      });
+      const tab = createTab({ content });
+      render(<FilePanelContent tab={tab} {...defaultProps} />);
+
+      expect(screen.getByText('src/index.ts')).toHaveAttribute('title', 'src/index.ts');
+    });
+
     // [Issue #723] Virtualization test — synthesise a 10,000-line file and
     // assert that mounted rows are far fewer than the total line count.
     it('virtualizes large files so DOM only contains visible rows (Issue #723)', () => {

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -93,6 +93,30 @@ describe('FileTreeView', () => {
     });
   });
 
+  // [Issue #852] Full filename on hover via native title tooltip for truncated names
+  describe('Filename tooltip (Issue #852)', () => {
+    it('should set title attribute with full name on file name span', async () => {
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('package.json')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('package.json')).toHaveAttribute('title', 'package.json');
+      expect(screen.getByText('README.md')).toHaveAttribute('title', 'README.md');
+    });
+
+    it('should set title attribute with full name on directory name span', async () => {
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('src')).toHaveAttribute('title', 'src');
+    });
+  });
+
   describe('Directory expand/collapse', () => {
     it('should show chevron icon for directories', async () => {
       render(<FileTreeView worktreeId="test-worktree" />);


### PR DESCRIPTION
## 概要
Issue #852。Files でファイル名が truncate された際、hover で全名をツールチップ表示。

## 主な変更
- `TreeNode.tsx` name span に title={item.name}
- `FilePanelContent.tsx` path span に title={filePath}
- テスト追加（title 属性アサーション）

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)