### PR TITLE
feat(file-tree): FilesツールバーからCMATEボタンを削除（PC・モバイル） (#860)

### DIFF
--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -25,7 +25,7 @@ import { ContextMenu } from '@/components/worktree/ContextMenu';
 import { TreeNode } from '@/components/worktree/TreeNode';
 import { computeMatchedPaths } from '@/lib/utils';
 import { useLocale } from 'next-intl';
-import { FilePlus, FolderPlus, FileText, AlertCircle } from 'lucide-react';
+import { FilePlus, FolderPlus, AlertCircle } from 'lucide-react';
 
 // ============================================================================
 // Types
@@ -60,8 +60,6 @@ export interface FileTreeViewProps {
   searchResults?: SearchResultItem[];
   /** [Issue #21] Callback when a search result is selected (optional) */
   onSearchResultSelect?: (filePath: string) => void;
-  /** [Issue #294] Callback for CMATE.md setup/validate button */
-  onCmateSetup?: () => void;
 }
 
 /** Maximum number of concurrent directory fetches during tree reload */
@@ -101,7 +99,6 @@ export const FileTreeView = memo(function FileTreeView({
   searchMode,
   searchResults,
   onSearchResultSelect,
-  onCmateSetup,
 }: FileTreeViewProps) {
   // [Issue #162] Get locale for date formatting
   const locale = useLocale();
@@ -471,7 +468,7 @@ export const FileTreeView = memo(function FileTreeView({
       className={`overflow-auto bg-white dark:bg-gray-900 ${className}`}
     >
       {/* [Issue #300] Toolbar for root-level file/directory creation */}
-      {(onNewFile || onNewDirectory || onCmateSetup || isRefetching) && (
+      {(onNewFile || onNewDirectory || isRefetching) && (
         <div
           data-testid="file-tree-toolbar"
           className="flex items-center gap-1 p-1 border-b border-gray-200 dark:border-gray-700"
@@ -494,16 +491,6 @@ export const FileTreeView = memo(function FileTreeView({
             >
               <FolderPlus className="w-4 h-4" aria-hidden="true" />
               <span>New Directory</span>
-            </button>
-          )}
-          {onCmateSetup && (
-            <button
-              data-testid="toolbar-cmate-button"
-              onClick={onCmateSetup}
-              className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
-            >
-              <FileText className="w-4 h-4" aria-hidden="true" />
-              <span>CMATE</span>
             </button>
           )}
           {/* [Issue #706] Compact refetch indicator. Anchored to the right

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -126,7 +126,6 @@ export interface WorktreeDetailDesktopProps {
   onDelete: (path: string) => void;
   onUpload: (targetDir: string) => void;
   onMove: (path: string, type: 'file' | 'directory') => void;
-  onCmateSetup: () => void;
 
   // Git activity
   onDiffSelect: (diff: string, filePath: string) => void;
@@ -231,7 +230,6 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
   onDelete,
   onUpload,
   onMove,
-  onCmateSetup,
   onDiffSelect,
   onSelectedAgentsChange,
   vibeLocalModel,
@@ -509,7 +507,6 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
             onDelete={onDelete}
             onUpload={onUpload}
             onMove={onMove}
-            onCmateSetup={onCmateSetup}
             refreshTrigger={fileTreeRefresh}
             searchQuery={fileSearch.query}
             searchMode={fileSearch.mode}
@@ -574,7 +571,6 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       onDelete,
       onUpload,
       onMove,
-      onCmateSetup,
       fileTreeRefresh,
       onDiffSelect,
       handleInsertToMessage,

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -131,8 +131,6 @@ interface MobileContentProps {
   /** [Issue #211] Toast notification callback for copy feedback.
    *  Issue #786 (D-5): widened to the shared `ShowToast` alias for type parity. */
   showToast?: ShowToast;
-  /** [Issue #294] CMATE setup callback */
-  onCmateSetup?: () => void;
   /**
    * [Issue #368 / #837] Agents for the Agent tab. On mobile this is the
    * localStorage-backed mobile preference, not the DB `selectedAgents`.
@@ -229,7 +227,6 @@ export const MobileContent = memo(function MobileContent({
   refreshTrigger,
   fileSearch,
   showToast,
-  onCmateSetup,
   selectedAgents,
   onSelectedAgentsChange,
   availableAgents,
@@ -344,7 +341,6 @@ export const MobileContent = memo(function MobileContent({
               onDelete={onDelete}
               onUpload={onUpload}
               onMove={onMove}
-              onCmateSetup={onCmateSetup}
               refreshTrigger={refreshTrigger}
               searchQuery={fileSearch.query}
               searchMode={fileSearch.mode}

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -113,7 +113,6 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     handleAutoYesToggle,
     handleBackClick,
     handleCloseDiff,
-    handleCmateSetup,
     handleDelete,
     handleDiffSelect,
     handleDirtyChange,
@@ -272,7 +271,6 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           onDelete={handleDelete}
           onUpload={handleUpload}
           onMove={handleMove}
-          onCmateSetup={handleCmateSetup}
           onDiffSelect={handleDiffSelect}
           onSelectedAgentsChange={handleSelectedAgentsChange}
           vibeLocalModel={vibeLocalModel}
@@ -450,7 +448,6 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
             refreshTrigger={fileTreeRefresh}
             fileSearch={fileSearch}
             showToast={showToast}
-            onCmateSetup={handleCmateSetup}
             // Issue #837/#851: the Agent tab edits the mobile-only localStorage
             // preference and never the DB. `availableAgents` is the full agent
             // pool so mobile can pick any of the CLI tools independently of the

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -52,7 +52,6 @@ import { useMobileSelectedAgents } from '@/hooks/useMobileSelectedAgents';
 import { useTranslations } from 'next-intl';
 import { useFileOperations } from '@/hooks/useFileOperations';
 import { encodePathForUrl } from '@/lib/url-path-encoder';
-import { parseCmateContent, validateScheduleHeaders, validateSchedulesSection, CMATE_TEMPLATE_CONTENT } from '@/lib/cmate-validator';
 import {
   HISTORY_DISPLAY_LIMIT_STORAGE_KEY,
   HISTORY_USER_ONLY_STORAGE_KEY,
@@ -146,7 +145,6 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   const tError = useTranslations('error');
   const tCommon = useTranslations('common');
   const tAutoYes = useTranslations('autoYes');
-  const tSchedule = useTranslations('schedule');
 
   // Issue #839: Stale-while-revalidate priming. The worktree *list* is already
   // cached by useWorktreesCache (exposed via WorktreesCacheProvider). When the
@@ -1005,92 +1003,6 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     fileInputRef.current?.click();
   }, []);
 
-  /** [Issue #294] Handle CMATE.md setup/validate button */
-  const handleCmateSetup = useCallback(async () => {
-    try {
-      // Check if CMATE.md exists via tree listing (avoids 404 console noise)
-      const treeResponse = await fetch(`/api/worktrees/${worktreeId}/tree`);
-      if (!treeResponse.ok) {
-        throw new Error(`Failed to list worktree files: ${treeResponse.status}`);
-      }
-      const treeData = await treeResponse.json();
-      const treeItems: { name: string }[] = treeData.items ?? [];
-      const cmateExists = treeItems.some(item => item.name === 'CMATE.md');
-
-      let content: string;
-
-      if (!cmateExists) {
-        // File does not exist - create with template
-        const createResponse = await fetch(
-          `/api/worktrees/${worktreeId}/files/CMATE.md`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ type: 'file', content: CMATE_TEMPLATE_CONTENT }),
-          }
-        );
-        if (!createResponse.ok) {
-          throw new Error('Failed to create CMATE.md');
-        }
-        showToast(tSchedule('cmateCreated'), 'success');
-        setFileTreeRefresh(prev => prev + 1);
-        // Use template content directly for validation
-        content = CMATE_TEMPLATE_CONTENT;
-      } else {
-        // File exists - read content for validation
-        const fileResponse = await fetch(
-          `/api/worktrees/${worktreeId}/files/CMATE.md`
-        );
-        if (!fileResponse.ok) {
-          throw new Error(`Failed to read CMATE.md: ${fileResponse.status}`);
-        }
-        const data = await fileResponse.json();
-        if (typeof data.content !== 'string') {
-          showToast(tSchedule('cmateValidation.failed'), 'error');
-          return;
-        }
-        content = data.content;
-      }
-
-      // Validate content
-      const headerErrors = validateScheduleHeaders(content);
-      const sections = parseCmateContent(content);
-      const scheduleRows = sections.get('Schedules');
-
-      if (!scheduleRows || scheduleRows.length === 0) {
-        showToast(tSchedule('cmateValidation.noSchedulesSection'), 'error');
-        return;
-      }
-
-      const rowErrors = validateSchedulesSection(scheduleRows);
-      const errors = [...headerErrors, ...rowErrors];
-
-      if (errors.length === 0) {
-        showToast(
-          tSchedule('cmateValidation.valid', { count: String(scheduleRows.length) }),
-          'success'
-        );
-      } else {
-        const maxDisplay = 3;
-        const details = errors
-          .slice(0, maxDisplay)
-          .map((e) => e.message)
-          .join('; ');
-        const suffix = errors.length > maxDisplay ? ` (+${errors.length - maxDisplay})` : '';
-        showToast(
-          tSchedule('cmateValidation.errors', {
-            errorCount: String(errors.length),
-            details: details + suffix,
-          }),
-          'error'
-        );
-      }
-    } catch (err) {
-      console.error('[WorktreeDetailRefactored] CMATE setup error:', err);
-      showToast(tSchedule('cmateValidation.failed'), 'error');
-    }
-  }, [worktreeId, showToast, tSchedule]);
-
   /** Handle file input change - perform actual upload */
   const handleFileInputChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -1428,7 +1340,6 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     handleAutoYesToggle,
     handleBackClick,
     handleCloseDiff,
-    handleCmateSetup,
     handleDelete,
     handleDiffSelect,
     handleDirtyChange,


### PR DESCRIPTION
## 概要
共有FileTreeViewからCMATEボタンと関連handler/import/prop連鎖を完全削除（−89行）。Schedules機能に影響なし。

Closes #860

## 検証
- npm run lint ✅ / npx tsc --noEmit ✅ / npm run test:unit ✅ / npm run build ✅（オーケストレーター独立ゲートで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code) — /orchestrate