### PR TITLE
feat(sidebar): ブランチ左のステータスアイコンを1つに集約 (#867)

### DIFF
--- a/docs/en/features/sidebar-status-indicator.md
+++ b/docs/en/features/sidebar-status-indicator.md
@@ -19,6 +19,32 @@ It directly parses terminal output to accurately detect Claude's state (waiting 
 | `waiting` | ● | Yellow | Waiting for user input (yes/no, choices, etc.) |
 | `generating` | ⟳ | Blue spinner | Generating response |
 
+## Aggregated status icon to the left of the branch (Issue #867)
+
+Each branch in the sidebar shows the status of all selected agents **aggregated into a single icon** to the left of the branch name (previously it rendered up to five separate dots).
+
+### Aggregation logic
+
+`aggregateCliStatus(cliStatus)` (`src/types/sidebar.ts`) picks the single most significant status across all agents. The priority order (distinct from the sort-only `STATUS_PRIORITY`) is:
+
+```
+waiting > running / generating > ready > idle
+```
+
+- If any agent is `waiting`, the icon is `waiting` (yellow dot).
+- Otherwise, if any agent is `running` or `generating`, the icon is a spinner (`running` wins).
+- Otherwise, if any agent is `ready`, the icon is `ready` (green dot).
+- Otherwise, `idle` (gray dot).
+
+### Per-agent breakdown
+
+Aggregation does not lose per-agent detail. The icon's `title` / `aria-label` is set from
+`formatCliStatusBreakdown(cliStatus)` (e.g. `Claude: running, Codex: idle`), so the breakdown is
+revealed on hover/focus.
+
+> Sorting (`STATUS_PRIORITY`, `waiting` first) operates on the per-branch `status`, so this
+> aggregated icon does not change existing sort behavior.
+
 ## Detection Logic
 
 ### Thinking Indicator Detection

--- a/docs/features/sidebar-status-indicator.md
+++ b/docs/features/sidebar-status-indicator.md
@@ -19,6 +19,32 @@
 | `waiting` | ● | 黄 | ユーザー入力待ち（yes/no、選択肢など） |
 | `generating` | ⟳ | 青スピナー | レスポンス生成中 |
 
+## ブランチ左の集約ステータスアイコン（Issue #867）
+
+サイドバーの各ブランチ左には、選択中エージェントごとのステータスを**1つのアイコンに集約**して表示します（以前は最大5個のドットを並べて描画していました）。
+
+### 集約ロジック
+
+`aggregateCliStatus(cliStatus)`（`src/types/sidebar.ts`）が、各エージェントのステータスから最も重要な1つを選びます。優先度は以下の通りです（ソート用の `STATUS_PRIORITY` とは別物）。
+
+```
+waiting > running / generating > ready > idle
+```
+
+- いずれかのエージェントが `waiting` なら `waiting`（黄ドット）。
+- `waiting` がなく `running` または `generating` があればスピナー（`running` を優先）。
+- 上記がなく `ready` があれば `ready`（緑ドット）。
+- それ以外は `idle`（グレードット）。
+
+### エージェント別内訳の表示
+
+集約後も各エージェントのステータスは失われません。アイコンの `title` / `aria-label` に
+`formatCliStatusBreakdown(cliStatus)` が生成する内訳（例: `Claude: running, Codex: idle`）を設定し、
+ホバー／フォーカスで確認できます。
+
+> ソート（`STATUS_PRIORITY`、`waiting` 優先）はブランチ単位の `status` を基準としており、
+> この集約アイコンの導入によって既存のソート挙動は変わりません。
+
 ## 検出ロジック
 
 ### 思考インジケータの検出

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -9,9 +9,9 @@
 
 import React, { memo, useRef, useState, useEffect, useCallback } from 'react';
 import ReactDOM from 'react-dom';
-import type { SidebarBranchItem, BranchStatus } from '@/types/sidebar';
-import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
-import { getCliToolDisplayName, type CLIToolType } from '@/lib/cli-tools/types';
+import type { SidebarBranchItem } from '@/types/sidebar';
+import { aggregateCliStatus, formatCliStatusBreakdown } from '@/types/sidebar';
+import { BranchStatusIndicator } from '@/components/sidebar/BranchStatusIndicator';
 
 // ============================================================================
 // Types
@@ -32,30 +32,6 @@ export interface BranchListItemProps {
 // ============================================================================
 // Sub-components
 // ============================================================================
-
-/** Small status indicator dot for a CLI tool */
-function CliStatusDot({ status, label }: { status: BranchStatus; label: string }) {
-  const config = SIDEBAR_STATUS_CONFIG[status];
-  const title = `${label}: ${config.label}`;
-
-  if (config.type === 'spinner') {
-    return (
-      <span
-        className={`w-2 h-2 rounded-full flex-shrink-0 border-2 border-t-transparent animate-spin ${config.className}`}
-        title={title}
-        aria-label={title}
-      />
-    );
-  }
-
-  return (
-    <span
-      className={`w-2 h-2 rounded-full flex-shrink-0 ${config.className}`}
-      title={title}
-      aria-label={title}
-    />
-  );
-}
 
 /**
  * Tooltip shown on hover/focus with branch details (Issue #651, #676).
@@ -263,18 +239,19 @@ export const BranchListItem = memo(function BranchListItem({
         ${isSelected ? 'bg-gray-600 border-l-2 border-cyan-500' : 'border-l-2 border-transparent'}
       `}
     >
-      {/* Main row: CLI status dots, info, unread */}
+      {/* Main row: aggregated CLI status, info, unread */}
       <div className="flex items-center gap-3 w-full">
-        {/* CLI tool status dots (Issue #368: dynamic from selectedAgents) */}
+        {/*
+          Aggregated CLI tool status (Issue #867): a single icon replaces the
+          per-agent dots. The most significant status is shown; hover/focus
+          reveals the per-agent breakdown via the indicator's title/aria-label.
+        */}
         {branch.cliStatus && Object.keys(branch.cliStatus).length > 0 && (
-          <div className="flex items-center gap-1 flex-shrink-0 w-11" aria-label="CLI tool status">
-            {Object.entries(branch.cliStatus).map(([tool, status]) => (
-              <CliStatusDot
-                key={tool}
-                status={status ?? 'idle'}
-                label={getCliToolDisplayName(tool as CLIToolType)}
-              />
-            ))}
+          <div className="flex items-center justify-center flex-shrink-0 w-4" aria-label="CLI tool status">
+            <BranchStatusIndicator
+              status={aggregateCliStatus(branch.cliStatus)}
+              label={formatCliStatusBreakdown(branch.cliStatus)}
+            />
           </div>
         )}
 

--- a/src/components/sidebar/BranchStatusIndicator.tsx
+++ b/src/components/sidebar/BranchStatusIndicator.tsx
@@ -21,6 +21,13 @@ import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 export interface BranchStatusIndicatorProps {
   /** Current branch status */
   status: BranchStatus;
+  /**
+   * Optional accessible label override (Issue #867).
+   * When provided (e.g. a per-agent breakdown like "Claude: running, Codex: idle"),
+   * it replaces the default status-config label for both `title` and `aria-label`.
+   * Falls back to the status config label when omitted.
+   */
+  label?: string;
 }
 
 // ============================================================================
@@ -37,8 +44,11 @@ export interface BranchStatusIndicatorProps {
  */
 export const BranchStatusIndicator = memo(function BranchStatusIndicator({
   status,
+  label,
 }: BranchStatusIndicatorProps) {
   const config = SIDEBAR_STATUS_CONFIG[status];
+  // Issue #867: prefer the caller-supplied breakdown label when present.
+  const accessibleLabel = label ?? config.label;
 
   if (config.type === 'spinner') {
     return (
@@ -50,8 +60,8 @@ export const BranchStatusIndicator = memo(function BranchStatusIndicator({
           ${config.className}
           animate-spin
         `}
-        title={config.label}
-        aria-label={config.label}
+        title={accessibleLabel}
+        aria-label={accessibleLabel}
       />
     );
   }
@@ -63,8 +73,8 @@ export const BranchStatusIndicator = memo(function BranchStatusIndicator({
         w-3 h-3 rounded-full flex-shrink-0
         ${config.className}
       `}
-      title={config.label}
-      aria-label={config.label}
+      title={accessibleLabel}
+      aria-label={accessibleLabel}
     />
   );
 });

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Worktree } from '@/types/models';
-import type { CLIToolType } from '@/lib/cli-tools/types';
+import { getCliToolDisplayName, type CLIToolType } from '@/lib/cli-tools/types';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
 
 /**
@@ -37,6 +37,57 @@ export function deriveCliStatus(
   if (toolStatus.isProcessing) return 'running';
   if (toolStatus.isRunning) return 'ready';
   return 'idle';
+}
+
+/**
+ * Aggregate per-agent CLI statuses into a single representative BranchStatus
+ * for the sidebar's single status indicator (Issue #867).
+ *
+ * Priority (highest first): waiting > running/generating > ready > idle.
+ * The first matching tier wins, so any agent waiting for input dominates the
+ * icon, then any active (running/generating) agent, then ready, then idle.
+ * An empty or absent map yields 'idle'.
+ *
+ * NOTE: This priority is intentionally distinct from `STATUS_PRIORITY`
+ * (sidebar-utils.ts) which orders the sidebar SORT. Sorting keeps
+ * ready above running; the aggregated icon surfaces active work above ready.
+ *
+ * @param cliStatus - Per-CLI tool status map (e.g. from `SidebarBranchItem`)
+ * @returns The single most significant status to display
+ */
+export function aggregateCliStatus(
+  cliStatus?: Partial<Record<CLIToolType, BranchStatus>>
+): BranchStatus {
+  if (!cliStatus) return 'idle';
+  const statuses = Object.values(cliStatus).filter(
+    (s): s is BranchStatus => s !== undefined
+  );
+  if (statuses.length === 0) return 'idle';
+  if (statuses.includes('waiting')) return 'waiting';
+  if (statuses.includes('running')) return 'running';
+  if (statuses.includes('generating')) return 'generating';
+  if (statuses.includes('ready')) return 'ready';
+  return 'idle';
+}
+
+/**
+ * Format a per-agent status breakdown for tooltips / aria-labels (Issue #867),
+ * e.g. "Claude: running, Codex: idle". Lets the single aggregated icon still
+ * expose each agent's individual status on hover/focus.
+ *
+ * @param cliStatus - Per-CLI tool status map
+ * @returns Comma-separated "DisplayName: status" string ('' when empty/absent)
+ */
+export function formatCliStatusBreakdown(
+  cliStatus?: Partial<Record<CLIToolType, BranchStatus>>
+): string {
+  if (!cliStatus) return '';
+  return Object.entries(cliStatus)
+    .map(
+      ([tool, status]) =>
+        `${getCliToolDisplayName(tool as CLIToolType)}: ${status ?? 'idle'}`
+    )
+    .join(', ');
 }
 
 /**

--- a/tests/unit/components/sidebar/BranchListItem.test.tsx
+++ b/tests/unit/components/sidebar/BranchListItem.test.tsx
@@ -223,6 +223,75 @@ describe('BranchListItem', () => {
     });
   });
 
+  describe('Aggregated CLI status indicator (Issue #867)', () => {
+    it('should render exactly one status indicator regardless of agent count', () => {
+      render(
+        <BranchListItem
+          branch={{
+            ...defaultBranch,
+            cliStatus: { claude: 'idle', codex: 'running', gemini: 'ready' },
+          }}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      // A single aggregated icon, not one dot per agent.
+      expect(screen.getAllByTestId('status-indicator')).toHaveLength(1);
+    });
+
+    it('should reflect waiting as the highest-priority aggregated status', () => {
+      render(
+        <BranchListItem
+          branch={{
+            ...defaultBranch,
+            cliStatus: { claude: 'running', codex: 'waiting', gemini: 'idle' },
+          }}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const indicator = screen.getByTestId('status-indicator');
+      // waiting renders as a static yellow dot (no spinner).
+      expect(indicator.className).toMatch(/bg-yellow-500/);
+      expect(indicator.className).not.toMatch(/animate-spin/);
+    });
+
+    it('should prioritize running over ready in the aggregated icon', () => {
+      render(
+        <BranchListItem
+          branch={{
+            ...defaultBranch,
+            cliStatus: { claude: 'ready', codex: 'running' },
+          }}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const indicator = screen.getByTestId('status-indicator');
+      expect(indicator.className).toMatch(/animate-spin/);
+    });
+
+    it('should expose the per-agent breakdown via the indicator label', () => {
+      render(
+        <BranchListItem
+          branch={{
+            ...defaultBranch,
+            cliStatus: { claude: 'running', codex: 'idle' },
+          }}
+          isSelected={false}
+          onClick={() => {}}
+        />
+      );
+
+      const indicator = screen.getByTestId('status-indicator');
+      expect(indicator.getAttribute('aria-label')).toBe('Claude: running, Codex: idle');
+      expect(indicator.getAttribute('title')).toBe('Claude: running, Codex: idle');
+    });
+  });
+
   describe('Unread indicator', () => {
     it('should show unread indicator when hasUnread is true', () => {
       render(

--- a/tests/unit/components/sidebar/BranchStatusIndicator.test.tsx
+++ b/tests/unit/components/sidebar/BranchStatusIndicator.test.tsx
@@ -158,6 +158,23 @@ describe('BranchStatusIndicator', () => {
       expect(indicator.getAttribute('title')).toBe('Generating');
       expect(indicator.getAttribute('aria-label')).toBe('Generating');
     });
+
+    it('should override the label when a custom label is provided (Issue #867)', () => {
+      render(
+        <BranchStatusIndicator status="running" label="Claude: running, Codex: idle" />
+      );
+
+      const indicator = screen.getByTestId('status-indicator');
+      expect(indicator.getAttribute('title')).toBe('Claude: running, Codex: idle');
+      expect(indicator.getAttribute('aria-label')).toBe('Claude: running, Codex: idle');
+    });
+
+    it('should fall back to the config label when label is omitted (Issue #867)', () => {
+      render(<BranchStatusIndicator status="waiting" />);
+
+      const indicator = screen.getByTestId('status-indicator');
+      expect(indicator.getAttribute('aria-label')).toBe('Waiting for response');
+    });
   });
 
   describe('All status types', () => {

--- a/tests/unit/types/sidebar.test.ts
+++ b/tests/unit/types/sidebar.test.ts
@@ -6,7 +6,12 @@
 
 import { describe, it, expect } from 'vitest';
 import type { BranchStatus, SidebarBranchItem } from '@/types/sidebar';
-import { toBranchItem, deriveCliStatus } from '@/types/sidebar';
+import {
+  toBranchItem,
+  deriveCliStatus,
+  aggregateCliStatus,
+  formatCliStatusBreakdown,
+} from '@/types/sidebar';
 import type { Worktree } from '@/types/models';
 
 describe('sidebar types', () => {
@@ -329,6 +334,74 @@ describe('sidebar types', () => {
 
     it('should prioritize waiting over running', () => {
       expect(deriveCliStatus({ isRunning: true, isWaitingForResponse: true, isProcessing: true })).toBe('waiting');
+    });
+  });
+
+  describe('aggregateCliStatus (Issue #867)', () => {
+    it('should return idle when cliStatus is undefined', () => {
+      expect(aggregateCliStatus(undefined)).toBe('idle');
+    });
+
+    it('should return idle for an empty map', () => {
+      expect(aggregateCliStatus({})).toBe('idle');
+    });
+
+    it('should return idle when all agents are idle', () => {
+      expect(aggregateCliStatus({ claude: 'idle', codex: 'idle' })).toBe('idle');
+    });
+
+    it('should prioritize waiting above everything else', () => {
+      expect(
+        aggregateCliStatus({ claude: 'running', codex: 'waiting', gemini: 'ready' })
+      ).toBe('waiting');
+    });
+
+    it('should prioritize running over ready and idle', () => {
+      expect(aggregateCliStatus({ claude: 'ready', codex: 'running' })).toBe('running');
+    });
+
+    it('should prioritize generating over ready and idle', () => {
+      expect(aggregateCliStatus({ claude: 'ready', codex: 'generating' })).toBe('generating');
+    });
+
+    it('should prefer running over generating when both are present', () => {
+      // Both render as spinners; ordering is deterministic (running wins).
+      expect(aggregateCliStatus({ claude: 'generating', codex: 'running' })).toBe('running');
+    });
+
+    it('should return ready when the highest status is ready', () => {
+      expect(aggregateCliStatus({ claude: 'idle', codex: 'ready' })).toBe('ready');
+    });
+
+    it('should ignore undefined per-agent entries', () => {
+      expect(aggregateCliStatus({ claude: undefined, codex: 'ready' })).toBe('ready');
+      expect(aggregateCliStatus({ claude: undefined })).toBe('idle');
+    });
+  });
+
+  describe('formatCliStatusBreakdown (Issue #867)', () => {
+    it('should return an empty string when cliStatus is undefined', () => {
+      expect(formatCliStatusBreakdown(undefined)).toBe('');
+    });
+
+    it('should return an empty string for an empty map', () => {
+      expect(formatCliStatusBreakdown({})).toBe('');
+    });
+
+    it('should format each agent with its display name and status', () => {
+      expect(
+        formatCliStatusBreakdown({ claude: 'running', codex: 'idle' })
+      ).toBe('Claude: running, Codex: idle');
+    });
+
+    it('should use the friendly display name for hyphenated agent ids', () => {
+      expect(
+        formatCliStatusBreakdown({ claude: 'idle', 'vibe-local': 'ready' })
+      ).toBe('Claude: idle, Vibe Local: ready');
+    });
+
+    it('should fall back to idle for undefined per-agent entries', () => {
+      expect(formatCliStatusBreakdown({ claude: undefined })).toBe('Claude: idle');
     });
   });
 });


### PR DESCRIPTION
## 概要
エージェント別の複数ドットを集約ステータス1アイコンに。aggregateCliStatus()新設、ツールチップで内訳表示。Epic #866 (A)。

Epic: #866
Closes #867

## 検証
- npm run lint ✅ / npx tsc --noEmit ✅ / npm run test:unit ✅ / npm run build ✅（オーケストレーター独立ゲート）

🤖 Generated with [Claude Code](https://claude.com/claude-code) — /orchestrate