### PR TITLE
fix(db): v33 migration が孤児session_states行でFK失敗する不具合を修正

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -8,7 +8,9 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import { initDatabase } from '../src/lib/db';
 
-const dbPath = path.join(process.cwd(), 'db.sqlite');
+// Respect CM_DB_PATH so `db:init` (incl. build-and-start) migrates the same
+// database the server uses; fall back to ./db.sqlite for local/dev defaults.
+const dbPath = process.env.CM_DB_PATH || path.join(process.cwd(), 'db.sqlite');
 
 console.log('Initializing database...');
 console.log(`Database path: ${dbPath}`);

--- a/src/lib/db/migrations/v33-agent-instances.ts
+++ b/src/lib/db/migrations/v33-agent-instances.ts
@@ -67,6 +67,12 @@ export const v33_migrations: Migration[] = [
       `);
 
       // Backfill instance_id = cli_tool_id (primary-instance anchor).
+      // NOTE: long-lived databases can accumulate orphaned session_states rows
+      // whose worktree was deleted (the pre-v33 table had a FK but rows may
+      // predate it / FK enforcement was off at write time). The new table's
+      // FOREIGN KEY would reject those orphans and abort the whole migration,
+      // so we skip rows without a matching worktree. PRAGMA foreign_keys cannot
+      // be toggled inside the migration transaction, hence the WHERE filter.
       db.exec(`
         INSERT INTO session_states_new
           (worktree_id, cli_tool_id, instance_id, last_captured_line, in_progress_message_id)
@@ -76,7 +82,8 @@ export const v33_migrations: Migration[] = [
           COALESCE(cli_tool_id, 'claude'),
           last_captured_line,
           in_progress_message_id
-        FROM session_states;
+        FROM session_states
+        WHERE worktree_id IN (SELECT id FROM worktrees);
       `);
 
       db.exec(`DROP TABLE session_states;`);

--- a/tests/unit/db/migration-v33-agent-instances.test.ts
+++ b/tests/unit/db/migration-v33-agent-instances.test.ts
@@ -160,4 +160,28 @@ describe('migration v33: legacy backfill (up() in isolation)', () => {
     ).all('wt-d') as Array<{ instance_id: string; cli_tool_id: string }>;
     expect(rows).toEqual([{ instance_id: 'codex', cli_tool_id: 'codex' }]);
   });
+
+  it('skips orphaned session_states rows so the FK rebuild does not abort (regression)', () => {
+    // Production enforces FK; long-lived DBs accumulate session_states rows
+    // whose worktree was deleted. The rebuilt table's FK would reject them and
+    // abort the whole migration ("FOREIGN KEY constraint failed").
+    db.pragma('foreign_keys = ON');
+    db.prepare(`INSERT INTO worktrees (id, name, path, cli_tool_id, selected_agents, updated_at) VALUES (?,?,?,?,?,?)`)
+      .run('wt-live', 'Live', '/tmp/live', 'claude', null, 1700000000000);
+    // Valid row + orphan row (worktree 'wt-gone' does not exist).
+    db.prepare(`INSERT INTO session_states (worktree_id, cli_tool_id, last_captured_line) VALUES (?,?,?)`)
+      .run('wt-live', 'claude', 7);
+    db.prepare(`INSERT INTO session_states (worktree_id, cli_tool_id, last_captured_line) VALUES (?,?,?)`)
+      .run('wt-gone', 'claude', 99);
+
+    expect(() => runV33()).not.toThrow();
+
+    // Migration completed: agent_instances exists, valid row kept, orphan dropped.
+    expect(tableExists(db, 'agent_instances')).toBe(true);
+    const live = db.prepare(`SELECT last_captured_line FROM session_states WHERE worktree_id = ?`)
+      .get('wt-live') as { last_captured_line: number } | undefined;
+    expect(live?.last_captured_line).toBe(7);
+    const orphan = db.prepare(`SELECT 1 FROM session_states WHERE worktree_id = ?`).get('wt-gone');
+    expect(orphan).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## 概要
migration v33(#868) が本番DB(foreign_keys=ON)で **FOREIGN KEY constraint failed** で失敗し、毎起動ロールバック→`agent_instances` 未作成→worktrees API が常時エラーになる不具合のホットフィックス。

## 根本原因
v33 は session_states を FK付き新テーブルへ全行コピーするが、長期運用DBには削除済みworktreeを参照する孤児行（実測 972/1015）が存在し、FK違反でマイグレーション全体がabortしていた。テスト/新規DBは孤児が無く foreign_keys 既定OFFのため未検出。

## 修正
- `v33.up()`: session_states コピーを `WHERE worktree_id IN (SELECT id FROM worktrees)` に限定（孤児=死データを除外）。FK pragma はトランザクション内で切れないため WHERE 方式。
- `scripts/init-db.ts`: `CM_DB_PATH` を尊重（db:init が実DBを対象にするよう修正）。
- 回帰テスト追加（foreign_keys=ON + 孤児行で abort しないこと）。

## 検証
- lint ✅ / tsc ✅ / test:unit ✅(7755) / build ✅

関連: #868 / Epic #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)