### PR TITLE
fix(agents): 別名インスタンスのステータス/「X End」表示不具合を修正（per-instance状態検出） (#875)

### DIFF
--- a/src/app/api/worktrees/[id]/route.ts
+++ b/src/app/api/worktrees/[id]/route.ts
@@ -74,6 +74,7 @@ export async function GET(
         db,
         getMessages,
         markPendingPromptsAsAnswered,
+        getAgentInstances,
       ),
       getGitStatus(worktree.path, initialBranch).catch((gitError) => {
         // Log but don't fail - git status is non-critical

--- a/src/app/api/worktrees/route.ts
+++ b/src/app/api/worktrees/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 // Force dynamic rendering - this route uses searchParams and database access
 export const dynamic = 'force-dynamic';
 import { getDbInstance } from '@/lib/db/db-instance';
-import { getWorktrees, getRepositories, getMessages, markPendingPromptsAsAnswered } from '@/lib/db';
+import { getWorktrees, getRepositories, getMessages, markPendingPromptsAsAnswered, getAgentInstances } from '@/lib/db';
 import { listSessions } from '@/lib/tmux/tmux';
 import { detectWorktreeSessionStatus } from '@/lib/session/worktree-status-helper';
 import { parseIncludeParam } from '@/lib/api/worktrees-include-parser';
@@ -59,6 +59,7 @@ export async function GET(request: NextRequest) {
           db,
           getMessages,
           markPendingPromptsAsAnswered,
+          getAgentInstances,
         );
 
         const base = {

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -321,11 +321,15 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       const paneAutoYes = autoYesStateMap.get(paneCli);
       const paneAutoYesEnabled = paneAutoYes?.enabled ?? false;
       const paneAutoYesExpiresAt = paneAutoYes?.expiresAt ?? null;
-      // Issue #743: derive THIS pane's AI agent status from the per-CLI session
-      // flags. Only the resolved BranchStatus string is handed to the child, so
-      // a polling tick that leaves the status unchanged does not break the
-      // child's memo (S3-001 memo-safe).
-      const paneCliStatus = deriveCliStatus(worktree?.sessionStatusByCli?.[paneCli]);
+      // Issue #743/#875: derive THIS pane's AI agent status. Splits are
+      // per-instance, so resolve from the per-instance status map keyed by the
+      // pane's instanceId (alias instances show their own status); fall back to
+      // the per-CLI map for backward compat. Only the resolved BranchStatus
+      // string is handed to the child, so a polling tick that leaves the status
+      // unchanged does not break the child's memo (S3-001 memo-safe).
+      const paneCliStatus = deriveCliStatus(
+        worktree?.sessionStatusByInstance?.[paneInstanceId] ?? worktree?.sessionStatusByCli?.[paneCli]
+      );
       return (
         <TerminalSplitPaneContent
           worktreeId={worktreeId}
@@ -395,10 +399,11 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       setActiveInstanceId,
       lastAutoResponse,
       makeAutoYesToggleHandler,
-      // Issue #743: re-create renderPane when the per-CLI session status map
-      // changes so the derived `cliStatus` stays current. The child only
+      // Issue #743/#875: re-create renderPane when the session status maps
+      // change so the derived `cliStatus` stays current. The child only
       // re-renders when its resolved status string actually changes (memo-safe).
       worktree?.sessionStatusByCli,
+      worktree?.sessionStatusByInstance,
       // Issue #744: embedded HistoryPane wiring deps.
       onFilePathClick,
       showToast,
@@ -640,6 +645,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
             worktreeStatus={worktree?.status ?? null}
             onWorktreeStatusChange={onWorktreeStatusChange}
             sessionStatusByCli={worktree?.sessionStatusByCli}
+            sessionStatusByInstance={worktree?.sessionStatusByInstance}
             instances={instances}
             activeInstanceId={activeInstanceId}
             onActiveInstanceChange={setActiveInstanceId}

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -441,9 +441,17 @@ interface DesktopHeaderProps {
   /** Per-CLI session status map (PC only, optional). Issue #749 */
   sessionStatusByCli?: Worktree['sessionStatusByCli'];
   /**
+   * Per-instance session status map keyed by instanceId (PC only, optional).
+   * Issue #875: the per-agent status row and "End" button resolve each
+   * instance's status from here so alias instances (instanceId !== cliToolId)
+   * show their own status. Falls back to {@link sessionStatusByCli} per backing
+   * CLI tool when an instance entry is absent (transition / backward compat).
+   */
+  sessionStatusByInstance?: Worktree['sessionStatusByInstance'];
+  /**
    * Issue #869: agent instance roster (PC only, optional). The per-agent status
    * row is now an instance-tab switcher: one tab per instance, labelled by alias
-   * (`getInstanceLabel`). Status is still resolved per backing CLI tool.
+   * (`getInstanceLabel`). Status is resolved per instance (Issue #875).
    */
   instances?: AgentInstance[];
   /** Issue #869: currently active agent instance id (PC only, optional). */
@@ -493,6 +501,7 @@ export const DesktopHeader = memo(function DesktopHeader({
   worktreeStatus,
   onWorktreeStatusChange,
   sessionStatusByCli,
+  sessionStatusByInstance,
   instances,
   activeInstanceId,
   onActiveInstanceChange,
@@ -510,10 +519,16 @@ export const DesktopHeader = memo(function DesktopHeader({
   // published to the splits goes through onAgentDragStart/onAgentDragEnd.
   const [draggingInstanceId, setDraggingInstanceId] = useState<string | null>(null);
 
-  // Issue #869: the CLI tool backing the active instance. Kill-session controls
-  // remain keyed on the CLI tool (a CLI session is per worktree+tool), so we
-  // resolve the active instance's CLI tool for the running-session check below.
-  const activeCliTab = instances?.find((inst) => inst.id === activeInstanceId)?.cliTool;
+  // Issue #875: the active instance's CLI tool + its own running state. The
+  // "End" button targets the active *instance* (kill-session is instance-scoped),
+  // so its visibility is driven by the per-instance status; we fall back to the
+  // per-CLI map when the per-instance entry is absent (transition / backward compat).
+  const activeInstance = instances?.find((inst) => inst.id === activeInstanceId);
+  const activeInstanceRunning = activeInstanceId
+    ? (sessionStatusByInstance?.[activeInstanceId]?.isRunning
+        ?? (activeInstance ? sessionStatusByCli?.[activeInstance.cliTool]?.isRunning : undefined)
+        ?? false)
+    : false;
 
   const handleAgentDragStart = useCallback(
     (e: React.DragEvent<HTMLButtonElement>, instanceId: string) => {
@@ -635,7 +650,12 @@ export const DesktopHeader = memo(function DesktopHeader({
         {instances && instances.length > 0 && (
           <div className="flex items-center gap-2 flex-shrink-0" data-testid="desktop-agent-status-row">
             {instances.map((inst) => {
-              const cliStatus = deriveCliStatus(sessionStatusByCli?.[inst.cliTool]);
+              // Issue #875: resolve each instance's status from the per-instance
+              // map so alias instances (instanceId !== cliToolId) show their own
+              // status; fall back to the per-CLI map for backward compat.
+              const cliStatus = deriveCliStatus(
+                sessionStatusByInstance?.[inst.id] ?? sessionStatusByCli?.[inst.cliTool]
+              );
               const agentStatusConfig = SIDEBAR_STATUS_CONFIG[cliStatus];
               const isActive = inst.id === activeInstanceId;
               const label = getInstanceLabel(inst);
@@ -683,7 +703,7 @@ export const DesktopHeader = memo(function DesktopHeader({
             Mobile kill button (WorktreeDetailRefactored.tsx:409-421). Rendered
             only when a kill handler is wired AND the active CLI session is
             running; click opens the existing confirmation modal. */}
-        {onKillSession && activeCliTab && sessionStatusByCli?.[activeCliTab]?.isRunning && (
+        {onKillSession && activeInstanceRunning && (
           <button
             type="button"
             onClick={onKillSession}

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -976,11 +976,13 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   const handleKillConfirm = useCallback(async (): Promise<void> => {
     setShowKillConfirm(false);
     try {
-      // Issue #874: on mobile scope the kill to the active agent instance; PC
-      // omits the param (byte-identical, kill resolves to the primary instance).
-      const killUrl = isMobileRef.current
-        ? `/api/worktrees/${worktreeId}/kill-session?cliTool=${activeCliTab}&instance=${encodeURIComponent(activeInstanceIdRef.current)}`
-        : `/api/worktrees/${worktreeId}/kill-session?cliTool=${activeCliTab}`;
+      // Issue #874/#875: always scope the kill to the active agent instance, on
+      // PC as well as mobile. The primary instance uses instanceId === cliToolId
+      // (byte-identical session name), so this is unchanged for primary
+      // instances; for alias instances it terminates only that instance's
+      // session instead of every session of the backing CLI tool.
+      const killUrl =
+        `/api/worktrees/${worktreeId}/kill-session?cliTool=${activeCliTab}&instance=${encodeURIComponent(activeInstanceIdRef.current)}`;
       const response = await fetch(killUrl, { method: 'POST' });
       if (!response.ok) return;
       actions.clearMessages();

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -332,14 +332,23 @@ export const worktreeApi = {
    * Kill the tmux session for a worktree
    * @param id - Worktree ID
    * @param cliToolId - Optional CLI tool ID (claude, codex, gemini). If not specified, uses worktree's default.
+   * @param instanceId - Optional agent instance ID (Issue #875). When provided,
+   *   scopes the kill to that single instance; the primary instance uses
+   *   instanceId === cliToolId. Sent as the `instance` query parameter that the
+   *   kill-session route already understands.
    */
-  async killSession(id: string, cliToolId?: CLIToolType): Promise<{ success: boolean; message: string }> {
+  async killSession(
+    id: string,
+    cliToolId?: CLIToolType,
+    instanceId?: string,
+  ): Promise<{ success: boolean; message: string }> {
+    const query = new URLSearchParams();
+    if (cliToolId) query.set('cliTool', cliToolId);
+    if (instanceId) query.set('instance', instanceId);
+    const queryString = query.toString();
     return fetchApi<{ success: boolean; message: string }>(
-      `/api/worktrees/${id}/kill-session`,
-      {
-        method: 'POST',
-        body: cliToolId ? JSON.stringify({ cliToolId }) : undefined,
-      }
+      `/api/worktrees/${id}/kill-session${queryString ? `?${queryString}` : ''}`,
+      { method: 'POST' }
     );
   },
 };

--- a/src/lib/session/worktree-status-helper.ts
+++ b/src/lib/session/worktree-status-helper.ts
@@ -22,7 +22,7 @@ import { STATUS_CAPTURE_LINES } from '@/config/status-capture-config';
 import { isSessionHealthy } from './claude-session';
 import { getLastServerResponseTimestamp, buildCompositeKey } from '@/lib/polling/auto-yes-manager';
 import { GLOBAL_SESSION_WORKTREE_ID } from '@/lib/session/global-session-constants';
-import type { getMessages as GetMessagesFn, markPendingPromptsAsAnswered as MarkPendingFn } from '@/lib/db';
+import type { getMessages as GetMessagesFn, markPendingPromptsAsAnswered as MarkPendingFn, getAgentInstances as GetAgentInstancesFn } from '@/lib/db';
 
 function getStatusCaptureLines(cliToolId: CLIToolType): number {
   if (cliToolId === 'opencode') {
@@ -45,14 +45,107 @@ export interface CliToolSessionStatus {
 
 /** Aggregated session status result for a worktree */
 export interface WorktreeSessionStatus {
-  /** Per-CLI-tool session status map */
+  /**
+   * Per-CLI-tool session status map.
+   *
+   * Issue #875: when a worktree has alias instances (instanceId !== cliToolId),
+   * each tool's entry is the aggregate (logical-OR of the flags) across all of
+   * its instances, so worktree-level consumers (sidebar #867, header dot) reflect
+   * activity in alias instances as well as the primary one.
+   */
   sessionStatusByCli: Partial<Record<CLIToolType, CliToolSessionStatus>>;
+  /**
+   * Per-agent-instance session status map keyed by instanceId (Issue #875).
+   *
+   * Primary instances are keyed by their CLI tool id (instanceId === cliToolId);
+   * alias instances are keyed by their own instanceId. Each entry is that single
+   * instance's own status (NOT aggregated), so the per-instance UI (status
+   * dot/spinner, "End" button) can resolve each instance independently.
+   */
+  sessionStatusByInstance: Partial<Record<string, CliToolSessionStatus>>;
   /** Whether any CLI tool session is running */
   isSessionRunning: boolean;
   /** Whether any CLI tool is waiting for a user response */
   isWaitingForResponse: boolean;
   /** Whether any CLI tool is actively processing */
   isProcessing: boolean;
+}
+
+/** Merge two per-instance statuses into an aggregate (logical-OR of each flag). */
+function mergeSessionStatus(
+  a: CliToolSessionStatus,
+  b: CliToolSessionStatus,
+): CliToolSessionStatus {
+  return {
+    isRunning: a.isRunning || b.isRunning,
+    isWaitingForResponse: a.isWaitingForResponse || b.isWaitingForResponse,
+    isProcessing: a.isProcessing || b.isProcessing,
+  };
+}
+
+/**
+ * Detect the session status of a single (cliTool, instance) session.
+ *
+ * Issue #875: extracted from the per-CLI loop so both primary instances
+ * (instanceId === cliToolId) and alias instances can be detected through one
+ * code path. The capture / messages / pending-prompt cleanup are all scoped to
+ * the given instanceId, so each instance's status is independent.
+ */
+async function detectInstanceSessionStatus(
+  worktreeId: string,
+  cliToolId: CLIToolType,
+  instanceId: string,
+  sessionName: string,
+  sessionNameSet: Set<string>,
+  db: ReturnType<typeof import('@/lib/db/db-instance').getDbInstance>,
+  getMessages: typeof GetMessagesFn,
+  markPendingPromptsAsAnswered: typeof MarkPendingFn,
+): Promise<CliToolSessionStatus> {
+  // Issue #405: Use Set.has() instead of individual hasSession() calls
+  let isRunning = sessionNameSet.has(sessionName);
+
+  // [DR1-005] Claude-only health check (other tools use simple session existence)
+  if (isRunning && cliToolId === 'claude') {
+    const healthResult = await isSessionHealthy(sessionName);
+    if (!healthResult.healthy) {
+      isRunning = false;
+    }
+  }
+
+  // Check status based on terminal state
+  let isWaitingForResponse = false;
+  let isProcessing = false;
+  if (isRunning) {
+    try {
+      const captureLines = getStatusCaptureLines(cliToolId);
+      const output = await captureSessionOutput(worktreeId, cliToolId, captureLines, instanceId);
+      // Issue #501, #525: Pass last server response timestamp using compositeKey.
+      // Auto-yes / last-response tracking stays cliTool-keyed (#869), so alias
+      // instances share the tool's composite key — acceptable as a status hint.
+      const compositeKey = buildCompositeKey(worktreeId, cliToolId);
+      const lastServerResponseTs = getLastServerResponseTimestamp(compositeKey);
+      const lastOutputTimestamp = lastServerResponseTs ? new Date(lastServerResponseTs) : undefined;
+      const statusResult = detectSessionStatus(output, cliToolId, lastOutputTimestamp);
+      isWaitingForResponse = statusResult.status === 'waiting';
+      isProcessing = statusResult.status === 'running';
+
+      // Clean up stale pending prompts (scoped to this instance) if none is showing
+      if (!statusResult.hasActivePrompt) {
+        const messages = getMessages(db, worktreeId, { limit: 10, cliToolId, instanceId });
+        const hasPendingPrompt = messages.some(
+          msg => msg.messageType === 'prompt' && msg.promptData?.status !== 'answered'
+        );
+        if (hasPendingPrompt) {
+          markPendingPromptsAsAnswered(db, worktreeId, cliToolId, instanceId);
+        }
+      }
+    } catch {
+      // If capture fails, assume processing
+      isProcessing = true;
+    }
+  }
+
+  return { isRunning, isWaitingForResponse, isProcessing };
 }
 
 /**
@@ -66,6 +159,7 @@ export interface WorktreeSessionStatus {
  * @param db - Database instance
  * @param getMessages - DB function to get messages for a worktree
  * @param markPendingPromptsAsAnswered - DB function to mark stale prompts as answered
+ * @param getAgentInstances - DB function returning the worktree's agent-instance roster (Issue #875)
  * @returns Aggregated session status for the worktree
  */
 export async function detectWorktreeSessionStatus(
@@ -74,12 +168,14 @@ export async function detectWorktreeSessionStatus(
   db: ReturnType<typeof import('@/lib/db/db-instance').getDbInstance>,
   getMessages: typeof GetMessagesFn,
   markPendingPromptsAsAnswered: typeof MarkPendingFn,
+  getAgentInstances: typeof GetAgentInstancesFn,
 ): Promise<WorktreeSessionStatus> {
   // Issue #649: Skip status detection for global assistant sessions.
   // Global sessions are not real worktrees and should not appear in the sidebar.
   if (worktreeId === GLOBAL_SESSION_WORKTREE_ID) {
     return {
       sessionStatusByCli: {},
+      sessionStatusByInstance: {},
       isSessionRunning: false,
       isWaitingForResponse: false,
       isProcessing: false,
@@ -89,66 +185,62 @@ export async function detectWorktreeSessionStatus(
   const manager = CLIToolManager.getInstance();
   const allCliTools: readonly CLIToolType[] = CLI_TOOL_IDS;
 
-  // Parallel status detection for all CLI tools (previously sequential loop).
-  // Each tool's capture + status detection is independent, so Promise.all is safe.
+  // Issue #875: detect each instance's session independently. The primary
+  // instance of every CLI tool (instanceId === cliToolId) is always probed for
+  // backward compatibility; alias instances (instanceId !== cliToolId) from the
+  // roster are probed in addition. Each probe is independent, so Promise.all is
+  // safe. de-dup primaries already covered by the per-tool list.
+  const aliasInstances = getAgentInstances(db, worktreeId).filter(
+    (inst) => inst.id !== inst.cliTool
+  );
+
+  type Probe = { cliToolId: CLIToolType; instanceId: string; sessionName: string };
+  const probes: Probe[] = allCliTools.map((cliToolId) => ({
+    cliToolId,
+    instanceId: cliToolId,
+    sessionName: manager.getTool(cliToolId).getSessionName(worktreeId, cliToolId),
+  }));
+  for (const inst of aliasInstances) {
+    probes.push({
+      cliToolId: inst.cliTool,
+      instanceId: inst.id,
+      sessionName: manager.getTool(inst.cliTool).getSessionName(worktreeId, inst.id),
+    });
+  }
+
   const results = await Promise.all(
-    allCliTools.map(async (cliToolId): Promise<[CLIToolType, CliToolSessionStatus]> => {
-      const cliTool = manager.getTool(cliToolId);
-      const sessionName = cliTool.getSessionName(worktreeId);
-
-      // Issue #405: Use Set.has() instead of individual hasSession() calls
-      let isRunning = sessionNameSet.has(sessionName);
-
-      // [DR1-005] Claude-only health check (other tools use simple session existence)
-      if (isRunning && cliToolId === 'claude') {
-        const healthResult = await isSessionHealthy(sessionName);
-        if (!healthResult.healthy) {
-          isRunning = false;
-        }
-      }
-
-      // Check status based on terminal state
-      let isWaitingForResponse = false;
-      let isProcessing = false;
-      if (isRunning) {
-        try {
-          const captureLines = getStatusCaptureLines(cliToolId);
-          const output = await captureSessionOutput(worktreeId, cliToolId, captureLines);
-          // Issue #501, #525: Pass last server response timestamp using compositeKey
-          const compositeKey = buildCompositeKey(worktreeId, cliToolId);
-          const lastServerResponseTs = getLastServerResponseTimestamp(compositeKey);
-          const lastOutputTimestamp = lastServerResponseTs ? new Date(lastServerResponseTs) : undefined;
-          const statusResult = detectSessionStatus(output, cliToolId, lastOutputTimestamp);
-          isWaitingForResponse = statusResult.status === 'waiting';
-          isProcessing = statusResult.status === 'running';
-
-          // Clean up stale pending prompts if no prompt is showing
-          if (!statusResult.hasActivePrompt) {
-            const messages = getMessages(db, worktreeId, { limit: 10, cliToolId });
-            const hasPendingPrompt = messages.some(
-              msg => msg.messageType === 'prompt' && msg.promptData?.status !== 'answered'
-            );
-            if (hasPendingPrompt) {
-              markPendingPromptsAsAnswered(db, worktreeId, cliToolId);
-            }
-          }
-        } catch {
-          // If capture fails, assume processing
-          isProcessing = true;
-        }
-      }
-
-      return [cliToolId, { isRunning, isWaitingForResponse, isProcessing }];
+    probes.map(async (probe): Promise<Probe & { status: CliToolSessionStatus }> => {
+      const status = await detectInstanceSessionStatus(
+        worktreeId,
+        probe.cliToolId,
+        probe.instanceId,
+        probe.sessionName,
+        sessionNameSet,
+        db,
+        getMessages,
+        markPendingPromptsAsAnswered,
+      );
+      return { ...probe, status };
     })
   );
 
   const sessionStatusByCli: Partial<Record<CLIToolType, CliToolSessionStatus>> = {};
+  const sessionStatusByInstance: Partial<Record<string, CliToolSessionStatus>> = {};
+
+  for (const { cliToolId, instanceId, status } of results) {
+    // Per-instance: each instance keeps its own (un-aggregated) status.
+    sessionStatusByInstance[instanceId] = status;
+    // Per-CLI: aggregate (logical-OR) across every instance of the tool so the
+    // sidebar / header dot reflect alias-instance activity too.
+    const existing = sessionStatusByCli[cliToolId];
+    sessionStatusByCli[cliToolId] = existing ? mergeSessionStatus(existing, status) : status;
+  }
+
   let anyRunning = false;
   let anyWaiting = false;
   let anyProcessing = false;
-
-  for (const [cliToolId, status] of results) {
-    sessionStatusByCli[cliToolId] = status;
+  for (const status of Object.values(sessionStatusByCli)) {
+    if (!status) continue;
     if (status.isRunning) anyRunning = true;
     if (status.isWaitingForResponse) anyWaiting = true;
     if (status.isProcessing) anyProcessing = true;
@@ -156,6 +248,7 @@ export async function detectWorktreeSessionStatus(
 
   return {
     sessionStatusByCli,
+    sessionStatusByInstance,
     isSessionRunning: anyRunning,
     isWaitingForResponse: anyWaiting,
     isProcessing: anyProcessing,

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -88,6 +88,13 @@ export interface Worktree {
   isProcessing?: boolean;
   /** Session status per CLI tool */
   sessionStatusByCli?: Partial<Record<CLIToolType, { isRunning: boolean; isWaitingForResponse: boolean; isProcessing: boolean }>>;
+  /**
+   * Session status per agent instance (Issue #875), keyed by instanceId.
+   * Primary instances are keyed by their CLI tool id (instanceId === cliToolId);
+   * alias instances by their own instanceId. Each entry is that instance's own
+   * (un-aggregated) status, so the per-instance UI can resolve each independently.
+   */
+  sessionStatusByInstance?: Partial<Record<string, { isRunning: boolean; isWaitingForResponse: boolean; isProcessing: boolean }>>;
   /** Whether this worktree is marked as favorite */
   favorite?: boolean;
   /** Worktree status: ready, in_progress, in_review, done, or null if not set */

--- a/tests/unit/components/worktree/WorktreeDetailSubComponents.test.tsx
+++ b/tests/unit/components/worktree/WorktreeDetailSubComponents.test.tsx
@@ -433,6 +433,105 @@ describe('DesktopHeader session kill button (Issue #784 / #869)', () => {
 });
 
 /**
+ * Issue #875: per-instance status resolution. The status dot/spinner and the
+ * "End" button must resolve each instance's status from `sessionStatusByInstance`
+ * (keyed by instanceId) so alias instances (instanceId !== cliToolId) show their
+ * own status. The per-CLI map is only a fallback when an instance entry is absent.
+ */
+describe('DesktopHeader per-instance status resolution (Issue #875)', () => {
+  type InstanceStatusMap = NonNullable<Worktree['sessionStatusByInstance']>;
+
+  const dualClaude: AgentInstance[] = [
+    { id: 'claude', cliTool: 'claude', alias: 'Primary', order: 0 },
+    { id: 'claude-2', cliTool: 'claude', alias: 'Photon', order: 1 },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows independent status for two instances of the same CLI tool', () => {
+    // Primary idle, alias processing — same backing CLI tool.
+    const sessionStatusByInstance: InstanceStatusMap = {
+      claude: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+      'claude-2': { isRunning: true, isWaitingForResponse: false, isProcessing: true },
+    };
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={dualClaude}
+        sessionStatusByInstance={sessionStatusByInstance}
+      />
+    );
+
+    const primarySpan = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
+    const aliasSpan = screen.getByTestId('desktop-agent-status-claude-2').querySelector('span');
+
+    // Primary → idle gray dot, no spinner.
+    expect(primarySpan?.className).toContain(SIDEBAR_STATUS_CONFIG.idle.className);
+    expect(primarySpan?.className).not.toContain('animate-spin');
+    // Alias → running blue spinner.
+    expect(aliasSpan?.className).toContain(SIDEBAR_STATUS_CONFIG.running.className);
+    expect(aliasSpan?.className).toContain('animate-spin');
+  });
+
+  it('renders the "End" button for an alias instance whose own session is running', () => {
+    // Primary not running; alias running. Button must follow the active alias.
+    const sessionStatusByInstance: InstanceStatusMap = {
+      claude: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+      'claude-2': { isRunning: true, isWaitingForResponse: false, isProcessing: false },
+    };
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={dualClaude}
+        activeInstanceId="claude-2"
+        sessionStatusByInstance={sessionStatusByInstance}
+        onKillSession={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('desktop-kill-session')).toBeDefined();
+  });
+
+  it('hides the "End" button for an alias whose own session is idle even if the primary (same tool) is running', () => {
+    const sessionStatusByInstance: InstanceStatusMap = {
+      claude: { isRunning: true, isWaitingForResponse: false, isProcessing: false },
+      'claude-2': { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+    };
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={dualClaude}
+        activeInstanceId="claude-2"
+        sessionStatusByInstance={sessionStatusByInstance}
+        onKillSession={vi.fn()}
+      />
+    );
+    // Keyed by instance, not by tool → no button for the idle alias.
+    expect(screen.queryByTestId('desktop-kill-session')).toBeNull();
+  });
+
+  it('falls back to the per-CLI map when no per-instance entry exists (backward compat)', () => {
+    const sessionStatusByCli: SessionStatusMap = {
+      claude: { isRunning: true, isWaitingForResponse: false, isProcessing: false },
+    };
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={mkInstances(['claude'])}
+        activeInstanceId="claude"
+        sessionStatusByCli={sessionStatusByCli}
+        onKillSession={vi.fn()}
+      />
+    );
+    // No sessionStatusByInstance → primary resolves via sessionStatusByCli.
+    const span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
+    expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.ready.className);
+    expect(screen.getByTestId('desktop-kill-session')).toBeDefined();
+  });
+});
+
+/**
  * Issue #786 / #869: DesktopHeader per-instance indicator as a drag source.
  *
  * The `desktop-agent-status-${instanceId}` button is draggable so it can be

--- a/tests/unit/lib/worktree-status-helper.test.ts
+++ b/tests/unit/lib/worktree-status-helper.test.ts
@@ -3,16 +3,23 @@
  *
  * Issue #501: Verify that detectSessionStatus() receives lastOutputTimestamp
  * from getLastServerResponseTimestamp() when auto-yes is active.
+ *
+ * Issue #875: Verify per-instance status detection (sessionStatusByInstance),
+ * alias-instance detection, and the per-CLI aggregate folding alias activity in.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CLIToolType } from '@/lib/cli-tools/types';
+import type { CLIToolType, AgentInstance } from '@/lib/cli-tools/types';
 
-// Mock all dependencies
+// Mock all dependencies. getSessionName honors instanceId so alias instances
+// (instanceId !== cliToolId) map to a distinct session name (Issue #875).
 vi.mock('@/lib/cli-tools/manager', () => ({
   CLIToolManager: {
     getInstance: () => ({
       getTool: (cliToolId: string) => ({
-        getSessionName: (worktreeId: string) => `${cliToolId}-${worktreeId}`,
+        getSessionName: (worktreeId: string, instanceId?: string) =>
+          instanceId && instanceId !== cliToolId
+            ? `${cliToolId}-${worktreeId}-${instanceId}`
+            : `${cliToolId}-${worktreeId}`,
         name: cliToolId,
       }),
     }),
@@ -66,9 +73,12 @@ describe('worktree-status-helper (Issue #501)', () => {
   const mockDb = {} as ReturnType<typeof import('@/lib/db/db-instance').getDbInstance>;
   const mockGetMessages = vi.fn().mockReturnValue([]);
   const mockMarkPending = vi.fn();
+  const mockGetAgentInstances = vi.fn(() => [] as AgentInstance[]);
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetMessages.mockReturnValue([]);
+    mockGetAgentInstances.mockReturnValue([]);
   });
 
   it('should pass lastOutputTimestamp as Date to detectSessionStatus when timestamp exists', async () => {
@@ -76,7 +86,7 @@ describe('worktree-status-helper (Issue #501)', () => {
     vi.mocked(getLastServerResponseTimestamp).mockReturnValue(timestamp);
 
     const sessionNameSet = new Set(['claude-wt-1']);
-    await detectWorktreeSessionStatus('wt-1', sessionNameSet, mockDb, mockGetMessages, mockMarkPending);
+    await detectWorktreeSessionStatus('wt-1', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances);
 
     expect(detectSessionStatus).toHaveBeenCalledWith(
       expect.any(String),
@@ -94,7 +104,7 @@ describe('worktree-status-helper (Issue #501)', () => {
     vi.mocked(getLastServerResponseTimestamp).mockReturnValue(null);
 
     const sessionNameSet = new Set(['claude-wt-2']);
-    await detectWorktreeSessionStatus('wt-2', sessionNameSet, mockDb, mockGetMessages, mockMarkPending);
+    await detectWorktreeSessionStatus('wt-2', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances);
 
     expect(detectSessionStatus).toHaveBeenCalledWith(
       expect.any(String),
@@ -108,7 +118,7 @@ describe('worktree-status-helper (Issue #501)', () => {
 
     // No session running (empty set)
     const sessionNameSet = new Set<string>();
-    const result = await detectWorktreeSessionStatus('wt-3', sessionNameSet, mockDb, mockGetMessages, mockMarkPending);
+    const result = await detectWorktreeSessionStatus('wt-3', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances);
 
     // detectSessionStatus should not be called when session is not running
     expect(detectSessionStatus).not.toHaveBeenCalled();
@@ -119,9 +129,85 @@ describe('worktree-status-helper (Issue #501)', () => {
     vi.mocked(getLastServerResponseTimestamp).mockReturnValue(null);
 
     const sessionNameSet = new Set(['gemini-wt-4']);
-    await detectWorktreeSessionStatus('wt-4', sessionNameSet, mockDb, mockGetMessages, mockMarkPending);
+    await detectWorktreeSessionStatus('wt-4', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances);
 
     const { captureSessionOutput } = await import('@/lib/session/cli-session');
-    expect(captureSessionOutput).toHaveBeenCalledWith('wt-4', 'gemini', 200);
+    // Issue #875: primary instances pass instanceId === cliToolId.
+    expect(captureSessionOutput).toHaveBeenCalledWith('wt-4', 'gemini', 200, 'gemini');
+  });
+});
+
+describe('worktree-status-helper per-instance detection (Issue #875)', () => {
+  const mockDb = {} as ReturnType<typeof import('@/lib/db/db-instance').getDbInstance>;
+  const mockGetMessages = vi.fn().mockReturnValue([]);
+  const mockMarkPending = vi.fn();
+  const mockGetAgentInstances = vi.fn(() => [] as AgentInstance[]);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMessages.mockReturnValue([]);
+    mockGetAgentInstances.mockReturnValue([]);
+    vi.mocked(getLastServerResponseTimestamp).mockReturnValue(null);
+  });
+
+  it('keys primary instances in sessionStatusByInstance by their cliToolId', async () => {
+    const sessionNameSet = new Set(['claude-wt-p']);
+    const result = await detectWorktreeSessionStatus(
+      'wt-p', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances
+    );
+
+    expect(result.sessionStatusByInstance.claude?.isRunning).toBe(true);
+    expect(result.sessionStatusByInstance.gemini?.isRunning).toBe(false);
+    // Primary status mirrors the per-CLI map for backward compat.
+    expect(result.sessionStatusByCli.claude?.isRunning).toBe(true);
+  });
+
+  it('detects an alias instance session and keys it by instanceId', async () => {
+    mockGetAgentInstances.mockReturnValue([
+      { id: 'claude-2', cliTool: 'claude', alias: 'photon', order: 1 },
+    ]);
+    // Only the alias session is running; the primary claude session is NOT.
+    const sessionNameSet = new Set(['claude-wt-a-claude-2']);
+
+    const result = await detectWorktreeSessionStatus(
+      'wt-a', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances
+    );
+
+    // Alias instance is detected independently of the primary.
+    expect(result.sessionStatusByInstance['claude-2']?.isRunning).toBe(true);
+    expect(result.sessionStatusByInstance.claude?.isRunning).toBe(false);
+    // Per-CLI aggregate folds the alias activity in (sidebar #867 correctness).
+    expect(result.sessionStatusByCli.claude?.isRunning).toBe(true);
+    // Worktree-level flag reflects an alias-only running session.
+    expect(result.isSessionRunning).toBe(true);
+  });
+
+  it('reports independent statuses for two instances of the same CLI tool', async () => {
+    mockGetAgentInstances.mockReturnValue([
+      { id: 'claude-2', cliTool: 'claude', alias: 'photon', order: 1 },
+    ]);
+    // Primary running, alias not running.
+    const sessionNameSet = new Set(['claude-wt-b']);
+
+    const result = await detectWorktreeSessionStatus(
+      'wt-b', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances
+    );
+
+    expect(result.sessionStatusByInstance.claude?.isRunning).toBe(true);
+    expect(result.sessionStatusByInstance['claude-2']?.isRunning).toBe(false);
+  });
+
+  it('captures alias output scoped to the alias instanceId', async () => {
+    mockGetAgentInstances.mockReturnValue([
+      { id: 'claude-2', cliTool: 'claude', alias: 'photon', order: 1 },
+    ]);
+    const sessionNameSet = new Set(['claude-wt-c-claude-2']);
+
+    await detectWorktreeSessionStatus(
+      'wt-c', sessionNameSet, mockDb, mockGetMessages, mockMarkPending, mockGetAgentInstances
+    );
+
+    const { captureSessionOutput } = await import('@/lib/session/cli-session');
+    expect(captureSessionOutput).toHaveBeenCalledWith('wt-c', 'claude', expect.any(Number), 'claude-2');
   });
 });


### PR DESCRIPTION
## 概要
別名インスタンスのステータスアイコン/「X End」ボタンが表示されない不具合を修正。状態検出を per-instance 化（sessionStatusByInstance）し、UI のステータス/Endボタン判定と kill-session 呼び出しを instanceId 連携に。

Epic: #866
Closes #875

## 修正
- worktree-status-helper: agent_instances を読み各インスタンスのtmuxセッション状態を検出→sessionStatusByInstance を返却
- models.ts / API: sessionStatusByInstance を追加・返却
- UI(WorktreeDetailSubComponents/Desktop): ステータス/Endボタンを sessionStatusByInstance[inst.id] で判定
- kill-session: api-client/useWorktreeDetailController で instanceId を付与
- 回帰テスト追加

## 検証
- lint ✅ / tsc ✅ / test:unit ✅(7770) / build ✅（独立ゲート）

🤖 Generated with [Claude Code](https://claude.com/claude-code) — /orchestrate