### PR TITLE
fix(sidebar): selectedAgents外/別名インスタンスの稼働をサイドバーに反映（per-instance集約） (#878)

### DIFF
--- a/src/app/api/worktrees/[id]/route.ts
+++ b/src/app/api/worktrees/[id]/route.ts
@@ -8,7 +8,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDbInstance } from '@/lib/db/db-instance';
 import { getWorktreeById, updateWorktreeDescription, updateWorktreeLink, updateFavorite, updateStatus, updateCliToolId, updateSelectedAgents, updateVibeLocalModel, updateVibeLocalContextWindow, getMessages, markPendingPromptsAsAnswered, getInitialBranch, getAgentInstances, setAgentInstances, AgentInstanceLimitError, InvalidAgentInstanceError } from '@/lib/db';
 import { CLIToolManager } from '@/lib/cli-tools/manager';
-import { CLI_TOOL_IDS, OLLAMA_MODEL_PATTERN, isValidVibeLocalContextWindow, VIBE_LOCAL_CONTEXT_WINDOW_MIN, VIBE_LOCAL_CONTEXT_WINDOW_MAX, agentInstancesFromSelectedAgents, type CLIToolType, type AgentInstance } from '@/lib/cli-tools/types';
+import { CLI_TOOL_IDS, OLLAMA_MODEL_PATTERN, isValidVibeLocalContextWindow, VIBE_LOCAL_CONTEXT_WINDOW_MIN, VIBE_LOCAL_CONTEXT_WINDOW_MAX, type CLIToolType, type AgentInstance } from '@/lib/cli-tools/types';
+import { resolveAgentInstances } from '@/lib/session/agent-instances-resolver';
 import { getGitStatus } from '@/lib/git/git-utils';
 import type { GitStatus } from '@/types/models';
 import { isValidWorktreeId } from '@/lib/security/path-validator';
@@ -19,24 +20,6 @@ import { detectWorktreeSessionStatus } from '@/lib/session/worktree-status-helpe
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('api/worktrees');
-
-/**
- * Resolve the agent-instance roster for a worktree (Issue #869).
- * Prefers the explicit `agent_instances` rows; when none exist (legacy
- * worktrees), derives primary instances from `selectedAgents` so the client
- * always receives a non-empty roster.
- */
-function resolveAgentInstances(
-  db: ReturnType<typeof getDbInstance>,
-  worktreeId: string,
-  selectedAgents: CLIToolType[] | undefined,
-): AgentInstance[] {
-  const stored = getAgentInstances(db, worktreeId);
-  if (stored.length > 0) {
-    return stored;
-  }
-  return agentInstancesFromSelectedAgents(selectedAgents ?? []);
-}
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/worktrees/route.ts
+++ b/src/app/api/worktrees/route.ts
@@ -15,6 +15,7 @@ import { detectWorktreeSessionStatus } from '@/lib/session/worktree-status-helpe
 import { parseIncludeParam } from '@/lib/api/worktrees-include-parser';
 import { isWorktreeStalled } from '@/lib/detection/stalled-detector';
 import { getNextAction, getReviewStatus } from '@/lib/session/next-action-helper';
+import { resolveAgentInstances } from '@/lib/session/agent-instances-resolver';
 import { createLogger } from '@/lib/logger';
 import type { SessionStatus } from '@/lib/detection/status-detector';
 import type { PromptType } from '@/types/models';
@@ -62,9 +63,14 @@ export async function GET(request: NextRequest) {
           getAgentInstances,
         );
 
+        // Issue #878: include the agent-instance roster so the sidebar can
+        // aggregate per-instance status (matches the single worktree API).
+        const agentInstances = resolveAgentInstances(db, worktree.id, worktree.selectedAgents);
+
         const base = {
           ...worktree,
           ...status,
+          agentInstances,
         };
 
         // Issue #600: Add review fields when ?include=review

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -250,7 +250,7 @@ export const BranchListItem = memo(function BranchListItem({
           <div className="flex items-center justify-center flex-shrink-0 w-4" aria-label="CLI tool status">
             <BranchStatusIndicator
               status={aggregateCliStatus(branch.cliStatus)}
-              label={formatCliStatusBreakdown(branch.cliStatus)}
+              label={formatCliStatusBreakdown(branch.cliStatus, branch.cliStatusLabels)}
             />
           </div>
         )}

--- a/src/lib/session/agent-instances-resolver.ts
+++ b/src/lib/session/agent-instances-resolver.ts
@@ -1,0 +1,37 @@
+/**
+ * Agent-instance roster resolver (Issue #869 / #878).
+ *
+ * Prefers the explicit `agent_instances` rows; when none exist (legacy
+ * worktrees) derives one PRIMARY instance per `selectedAgents` so every API
+ * surface returns a non-empty roster. Shared by the single worktree API
+ * (`GET /api/worktrees/[id]`) and the list API (`GET /api/worktrees`) so both
+ * expose the same roster to the client (Issue #878).
+ */
+import type Database from 'better-sqlite3';
+import { getAgentInstances } from '@/lib/db';
+import {
+  agentInstancesFromSelectedAgents,
+  type AgentInstance,
+  type CLIToolType,
+} from '@/lib/cli-tools/types';
+
+/**
+ * Resolve the agent-instance roster for a worktree.
+ *
+ * @param db - Database instance
+ * @param worktreeId - Worktree ID
+ * @param selectedAgents - Worktree's selected agents (fallback source)
+ * @returns Stored instances when present, otherwise primaries derived from
+ *   `selectedAgents` (empty array when neither is available)
+ */
+export function resolveAgentInstances(
+  db: Database.Database,
+  worktreeId: string,
+  selectedAgents: CLIToolType[] | undefined,
+): AgentInstance[] {
+  const stored = getAgentInstances(db, worktreeId);
+  if (stored.length > 0) {
+    return stored;
+  }
+  return agentInstancesFromSelectedAgents(selectedAgents ?? []);
+}

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -5,7 +5,14 @@
  */
 
 import type { Worktree } from '@/types/models';
-import { getCliToolDisplayName, type CLIToolType } from '@/lib/cli-tools/types';
+import {
+  getCliToolDisplayName,
+  getCliToolDisplayNameSafe,
+  getInstanceLabel,
+  agentInstancesFromSelectedAgents,
+  CLI_TOOL_IDS,
+  type AgentInstance,
+} from '@/lib/cli-tools/types';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
 
 /**
@@ -52,11 +59,12 @@ export function deriveCliStatus(
  * (sidebar-utils.ts) which orders the sidebar SORT. Sorting keeps
  * ready above running; the aggregated icon surfaces active work above ready.
  *
- * @param cliStatus - Per-CLI tool status map (e.g. from `SidebarBranchItem`)
+ * @param cliStatus - Per-instance status map (e.g. from `SidebarBranchItem`),
+ *   keyed by agent-instance id (Issue #878)
  * @returns The single most significant status to display
  */
 export function aggregateCliStatus(
-  cliStatus?: Partial<Record<CLIToolType, BranchStatus>>
+  cliStatus?: Partial<Record<string, BranchStatus>>
 ): BranchStatus {
   if (!cliStatus) return 'idle';
   const statuses = Object.values(cliStatus).filter(
@@ -71,21 +79,25 @@ export function aggregateCliStatus(
 }
 
 /**
- * Format a per-agent status breakdown for tooltips / aria-labels (Issue #867),
- * e.g. "Claude: running, Codex: idle". Lets the single aggregated icon still
- * expose each agent's individual status on hover/focus.
+ * Format a per-instance status breakdown for tooltips / aria-labels
+ * (Issue #867, per-instance keys since #878), e.g.
+ * "Claude: running, Claude 2: idle". Lets the single aggregated icon still
+ * expose each instance's individual status on hover/focus.
  *
- * @param cliStatus - Per-CLI tool status map
- * @returns Comma-separated "DisplayName: status" string ('' when empty/absent)
+ * @param cliStatus - Per-instance status map, keyed by agent-instance id
+ * @param labels - Optional instance-id → display-label map (Issue #878). When a
+ *   key is absent, falls back to the CLI tool display name for that id.
+ * @returns Comma-separated "Label: status" string ('' when empty/absent)
  */
 export function formatCliStatusBreakdown(
-  cliStatus?: Partial<Record<CLIToolType, BranchStatus>>
+  cliStatus?: Partial<Record<string, BranchStatus>>,
+  labels?: Record<string, string>
 ): string {
   if (!cliStatus) return '';
   return Object.entries(cliStatus)
     .map(
-      ([tool, status]) =>
-        `${getCliToolDisplayName(tool as CLIToolType)}: ${status ?? 'idle'}`
+      ([instanceId, status]) =>
+        `${labels?.[instanceId] ?? getCliToolDisplayNameSafe(instanceId, instanceId)}: ${status ?? 'idle'}`
     )
     .join(', ');
 }
@@ -109,8 +121,10 @@ export interface SidebarBranchItem {
   lastActivity?: Date | string;
   /** User description for this branch */
   description?: string;
-  /** Per-CLI tool status for sidebar display */
-  cliStatus?: Partial<Record<CLIToolType, BranchStatus>>;
+  /** Per-instance status for sidebar display, keyed by agent-instance id (Issue #878) */
+  cliStatus?: Partial<Record<string, BranchStatus>>;
+  /** Instance-id → display-label map for the status breakdown tooltip (Issue #878) */
+  cliStatusLabels?: Record<string, string>;
   /** Absolute path to the worktree directory (Issue #651) */
   worktreePath?: string;
 }
@@ -142,6 +156,84 @@ export function calculateHasUnread(worktree: Worktree): boolean {
 }
 
 /**
+ * Resolve a human-readable label for an agent-instance id that is NOT part of
+ * the configured roster (Issue #878) — e.g. an alias instance (`claude-2`) that
+ * is running but was not persisted to `agentInstances`. Primary instance ids are
+ * valid CLI tool ids; alias ids carry a `{cliTool}-{suffix}` shape, so we
+ * recover the backing tool from the prefix and append the suffix.
+ */
+function labelForUnknownInstance(instanceId: string): string {
+  const cliTool = CLI_TOOL_IDS.find((id) => instanceId.startsWith(`${id}-`));
+  if (cliTool) {
+    const suffix = instanceId.slice(cliTool.length + 1);
+    return `${getCliToolDisplayName(cliTool)} ${suffix}`;
+  }
+  return getCliToolDisplayNameSafe(instanceId, instanceId);
+}
+
+/**
+ * Derive the sidebar's per-instance status map (Issue #878).
+ *
+ * The aggregated sidebar icon must reflect ANY running agent instance — even
+ * ones absent from `selectedAgents` (e.g. an ad-hoc `claude` session) or alias
+ * instances (`claude-2`). We therefore key the map by INSTANCE ID and read each
+ * status from `sessionStatusByInstance` (the un-aggregated, per-instance source
+ * from #875), unioning:
+ *   1. the configured roster (`agentInstances`, or one primary per
+ *      `selectedAgents` for legacy worktrees) so the breakdown stays stable; and
+ *   2. any instance currently running but absent from that roster.
+ *
+ * Falls back to the legacy `selectedAgents` + `sessionStatusByCli` path when
+ * `sessionStatusByInstance` is absent (older API payloads / unit fixtures), so
+ * existing behaviour is preserved byte-for-byte.
+ */
+function deriveSidebarCliStatus(worktree: Worktree): {
+  cliStatus: Partial<Record<string, BranchStatus>>;
+  cliStatusLabels: Record<string, string>;
+} {
+  const cliStatus: Partial<Record<string, BranchStatus>> = {};
+  const cliStatusLabels: Record<string, string> = {};
+
+  const byInstance = worktree.sessionStatusByInstance;
+
+  // Legacy fallback: no per-instance data → key by selectedAgents / CLI tool.
+  if (!byInstance) {
+    const agents = worktree.selectedAgents ?? DEFAULT_SELECTED_AGENTS;
+    for (const agent of agents) {
+      cliStatus[agent] = deriveCliStatus(worktree.sessionStatusByCli?.[agent]);
+      cliStatusLabels[agent] = getCliToolDisplayName(agent);
+    }
+    return { cliStatus, cliStatusLabels };
+  }
+
+  // Configured roster: explicit agentInstances, else primaries per selectedAgents.
+  const roster: AgentInstance[] =
+    worktree.agentInstances && worktree.agentInstances.length > 0
+      ? worktree.agentInstances
+      : agentInstancesFromSelectedAgents(worktree.selectedAgents ?? DEFAULT_SELECTED_AGENTS);
+
+  const rosterIds = new Set<string>();
+  for (const instance of roster) {
+    rosterIds.add(instance.id);
+    cliStatus[instance.id] = deriveCliStatus(byInstance[instance.id]);
+    cliStatusLabels[instance.id] = getInstanceLabel(instance);
+  }
+
+  // Surface any RUNNING instance missing from the roster (e.g. a `claude`
+  // session started even though claude is not in selectedAgents) so the
+  // aggregated icon reflects it.
+  for (const [instanceId, status] of Object.entries(byInstance)) {
+    if (rosterIds.has(instanceId)) continue;
+    const derived = deriveCliStatus(status);
+    if (derived === 'idle') continue;
+    cliStatus[instanceId] = derived;
+    cliStatusLabels[instanceId] = labelForUnknownInstance(instanceId);
+  }
+
+  return { cliStatus, cliStatusLabels };
+}
+
+/**
  * Convert Worktree to SidebarBranchItem for display
  *
  * @param worktree - Source worktree data
@@ -162,13 +254,11 @@ export function toBranchItem(worktree: Worktree): SidebarBranchItem {
   // Use new hasUnread logic based on lastAssistantMessageAt and lastViewedAt
   const hasUnread = calculateHasUnread(worktree);
 
-  // Issue #368: Use selectedAgents to determine which tools to show status for
-  // Falls back to DEFAULT_SELECTED_AGENTS when selectedAgents is not set
-  const agents = worktree.selectedAgents ?? DEFAULT_SELECTED_AGENTS;
-  const cliStatus: Partial<Record<CLIToolType, BranchStatus>> = {};
-  for (const agent of agents) {
-    cliStatus[agent] = deriveCliStatus(worktree.sessionStatusByCli?.[agent]);
-  }
+  // Issue #878: aggregate per-instance status (from sessionStatusByInstance /
+  // agentInstances) so instances outside selectedAgents and alias instances are
+  // reflected. Falls back to the legacy selectedAgents path when no per-instance
+  // data is present.
+  const { cliStatus, cliStatusLabels } = deriveSidebarCliStatus(worktree);
 
   return {
     id: worktree.id,
@@ -179,6 +269,7 @@ export function toBranchItem(worktree: Worktree): SidebarBranchItem {
     lastActivity: worktree.updatedAt,
     description: worktree.description,
     cliStatus,
+    cliStatusLabels,
     worktreePath: worktree.path,
   };
 }

--- a/tests/integration/api-worktrees.test.ts
+++ b/tests/integration/api-worktrees.test.ts
@@ -124,6 +124,33 @@ describe('GET /api/worktrees', () => {
     expect(data.worktrees[0].lastMessageSummary).toBe('Last message summary');
   });
 
+  it('should include agentInstances roster for each worktree (Issue #878)', async () => {
+    const worktree: Worktree = {
+      id: 'feature-instances',
+      name: 'feature/instances',
+      path: '/path/to/feature-instances',
+      repositoryPath: '/path/to/repo',
+      repositoryName: 'TestRepo',
+    };
+
+    upsertWorktree(db, worktree);
+
+    const request = new Request('http://localhost:3000/api/worktrees');
+    const response = await getWorktrees(request as unknown as import('next/server').NextRequest);
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    const item = data.worktrees.find((w: { id: string }) => w.id === 'feature-instances');
+    expect(item).toBeDefined();
+    // With no explicit agent_instances rows, the roster is derived as one
+    // primary instance per selectedAgent (id === cliTool).
+    expect(Array.isArray(item.agentInstances)).toBe(true);
+    expect(item.agentInstances.length).toBeGreaterThan(0);
+    expect(item.agentInstances.map((i: { id: string }) => i.id)).toEqual(item.selectedAgents);
+    expect(item.agentInstances.every((i: { id: string; cliTool: string }) => i.id === i.cliTool)).toBe(true);
+  });
+
   it('should return 500 on database error', async () => {
     // Close database to simulate error
     db.close();

--- a/tests/unit/types/sidebar.test.ts
+++ b/tests/unit/types/sidebar.test.ts
@@ -311,6 +311,168 @@ describe('sidebar types', () => {
     });
   });
 
+  describe('toBranchItem per-instance aggregation (Issue #878)', () => {
+    const baseWorktree: Worktree = {
+      id: 'photon-mlx-develop',
+      name: 'photon-mlx/develop',
+      path: '/path/to/worktree',
+      repositoryPath: '/path/to/repo',
+      repositoryName: 'MyRepo',
+    };
+
+    it('should reflect a running instance NOT in selectedAgents (e.g. claude)', () => {
+      // Regression: photon-mlx-develop has selectedAgents=[copilot,codex] but a
+      // claude session is running. The sidebar icon must show "running"/"ready".
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['copilot', 'codex'],
+        isSessionRunning: true,
+        sessionStatusByInstance: {
+          claude: { isRunning: true, isWaitingForResponse: false, isProcessing: false },
+          copilot: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          codex: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      // claude (running) is surfaced even though it is not in selectedAgents
+      expect(result.cliStatus?.claude).toBe('ready');
+      expect(result.cliStatus?.copilot).toBe('idle');
+      expect(result.cliStatus?.codex).toBe('idle');
+      // The aggregated sidebar icon reflects the running instance
+      expect(aggregateCliStatus(result.cliStatus)).toBe('ready');
+    });
+
+    it('should reflect an alias instance (claude-2) running via the roster', () => {
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['copilot'],
+        agentInstances: [
+          { id: 'copilot', cliTool: 'copilot', alias: 'Copilot', order: 0 },
+          { id: 'claude', cliTool: 'claude', alias: 'Claude', order: 1 },
+          { id: 'claude-2', cliTool: 'claude', alias: 'Claude 2', order: 2 },
+        ],
+        sessionStatusByInstance: {
+          copilot: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          claude: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          'claude-2': { isRunning: true, isWaitingForResponse: false, isProcessing: true },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      expect(result.cliStatus?.['claude-2']).toBe('running');
+      expect(aggregateCliStatus(result.cliStatus)).toBe('running');
+      // The breakdown label uses the instance alias
+      expect(result.cliStatusLabels?.['claude-2']).toBe('Claude 2');
+    });
+
+    it('should surface a running alias instance even when absent from the roster', () => {
+      // No agentInstances roster (legacy) → roster derives from selectedAgents.
+      // A running claude-2 alias is still surfaced via sessionStatusByInstance.
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['copilot', 'codex'],
+        sessionStatusByInstance: {
+          copilot: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          codex: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          'claude-2': { isRunning: true, isWaitingForResponse: true, isProcessing: false },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      expect(result.cliStatus?.['claude-2']).toBe('waiting');
+      expect(aggregateCliStatus(result.cliStatus)).toBe('waiting');
+      // Label is derived from the instance id when no roster alias exists
+      expect(result.cliStatusLabels?.['claude-2']).toBe('Claude 2');
+    });
+
+    it('should NOT surface idle instances outside the roster', () => {
+      // sessionStatusByInstance from the list API contains every primary tool;
+      // idle non-roster instances should not clutter the breakdown.
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['copilot', 'codex'],
+        sessionStatusByInstance: {
+          copilot: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          codex: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          claude: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          gemini: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      expect(Object.keys(result.cliStatus ?? {}).sort()).toEqual(['codex', 'copilot']);
+      expect(aggregateCliStatus(result.cliStatus)).toBe('idle');
+    });
+
+    it('should use the agentInstances roster to key and label cliStatus', () => {
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['claude', 'codex'],
+        agentInstances: [
+          { id: 'claude', cliTool: 'claude', alias: 'Claude', order: 0 },
+          { id: 'codex', cliTool: 'codex', alias: 'My Codex', order: 1 },
+        ],
+        sessionStatusByInstance: {
+          claude: { isRunning: true, isWaitingForResponse: false, isProcessing: true },
+          codex: { isRunning: true, isWaitingForResponse: false, isProcessing: false },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      expect(result.cliStatus).toEqual({ claude: 'running', codex: 'ready' });
+      expect(result.cliStatusLabels).toEqual({ claude: 'Claude', codex: 'My Codex' });
+    });
+
+    it('should preserve legacy behaviour when sessionStatusByInstance is absent', () => {
+      // No per-instance data → fall back to selectedAgents + sessionStatusByCli.
+      // A running claude is NOT surfaced because it is not in selectedAgents and
+      // there is no per-instance source (matches pre-#878 behaviour).
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['copilot', 'codex'],
+        sessionStatusByCli: {
+          codex: { isRunning: true, isWaitingForResponse: false, isProcessing: false },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      expect(result.cliStatus).toEqual({ copilot: 'idle', codex: 'ready' });
+      expect(result.cliStatus?.claude).toBeUndefined();
+    });
+
+    it('should not break the all-agents default selection', () => {
+      const worktree: Worktree = {
+        ...baseWorktree,
+        selectedAgents: ['claude', 'codex', 'gemini', 'opencode', 'copilot'],
+        sessionStatusByInstance: {
+          claude: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          codex: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          gemini: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          opencode: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+          copilot: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+        },
+      };
+
+      const result = toBranchItem(worktree);
+
+      expect(result.cliStatus).toEqual({
+        claude: 'idle',
+        codex: 'idle',
+        gemini: 'idle',
+        opencode: 'idle',
+        copilot: 'idle',
+      });
+      expect(aggregateCliStatus(result.cliStatus)).toBe('idle');
+    });
+  });
+
   describe('deriveCliStatus', () => {
     it('should return idle when toolStatus is undefined', () => {
       expect(deriveCliStatus(undefined)).toBe('idle');
@@ -402,6 +564,21 @@ describe('sidebar types', () => {
 
     it('should fall back to idle for undefined per-agent entries', () => {
       expect(formatCliStatusBreakdown({ claude: undefined })).toBe('Claude: idle');
+    });
+
+    it('should use the provided instance-id label map (Issue #878)', () => {
+      expect(
+        formatCliStatusBreakdown(
+          { claude: 'running', 'claude-2': 'idle' },
+          { claude: 'Claude', 'claude-2': 'Claude 2' }
+        )
+      ).toBe('Claude: running, Claude 2: idle');
+    });
+
+    it('should fall back to a derived label for alias instance ids without a label map (Issue #878)', () => {
+      // 'claude-2' is not a CLI tool id → getCliToolDisplayNameSafe returns the
+      // id itself as the fallback rather than a generic 'Assistant'.
+      expect(formatCliStatusBreakdown({ 'claude-2': 'running' })).toBe('claude-2: running');
     });
   });
 });


### PR DESCRIPTION
## 概要
サイドバーのステータスが selectedAgents 外/別名インスタンスの稼働を反映しない不具合を修正。toBranchItem を per-instance 集約に変更し、一覧API GET /api/worktrees に agentInstances を追加。

Epic: #866
Closes #878

## 修正
- types/sidebar.ts: toBranchItem を sessionStatusByInstance / agentInstances ベースの per-instance 集約に（selectedAgents 依存を解消）
- api/worktrees/route.ts: 一覧APIに agentInstances を追加（resolveAgentInstances を共有モジュール化）
- 回帰テスト: unit(sidebar) + integration(api-worktrees)

## 検証
- lint ✅ / tsc ✅ / test:unit ✅(7779) / build ✅（独立ゲート）

🤖 Generated with [Claude Code](https://claude.com/claude-code) — /orchestrate