### PR TITLE
feat(repositories): サイドバーに/repositoriesリンク＋管理ページのAdd/Sync Allを上部に (#880)

### DIFF
--- a/src/app/repositories/page.tsx
+++ b/src/app/repositories/page.tsx
@@ -3,12 +3,13 @@
  *
  * Issue #600: UX refresh - Repository management.
  * Issue #644: Repository list + inline display_name edit.
- *   - RepositoryList is placed ABOVE RepositoryManager.
  *   - refreshKey is incremented when Add/Sync finishes in RepositoryManager
  *     so RepositoryList refetches automatically.
  *   - It is also incremented when a row's display_name is updated so that
  *     other screens reading the same data via worktreeApi can be refreshed
  *     indirectly (via parent refreshKey bump).
+ * Issue #880: RepositoryManager (Add Repository / Sync All actions) is placed
+ *   ABOVE RepositoryList so the action buttons appear at the top of the page.
  */
 
 'use client';
@@ -35,8 +36,8 @@ export default function RepositoriesPage() {
         </div>
 
         <div className="space-y-6">
-          <RepositoryList refreshKey={refreshKey} onChanged={handleChanged} />
           <RepositoryManager onRepositoryAdded={handleChanged} />
+          <RepositoryList refreshKey={refreshKey} onChanged={handleChanged} />
         </div>
       </div>
     </AppShell>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -12,8 +12,10 @@
 'use client';
 
 import React, { memo, useState, useMemo, useCallback, useEffect, useLayoutEffect, useRef, useDeferredValue } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { Database } from 'lucide-react';
 import {
   DndContext,
   PointerSensor,
@@ -429,6 +431,16 @@ export const Sidebar = memo(function Sidebar() {
             <ViewModeToggle viewMode={viewMode} onToggle={setViewMode} />
             <SortSelector />
             <SyncButton refreshWorktrees={refreshWorktrees} />
+            <Link
+              href="/repositories"
+              aria-label="Repositories"
+              title="Repositories"
+              className="p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
+                focus:outline-none focus:ring-2 focus:ring-blue-500
+                transition-colors inline-flex items-center"
+            >
+              <Database className="w-3 h-3" aria-hidden="true" />
+            </Link>
           </div>
         </div>
       </div>

--- a/tests/unit/app/repositories/page.test.tsx
+++ b/tests/unit/app/repositories/page.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Tests for the Repositories page (/repositories)
+ *
+ * Issue #880: The action area (RepositoryManager: "+ Add Repository" / "Sync All")
+ * must be rendered ABOVE the repository list so the buttons appear at the top
+ * of the page.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import RepositoriesPage from '@/app/repositories/page';
+
+// AppShell pulls in the full layout (sidebar/header/contexts); stub it to a
+// passthrough so we can render the page body in isolation.
+vi.mock('@/components/layout', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Stub the heavy child components with identifiable markers so we can assert
+// their relative order in the DOM.
+vi.mock('@/components/repository', () => ({
+  RepositoryManager: () => <div data-testid="repository-manager" />,
+  RepositoryList: () => <div data-testid="repository-list" />,
+}));
+
+describe('RepositoriesPage (Issue #880)', () => {
+  it('renders RepositoryManager (action buttons) above RepositoryList', () => {
+    render(<RepositoriesPage />);
+
+    const manager = screen.getByTestId('repository-manager');
+    const list = screen.getByTestId('repository-list');
+
+    expect(manager).toBeInTheDocument();
+    expect(list).toBeInTheDocument();
+
+    // Manager must precede the list in document order (top of the page).
+    const position = manager.compareDocumentPosition(list);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders the page title', () => {
+    render(<RepositoriesPage />);
+    expect(screen.getByRole('heading', { name: 'Repositories' })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -546,6 +546,20 @@ describe('Sidebar', () => {
         expect(screen.getByText('Branches')).toBeInTheDocument();
       });
     });
+
+    // Issue #880: header link to the repository management page
+    it('should render a Repositories link pointing to /repositories', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const link = await screen.findByRole('link', { name: 'Repositories' });
+      expect(link).toHaveAttribute('href', '/repositories');
+      // The link lives inside the sidebar header alongside the other actions
+      expect(screen.getByTestId('sidebar-header')).toContainElement(link);
+    });
   });
 
   describe('Grouped view (default)', () => {


### PR DESCRIPTION
## 概要
サイドバー上部に /repositories への遷移リンクを追加し、/repositories ページの Add Repository / Sync All ボタンをページ上部に配置。

Closes #880

## 変更
- src/components/layout/Sidebar.tsx: ヘッダー右ボタン群に /repositories リンク（lucide アイコン）を追加
- src/app/repositories/page.tsx: Add/Sync ボタン領域をリストの上部へ再配置
- テスト追加（Sidebar / repositories page）

## 検証
- lint ✅ / tsc ✅ / test:unit ✅(7782) / build ✅（独立ゲート）

🤖 Generated with [Claude Code](https://claude.com/claude-code) — /orchestrate