### PR TITLE
feat(sidebar): サイドバー上部ボタンにホバー説明ツールチップを統一追加 (#882)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -16,5 +16,11 @@
   "syncSuccess": "Synced {count} worktrees",
   "syncError": "Sync failed",
   "syncAuthError": "Authentication error",
-  "syncButtonLabel": "Sync branches"
+  "syncButtonLabel": "Sync branches",
+  "tooltips": {
+    "viewMode": "Toggle view mode (grouped / flat)",
+    "sort": "Sort branches",
+    "sync": "Sync worktrees",
+    "repositories": "Manage repositories (add / sync)"
+  }
 }

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -16,5 +16,11 @@
   "syncSuccess": "{count}件のworktreeを同期しました",
   "syncError": "同期に失敗しました",
   "syncAuthError": "認証エラー",
-  "syncButtonLabel": "ブランチを同期"
+  "syncButtonLabel": "ブランチを同期",
+  "tooltips": {
+    "viewMode": "表示モード切替（グループ / フラット）",
+    "sort": "ブランチの並び替え",
+    "sync": "worktree を同期",
+    "repositories": "リポジトリを管理（追加・同期）"
+  }
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -35,6 +35,7 @@ import { useWorktreeSelection } from '@/contexts/WorktreeSelectionContext';
 import { useSidebarContext } from '@/contexts/SidebarContext';
 import { BranchListItem } from '@/components/sidebar/BranchListItem';
 import { SortSelector } from '@/components/sidebar/SortSelector';
+import { Tooltip } from '@/components/common/Tooltip';
 import { LocaleSwitcher } from '@/components/common/LocaleSwitcher';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import { LogoutButton } from '@/components/common/LogoutButton';
@@ -161,6 +162,7 @@ export const Sidebar = memo(function Sidebar() {
     refreshWorktrees,
   } = useWorktreeSelection();
   const { closeMobileDrawer, sortKey, sortDirection, viewMode, setViewMode } = useSidebarContext();
+  const t = useTranslations('common');
   const [searchQuery, setSearchQuery] = useState('');
   const branchListRef = useRef<HTMLDivElement>(null);
 
@@ -431,16 +433,17 @@ export const Sidebar = memo(function Sidebar() {
             <ViewModeToggle viewMode={viewMode} onToggle={setViewMode} />
             <SortSelector />
             <SyncButton refreshWorktrees={refreshWorktrees} />
-            <Link
-              href="/repositories"
-              aria-label="Repositories"
-              title="Repositories"
-              className="p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
-                focus:outline-none focus:ring-2 focus:ring-blue-500
-                transition-colors inline-flex items-center"
-            >
-              <Database className="w-3 h-3" aria-hidden="true" />
-            </Link>
+            <Tooltip content={t('tooltips.repositories')} placement="bottom">
+              <Link
+                href="/repositories"
+                aria-label="Repositories"
+                className="p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
+                  focus:outline-none focus:ring-2 focus:ring-blue-500
+                  transition-colors inline-flex items-center"
+              >
+                <Database className="w-3 h-3" aria-hidden="true" />
+              </Link>
+            </Tooltip>
           </div>
         </div>
       </div>
@@ -693,29 +696,31 @@ function ViewModeToggle({
   viewMode: ViewMode;
   onToggle: (mode: ViewMode) => void;
 }) {
+  const t = useTranslations('common');
   const handleClick = () => {
     onToggle(viewMode === 'grouped' ? 'flat' : 'grouped');
   };
 
   return (
-    <button
-      data-testid="view-mode-toggle"
-      type="button"
-      onClick={handleClick}
-      aria-label={viewMode === 'grouped' ? 'Switch to flat view' : 'Switch to grouped view'}
-      title={viewMode === 'grouped' ? 'Flat view' : 'Grouped view'}
-      className="
-        p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
-        focus:outline-none focus:ring-2 focus:ring-blue-500
-        transition-colors
-      "
-    >
-      {viewMode === 'grouped' ? (
-        <FlatListIcon className="w-3 h-3" />
-      ) : (
-        <GroupIcon className="w-3 h-3" />
-      )}
-    </button>
+    <Tooltip content={t('tooltips.viewMode')} placement="bottom">
+      <button
+        data-testid="view-mode-toggle"
+        type="button"
+        onClick={handleClick}
+        aria-label={viewMode === 'grouped' ? 'Switch to flat view' : 'Switch to grouped view'}
+        className="
+          p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
+          focus:outline-none focus:ring-2 focus:ring-blue-500
+          transition-colors
+        "
+      >
+        {viewMode === 'grouped' ? (
+          <FlatListIcon className="w-3 h-3" />
+        ) : (
+          <GroupIcon className="w-3 h-3" />
+        )}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -844,17 +849,19 @@ const SyncButton = memo(function SyncButton({
 
   return (
     <>
-      <button
-        type="button"
-        onClick={handleSync}
-        disabled={isSyncing}
-        aria-label={t('syncButtonLabel')}
-        className="p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
-          focus:outline-none focus:ring-2 focus:ring-blue-500
-          disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      >
-        <SyncIcon className={isSyncing ? 'animate-spin' : ''} />
-      </button>
+      <Tooltip content={t('tooltips.sync')} placement="bottom">
+        <button
+          type="button"
+          onClick={handleSync}
+          disabled={isSyncing}
+          aria-label={t('syncButtonLabel')}
+          className="p-1 rounded text-gray-300 hover:text-white hover:bg-gray-700
+            focus:outline-none focus:ring-2 focus:ring-blue-500
+            disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <SyncIcon className={isSyncing ? 'animate-spin' : ''} />
+        </button>
+      </Tooltip>
       <ToastContainer toasts={toasts} onClose={removeToast} />
     </>
   );

--- a/src/components/sidebar/SortSelector.tsx
+++ b/src/components/sidebar/SortSelector.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import React, { memo } from 'react';
+import { useTranslations } from 'next-intl';
 import { useSidebarContext } from '@/contexts/SidebarContext';
 import { SortSelectorBase } from './SortSelectorBase';
 import type { SortOption } from './SortSelectorBase';
@@ -49,6 +50,7 @@ const SIDEBAR_DEFAULT_DIRECTIONS = {
  */
 export const SortSelector = memo(function SortSelector() {
   const { sortKey, sortDirection, setSortKey, setSortDirection } = useSidebarContext();
+  const t = useTranslations('common');
 
   return (
     <SortSelectorBase
@@ -59,6 +61,7 @@ export const SortSelector = memo(function SortSelector() {
       options={SIDEBAR_SORT_OPTIONS}
       defaultDirections={SIDEBAR_DEFAULT_DIRECTIONS}
       compact
+      tooltip={t('tooltips.sort')}
     />
   );
 });

--- a/src/components/sidebar/SortSelectorBase.tsx
+++ b/src/components/sidebar/SortSelectorBase.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import React, { memo, useState, useRef, useEffect, useCallback } from 'react';
+import { Tooltip } from '@/components/common/Tooltip';
 import type { SortKey, SortDirection } from '@/lib/sidebar-utils';
 
 // ============================================================================
@@ -38,6 +39,12 @@ export interface SortSelectorBaseProps {
   defaultDirections?: Partial<Record<SortKey, SortDirection>>;
   /** When true, hides the label text to save horizontal space (used in compact sidebar) */
   compact?: boolean;
+  /**
+   * Optional hover tooltip for the trigger button (Issue #882). When provided,
+   * the trigger is wrapped in the shared {@link Tooltip} (placement `bottom`).
+   * Omitted callers (e.g. Sessions page) keep the plain button.
+   */
+  tooltip?: string;
 }
 
 // ============================================================================
@@ -60,6 +67,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
   options,
   defaultDirections,
   compact,
+  tooltip,
 }: SortSelectorBaseProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -118,26 +126,36 @@ export const SortSelectorBase = memo(function SortSelectorBase({
 
   const currentLabel = options.find((opt) => opt.key === sortKey)?.label || 'Sort';
 
+  const triggerButton = (
+    <button
+      type="button"
+      onClick={handleToggle}
+      aria-expanded={isOpen}
+      aria-haspopup="listbox"
+      aria-label={`Sort by ${currentLabel}`}
+      className="
+        flex items-center gap-1 px-2 py-1 rounded
+        text-xs text-gray-300 hover:text-white hover:bg-gray-700
+        focus:outline-none focus:ring-2 focus:ring-blue-500
+        transition-colors
+      "
+    >
+      <SortIcon className="w-3 h-3" />
+      <span className={compact ? 'hidden' : 'hidden sm:inline'}>{currentLabel}</span>
+    </button>
+  );
+
   return (
     <div ref={containerRef} className="relative" data-testid="sort-selector-base">
       {/* Trigger button */}
       <div className="flex items-center gap-1">
-        <button
-          type="button"
-          onClick={handleToggle}
-          aria-expanded={isOpen}
-          aria-haspopup="listbox"
-          aria-label={`Sort by ${currentLabel}`}
-          className="
-            flex items-center gap-1 px-2 py-1 rounded
-            text-xs text-gray-300 hover:text-white hover:bg-gray-700
-            focus:outline-none focus:ring-2 focus:ring-blue-500
-            transition-colors
-          "
-        >
-          <SortIcon className="w-3 h-3" />
-          <span className={compact ? 'hidden' : 'hidden sm:inline'}>{currentLabel}</span>
-        </button>
+        {tooltip ? (
+          <Tooltip content={tooltip} placement="bottom">
+            {triggerButton}
+          </Tooltip>
+        ) : (
+          triggerButton
+        )}
 
         {/* Direction toggle */}
         <button

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -562,6 +562,67 @@ describe('Sidebar', () => {
     });
   });
 
+  // Issue #882: unify hover tooltips on the four header action buttons via the
+  // shared Tooltip component (action-oriented text, native `title` removed,
+  // aria-label preserved for screen readers).
+  describe('Header action tooltips (Issue #882)', () => {
+    it('shows an action tooltip when hovering the Repositories link', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const link = await screen.findByRole('link', { name: 'Repositories' });
+      fireEvent.mouseEnter(link);
+
+      const tooltip = await screen.findByRole('tooltip', { hidden: true });
+      expect(tooltip).toHaveTextContent('common.tooltips.repositories');
+    });
+
+    it('drops the native title on the Repositories link but keeps aria-label', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const link = await screen.findByRole('link', { name: 'Repositories' });
+      expect(link).not.toHaveAttribute('title');
+      expect(link).toHaveAttribute('aria-label', 'Repositories');
+    });
+
+    it('shows an action tooltip when hovering the view mode toggle', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const toggle = await screen.findByTestId('view-mode-toggle');
+      // Native title is replaced by the shared Tooltip.
+      expect(toggle).not.toHaveAttribute('title');
+
+      fireEvent.mouseEnter(toggle);
+      const tooltip = await screen.findByRole('tooltip', { hidden: true });
+      expect(tooltip).toHaveTextContent('common.tooltips.viewMode');
+    });
+
+    it('shows an action tooltip when hovering the sync button', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const syncButton = await screen.findByLabelText('common.syncButtonLabel');
+      fireEvent.mouseEnter(syncButton);
+
+      const tooltip = await screen.findByRole('tooltip', { hidden: true });
+      expect(tooltip).toHaveTextContent('common.tooltips.sync');
+    });
+  });
+
   describe('Grouped view (default)', () => {
     const multiRepoWorktrees: Worktree[] = [
       {

--- a/tests/unit/components/sidebar/SortSelectorBase.test.tsx
+++ b/tests/unit/components/sidebar/SortSelectorBase.test.tsx
@@ -7,12 +7,13 @@
  * @vitest-environment jsdom
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { SortSelectorBase } from '@/components/sidebar/SortSelectorBase';
 import type { SortOption } from '@/components/sidebar/SortSelectorBase';
 import type { SortKey, SortDirection } from '@/lib/sidebar-utils';
+import { TOOLTIP_DELAY_MS } from '@/components/common/Tooltip';
 
 const TEST_OPTIONS: SortOption[] = [
   { key: 'repositoryName', label: 'Repository' },
@@ -27,6 +28,7 @@ function renderSelector(overrides: Partial<{
   onSortDirectionChange: (dir: SortDirection) => void;
   options: ReadonlyArray<SortOption>;
   defaultDirections: Partial<Record<SortKey, SortDirection>>;
+  tooltip: string;
 }> = {}) {
   const props = {
     sortKey: 'lastSent' as SortKey,
@@ -149,5 +151,42 @@ describe('SortSelectorBase', () => {
 
     fireEvent.click(screen.getByText('Repository'));
     expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  // Issue #882: optional shared Tooltip on the trigger button
+  describe('tooltip prop (Issue #882)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('shows the shared Tooltip on hover when tooltip prop is provided', () => {
+      renderSelector({ tooltip: 'Sort branches' });
+
+      const trigger = screen.getByRole('button', { name: /Sort by/i });
+      // mouseenter bubbles up to the Tooltip wrapper span
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        vi.advanceTimersByTime(TOOLTIP_DELAY_MS);
+      });
+
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      expect(tooltip).toHaveTextContent('Sort branches');
+      expect(tooltip).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('does NOT render a tooltip wrapper when tooltip prop is omitted', () => {
+      renderSelector();
+
+      const trigger = screen.getByRole('button', { name: /Sort by/i });
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        vi.advanceTimersByTime(TOOLTIP_DELAY_MS);
+      });
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## 概要
サイドバー上部の4ボタン（ViewModeToggle/SortSelector/SyncButton//repositoriesリンク）に共通Tooltipでホバー説明を統一付与。

Closes #882

## 検証
- lint ✅ / tsc ✅ / test:unit ✅(7788) / build ✅（独立ゲート）

🤖 Generated with [Claude Code](https://claude.com/claude-code) — /orchestrate