### PR TITLE
fix(notes): PC版Notesパネルが狭くてもinsert/copy/deleteボタンを常に表示

### DIFF
--- a/src/components/worktree/MemoCard.tsx
+++ b/src/components/worktree/MemoCard.tsx
@@ -197,7 +197,7 @@ export const MemoCard = memo(function MemoCard({
           onChange={handleTitleChange}
           onBlur={handleTitleBlur}
           placeholder="Memo title"
-          className="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100 bg-transparent border-none focus:outline-none focus:ring-0 p-0"
+          className="flex-1 min-w-0 text-sm font-medium text-gray-900 dark:text-gray-100 bg-transparent border-none focus:outline-none focus:ring-0 p-0"
         />
         {isSaving && (
           <span
@@ -214,7 +214,7 @@ export const MemoCard = memo(function MemoCard({
             data-testid="insert-memo-content"
             onClick={handleInsert}
             aria-label="Insert to message"
-            className="p-1 text-gray-400 dark:text-gray-500 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors rounded"
+            className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors rounded"
             title="Insert to message"
           >
             <ArrowDownToLine className="w-4 h-4" aria-hidden="true" />
@@ -225,7 +225,7 @@ export const MemoCard = memo(function MemoCard({
           type="button"
           onClick={handleCopy}
           aria-label="Copy memo content"
-          className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded"
+          className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded"
         >
           {copied ? (
             <Check className="w-4 h-4 text-green-600" />
@@ -237,7 +237,7 @@ export const MemoCard = memo(function MemoCard({
           type="button"
           onClick={handleDelete}
           aria-label="Delete memo"
-          className="p-1 text-gray-400 dark:text-gray-500 hover:text-red-500 transition-colors rounded"
+          className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-red-500 transition-colors rounded"
         >
           <svg
             className="w-4 h-4"

--- a/tests/unit/components/worktree/MemoCard.test.tsx
+++ b/tests/unit/components/worktree/MemoCard.test.tsx
@@ -237,6 +237,28 @@ describe('MemoCard', () => {
     });
   });
 
+  describe('Header layout (Issue #884)', () => {
+    it('should allow the title input to shrink so action buttons stay visible', () => {
+      render(<MemoCard {...defaultProps} onInsertToMessage={vi.fn()} />);
+
+      // min-w-0 lets the flex-1 input shrink below its content width,
+      // preventing it from pushing the action buttons out of the row.
+      const titleInput = screen.getByDisplayValue('Test Memo');
+      expect(titleInput).toHaveClass('flex-1');
+      expect(titleInput).toHaveClass('min-w-0');
+    });
+
+    it('should keep action buttons from shrinking', () => {
+      render(<MemoCard {...defaultProps} onInsertToMessage={vi.fn()} />);
+
+      // flex-shrink-0 keeps each button at its natural size when the title
+      // is long, so insert/copy/delete never collapse or overflow.
+      expect(screen.getByTestId('insert-memo-content')).toHaveClass('flex-shrink-0');
+      expect(getCopyButton()).toHaveClass('flex-shrink-0');
+      expect(screen.getByRole('button', { name: /delete/i })).toHaveClass('flex-shrink-0');
+    });
+  });
+
   describe('Insert to message (Issue #485)', () => {
     it('should render insert button when onInsertToMessage is provided', () => {
       const onInsert = vi.fn();


### PR DESCRIPTION
## 概要

Issue #884 の修正。PC版でアクティビティバーの **Notes** を選択した際、表示幅（パネル幅）が狭いと、各メモカードの insert / copy / delete ボタンが右端外へ押し出されて非表示になる問題を修正する。

## 原因

`src/components/worktree/MemoCard.tsx` のヘッダー flex 行で、タイトル入力 `<input>` が `flex-1`（伸びる）だが `min-w-0` を持たず、flexアイテムの既定 `min-width: auto` により intrinsic width 未満に縮まない。結果、入力欄が居座り右側のボタン群が押し出され、親の `overflow-hidden` でクリップされていた。

## 修正内容

`src/components/worktree/MemoCard.tsx`:
- タイトル入力に `min-w-0` を付与（`flex-1 min-w-0`）→ 幅に応じて縮小
- insert / copy / delete の各ボタンに `flex-shrink-0` を付与 → 潰れず常に表示

`tests/unit/components/worktree/MemoCard.test.tsx`:
- 「Header layout (Issue #884)」回帰テストを追加（input に `flex-1 min-w-0`、3ボタンに `flex-shrink-0` が付くことを検証）

## 品質チェック

- ✅ `npm run lint`
- ✅ `npx tsc --noEmit`
- ✅ `npm run test:unit`（7790 tests passed）
- ✅ `npm run build`

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
