### PR TITLE
fix(file-tree): Files表示中に展開済みサブディレクトリの新規ファイルが自動反映されない＋手動更新ボタン追加 (#888)

### DIFF
--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -24,8 +24,10 @@ import { useContextMenu } from '@/hooks/useContextMenu';
 import { ContextMenu } from '@/components/worktree/ContextMenu';
 import { TreeNode } from '@/components/worktree/TreeNode';
 import { computeMatchedPaths } from '@/lib/utils';
+import { useFilePolling } from '@/hooks/useFilePolling';
+import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import { useLocale } from 'next-intl';
-import { FilePlus, FolderPlus, AlertCircle } from 'lucide-react';
+import { FilePlus, FolderPlus, AlertCircle, RefreshCw } from 'lucide-react';
 
 // ============================================================================
 // Types
@@ -52,6 +54,14 @@ export interface FileTreeViewProps {
   className?: string;
   /** Trigger to refresh the tree (increment to refresh) */
   refreshTrigger?: number;
+  /**
+   * [Issue #888] When true, poll for external file changes across the root and
+   * all currently-expanded subdirectories, refreshing only when something
+   * actually changed. The caller passes the activation condition (e.g.
+   * `activeActivity === 'files'`) so detection stays scoped to when the tree
+   * is visible. Defaults to off.
+   */
+  pollingEnabled?: boolean;
   /** [Issue #21] Search query for filtering (optional) */
   searchQuery?: string;
   /** [Issue #21] Search mode: 'name' or 'content' (optional) */
@@ -95,6 +105,7 @@ export const FileTreeView = memo(function FileTreeView({
   onMove,
   className = '',
   refreshTrigger = 0,
+  pollingEnabled = false,
   searchQuery,
   searchMode,
   searchResults,
@@ -236,6 +247,97 @@ export const FileTreeView = memo(function FileTreeView({
     // is stable as long as fetchDirectory (= worktreeId) is unchanged.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reloadTreeWithExpandedDirs, refreshTrigger]);
+
+  // ==========================================================================
+  // [Issue #888] External change detection (polling)
+  //
+  // The previous implementation polled only the ROOT directory
+  // (useWorktreeDetailController), so files created inside an *expanded*
+  // subdirectory were never detected while the Files tab stayed mounted — the
+  // root listing (and thus its hash) was unchanged. Detection now lives here,
+  // next to `expandedRef` + `fetchDirectory`, and covers the root PLUS every
+  // expanded subdirectory, so the detection scope matches the refresh scope of
+  // `reloadTreeWithExpandedDirs()`. A real change triggers a single reload that
+  // preserves scroll/selection/expansion (Issue #706).
+  // ==========================================================================
+
+  // Per-directory content signature (path -> hash of its items) captured on the
+  // previous poll. Comparing per directory (rather than one flat hash) means
+  // newly-expanded dirs — freshly loaded by loadChildren — and collapsed dirs
+  // do NOT count as external changes, avoiding false-positive refreshes.
+  const pollSignatureRef = useRef<Map<string, string> | null>(null);
+  // Guard against overlapping polls if a tick fires before the previous one's
+  // fetches have settled.
+  const pollInFlightRef = useRef(false);
+
+  // Reset the baseline when the target worktree changes so a stale signature
+  // from a previous worktree can never trip a false refresh.
+  useEffect(() => {
+    pollSignatureRef.current = null;
+  }, [worktreeId]);
+
+  const detectExternalChanges = useCallback(async () => {
+    if (!mountedRef.current || pollInFlightRef.current) return;
+    pollInFlightRef.current = true;
+    try {
+      // The directories currently on screen: root ('') + expanded subdirs.
+      const paths = ['', ...Array.from(expandedRef.current)];
+      const signature = new Map<string, string>();
+
+      for (let i = 0; i < paths.length; i += CONCURRENT_LIMIT) {
+        if (!mountedRef.current) return;
+        const chunk = paths.slice(i, i + CONCURRENT_LIMIT);
+        const results = await Promise.all(
+          chunk.map(async (dirPath) => {
+            try {
+              const data = await fetchDirectory(dirPath);
+              return { dirPath, hash: JSON.stringify(data?.items ?? null) };
+            } catch {
+              // A directory we previously listed that now errors (deleted /
+              // inaccessible) is itself a change — record a sentinel so the
+              // comparison trips and the reload prunes the stale path.
+              return { dirPath, hash: ' unavailable' };
+            }
+          })
+        );
+        for (const { dirPath, hash } of results) {
+          signature.set(dirPath, hash);
+        }
+      }
+
+      if (!mountedRef.current) return;
+
+      const baseline = pollSignatureRef.current;
+      pollSignatureRef.current = signature;
+
+      // First poll only records a baseline (no reload) so we never fire a
+      // false-positive refresh that would disturb scroll/selection (Issue #706).
+      if (baseline === null) return;
+
+      // Reload only when a directory present in BOTH snapshots changed content.
+      let changed = false;
+      for (const [dirPath, hash] of signature) {
+        const prev = baseline.get(dirPath);
+        if (prev !== undefined && prev !== hash) {
+          changed = true;
+          break;
+        }
+      }
+
+      if (changed) {
+        void reloadTreeWithExpandedDirs();
+      }
+    } finally {
+      pollInFlightRef.current = false;
+    }
+  }, [fetchDirectory, reloadTreeWithExpandedDirs]);
+
+  // Reuse the shared polling lifecycle (5s interval + visibilitychange pause).
+  useFilePolling({
+    intervalMs: FILE_TREE_POLL_INTERVAL_MS,
+    enabled: pollingEnabled,
+    onPoll: detectExternalChanges,
+  });
 
   /**
    * Load children for a directory
@@ -467,41 +569,43 @@ export const FileTreeView = memo(function FileTreeView({
       aria-label="File tree"
       className={`overflow-auto bg-white dark:bg-gray-900 ${className}`}
     >
-      {/* [Issue #300] Toolbar for root-level file/directory creation */}
-      {(onNewFile || onNewDirectory || isRefetching) && (
-        <div
-          data-testid="file-tree-toolbar"
-          className="flex items-center gap-1 p-1 border-b border-gray-200 dark:border-gray-700"
-        >
-          {onNewFile && (
-            <button
-              data-testid="toolbar-new-file-button"
-              onClick={() => onNewFile('')}
-              className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
-            >
-              <FilePlus className="w-4 h-4" aria-hidden="true" />
-              <span>New File</span>
-            </button>
-          )}
-          {onNewDirectory && (
-            <button
-              data-testid="toolbar-new-directory-button"
-              onClick={() => onNewDirectory('')}
-              className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
-            >
-              <FolderPlus className="w-4 h-4" aria-hidden="true" />
-              <span>New Directory</span>
-            </button>
-          )}
-          {/* [Issue #706] Compact refetch indicator. Anchored to the right
-              edge of the existing toolbar so the tree DOM (and its scroll
-              position) is preserved while a background refresh is running. */}
+      {/* [Issue #300/#888] Toolbar: root-level create actions + manual refresh.
+          Always rendered so the manual refresh button (Issue #888) is available
+          even when no create callbacks are wired in. */}
+      <div
+        data-testid="file-tree-toolbar"
+        className="flex items-center gap-1 p-1 border-b border-gray-200 dark:border-gray-700"
+      >
+        {onNewFile && (
+          <button
+            data-testid="toolbar-new-file-button"
+            onClick={() => onNewFile('')}
+            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          >
+            <FilePlus className="w-4 h-4" aria-hidden="true" />
+            <span>New File</span>
+          </button>
+        )}
+        {onNewDirectory && (
+          <button
+            data-testid="toolbar-new-directory-button"
+            onClick={() => onNewDirectory('')}
+            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          >
+            <FolderPlus className="w-4 h-4" aria-hidden="true" />
+            <span>New Directory</span>
+          </button>
+        )}
+        {/* Right-aligned group: refetch indicator + manual refresh button. */}
+        <div className="ml-auto flex items-center gap-1">
+          {/* [Issue #706] Compact refetch indicator. The tree DOM (and its
+              scroll position) is preserved while a background refresh runs. */}
           {isRefetching && (
             <div
               data-testid="file-tree-refetch-indicator"
               role="status"
               aria-live="polite"
-              className="ml-auto flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+              className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
             >
               <span
                 aria-hidden="true"
@@ -510,8 +614,26 @@ export const FileTreeView = memo(function FileTreeView({
               <span className="sr-only">Refreshing files</span>
             </div>
           )}
+          {/* [Issue #888] Manual refresh: re-fetch the root + all expanded
+              directories on demand (preserves scroll/selection/expansion). */}
+          <button
+            data-testid="file-tree-refresh-button"
+            type="button"
+            onClick={() => {
+              void reloadTreeWithExpandedDirs();
+            }}
+            disabled={isRefetching}
+            aria-label="Refresh file tree"
+            title="更新"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <RefreshCw
+              className={`w-4 h-4 ${isRefetching ? 'animate-spin' : ''}`}
+              aria-hidden="true"
+            />
+          </button>
         </div>
-      )}
+      </div>
       {/* [Issue #706] Non-destructive refetch error banner. The previous
           tree DOM remains mounted, so we surface the error inline with a
           retry action instead of replacing the whole view. */}

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -527,6 +527,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
             onUpload={onUpload}
             onMove={onMove}
             refreshTrigger={fileTreeRefresh}
+            pollingEnabled={activeActivity === 'files'}
             searchQuery={fileSearch.query}
             searchMode={fileSearch.mode}
             searchResults={fileSearch.results?.results}
@@ -574,6 +575,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
     [
       worktreeId,
       worktree,
+      activeActivity,
       fileSearch.query,
       fileSearch.mode,
       fileSearch.isSearching,

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -372,6 +372,7 @@ export const MobileContent = memo(function MobileContent({
               onUpload={onUpload}
               onMove={onMove}
               refreshTrigger={refreshTrigger}
+              pollingEnabled={activeTab === 'files'}
               searchQuery={fileSearch.query}
               searchMode={fileSearch.mode}
               searchResults={fileSearch.results?.results}

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -31,8 +31,6 @@ import { useFileSearch } from '@/hooks/useFileSearch';
 import { useActivityBarState } from '@/hooks/useActivityBarState';
 import type { ActivityId } from '@/config/activity-bar-config';
 import { useFileTabs, MAX_FILE_TABS } from '@/hooks/useFileTabs';
-import { useFilePolling } from '@/hooks/useFilePolling';
-import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import { usePendingInsertText } from '@/hooks/usePendingInsertText';
 import {
   deriveWorktreeStatus,
@@ -306,32 +304,10 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   // `useHistoryPaneState` instance. Each `TerminalSplitPaneContent` owns its
   // own instance for the split-internal History visibility/width.
 
-  // [Issue #469] Tree polling: detect file tree changes via JSON comparison
-  const prevTreeHashRef = useRef<string | null>(null);
-  useFilePolling({
-    intervalMs: FILE_TREE_POLL_INTERVAL_MS,
-    enabled: activeActivity === 'files',
-    onPoll: async () => {
-      try {
-        const response = await fetch(`/api/worktrees/${worktreeId}/tree`);
-        if (!response.ok) return; // Ignore errors in polling
-        const data = await response.json();
-        const newHash = JSON.stringify(data?.items);
-        // [Issue #706] On the very first poll we have no baseline to
-        // compare against, so just record the hash. Firing a refresh here
-        // would be a false positive that resets the user's scroll/selection
-        // state in FileTreeView for no actual change.
-        if (prevTreeHashRef.current === null) {
-          prevTreeHashRef.current = newHash;
-        } else if (newHash !== prevTreeHashRef.current) {
-          prevTreeHashRef.current = newHash;
-          setFileTreeRefresh(prev => prev + 1);
-        }
-      } catch {
-        // Silently ignore network errors during polling
-      }
-    },
-  });
+  // [Issue #888] File-tree external-change detection was moved INTO
+  // FileTreeView (it now covers the root + every expanded subdirectory, not
+  // just the root). The controller only retains `fileTreeRefresh` to force an
+  // explicit refresh after local file operations (create/rename/delete/upload).
 
   // [Issue #447] History sub-tab: 'message' (default) or 'git'
   const [historySubTab, setHistorySubTab] = useState<'message' | 'git'>('message');

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { FileTreeView } from '@/components/worktree/FileTreeView';
+import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import type { TreeResponse } from '@/types/models';
 
 // Mock fetch globally
@@ -1540,7 +1541,7 @@ describe('FileTreeView', () => {
       expect(onNewFile).toHaveBeenCalledWith('');
     });
 
-    it('should not show file-tree-toolbar when neither onNewFile nor onNewDirectory is provided', async () => {
+    it('should always show file-tree-toolbar (manual refresh button) but omit create buttons when neither onNewFile nor onNewDirectory is provided (Issue #888)', async () => {
       render(
         <FileTreeView worktreeId="test-worktree" />
       );
@@ -1549,7 +1550,12 @@ describe('FileTreeView', () => {
         expect(screen.getByTestId('file-tree-view')).toBeInTheDocument();
       });
 
-      expect(screen.queryByTestId('file-tree-toolbar')).not.toBeInTheDocument();
+      // [Issue #888] The toolbar is now always present because it hosts the
+      // manual refresh button — but the create buttons remain callback-gated.
+      expect(screen.getByTestId('file-tree-toolbar')).toBeInTheDocument();
+      expect(screen.getByTestId('file-tree-refresh-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('toolbar-new-file-button')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('toolbar-new-directory-button')).not.toBeInTheDocument();
     });
 
     it('should still show empty-new-directory-button in empty state', async () => {
@@ -1745,6 +1751,160 @@ describe('FileTreeView', () => {
         expect(screen.queryByTestId('file-tree-refetch-error')).not.toBeInTheDocument();
       });
       expect(screen.getByText('src')).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Issue #888: Files 表示中に新規ファイルが自動反映されない問題の修正
+   *
+   * B案: Files パネルヘッダーに手動「更新」ボタンを追加。
+   */
+  describe('manual refresh button (Issue #888)', () => {
+    it('should render a manual refresh button in the toolbar', async () => {
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-view')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('file-tree-refresh-button')).toBeInTheDocument();
+    });
+
+    it('should re-fetch the root and all expanded directories when clicked', async () => {
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      // Expand src so the refresh must re-fetch the subdirectory too.
+      fireEvent.click(screen.getByTestId('tree-item-src'));
+      await waitFor(() => {
+        expect(screen.getByText('index.ts')).toBeInTheDocument();
+      });
+
+      mockFetch.mockClear();
+      fireEvent.click(screen.getByTestId('file-tree-refresh-button'));
+
+      await waitFor(() => {
+        const calls = mockFetch.mock.calls.map((c) => c[0]);
+        expect(calls).toContain('/api/worktrees/test-worktree/tree');
+        expect(calls).toContain('/api/worktrees/test-worktree/tree/src');
+      });
+    });
+  });
+
+  /**
+   * Issue #888: A案 - 監視範囲の是正
+   *
+   * 変更検知を FileTreeView 内へ移設し、ルート＋展開中の全サブディレクトリを
+   * 対象に合成ハッシュで変化検知する。変化時のみ reloadTreeWithExpandedDirs()
+   * を実行し、スクロール/選択/展開状態は維持する（Issue #706 配慮）。
+   */
+  describe('external change polling (Issue #888)', () => {
+    it('should NOT poll when pollingEnabled is omitted (default off)', async () => {
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        mockFetch.mockClear();
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(FILE_TREE_POLL_INTERVAL_MS * 3);
+        });
+        expect(mockFetch).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should only establish a baseline on the first poll tick (no reload — Issue #706)', async () => {
+      // Fake timers must be active BEFORE mount so the polling interval is
+      // registered against the fake clock.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        render(<FileTreeView worktreeId="test-worktree" pollingEnabled />);
+
+        // Flush the mount reload.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1);
+        });
+        expect(screen.getByText('src')).toBeInTheDocument();
+
+        mockFetch.mockClear();
+        // One poll tick: it reads the root exactly once to record the baseline
+        // and must NOT trigger a reload (which would read the root a 2nd time).
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(FILE_TREE_POLL_INTERVAL_MS);
+        });
+
+        const rootFetches = mockFetch.mock.calls.filter(
+          (c) => c[0] === '/api/worktrees/test-worktree/tree'
+        );
+        expect(rootFetches).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should refresh when a file is added inside an expanded subdirectory', async () => {
+      // Mutable src payload so a later poll observes the added file.
+      let srcData: TreeResponse = mockSrcData;
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/tree/src')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(srcData) });
+        }
+        if (url.includes('/tree')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockRootData) });
+        }
+        return Promise.reject(new Error('Not found'));
+      });
+
+      // Fake timers must be active BEFORE mount so the polling interval is
+      // registered against the fake clock.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        render(<FileTreeView worktreeId="test-worktree" pollingEnabled />);
+
+        // Flush the mount reload.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1);
+        });
+        expect(screen.getByText('src')).toBeInTheDocument();
+
+        // Expand src.
+        fireEvent.click(screen.getByTestId('tree-item-src'));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1);
+        });
+        expect(screen.getByText('index.ts')).toBeInTheDocument();
+
+        // Poll #1: baseline over root + src (unchanged), no reload.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(FILE_TREE_POLL_INTERVAL_MS);
+        });
+
+        // A new file appears inside the expanded src directory.
+        srcData = {
+          ...mockSrcData,
+          items: [
+            ...mockSrcData.items,
+            { name: 'new-file.ts', type: 'file' as const, size: 10, extension: 'ts' },
+          ],
+        };
+
+        // Poll #2: src content hash differs from baseline -> reload.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(FILE_TREE_POLL_INTERVAL_MS);
+        });
+
+        expect(screen.getByText('new-file.ts')).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
## 概要

Issue #888 の修正。Files（アクティビティバー）表示中に、**展開済みサブディレクトリ**内に作成されたファイルがタブ切替なしでは自動反映されない問題を解消する。あわせて手動「更新」ボタンを追加する。

Closes #888

## 根本原因

ツリー変更検知（`useWorktreeDetailController`）が**ルート直下のみ**を `/tree` でハッシュ比較していたため、展開中サブディレクトリ内の新規ファイルはルート一覧（=ハッシュ）が不変で検知されなかった。Files を一度離れて再選択すると `FileTreeView` が再マウントされ全体再取得 → そこで初めて反映される、という挙動だった。

## 対策

### A. 監視範囲の是正（主対応）
- 変更検知を `useWorktreeDetailController` から **`FileTreeView` 内へ移設**。`expandedRef` + `fetchDirectory` の隣で、**ルート＋展開中の全サブディレクトリ**を対象に検知する。
- 検知方式は「ディレクトリ単位の合成シグネチャ」（`Map<path, items ハッシュ>`）。**両スナップショットに共通するディレクトリの内容変化のみ**を変化と判定 → フォルダの新規展開/折り畳みでは誤って再読込しない。
- 検知範囲が `reloadTreeWithExpandedDirs()` の再描画範囲と一致するため、サブディレクトリ内の新規ファイルもタブ切替なしで反映される。
- 初回ポーリングはベースライン記録のみ（再読込なし）→ スクロール/選択/展開状態を保持（**Issue #706 の配慮を維持**）。
- in-flight ガード／worktree 切替時のベースラインリセット付き。
- 有効化条件は `pollingEnabled` prop で受け渡し（PC: `activeActivity==='files'`、モバイル: files タブ表示中）。既存の 5 秒周期・`visibilitychange` 制御（`useFilePolling`）を流用。

### B. 手動「更新」ボタン
- Files パネルヘッダーのツールバーに更新ボタン（`RefreshCw`）を追加し、`reloadTreeWithExpandedDirs()` を呼んで即時更新できるようにする。ツールバーを常時表示に変更（更新ボタンを常設）。

### スコープ外
- C（ポーリング間隔短縮）／D（サーバ側 `fs.watch`+push）は未対応。

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `src/components/worktree/FileTreeView.tsx` | A: 検知ロジック移設・B: 更新ボタン追加 |
| `src/hooks/useWorktreeDetailController.ts` | ルートのみ監視を撤去（`fileTreeRefresh` はローカル操作後の明示更新用に保持） |
| `src/components/worktree/WorktreeDetailDesktop.tsx` | `pollingEnabled` prop 配線 |
| `src/components/worktree/WorktreeDetailMobile.tsx` | `pollingEnabled` prop 配線 |
| `tests/unit/components/worktree/FileTreeView.test.tsx` | 回帰テスト追加・既存ツールバーテスト更新 |

## テスト

- `npm run lint` → ✅ エラー・警告なし
- `npx tsc --noEmit` → ✅ exit 0
- `npm run test:unit` → ✅ 7795 passed（413 files）
- `npm run build` → ✅ Compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)