### PR TITLE
fix(codex): 初回起動時の update/trust ダイアログ処理を決定的化 (#890)

### DIFF
--- a/src/lib/cli-tools/codex.ts
+++ b/src/lib/cli-tools/codex.ts
@@ -15,7 +15,7 @@ import {
 } from '../tmux/tmux';
 import { detectAndResendIfPastedText } from '../pasted-text-helper';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
-import { CODEX_PROMPT_PATTERN, stripAnsi } from '../detection/cli-patterns';
+import { isCodexPromptReady, stripAnsi } from '../detection/cli-patterns';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
@@ -121,7 +121,7 @@ export class CodexTool extends BaseCLITool {
    * Wait for Codex CLI to become ready (prompt visible).
    * Handles trust dialog ("Do you trust the contents of this directory?")
    * and update notification automatically by sending Enter/number keys.
-   * Polls until CODEX_PROMPT_PATTERN is detected or max attempts reached.
+   * Polls until a genuine interactive prompt is detected or max attempts reached.
    */
   private async waitForReady(sessionName: string): Promise<void> {
     let trustDialogHandled = false;
@@ -130,14 +130,13 @@ export class CodexTool extends BaseCLITool {
         const rawOutput = await capturePane(sessionName, 50);
         const output = stripAnsi(rawOutput);
 
-        // Check if interactive prompt is ready
-        if (CODEX_PROMPT_PATTERN.test(output)) {
-          // Verify it's the actual input prompt, not a prompt inside a dialog
-          // by checking no trust/update dialog is still active
-          if (!output.includes('Do you trust') && !output.includes('Press enter to continue')) {
-            logger.info('codex-prompt-detected');
-            return;
-          }
+        // Check if the genuine interactive input prompt is ready.
+        // Issue #890: CODEX_PROMPT_PATTERN also matches dialog option lines
+        // (e.g. "› 1. Update now"), so isCodexPromptReady() additionally rejects
+        // any still-active update/trust dialog before returning.
+        if (isCodexPromptReady(output)) {
+          logger.info('codex-prompt-detected');
+          return;
         }
 
         // Handle update notification BEFORE trust dialog check.
@@ -145,13 +144,20 @@ export class CodexTool extends BaseCLITool {
         // followed by "Press enter to continue". Must send "2" (Skip) to avoid
         // triggering npm install which kills the Codex process.
         if (output.includes('Update') && output.includes('Skip')) {
-          await sendKeys(sessionName, '2', true);
+          // Issue #890: Codex confirms a numbered selection instantly (no Enter).
+          // Appending Enter (sendEnter=true) would land on the NEXT screen as a
+          // stray keypress -- an empty submit on the main prompt, or worst case the
+          // default "1. Update now" confirm if "2" was dropped during a re-render.
+          // Send "2" alone and let the next poll observe the result.
+          await sendKeys(sessionName, '2', false);
           logger.info('skipped-codex-update');
           await new Promise((resolve) => setTimeout(resolve, CODEX_DIALOG_SETTLE_MS));
           continue;
         }
 
-        // Handle "Press enter to continue" (after update skip or other notification)
+        // Handle "Press enter to continue" (genuine press-enter screens only).
+        // Numbered selection dialogs are dismissed by the number key above, so this
+        // branch is reached only when no number selection is pending.
         if (output.includes('Press enter to continue')) {
           await sendSpecialKey(sessionName, 'Enter');
           logger.info('dismissed-codex-notification');
@@ -162,7 +168,8 @@ export class CodexTool extends BaseCLITool {
         // Handle trust dialog: "Do you trust the contents of this directory?"
         // Options: › 1. Yes, continue / 2. No, quit
         if (!trustDialogHandled && output.includes('Do you trust')) {
-          await sendKeys(sessionName, '1', true);
+          // Issue #890: number-key selection confirms instantly; no trailing Enter.
+          await sendKeys(sessionName, '1', false);
           trustDialogHandled = true;
           logger.info('auto-trusted-folder-for');
           await new Promise((resolve) => setTimeout(resolve, CODEX_DIALOG_SETTLE_MS));
@@ -187,7 +194,10 @@ export class CodexTool extends BaseCLITool {
       try {
         const rawOutput = await capturePane(sessionName, 50);
         const output = stripAnsi(rawOutput);
-        if (CODEX_PROMPT_PATTERN.test(output)) {
+        // Issue #890: apply the same dialog guard as waitForReady so a residual
+        // update/trust dialog ("› 1. ...") is never mistaken for a ready prompt,
+        // which would type the first message straight into the dialog.
+        if (isCodexPromptReady(output)) {
           return;
         }
       } catch {

--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -99,6 +99,49 @@ export const CLAUDE_TRUST_DIALOG_PATTERN = /Yes, I trust this folder/m;
 export const CODEX_PROMPT_PATTERN = /^›\s*/m;
 
 /**
+ * Codex INTERACTIVE startup dialog pattern (Issue #890)
+ *
+ * Codex shows interactive update-notification and trust dialogs on first launch.
+ * Their currently-selected option lines render as "› 1. Update now", which ALSO
+ * matches CODEX_PROMPT_PATTERN (the bare "^›" input-prompt pattern). So "is the
+ * input prompt ready?" cannot be decided by CODEX_PROMPT_PATTERN alone -- it must
+ * also confirm no INTERACTIVE dialog is still active. This pattern matches markers
+ * that appear ONLY in interactive dialogs:
+ *   - Interactive update dialog: "Skip until next version" (the option-3 label)
+ *   - Trust dialog:              "Do you trust the contents of this directory?"
+ *   - Dialog confirm footer:     "Press enter to continue"
+ *   - Numbered selection option: "› 1. ..." (leading ›, a digit, a dot)
+ *
+ * IMPORTANT (Issue #890 regression): the substring "Update available" is
+ * deliberately NOT a marker. After the update is skipped, codex keeps a
+ * non-interactive banner box ("✨ Update available! ... / Run npm install -g
+ * @openai/codex to update.") rendered ABOVE the genuine "› " prompt. Matching
+ * "Update available" would make isCodexPromptReady() return false for as long as
+ * that banner is visible, hanging waitForReady (~30s) and waitForPrompt (15s) on
+ * exactly the first-launch + update-pending case this fix targets. The interactive
+ * update dialog is still reliably detected via its other three markers above
+ * ("› 1. Update now" + "Skip until next version" + "Press enter to continue").
+ *
+ * No /g flag (would make .test() stateful); no nested quantifiers (ReDoS-safe).
+ */
+export const CODEX_DIALOG_PATTERN =
+  /Skip until next version|Do you trust|Press enter to continue|^\s*›\s*\d+\.\s/m;
+
+/**
+ * Decide whether Codex output shows a genuine interactive input prompt rather than
+ * a startup dialog (Issue #890).
+ *
+ * Returns true only when the prompt pattern matches AND no update/trust dialog
+ * marker is present. Used by both CodexTool.waitForReady() (startup) and
+ * CodexTool.waitForPrompt() (before every send) so a residual dialog is never
+ * mistaken for "ready", which would otherwise type the first message into the
+ * dialog or fire a stray Enter.
+ */
+export function isCodexPromptReady(output: string): boolean {
+  return CODEX_PROMPT_PATTERN.test(output) && !CODEX_DIALOG_PATTERN.test(output);
+}
+
+/**
  * Codex separator pattern
  */
 export const CODEX_SEPARATOR_PATTERN = /^─.*Worked for.*─+$/m;

--- a/tests/unit/cli-tools/codex-startup-dialog.test.ts
+++ b/tests/unit/cli-tools/codex-startup-dialog.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for CodexTool first-launch dialog handling (Issue #890)
+ *
+ * Verifies:
+ *  A) update-skip ('2') and trust ('1') number selections are sent WITHOUT a
+ *     trailing Enter (sendEnter=false), so no stray Enter lands on the next
+ *     screen (empty submit / accidental "Update now" confirm).
+ *  B) waitForReady / waitForPrompt treat a residual update/trust dialog as
+ *     "not ready" -- the dialog's "› 1." option line must not be mistaken for
+ *     the input prompt -- so the first message is never typed into a dialog.
+ *
+ * Separate file so vi.mock does not affect codex.test.ts (SF precedent:
+ * codex-pasted-text.test.ts).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock tmux module
+vi.mock('@/lib/tmux/tmux', () => ({
+  hasSession: vi.fn(),
+  createSession: vi.fn(),
+  sendKeys: vi.fn(),
+  capturePane: vi.fn(),
+  killSession: vi.fn(),
+  sendSpecialKey: vi.fn(),
+  sendSpecialKeys: vi.fn(),
+}));
+
+vi.mock('@/lib/pasted-text-helper', () => ({
+  detectAndResendIfPastedText: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/cli-tools/validation', () => ({
+  validateSessionName: vi.fn(),
+}));
+
+// BaseCLITool.isInstalled() uses promisify(exec); resolve it so isInstalled() === true
+vi.mock('child_process', () => ({ exec: vi.fn() }));
+vi.mock('util', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('util')>();
+  return {
+    ...actual,
+    promisify: () => vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { CodexTool } from '@/lib/cli-tools/codex';
+import { hasSession, createSession, sendKeys, sendSpecialKey, capturePane } from '@/lib/tmux/tmux';
+
+const WORKTREE_ID = 'test-worktree';
+const SESSION = 'mcbd-codex-test-worktree';
+
+// First-launch screens (each option dialog confirms on the number key alone -- no Enter).
+// The selected option marker "›" renders at column 0 (same column as the genuine
+// prompt), so CODEX_PROMPT_PATTERN alone is fooled -- the dialog guard must reject it.
+const UPDATE_DIALOG = [
+  '✨ Update available! 0.139.0 -> 0.140.0',
+  '› 1. Update now (runs `npm install -g @openai/codex`)',
+  '  2. Skip',
+  '  3. Skip until next version',
+  'Press enter to continue',
+].join('\n');
+
+const TRUST_DIALOG = [
+  'Do you trust the contents of this directory?',
+  '› 1. Yes, continue',
+  '  2. No, quit',
+].join('\n');
+
+const PROMPT = '› ';
+
+// Issue #890 regression: after the update is skipped, codex keeps a NON-interactive
+// "✨ Update available!" banner box rendered ABOVE the genuine prompt. This realistic
+// frame (banner + prompt coexisting) must be treated as READY -- otherwise matching
+// "Update available" would hang waitForReady (~30s) / waitForPrompt (15s).
+const READY_WITH_BANNER = [
+  '╭──────────────────────────────────────────────────╮',
+  '│ ✨ Update available! 0.139.0 -> 0.140.0          │',
+  '│ Run npm install -g @openai/codex to update.      │',
+  '╰──────────────────────────────────────────────────╯',
+  '',
+  '› Summarize recent commits',
+].join('\n');
+
+describe('CodexTool first-launch dialog handling (Issue #890)', () => {
+  let tool: CodexTool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tool = new CodexTool();
+    vi.mocked(createSession).mockResolvedValue();
+    vi.mocked(sendKeys).mockResolvedValue();
+    vi.mocked(sendSpecialKey).mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('waitForReady (A: no stray Enter on number selections)', () => {
+    it('untrusted dir: sends update-skip "2" and trust "1" WITHOUT trailing Enter, then reaches the prompt', async () => {
+      vi.mocked(hasSession).mockResolvedValue(false);
+      vi.mocked(capturePane)
+        .mockResolvedValueOnce(UPDATE_DIALOG)
+        .mockResolvedValueOnce(TRUST_DIALOG)
+        .mockResolvedValue(PROMPT);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.startSession(WORKTREE_ID, '/test/path');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // The launch command keeps its Enter; the number selections must not.
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'codex', true);
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, '2', false);
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, '1', false);
+
+      // Regression guard: number selections must NEVER be sent with a trailing Enter.
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '2', true);
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '1', true);
+    });
+
+    it('already-trusted dir: skips update without Enter and never sends a trust selection', async () => {
+      vi.mocked(hasSession).mockResolvedValue(false);
+      vi.mocked(capturePane)
+        .mockResolvedValueOnce(UPDATE_DIALOG)
+        .mockResolvedValue(PROMPT);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.startSession(WORKTREE_ID, '/test/path');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, '2', false);
+      // No trust dialog appeared, so '1' must never be sent.
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '1', false);
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '1', true);
+    });
+  });
+
+  describe('waitForPrompt (B: dialog option line is not mistaken for the prompt)', () => {
+    it('keeps polling while a dialog is active and only sends the message once a genuine prompt is ready', async () => {
+      vi.mocked(hasSession).mockResolvedValue(true);
+      vi.mocked(capturePane)
+        .mockResolvedValueOnce(UPDATE_DIALOG) // residual dialog -> not ready, keep polling
+        .mockResolvedValueOnce(TRUST_DIALOG)  // residual dialog -> not ready, keep polling
+        .mockResolvedValue(PROMPT);           // genuine prompt -> ready
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.sendMessage(WORKTREE_ID, 'hello world');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // With the legacy guardless check, the "› 1." option line would be treated as
+      // ready and capturePane would be called only once. The hardened check polls past
+      // both dialog frames.
+      expect(vi.mocked(capturePane).mock.calls.length).toBeGreaterThanOrEqual(3);
+
+      // Message is delivered without Enter; Enter is sent separately as C-m.
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello world', false);
+      expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+    });
+  });
+
+  describe('persistent post-skip "Update available" banner (Issue #890 regression)', () => {
+    it('waitForReady: reaches the prompt immediately when the banner coexists with the prompt (no timeout polling)', async () => {
+      vi.mocked(hasSession).mockResolvedValue(false);
+      vi.mocked(capturePane).mockResolvedValue(READY_WITH_BANNER);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.startSession(WORKTREE_ID, '/test/path');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // The banner is non-interactive, so it must be treated as ready on the first
+      // poll. With the regressed pattern (matching "Update available") this would
+      // never be ready and capturePane would be called ~CODEX_INIT_MAX_ATTEMPTS times.
+      expect(vi.mocked(capturePane).mock.calls.length).toBeLessThanOrEqual(2);
+      // A ready banner frame is not a dialog: no skip/trust number keys are sent.
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '2', false);
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '1', false);
+    });
+
+    it('waitForPrompt: sends the message immediately when the banner coexists with the prompt (no timeout polling)', async () => {
+      vi.mocked(hasSession).mockResolvedValue(true);
+      vi.mocked(capturePane).mockResolvedValue(READY_WITH_BANNER);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.sendMessage(WORKTREE_ID, 'hello world');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // Ready on the first poll -> no 15s timeout wait (regressed pattern would poll
+      // ~30 times until the waitForPrompt timeout before sending anyway).
+      expect(vi.mocked(capturePane).mock.calls.length).toBeLessThanOrEqual(2);
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello world', false);
+      expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+    });
+  });
+});

--- a/tests/unit/lib/cli-patterns.test.ts
+++ b/tests/unit/lib/cli-patterns.test.ts
@@ -7,11 +7,11 @@ import { describe, it, expect } from 'vitest';
 import {
   CODEX_THINKING_PATTERN,
   CODEX_PROMPT_PATTERN,
+  CODEX_DIALOG_PATTERN,
+  isCodexPromptReady,
   PASTED_TEXT_PATTERN,
   PASTED_TEXT_DETECT_DELAY,
   MAX_PASTED_TEXT_RETRIES,
-  OPENCODE_THINKING_PATTERN,
-  OPENCODE_PROMPT_PATTERN,
   GEMINI_PROMPT_PATTERN,
   getCliToolPatterns,
   detectThinking,
@@ -19,7 +19,6 @@ import {
   stripAnsi,
   stripBoxDrawing,
 } from '@/lib/detection/cli-patterns';
-import type { CLIToolType } from '@/lib/cli-tools/types';
 
 describe('cli-patterns', () => {
   describe('CODEX_THINKING_PATTERN', () => {
@@ -76,6 +75,115 @@ More text`;
     it('should not match non-prompt lines', () => {
       expect(CODEX_PROMPT_PATTERN.test('Some random text')).toBe(false);
       expect(CODEX_PROMPT_PATTERN.test('> not codex prompt')).toBe(false);
+    });
+  });
+
+  // Issue #890: startup dialog detection so the input-prompt check is not fooled
+  // by dialog option lines like "› 1. Update now".
+  describe('CODEX_DIALOG_PATTERN (Issue #890)', () => {
+    // Real codex captures render the selected option marker "›" at column 0
+    // (same column as the genuine input prompt), which is why "^›" is fooled.
+    const UPDATE_DIALOG = [
+      '✨ Update available! 0.139.0 -> 0.140.0',
+      '› 1. Update now (runs `npm install -g @openai/codex`)',
+      '  2. Skip',
+      '  3. Skip until next version',
+      'Press enter to continue',
+    ].join('\n');
+
+    const TRUST_DIALOG = [
+      'Do you trust the contents of this directory?',
+      '› 1. Yes, continue',
+      '  2. No, quit',
+    ].join('\n');
+
+    it('should match the update notification dialog', () => {
+      expect(CODEX_DIALOG_PATTERN.test(UPDATE_DIALOG)).toBe(true);
+    });
+
+    it('should match the trust dialog', () => {
+      expect(CODEX_DIALOG_PATTERN.test(TRUST_DIALOG)).toBe(true);
+    });
+
+    it('should match a numbered selection option line ("› 1. ...")', () => {
+      expect(CODEX_DIALOG_PATTERN.test('   › 1. Update now')).toBe(true);
+      expect(CODEX_DIALOG_PATTERN.test('› 2. Skip')).toBe(true);
+    });
+
+    it('should match the "Press enter to continue" footer', () => {
+      expect(CODEX_DIALOG_PATTERN.test('Press enter to continue')).toBe(true);
+    });
+
+    it('should NOT match a genuine empty or suggestion prompt', () => {
+      expect(CODEX_DIALOG_PATTERN.test('› ')).toBe(false);
+      expect(CODEX_DIALOG_PATTERN.test('› Find and fix a bug in @filename')).toBe(false);
+    });
+  });
+
+  describe('isCodexPromptReady (Issue #890)', () => {
+    it('should be true for a genuine empty prompt', () => {
+      expect(isCodexPromptReady('› ')).toBe(true);
+    });
+
+    it('should be true for a genuine prompt with placeholder suggestion', () => {
+      expect(isCodexPromptReady('› Find and fix a bug in @filename')).toBe(true);
+    });
+
+    it('should be FALSE while the update dialog is active (prompt pattern matches "› 1.")', () => {
+      const output = [
+        '✨ Update available! 0.139.0 -> 0.140.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        'Press enter to continue',
+      ].join('\n');
+      // Sanity: the legacy prompt pattern alone is fooled by the "› 1." option line.
+      expect(CODEX_PROMPT_PATTERN.test(output)).toBe(true);
+      // The hardened check rejects it.
+      expect(isCodexPromptReady(output)).toBe(false);
+    });
+
+    it('should be FALSE while the trust dialog is active', () => {
+      const output = [
+        'Do you trust the contents of this directory?',
+        '› 1. Yes, continue',
+        '  2. No, quit',
+      ].join('\n');
+      // "^›" matches the "› 1." option line, but the dialog guard rejects it.
+      expect(CODEX_PROMPT_PATTERN.test(output)).toBe(true);
+      expect(isCodexPromptReady(output)).toBe(false);
+    });
+
+    it('should be FALSE for non-prompt output (no › at all)', () => {
+      expect(isCodexPromptReady('Loading Codex...')).toBe(false);
+    });
+
+    // Issue #890 regression: after skipping the update, codex keeps a NON-interactive
+    // "✨ Update available!" banner box rendered above the genuine prompt. The prompt
+    // must still be considered ready -- matching "Update available" here would hang
+    // waitForReady / waitForPrompt for the whole timeout window.
+    it('should be TRUE when the persistent post-skip "Update available" banner coexists with the prompt', () => {
+      const output = [
+        '╭──────────────────────────────────────────────────╮',
+        '│ ✨ Update available! 0.139.0 -> 0.140.0          │',
+        '│ Run npm install -g @openai/codex to update.      │',
+        '╰──────────────────────────────────────────────────╯',
+        '',
+        '› Summarize recent commits',
+      ].join('\n');
+      expect(isCodexPromptReady(output)).toBe(true);
+    });
+
+    it('should still be FALSE for the INTERACTIVE update dialog (detected without "Update available")', () => {
+      const output = [
+        '✨ Update available! 0.139.0 -> 0.140.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        '  3. Skip until next version',
+        'Press enter to continue',
+      ].join('\n');
+      // The interactive dialog is detected via "› 1.", "Skip until next version",
+      // and "Press enter to continue" -- never via the "Update available" substring.
+      expect(isCodexPromptReady(output)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## 概要

Closes #890

codex CLI の初回起動時、update 通知ダイアログ / trust ダイアログの処理が不安定で、(1) 番号選択への余分な Enter による誤確定・空送信、(2) ダイアログ画面を入力プロンプトと誤検出して最初のメッセージをダイアログに打ち込む、という問題があった。これを決定的に修正する。

## 根本原因

- codex の番号選択ダイアログ（"Update available" / "Do you trust"）は**数字キー単体で即確定**する。`waitForReady` が `sendKeys('2', true)` / `sendKeys('1', true)` のように Enter 付きで送っていたため、確定後の次画面に余分な Enter が落ち、空送信や意図しない "Update now" 確定を招いていた。
- プロンプト判定が `CODEX_PROMPT_PATTERN`（`^›`）のみで、ダイアログの選択中行 "› 1. ..." を本物の入力プロンプトと誤検出していた。`waitForPrompt` に至ってはガードが無く、残存ダイアログへ最初のメッセージを誤送信し得た。

## 修正内容（対策 A + B）

### A. 番号選択を Enter なしで送信
- `waitForReady` の update skip / trust 選択を `sendKeys('2', false)` / `sendKeys('1', false)` に変更。codex は番号即確定のため迷子 Enter を排除。

### B. プロンプト判定の堅牢化（ダイアログ行を除外）
- `CODEX_DIALOG_PATTERN` と `isCodexPromptReady()` を `cli-patterns.ts` に追加。`waitForReady` と、従来ガード無しだった `waitForPrompt` の両方に適用し、残存ダイアログへの誤送信を防止。
- ダイアログ判定は**対話的マーカーのみ**（`Skip until next version` / `Do you trust` / `Press enter to continue` / 番号選択行 `^\s*›\s*\d+\.\s`）。

### 回帰対策（重要）
- update を skip した後も codex は**非対話の常駐バナー**（`✨ Update available! ... / Run npm install -g @openai/codex to update.`）を本物プロンプト上部に表示し続ける（実機検証済み）。`Update available` をダイアログマーカーにすると、本物プロンプトでも `isCodexPromptReady()` が常時 false となり `waitForReady`(~30s)/`waitForPrompt`(15s) がタイムアウトする＝まさに本Issueの「初回起動＋update pending」ケースで遅延する。このため `Update available` はマーカーから意図的に除外。対話的 update ダイアログは残り3マーカーで依然確実に検出される。

### スコープ外
- update の自動適用（"Update now" 実行）は対象外。従来どおり Skip。

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `src/lib/cli-tools/codex.ts` | A: 番号選択を Enter なしに / B: `isCodexPromptReady` を waitForReady・waitForPrompt に適用 |
| `src/lib/detection/cli-patterns.ts` | `CODEX_DIALOG_PATTERN` / `isCodexPromptReady()` 追加（常駐バナー誤検出を回避） |
| `tests/unit/cli-tools/codex-startup-dialog.test.ts` | A/B + 常駐バナー共存時の回帰テスト（新規） |
| `tests/unit/lib/cli-patterns.test.ts` | `CODEX_DIALOG_PATTERN` / `isCodexPromptReady` テスト追加 |

## 品質チェック

| 項目 | 結果 |
|------|------|
| npm run lint | ✅ Pass |
| npx tsc --noEmit | ✅ Pass (exit 0) |
| npm run test:unit | ✅ Pass (7807 tests) |
| npm run build | ✅ Compiled successfully |

🤖 Generated with [Claude Code](https://claude.com/claude-code)