### PR TITLE
fix(codex): 位置ベース判定で scrollback 残存ダイアログの誤検出とタイムアウト後送信を解消 (#892)

### DIFF
--- a/src/lib/cli-tools/codex.ts
+++ b/src/lib/cli-tools/codex.ts
@@ -15,7 +15,7 @@ import {
 } from '../tmux/tmux';
 import { detectAndResendIfPastedText } from '../pasted-text-helper';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
-import { isCodexPromptReady, stripAnsi } from '../detection/cli-patterns';
+import { isCodexPromptReady, getCodexActiveDialog, stripAnsi } from '../detection/cli-patterns';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
@@ -124,6 +124,10 @@ export class CodexTool extends BaseCLITool {
    * Polls until a genuine interactive prompt is detected or max attempts reached.
    */
   private async waitForReady(sessionName: string): Promise<void> {
+    // Issue #892: one-shot guards. capturePane(50) keeps a dismissed dialog in
+    // scrollback, so a key must be sent at most once per dialog -- otherwise the
+    // update branch re-sends "2" every poll and the live prompt gets "222...".
+    let updateDialogHandled = false;
     let trustDialogHandled = false;
     for (let i = 0; i < CODEX_INIT_MAX_ATTEMPTS; i++) {
       try {
@@ -131,25 +135,31 @@ export class CodexTool extends BaseCLITool {
         const output = stripAnsi(rawOutput);
 
         // Check if the genuine interactive input prompt is ready.
-        // Issue #890: CODEX_PROMPT_PATTERN also matches dialog option lines
-        // (e.g. "› 1. Update now"), so isCodexPromptReady() additionally rejects
-        // any still-active update/trust dialog before returning.
+        // Issue #892: isCodexPromptReady() is position-based -- a genuine "› " line
+        // below stale dialog scrollback IS ready, while an active dialog (option
+        // line "› 1." as the bottom element) is not.
         if (isCodexPromptReady(output)) {
           logger.info('codex-prompt-detected');
           return;
         }
 
+        // Issue #892: classify the bottom-most ACTIVE dialog by position. A dialog
+        // whose text is only residual scrollback above a genuine prompt returns
+        // null here, so no stray key is sent after it has been dismissed.
+        const activeDialog = getCodexActiveDialog(output);
+
         // Handle update notification BEFORE trust dialog check.
         // Update notification shows: › 1. Update now / 2. Skip / 3. Skip until next version
         // followed by "Press enter to continue". Must send "2" (Skip) to avoid
         // triggering npm install which kills the Codex process.
-        if (output.includes('Update') && output.includes('Skip')) {
+        if (activeDialog === 'update' && !updateDialogHandled) {
           // Issue #890: Codex confirms a numbered selection instantly (no Enter).
           // Appending Enter (sendEnter=true) would land on the NEXT screen as a
           // stray keypress -- an empty submit on the main prompt, or worst case the
           // default "1. Update now" confirm if "2" was dropped during a re-render.
           // Send "2" alone and let the next poll observe the result.
           await sendKeys(sessionName, '2', false);
+          updateDialogHandled = true;
           logger.info('skipped-codex-update');
           await new Promise((resolve) => setTimeout(resolve, CODEX_DIALOG_SETTLE_MS));
           continue;
@@ -158,7 +168,7 @@ export class CodexTool extends BaseCLITool {
         // Handle "Press enter to continue" (genuine press-enter screens only).
         // Numbered selection dialogs are dismissed by the number key above, so this
         // branch is reached only when no number selection is pending.
-        if (output.includes('Press enter to continue')) {
+        if (activeDialog === 'press-enter') {
           await sendSpecialKey(sessionName, 'Enter');
           logger.info('dismissed-codex-notification');
           await new Promise((resolve) => setTimeout(resolve, CODEX_DIALOG_SETTLE_MS));
@@ -167,7 +177,7 @@ export class CodexTool extends BaseCLITool {
 
         // Handle trust dialog: "Do you trust the contents of this directory?"
         // Options: › 1. Yes, continue / 2. No, quit
-        if (!trustDialogHandled && output.includes('Do you trust')) {
+        if (activeDialog === 'trust' && !trustDialogHandled) {
           // Issue #890: number-key selection confirms instantly; no trailing Enter.
           await sendKeys(sessionName, '1', false);
           trustDialogHandled = true;
@@ -186,6 +196,13 @@ export class CodexTool extends BaseCLITool {
   /**
    * Wait for Codex prompt before sending a message.
    * Used by sendMessage to ensure Codex is ready to accept input.
+   *
+   * Issue #892: throws on timeout instead of falling through. The previous version
+   * only logged and returned, so sendMessage typed the message regardless of
+   * readiness -- the exact path that let "222..." (or an empty submit) reach the
+   * session when detection failed. A failed readiness check must STOP the send.
+   *
+   * @throws Error when the genuine input prompt is not detected within the timeout
    */
   private async waitForPrompt(sessionName: string): Promise<void> {
     const startTime = Date.now();
@@ -194,9 +211,9 @@ export class CodexTool extends BaseCLITool {
       try {
         const rawOutput = await capturePane(sessionName, 50);
         const output = stripAnsi(rawOutput);
-        // Issue #890: apply the same dialog guard as waitForReady so a residual
-        // update/trust dialog ("› 1. ...") is never mistaken for a ready prompt,
-        // which would type the first message straight into the dialog.
+        // Issue #890/#892: position-based guard so a residual update/trust dialog
+        // ("› 1. ...") is never mistaken for a ready prompt -- yet a genuine "› "
+        // prompt below stale dialog scrollback IS accepted.
         if (isCodexPromptReady(output)) {
           return;
         }
@@ -206,6 +223,9 @@ export class CodexTool extends BaseCLITool {
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
     logger.info('codex-prompt-not');
+    throw new Error(
+      'Codex prompt not ready: timed out waiting for the input prompt before sending'
+    );
   }
 
   /**

--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -128,17 +128,103 @@ export const CODEX_DIALOG_PATTERN =
   /Skip until next version|Do you trust|Press enter to continue|^\s*›\s*\d+\.\s/m;
 
 /**
- * Decide whether Codex output shows a genuine interactive input prompt rather than
- * a startup dialog (Issue #890).
+ * Codex genuine input-prompt line (Issue #892).
  *
- * Returns true only when the prompt pattern matches AND no update/trust dialog
- * marker is present. Used by both CodexTool.waitForReady() (startup) and
- * CodexTool.waitForPrompt() (before every send) so a residual dialog is never
- * mistaken for "ready", which would otherwise type the first message into the
- * dialog or fire a stray Enter.
+ * A line whose first non-space glyph is "›" but which is NOT a numbered dialog
+ * option ("› 1. ..."). The selected dialog option renders "›" at column 0 too
+ * (same column as the live prompt), so the digit-dot negative lookahead is what
+ * distinguishes the genuine input line from a dialog option line. Single-line
+ * (no /m, no /g) -- callers test it per line to locate the prompt's position.
+ */
+const CODEX_GENUINE_PROMPT_LINE = /^\s*›(?!\s*\d+\.)/;
+
+/**
+ * Decide whether Codex output shows a genuine interactive input prompt rather than
+ * a startup dialog (Issue #890, reworked in Issue #892).
+ *
+ * POSITION-based: capturePane(50) returns scrollback, so a dismissed update/trust
+ * dialog lingers ABOVE the live prompt. The original Issue #890 form
+ * (`CODEX_PROMPT_PATTERN && !CODEX_DIALOG_PATTERN`) is a whole-window test, so a
+ * residual dialog line anywhere in the frame keeps it false forever -- hanging
+ * waitForReady/waitForPrompt and (via the re-firing branches) injecting "222...".
+ *
+ * Instead the frame is ready when a genuine input-prompt line sits BELOW every
+ * interactive dialog marker -- i.e. the prompt is the bottom-most active element.
+ * CODEX_PROMPT_PATTERN / CODEX_DIALOG_PATTERN are intentionally unchanged here
+ * (status-detector.ts / response-checker.ts depend on them).
+ *
+ * Used by both CodexTool.waitForReady() (startup) and CodexTool.waitForPrompt()
+ * (before every send) so a residual dialog is never mistaken for "ready" and, just
+ * as importantly, a genuine prompt below stale dialog scrollback IS detected.
  */
 export function isCodexPromptReady(output: string): boolean {
-  return CODEX_PROMPT_PATTERN.test(output) && !CODEX_DIALOG_PATTERN.test(output);
+  const lines = output.split('\n');
+  let lastDialogMarkerIdx = -1;
+  let lastPromptIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (CODEX_DIALOG_PATTERN.test(line)) {
+      // A dialog marker/option line is never itself a genuine prompt.
+      lastDialogMarkerIdx = i;
+      continue;
+    }
+    if (CODEX_GENUINE_PROMPT_LINE.test(line)) {
+      lastPromptIdx = i;
+    }
+  }
+  return lastPromptIdx >= 0 && lastPromptIdx > lastDialogMarkerIdx;
+}
+
+/**
+ * The bottom-most active Codex startup dialog awaiting a key press (Issue #892).
+ * `null` means no dialog needs handling -- either none is present, or the only
+ * dialog text is residual scrollback above a genuine prompt.
+ */
+export type CodexActiveDialog = 'update' | 'press-enter' | 'trust' | null;
+
+/**
+ * Classify the bottom-most active Codex startup dialog (Issue #892).
+ *
+ * POSITION-based companion to isCodexPromptReady(): only dialog text appearing
+ * BELOW the genuine input-prompt line is considered "active". Dialog lines that
+ * remain in scrollback ABOVE a live prompt are ignored, so a dismissed dialog is
+ * never re-acted on (this is what stops the update branch from re-sending "2" once
+ * the dialog has been skipped -- the root cause of the "222..." prefix).
+ *
+ * Precedence matches CodexTool.waitForReady()'s historical branch order: the
+ * update dialog wins over its own "Press enter to continue" footer, because Enter
+ * on the update dialog could confirm the default "1. Update now" (npm install).
+ */
+export function getCodexActiveDialog(output: string): CodexActiveDialog {
+  const lines = output.split('\n');
+  // Index of the bottom-most genuine input-prompt line (-1 if none).
+  let promptIdx = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (CODEX_GENUINE_PROMPT_LINE.test(lines[i])) {
+      promptIdx = i;
+      break;
+    }
+  }
+  // Active region = lines strictly below the genuine prompt (the whole frame when
+  // there is no genuine prompt). Residual dialog text above a live prompt is
+  // excluded, so a dialog lingering in scrollback is never treated as active.
+  const active = lines.slice(promptIdx + 1).join('\n');
+  if (active === '') {
+    return null;
+  }
+  if (
+    active.includes('Skip until next version') ||
+    (active.includes('Update') && active.includes('Skip'))
+  ) {
+    return 'update';
+  }
+  if (active.includes('Do you trust')) {
+    return 'trust';
+  }
+  if (active.includes('Press enter to continue')) {
+    return 'press-enter';
+  }
+  return null;
 }
 
 /**

--- a/tests/unit/cli-tools/codex-startup-dialog.test.ts
+++ b/tests/unit/cli-tools/codex-startup-dialog.test.ts
@@ -84,6 +84,20 @@ const READY_WITH_BANNER = [
   '› Summarize recent commits',
 ].join('\n');
 
+// Issue #892: capturePane(50) returns scrollback, so the just-dismissed update
+// dialog stays in the SAME capture ABOVE the now-live genuine prompt. This is the
+// real-device frame the Issue #890 whole-window check missed -- it stayed "not
+// ready" forever (hang) AND kept re-matching "Update"+"Skip", re-sending "2" every
+// poll ("222..."). Position-based detection must treat this as READY.
+const UPDATE_RESIDUAL_PLUS_PROMPT = [
+  '✨ Update available! 0.139.0 -> 0.140.0',
+  '› 1. Update now (runs `npm install -g @openai/codex`)',
+  '  2. Skip',
+  '  3. Skip until next version',
+  'Press enter to continue',
+  '› ',
+].join('\n');
+
 describe('CodexTool first-launch dialog handling (Issue #890)', () => {
   let tool: CodexTool;
 
@@ -218,6 +232,96 @@ describe('CodexTool first-launch dialog handling (Issue #890)', () => {
       expect(vi.mocked(capturePane).mock.calls.length).toBeLessThanOrEqual(2);
       expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello world', false);
       expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+    });
+  });
+
+  // Issue #892: scrollback retention of a dismissed dialog in the SAME capture.
+  describe('residual dialog + genuine prompt coexist in one capture (Issue #892)', () => {
+    it('waitForReady: sends update "2" exactly ONCE and never re-sends on the residual dialog ("222..." guard)', async () => {
+      vi.mocked(hasSession).mockResolvedValue(false);
+      vi.mocked(capturePane)
+        .mockResolvedValueOnce(UPDATE_DIALOG)                // active dialog -> send "2"
+        .mockResolvedValueOnce(UPDATE_DIALOG)                // transient: dialog still bottom, must NOT re-send
+        .mockResolvedValue(UPDATE_RESIDUAL_PLUS_PROMPT);     // dialog now residual above the live prompt -> ready
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.startSession(WORKTREE_ID, '/test/path');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // The core "222..." regression: "2" must be sent exactly once even though the
+      // dialog text re-appears in later captures (transient + residual scrollback).
+      const skipCalls = vi.mocked(sendKeys).mock.calls.filter(
+        (c) => c[0] === SESSION && c[1] === '2'
+      );
+      expect(skipCalls).toHaveLength(1);
+    });
+
+    it('waitForReady: treats the residual-dialog-above-prompt frame as ready without sending any number key', async () => {
+      vi.mocked(hasSession).mockResolvedValue(false);
+      vi.mocked(capturePane).mockResolvedValue(UPDATE_RESIDUAL_PLUS_PROMPT);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.startSession(WORKTREE_ID, '/test/path');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // Genuine prompt is below the stale dialog -> ready on the first poll, no keys.
+      expect(vi.mocked(capturePane).mock.calls.length).toBeLessThanOrEqual(2);
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '2', false);
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '1', false);
+    });
+
+    it('waitForPrompt: sends the message immediately when a stale dialog sits above the live prompt', async () => {
+      vi.mocked(hasSession).mockResolvedValue(true);
+      vi.mocked(capturePane).mockResolvedValue(UPDATE_RESIDUAL_PLUS_PROMPT);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.sendMessage(WORKTREE_ID, 'explain this branch');
+        await vi.runAllTimersAsync();
+        await promise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // No "2" prefix is injected; the message is delivered cleanly.
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '2', false);
+      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'explain this branch', false);
+      expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+    });
+  });
+
+  // Issue #892: fall-through removal -- a failed readiness check must STOP the send.
+  describe('waitForPrompt timeout does not send the message (Issue #892)', () => {
+    it('throws (no message typed) when the prompt never becomes ready before the timeout', async () => {
+      vi.mocked(hasSession).mockResolvedValue(true);
+      // Dialog stays active forever -> isCodexPromptReady never true -> timeout.
+      vi.mocked(capturePane).mockResolvedValue(UPDATE_DIALOG);
+
+      vi.useFakeTimers();
+      try {
+        const promise = tool.sendMessage(WORKTREE_ID, 'should never be typed');
+        const assertion = expect(promise).rejects.toThrow(
+          /Failed to send message to Codex/
+        );
+        await vi.runAllTimersAsync();
+        await assertion;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // The whole point: on timeout the message is NOT typed and Enter is NOT sent.
+      expect(sendKeys).not.toHaveBeenCalledWith(SESSION, 'should never be typed', false);
+      expect(sendSpecialKey).not.toHaveBeenCalledWith(SESSION, 'C-m');
     });
   });
 });

--- a/tests/unit/lib/cli-patterns.test.ts
+++ b/tests/unit/lib/cli-patterns.test.ts
@@ -9,6 +9,7 @@ import {
   CODEX_PROMPT_PATTERN,
   CODEX_DIALOG_PATTERN,
   isCodexPromptReady,
+  getCodexActiveDialog,
   PASTED_TEXT_PATTERN,
   PASTED_TEXT_DETECT_DELAY,
   MAX_PASTED_TEXT_RETRIES,
@@ -184,6 +185,117 @@ More text`;
       // The interactive dialog is detected via "› 1.", "Skip until next version",
       // and "Press enter to continue" -- never via the "Update available" substring.
       expect(isCodexPromptReady(output)).toBe(false);
+    });
+  });
+
+  // Issue #892: capturePane(50) returns scrollback, so a dismissed update/trust
+  // dialog can remain in the SAME capture ABOVE the now-live genuine prompt. The
+  // whole-window Issue #890 form stayed false here forever (hang + "222..." re-send);
+  // position-based detection treats the bottom-most genuine prompt as ready.
+  describe('isCodexPromptReady - position-based (Issue #892)', () => {
+    it('is TRUE when a dismissed update dialog lingers in scrollback ABOVE the live prompt', () => {
+      const output = [
+        '✨ Update available! 0.139.0 -> 0.140.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        '  3. Skip until next version',
+        'Press enter to continue',
+        '› ',
+      ].join('\n');
+      // The whole-window check (CODEX_DIALOG_PATTERN.test) still matches the stale
+      // dialog lines -- proving the regression scenario -- yet the prompt is ready.
+      expect(CODEX_DIALOG_PATTERN.test(output)).toBe(true);
+      expect(isCodexPromptReady(output)).toBe(true);
+    });
+
+    it('is TRUE when a dismissed trust dialog lingers in scrollback ABOVE the live prompt', () => {
+      const output = [
+        'Do you trust the contents of this directory?',
+        '› 1. Yes, continue',
+        '  2. No, quit',
+        '',
+        '› ',
+      ].join('\n');
+      expect(CODEX_DIALOG_PATTERN.test(output)).toBe(true);
+      expect(isCodexPromptReady(output)).toBe(true);
+    });
+
+    it('is TRUE for a genuine prompt carrying a suggestion below residual dialog lines', () => {
+      const output = [
+        'Press enter to continue',
+        '› Summarize recent commits',
+      ].join('\n');
+      expect(isCodexPromptReady(output)).toBe(true);
+    });
+
+    it('is FALSE while the dialog is the bottom-most element (no genuine prompt below)', () => {
+      const output = [
+        '› ',
+        '✨ Update available! 0.139.0 -> 0.140.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        '  3. Skip until next version',
+        'Press enter to continue',
+      ].join('\n');
+      // A genuine "› " appears, but it is ABOVE the active dialog -- not ready.
+      expect(isCodexPromptReady(output)).toBe(false);
+    });
+  });
+
+  describe('getCodexActiveDialog (Issue #892)', () => {
+    it('classifies an active update dialog', () => {
+      const output = [
+        '✨ Update available! 0.139.0 -> 0.140.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        '  3. Skip until next version',
+        'Press enter to continue',
+      ].join('\n');
+      expect(getCodexActiveDialog(output)).toBe('update');
+    });
+
+    it('classifies an active trust dialog', () => {
+      const output = [
+        'Do you trust the contents of this directory?',
+        '› 1. Yes, continue',
+        '  2. No, quit',
+      ].join('\n');
+      expect(getCodexActiveDialog(output)).toBe('trust');
+    });
+
+    it('classifies a standalone press-enter screen', () => {
+      const output = ['Some release notes', 'Press enter to continue'].join('\n');
+      expect(getCodexActiveDialog(output)).toBe('press-enter');
+    });
+
+    it('returns null for a genuine prompt with no dialog', () => {
+      expect(getCodexActiveDialog('› ')).toBeNull();
+    });
+
+    it('returns null when the dialog is only residual scrollback ABOVE the live prompt', () => {
+      // The core "222..." fix: a dismissed update dialog left in scrollback must NOT
+      // be treated as active, so waitForReady does not re-send "2".
+      const output = [
+        '✨ Update available! 0.139.0 -> 0.140.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        '  3. Skip until next version',
+        'Press enter to continue',
+        '› ',
+      ].join('\n');
+      expect(getCodexActiveDialog(output)).toBeNull();
+    });
+
+    it('prefers update over its own "Press enter to continue" footer', () => {
+      const output = [
+        '› 1. Update now',
+        '  2. Skip',
+        '  3. Skip until next version',
+        'Press enter to continue',
+      ].join('\n');
+      // Enter on the update dialog could confirm "1. Update now" (npm install), so
+      // the update classification must win over the footer.
+      expect(getCodexActiveDialog(output)).toBe('update');
     });
   });
 


### PR DESCRIPTION
## 概要

Issue #892 — #890（PR #891）の残存バグ修正。codex 初回起動時、ユーザー入力の前に `222...` が混入する事象（実機 `› 22222222222222222222222222222このブランチについて教えて`）を解消する。

Closes #892

## 根本原因

`capturePane(sessionName, 50)` は scrollback 込みの直近50行を返す。codex は dismiss したダイアログを画面から消しても scrollback に残すため、whole-window の `CODEX_PROMPT_PATTERN && !CODEX_DIALOG_PATTERN` 判定が残存テキストに反応し続けた：

1. `isCodexPromptReady` が残存ダイアログ行で **false に張り付く** → `waitForReady` / `waitForPrompt` がタイムアウト。
2. update 分岐（handled ガード無し）が `Update`+`Skip` 残存に毎ポーリングでマッチ → `'2'` を再送 → `222...`。
3. `waitForPrompt` がタイムアウト後も **fall-through で送信** → 検出失敗が即・誤入力に直結。

## 修正（`CODEX_PROMPT_PATTERN` / `CODEX_DIALOG_PATTERN` の定義は不変）

- **`isCodexPromptReady` を位置ベース化**（`cli-patterns.ts`）: 本物プロンプト行（`^›` かつ `› N.` でない）が**全ダイアログマーカーより下＝最下部のアクティブ要素**のとき ready。残存スクロールバック上の `› ` プロンプトを正しく検出。
- **`getCodexActiveDialog`（新規ヘルパー）**: 本物プロンプトより下の領域のみを分類。残存スクロールバックは `null` を返し、消えたダイアログに再アクションしない（`'2'` 連打の根本対策）。update はその footer（`Press enter to continue`）より優先（Enter が `1. Update now`＝npm install を確定し得るため）。
- **`waitForReady` の全分岐を `getCodexActiveDialog` で gating** + `updateDialogHandled` one-shot ガード（`trustDialogHandled` と対称）→ `'2'` 再送を構造的に防止。
- **`waitForPrompt` をタイムアウト時 throw**（fall-through 廃止）→ `sendMessage` が盲打ちせず中断。

## テスト（同一capture内のダイアログ残存＋本物プロンプト共存を新規にカバー）

- 残存 update/trust ダイアログが live プロンプト上にある frame → `isCodexPromptReady` = true
- ダイアログが最下部（本物プロンプト無し）→ false
- `waitForReady`: `'2'` を厳密に1回のみ送信・残存で再送しない（222ガード）
- `waitForPrompt`: タイムアウト時 throw（メッセージ非送信）
- `getCodexActiveDialog`: active update/trust/press-enter 分類・残存スクロールバックは null・update 優先

## 品質チェック

| 項目 | worker | orchestrator独立検証 |
|------|--------|---------------------|
| npm run lint | ✅ | ✅ No warnings/errors |
| npx tsc --noEmit | ✅ | ✅ exit 0 |
| npm run test:unit | ✅ 7826 passed | ✅ 対象2ファイル 89 passed |
| npm run build | ✅ succeeded | — (CI) |

## copilot / gemini 水平調査（本PRスコープ外・別PR推奨）

両者とも `capturePane(50/200)` + whole-window prompt 判定 + 非throw タイムアウトの同型アンチパターンを持つが、codex のような番号キー再送ループは無い（copilot は `COPILOT_PROMPT_PATTERN` テストのみでキー送信なし、gemini は trust-Enter を guard 付きで1回）。→ `222...` 症状は無く、低重大度の premature-send リスクのみ。同じ位置ベース化＋throw-on-timeout を別PRで適用推奨。

## 残存考慮（フォローアップ候補）

初回起動・未信頼ディレクトリで update→trust の順にダイアログが出て、かつ `Skip until next version` が trust ダイアログ表示中も scrollback に残るケースでは、本物プロンプトが無いため `getCodexActiveDialog` が `update` を返し trust 分岐に到達しない可能性がある。ただし update 既処理ガードにより誤送信は起こらず、最悪でも trust 未処理→送信時に明示 throw（従来の `'2'`＝No,quit でcodex終了より安全）。ユーザーの実利用（信頼済みディレクトリ・update のみ）では発生しない。
