### PR TITLE
feat: Home にリポジトリ別の軽量 ToDo 機能を追加

### DIFF
--- a/src/app/api/repositories/[id]/todos/[todoId]/route.ts
+++ b/src/app/api/repositories/[id]/todos/[todoId]/route.ts
@@ -1,0 +1,134 @@
+/**
+ * API Route: /api/repositories/:id/todos/:todoId
+ * PATCH: Updates a specific todo (content and/or done state)
+ * DELETE: Deletes a specific todo
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { getTodoById, updateTodo, deleteTodo } from '@/lib/db';
+import { createLogger } from '@/lib/logger';
+import { MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
+
+const logger = createLogger('api/repository-todos');
+
+/**
+ * PATCH /api/repositories/:id/todos/:todoId
+ * Updates a todo's content and/or done state.
+ *
+ * Request body:
+ * - content?: string - New content (non-empty, max 2000 chars)
+ * - done?: boolean - Completion state
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; todoId: string }> }
+) {
+  try {
+    const { id, todoId } = await params;
+    const db = getDbInstance();
+
+    const repository = getRepositoryById(db, id);
+    if (!repository) {
+      return NextResponse.json(
+        { error: `Repository '${id}' not found` },
+        { status: 404 }
+      );
+    }
+
+    const existing = getTodoById(db, todoId);
+    if (!existing || existing.repositoryId !== id) {
+      return NextResponse.json(
+        { error: `Todo '${todoId}' not found` },
+        { status: 404 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { content, done } = body;
+
+    if (content === undefined && done === undefined) {
+      return NextResponse.json(
+        { error: 'content or done is required' },
+        { status: 400 }
+      );
+    }
+
+    let trimmed: string | undefined;
+    if (content !== undefined) {
+      if (typeof content !== 'string' || content.trim().length === 0) {
+        return NextResponse.json(
+          { error: 'content must be a non-empty string' },
+          { status: 400 }
+        );
+      }
+      trimmed = content.trim();
+      if (trimmed.length > MAX_TODO_CONTENT_LENGTH) {
+        return NextResponse.json(
+          { error: `content must be ${MAX_TODO_CONTENT_LENGTH} characters or less` },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (done !== undefined && typeof done !== 'boolean') {
+      return NextResponse.json(
+        { error: 'done must be a boolean' },
+        { status: 400 }
+      );
+    }
+
+    updateTodo(db, todoId, { content: trimmed, done });
+
+    const updatedTodo = getTodoById(db, todoId);
+
+    return NextResponse.json({ todo: updatedTodo }, { status: 200 });
+  } catch (error) {
+    logger.error('error-updating-todo:', { error: error instanceof Error ? error.message : String(error) });
+    return NextResponse.json(
+      { error: 'Failed to update todo' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/repositories/:id/todos/:todoId
+ * Deletes a specific todo.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; todoId: string }> }
+) {
+  try {
+    const { id, todoId } = await params;
+    const db = getDbInstance();
+
+    const repository = getRepositoryById(db, id);
+    if (!repository) {
+      return NextResponse.json(
+        { error: `Repository '${id}' not found` },
+        { status: 404 }
+      );
+    }
+
+    const existing = getTodoById(db, todoId);
+    if (!existing || existing.repositoryId !== id) {
+      return NextResponse.json(
+        { error: `Todo '${todoId}' not found` },
+        { status: 404 }
+      );
+    }
+
+    deleteTodo(db, todoId);
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    logger.error('error-deleting-todo:', { error: error instanceof Error ? error.message : String(error) });
+    return NextResponse.json(
+      { error: 'Failed to delete todo' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/repositories/[id]/todos/route.ts
+++ b/src/app/api/repositories/[id]/todos/route.ts
@@ -1,0 +1,115 @@
+/**
+ * API Route: /api/repositories/:id/todos
+ * GET: Returns all todos for a repository
+ * POST: Creates a new todo for a repository
+ *
+ * Global Home ToDo feature: lightweight, checkbox-style notes scoped to a
+ * repository (repositories.id).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getRepositoryById } from '@/lib/db/db-repository';
+import { getTodosByRepositoryId, createTodo } from '@/lib/db';
+import { createLogger } from '@/lib/logger';
+import { MAX_TODOS_PER_REPOSITORY, MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
+
+const logger = createLogger('api/repository-todos');
+
+/**
+ * GET /api/repositories/:id/todos
+ * Returns all todos for a repository sorted by position.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const db = getDbInstance();
+
+    const repository = getRepositoryById(db, id);
+    if (!repository) {
+      return NextResponse.json(
+        { error: `Repository '${id}' not found` },
+        { status: 404 }
+      );
+    }
+
+    const todos = getTodosByRepositoryId(db, id);
+
+    return NextResponse.json({ todos }, { status: 200 });
+  } catch (error) {
+    logger.error('error-fetching-todos:', { error: error instanceof Error ? error.message : String(error) });
+    return NextResponse.json(
+      { error: 'Failed to fetch todos' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/repositories/:id/todos
+ * Creates a new todo for a repository.
+ *
+ * Request body:
+ * - content: string - ToDo text (required, non-empty, max 2000 chars)
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const db = getDbInstance();
+
+    const repository = getRepositoryById(db, id);
+    if (!repository) {
+      return NextResponse.json(
+        { error: `Repository '${id}' not found` },
+        { status: 404 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { content } = body;
+
+    // Validate content
+    if (typeof content !== 'string' || content.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'content is required' },
+        { status: 400 }
+      );
+    }
+
+    const trimmed = content.trim();
+    if (trimmed.length > MAX_TODO_CONTENT_LENGTH) {
+      return NextResponse.json(
+        { error: `content must be ${MAX_TODO_CONTENT_LENGTH} characters or less` },
+        { status: 400 }
+      );
+    }
+
+    // Check todo limit
+    const existing = getTodosByRepositoryId(db, id);
+    if (existing.length >= MAX_TODOS_PER_REPOSITORY) {
+      return NextResponse.json(
+        { error: `Maximum todo limit (${MAX_TODOS_PER_REPOSITORY}) reached` },
+        { status: 400 }
+      );
+    }
+
+    const todo = createTodo(db, id, {
+      content: trimmed,
+      position: existing.length,
+    });
+
+    return NextResponse.json({ todo }, { status: 201 });
+  } catch (error) {
+    logger.error('error-creating-todo:', { error: error instanceof Error ? error.message : String(error) });
+    return NextResponse.json(
+      { error: 'Failed to create todo' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { AppShell } from '@/components/layout';
 import { HomeSessionSummary } from '@/components/home/HomeSessionSummary';
+import { TodoWidget } from '@/components/home/TodoWidget';
 import type { Worktree } from '@/types/models';
 
 /**
@@ -157,6 +158,12 @@ export default function Home() {
         <div className="mb-8">
           <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">Session Overview</h2>
           <HomeSessionSummary worktrees={worktrees} />
+        </div>
+
+        {/* ToDo */}
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">ToDo</h2>
+          <TodoWidget />
         </div>
 
         {/* Shortcut Cards */}

--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -1,0 +1,298 @@
+/**
+ * TodoWidget Component
+ *
+ * Home page lightweight ToDo widget. A single global widget where the user
+ * picks a target repository and jots down checkbox-style ToDo / memo items
+ * scoped to that repository.
+ *
+ * Repository list is fetched from GET /api/worktrees (the same `repositories`
+ * array used by the Home Assistant chat). ToDos are keyed by repository id and
+ * persisted via /api/repositories/:id/todos.
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { todoApi, type TodoItem } from '@/lib/api/todo-api';
+import { MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
+
+interface RepositoryOption {
+  id: string;
+  path: string;
+  name: string;
+  displayName?: string;
+}
+
+/** localStorage key remembering the last-selected repository for the widget. */
+const SELECTED_REPO_KEY = 'commandmate-home-todo-repo';
+
+function repoLabel(repo: RepositoryOption): string {
+  return repo.displayName?.trim() || repo.name;
+}
+
+export function TodoWidget() {
+  const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
+  const [selectedRepoId, setSelectedRepoId] = useState('');
+  const [todos, setTodos] = useState<TodoItem[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reposLoaded = useRef(false);
+
+  const remainingCount = useMemo(
+    () => todos.filter((t) => !t.done).length,
+    [todos],
+  );
+
+  // Load repositories once.
+  useEffect(() => {
+    async function fetchRepos() {
+      try {
+        const res = await fetch('/api/worktrees');
+        if (!res.ok) {
+          return;
+        }
+        const data = await res.json();
+        const repos: RepositoryOption[] = (data.repositories ?? []).map(
+          (repo: { id: string; path: string; name: string; displayName?: string }) => ({
+            id: repo.id,
+            path: repo.path,
+            name: repo.name,
+            displayName: repo.displayName,
+          }),
+        );
+        setRepositories(repos);
+
+        if (repos.length > 0) {
+          const saved =
+            typeof window !== 'undefined'
+              ? localStorage.getItem(SELECTED_REPO_KEY)
+              : null;
+          const initial =
+            saved && repos.some((r) => r.id === saved) ? saved : repos[0].id;
+          setSelectedRepoId(initial);
+        }
+      } catch {
+        // Silent fetch failure on home page
+      } finally {
+        reposLoaded.current = true;
+      }
+    }
+    void fetchRepos();
+  }, []);
+
+  const loadTodos = useCallback(async (repositoryId: string) => {
+    if (!repositoryId) {
+      setTodos([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const items = await todoApi.list(repositoryId);
+      setTodos(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load todos');
+      setTodos([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Reload todos whenever the selected repository changes.
+  useEffect(() => {
+    if (!selectedRepoId) {
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(SELECTED_REPO_KEY, selectedRepoId);
+    }
+    void loadTodos(selectedRepoId);
+  }, [selectedRepoId, loadTodos]);
+
+  const handleAdd = useCallback(async () => {
+    const content = input.trim();
+    if (!content || !selectedRepoId || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await todoApi.create(selectedRepoId, content);
+      setInput('');
+      await loadTodos(selectedRepoId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add todo');
+    } finally {
+      setBusy(false);
+    }
+  }, [input, selectedRepoId, busy, loadTodos]);
+
+  const handleToggle = useCallback(
+    async (todo: TodoItem) => {
+      if (!selectedRepoId) {
+        return;
+      }
+      // Optimistic update for snappy checkbox feedback.
+      setTodos((prev) =>
+        prev.map((t) => (t.id === todo.id ? { ...t, done: !t.done } : t)),
+      );
+      setError(null);
+      try {
+        await todoApi.update(selectedRepoId, todo.id, { done: !todo.done });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to update todo');
+        void loadTodos(selectedRepoId);
+      }
+    },
+    [selectedRepoId, loadTodos],
+  );
+
+  const handleDelete = useCallback(
+    async (todo: TodoItem) => {
+      if (!selectedRepoId) {
+        return;
+      }
+      setError(null);
+      try {
+        await todoApi.remove(selectedRepoId, todo.id);
+        setTodos((prev) => prev.filter((t) => t.id !== todo.id));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete todo');
+      }
+    },
+    [selectedRepoId],
+  );
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Guard against IME composition (Enter confirms candidate, not submit).
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+        e.preventDefault();
+        void handleAdd();
+      }
+    },
+    [handleAdd],
+  );
+
+  const hasRepositories = repositories.length > 0;
+
+  return (
+    <div
+      className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+      data-testid="home-todo-widget"
+    >
+      {/* Repository selector + remaining count */}
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 min-w-0">
+          <span className="shrink-0">Repository</span>
+          <select
+            value={selectedRepoId}
+            onChange={(e) => setSelectedRepoId(e.target.value)}
+            disabled={!hasRepositories}
+            data-testid="todo-repo-select"
+            className="min-w-0 max-w-[16rem] truncate rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-50"
+          >
+            {repositories.map((repo) => (
+              <option key={repo.id} value={repo.id}>
+                {repoLabel(repo)}
+              </option>
+            ))}
+          </select>
+        </label>
+        {hasRepositories && (
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500" data-testid="todo-remaining">
+            {remainingCount} open
+          </span>
+        )}
+      </div>
+
+      {!hasRepositories ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No repositories yet. Add one from the Repositories screen to start
+          adding todos.
+        </p>
+      ) : (
+        <>
+          {/* Add form */}
+          <div className="flex items-center gap-2 mb-3">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleInputKeyDown}
+              maxLength={MAX_TODO_CONTENT_LENGTH}
+              placeholder="Add a todo…"
+              data-testid="todo-input"
+              className="flex-1 min-w-0 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+            />
+            <button
+              type="button"
+              onClick={handleAdd}
+              disabled={busy || input.trim().length === 0}
+              data-testid="todo-add-button"
+              className="shrink-0 rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-700 disabled:opacity-50"
+            >
+              Add
+            </button>
+          </div>
+
+          {error && (
+            <p className="mb-2 text-xs text-red-600 dark:text-red-400" data-testid="todo-error">
+              {error}
+            </p>
+          )}
+
+          {/* Todo list */}
+          {loading ? (
+            <p className="text-sm text-gray-400 dark:text-gray-500">Loading…</p>
+          ) : todos.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="todo-empty">
+              No todos yet.
+            </p>
+          ) : (
+            <ul className="space-y-1" data-testid="todo-list">
+              {todos.map((todo) => (
+                <li
+                  key={todo.id}
+                  className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/40 group"
+                  data-testid="todo-item"
+                >
+                  <input
+                    type="checkbox"
+                    checked={todo.done}
+                    onChange={() => handleToggle(todo)}
+                    data-testid="todo-checkbox"
+                    aria-label={todo.done ? 'Mark as not done' : 'Mark as done'}
+                    className="shrink-0 h-4 w-4 rounded border-gray-300 text-cyan-600 focus:ring-cyan-400"
+                  />
+                  <span
+                    className={`flex-1 min-w-0 break-words text-sm ${
+                      todo.done
+                        ? 'line-through text-gray-400 dark:text-gray-500'
+                        : 'text-gray-800 dark:text-gray-200'
+                    }`}
+                  >
+                    {todo.content}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(todo)}
+                    aria-label="Delete todo"
+                    data-testid="todo-delete"
+                    className="shrink-0 text-gray-300 hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/config/todo-config.ts
+++ b/src/config/todo-config.ts
@@ -1,0 +1,15 @@
+/**
+ * Repository ToDo Configuration Constants
+ *
+ * Global Home ToDo feature: lightweight, checkbox-style notes scoped to a
+ * repository. Shared between the API route and the Home TodoWidget component.
+ *
+ * - API route: src/app/api/repositories/[id]/todos/route.ts (POST validation)
+ * - Client component: src/components/home/TodoWidget.tsx (UI display control)
+ */
+
+/** Maximum number of ToDo items allowed per repository. */
+export const MAX_TODOS_PER_REPOSITORY = 50;
+
+/** Maximum length (characters) of a single ToDo's content. */
+export const MAX_TODO_CONTENT_LENGTH = 2000;

--- a/src/lib/api/todo-api.ts
+++ b/src/lib/api/todo-api.ts
@@ -1,0 +1,76 @@
+/**
+ * Repository ToDo API client for the Home ToDo widget.
+ */
+
+/** A ToDo item as consumed by the UI. */
+export interface TodoItem {
+  id: string;
+  repositoryId: string;
+  content: string;
+  done: boolean;
+  position: number;
+}
+
+async function parseError(res: Response, fallback: string): Promise<never> {
+  const data = await res.json().catch(() => ({}));
+  throw new Error(data.error || `${fallback} (${res.status})`);
+}
+
+export const todoApi = {
+  async list(repositoryId: string): Promise<TodoItem[]> {
+    const res = await fetch(
+      `/api/repositories/${encodeURIComponent(repositoryId)}/todos`,
+    );
+    if (!res.ok) {
+      return parseError(res, 'Failed to load todos');
+    }
+    const data = (await res.json()) as { todos: TodoItem[] };
+    return data.todos ?? [];
+  },
+
+  async create(repositoryId: string, content: string): Promise<TodoItem> {
+    const res = await fetch(
+      `/api/repositories/${encodeURIComponent(repositoryId)}/todos`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      },
+    );
+    if (!res.ok) {
+      return parseError(res, 'Failed to create todo');
+    }
+    const data = (await res.json()) as { todo: TodoItem };
+    return data.todo;
+  },
+
+  async update(
+    repositoryId: string,
+    todoId: string,
+    updates: { content?: string; done?: boolean },
+  ): Promise<TodoItem> {
+    const res = await fetch(
+      `/api/repositories/${encodeURIComponent(repositoryId)}/todos/${encodeURIComponent(todoId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      },
+    );
+    if (!res.ok) {
+      return parseError(res, 'Failed to update todo');
+    }
+    const data = (await res.json()) as { todo: TodoItem };
+    return data.todo;
+  },
+
+  async remove(repositoryId: string, todoId: string): Promise<void> {
+    const res = await fetch(
+      `/api/repositories/${encodeURIComponent(repositoryId)}/todos/${encodeURIComponent(todoId)}`,
+      { method: 'DELETE' },
+    );
+    if (!res.ok) {
+      await parseError(res, 'Failed to delete todo');
+    }
+  },
+};

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -87,6 +87,16 @@ export {
   reorderMemos,
 } from './memo-db';
 
+// todo-db (repository-scoped Home ToDo widget)
+export {
+  getTodosByRepositoryId,
+  getTodoById,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} from './todo-db';
+export type { RepositoryTodo } from './todo-db';
+
 // timer-db (Issue #534, #540)
 export {
   createTimer,

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -16,6 +16,7 @@ import { v30_migrations } from './v30-assistant-context-snapshot';
 import { v31_migrations } from './v31-repository-visible';
 import { v32_migrations } from './v32-add-messages-role-composite-index';
 import { v33_migrations } from './v33-agent-instances';
+import { v34_migrations } from './v34-repository-todos';
 
 /**
  * Complete ordered list of all migrations.
@@ -37,4 +38,5 @@ export const migrations: Migration[] = [
   ...v31_migrations,
   ...v32_migrations,
   ...v33_migrations,
+  ...v34_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 33;
+export const CURRENT_SCHEMA_VERSION = 34;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v34-repository-todos.ts
+++ b/src/lib/db/migrations/v34-repository-todos.ts
@@ -1,0 +1,40 @@
+/** Migration v34: Add repository_todos table (global Home ToDo feature).
+ *
+ * A single, lightweight ToDo/memo widget on the Home page. Each ToDo item is
+ * scoped to a repository (repositories.id) so the user can pick a target
+ * repository and jot down checkbox-style tasks for it.
+ *
+ * Linkage uses repositories.id (the stable UUID primary key), mirroring how
+ * the Home Assistant chat keys conversations by repository id. ToDos are
+ * removed via ON DELETE CASCADE when the repository row is physically deleted.
+ */
+
+import type { Migration } from './runner';
+
+export const v34_migrations: Migration[] = [
+  {
+    version: 34,
+    name: 'add-repository-todos',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS repository_todos (
+          id TEXT PRIMARY KEY,
+          repository_id TEXT NOT NULL,
+          content TEXT NOT NULL,
+          done INTEGER NOT NULL DEFAULT 0,
+          position INTEGER NOT NULL DEFAULT 0,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE
+        );
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_repository_todos_repo
+          ON repository_todos(repository_id, position);
+      `);
+    },
+    down: (db) => {
+      db.exec('DROP TABLE IF EXISTS repository_todos;');
+    },
+  },
+];

--- a/src/lib/db/todo-db.ts
+++ b/src/lib/db/todo-db.ts
@@ -1,0 +1,171 @@
+/**
+ * Repository ToDo database operations
+ * CRUD operations for the repository_todos table (migration v34).
+ *
+ * A lightweight, checkbox-style ToDo list scoped to a repository
+ * (repositories.id), surfaced as a single widget on the Home page.
+ */
+
+import { randomUUID } from 'crypto';
+import Database from 'better-sqlite3';
+
+/**
+ * A single ToDo item scoped to a repository.
+ */
+export interface RepositoryTodo {
+  id: string;
+  repositoryId: string;
+  content: string;
+  done: boolean;
+  position: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Database row type for repository todos.
+ */
+type RepositoryTodoRow = {
+  id: string;
+  repository_id: string;
+  content: string;
+  done: number;
+  position: number;
+  created_at: number;
+  updated_at: number;
+};
+
+/**
+ * Map database row to RepositoryTodo model.
+ */
+function mapTodoRow(row: RepositoryTodoRow): RepositoryTodo {
+  return {
+    id: row.id,
+    repositoryId: row.repository_id,
+    content: row.content,
+    done: row.done === 1,
+    position: row.position,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+/**
+ * Get all todos for a repository, sorted by position then creation time.
+ */
+export function getTodosByRepositoryId(
+  db: Database.Database,
+  repositoryId: string
+): RepositoryTodo[] {
+  const stmt = db.prepare(`
+    SELECT id, repository_id, content, done, position, created_at, updated_at
+    FROM repository_todos
+    WHERE repository_id = ?
+    ORDER BY position ASC, created_at ASC
+  `);
+
+  const rows = stmt.all(repositoryId) as RepositoryTodoRow[];
+  return rows.map(mapTodoRow);
+}
+
+/**
+ * Get a todo by ID.
+ *
+ * @returns Todo or null if not found.
+ */
+export function getTodoById(
+  db: Database.Database,
+  todoId: string
+): RepositoryTodo | null {
+  const stmt = db.prepare(`
+    SELECT id, repository_id, content, done, position, created_at, updated_at
+    FROM repository_todos
+    WHERE id = ?
+  `);
+
+  const row = stmt.get(todoId) as RepositoryTodoRow | undefined;
+  return row ? mapTodoRow(row) : null;
+}
+
+/**
+ * Create a new todo for a repository.
+ */
+export function createTodo(
+  db: Database.Database,
+  repositoryId: string,
+  options: {
+    content: string;
+    position: number;
+  }
+): RepositoryTodo {
+  const id = randomUUID();
+  const now = Date.now();
+
+  const stmt = db.prepare(`
+    INSERT INTO repository_todos (id, repository_id, content, done, position, created_at, updated_at)
+    VALUES (?, ?, ?, 0, ?, ?, ?)
+  `);
+
+  stmt.run(id, repositoryId, options.content, options.position, now, now);
+
+  return {
+    id,
+    repositoryId,
+    content: options.content,
+    done: false,
+    position: options.position,
+    createdAt: new Date(now),
+    updatedAt: new Date(now),
+  };
+}
+
+/**
+ * Update an existing todo (content and/or done state).
+ */
+export function updateTodo(
+  db: Database.Database,
+  todoId: string,
+  updates: {
+    content?: string;
+    done?: boolean;
+  }
+): void {
+  const now = Date.now();
+  const assignments: string[] = ['updated_at = ?'];
+  const params: (string | number)[] = [now];
+
+  if (updates.content !== undefined) {
+    assignments.push('content = ?');
+    params.push(updates.content);
+  }
+
+  if (updates.done !== undefined) {
+    assignments.push('done = ?');
+    params.push(updates.done ? 1 : 0);
+  }
+
+  params.push(todoId);
+
+  const stmt = db.prepare(`
+    UPDATE repository_todos
+    SET ${assignments.join(', ')}
+    WHERE id = ?
+  `);
+
+  stmt.run(...params);
+}
+
+/**
+ * Delete a todo by ID.
+ */
+export function deleteTodo(
+  db: Database.Database,
+  todoId: string
+): void {
+  const stmt = db.prepare(`
+    DELETE FROM repository_todos
+    WHERE id = ?
+  `);
+
+  stmt.run(todoId);
+}

--- a/tests/integration/api/repository-todos.test.ts
+++ b/tests/integration/api/repository-todos.test.ts
@@ -1,0 +1,260 @@
+/**
+ * API Routes Integration Tests - Repository ToDos
+ *
+ * Tests for:
+ * - GET    /api/repositories/:id/todos          - List todos for a repository
+ * - POST   /api/repositories/:id/todos          - Create a todo
+ * - PATCH  /api/repositories/:id/todos/:todoId  - Update a todo (content/done)
+ * - DELETE /api/repositories/:id/todos/:todoId  - Delete a todo
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { createRepository } from '@/lib/db/db-repository';
+import { createTodo, getTodosByRepositoryId } from '@/lib/db';
+import type { NextRequest } from 'next/server';
+
+declare module '@/lib/db/db-instance' {
+  export function setMockDb(db: Database.Database): void;
+}
+
+vi.mock('@/lib/db/db-instance', () => {
+  let mockDb: Database.Database | null = null;
+  return {
+    getDbInstance: () => {
+      if (!mockDb) {
+        throw new Error('Mock database not initialized');
+      }
+      return mockDb;
+    },
+    setMockDb: (db: Database.Database) => {
+      mockDb = db;
+    },
+    closeDbInstance: () => {
+      if (mockDb) {
+        mockDb.close();
+        mockDb = null;
+      }
+    },
+  };
+});
+
+let db: Database.Database;
+let repoId: string;
+
+beforeEach(async () => {
+  db = new Database(':memory:');
+  runMigrations(db);
+
+  const { setMockDb } = await import('@/lib/db/db-instance');
+  setMockDb(db);
+
+  const repo = createRepository(db, {
+    name: 'TestRepo',
+    path: '/path/to/repo',
+    cloneSource: 'local',
+  });
+  repoId = repo.id;
+});
+
+afterEach(async () => {
+  const { closeDbInstance } = await import('@/lib/db/db-instance');
+  closeDbInstance();
+});
+
+const asReq = (req: Request) => req as unknown as NextRequest;
+
+describe('GET /api/repositories/:id/todos', () => {
+  it('returns an empty array when no todos exist', async () => {
+    const { GET } = await import('@/app/api/repositories/[id]/todos/route');
+    const res = await GET(
+      asReq(new Request(`http://localhost/api/repositories/${repoId}/todos`)),
+      { params: Promise.resolve({ id: repoId }) },
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todos).toEqual([]);
+  });
+
+  it('returns todos sorted by position', async () => {
+    createTodo(db, repoId, { content: 'second', position: 1 });
+    createTodo(db, repoId, { content: 'first', position: 0 });
+
+    const { GET } = await import('@/app/api/repositories/[id]/todos/route');
+    const res = await GET(
+      asReq(new Request(`http://localhost/api/repositories/${repoId}/todos`)),
+      { params: Promise.resolve({ id: repoId }) },
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todos.map((t: { content: string }) => t.content)).toEqual(['first', 'second']);
+  });
+
+  it('returns 404 for a non-existent repository', async () => {
+    const { GET } = await import('@/app/api/repositories/[id]/todos/route');
+    const res = await GET(
+      asReq(new Request('http://localhost/api/repositories/nope/todos')),
+      { params: Promise.resolve({ id: 'nope' }) },
+    );
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toContain('not found');
+  });
+
+  it('returns 500 on database error', async () => {
+    db.close();
+    const { GET } = await import('@/app/api/repositories/[id]/todos/route');
+    const res = await GET(
+      asReq(new Request(`http://localhost/api/repositories/${repoId}/todos`)),
+      { params: Promise.resolve({ id: repoId }) },
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/repositories/:id/todos', () => {
+  const post = async (id: string, body: unknown) => {
+    const { POST } = await import('@/app/api/repositories/[id]/todos/route');
+    return POST(
+      asReq(
+        new Request(`http://localhost/api/repositories/${id}/todos`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+      ),
+      { params: Promise.resolve({ id }) },
+    );
+  };
+
+  it('creates a todo', async () => {
+    const res = await post(repoId, { content: 'Write tests' });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.todo.content).toBe('Write tests');
+    expect(data.todo.done).toBe(false);
+    expect(data.todo.repositoryId).toBe(repoId);
+    expect(data.todo.position).toBe(0);
+  });
+
+  it('trims content and auto-assigns the next position', async () => {
+    await post(repoId, { content: 'one' });
+    const res = await post(repoId, { content: '  two  ' });
+    const data = await res.json();
+    expect(data.todo.content).toBe('two');
+    expect(data.todo.position).toBe(1);
+  });
+
+  it('returns 400 for empty content', async () => {
+    const res = await post(repoId, { content: '   ' });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain('content');
+  });
+
+  it('returns 400 for content exceeding the max length', async () => {
+    const res = await post(repoId, { content: 'a'.repeat(2001) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for a non-existent repository', async () => {
+    const res = await post('nope', { content: 'x' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PATCH /api/repositories/:id/todos/:todoId', () => {
+  const patch = async (id: string, todoId: string, body: unknown) => {
+    const { PATCH } = await import('@/app/api/repositories/[id]/todos/[todoId]/route');
+    return PATCH(
+      asReq(
+        new Request(`http://localhost/api/repositories/${id}/todos/${todoId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+      ),
+      { params: Promise.resolve({ id, todoId }) },
+    );
+  };
+
+  it('toggles done', async () => {
+    const todo = createTodo(db, repoId, { content: 'task', position: 0 });
+    const res = await patch(repoId, todo.id, { done: true });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todo.done).toBe(true);
+  });
+
+  it('updates content', async () => {
+    const todo = createTodo(db, repoId, { content: 'old', position: 0 });
+    const res = await patch(repoId, todo.id, { content: 'new' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todo.content).toBe('new');
+  });
+
+  it('returns 400 when neither content nor done is provided', async () => {
+    const todo = createTodo(db, repoId, { content: 'x', position: 0 });
+    const res = await patch(repoId, todo.id, {});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when done is not a boolean', async () => {
+    const todo = createTodo(db, repoId, { content: 'x', position: 0 });
+    const res = await patch(repoId, todo.id, { done: 'yes' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for a non-existent todo', async () => {
+    const res = await patch(repoId, 'missing', { done: true });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the todo belongs to a different repository', async () => {
+    const other = createRepository(db, {
+      name: 'Other',
+      path: '/path/to/other',
+      cloneSource: 'local',
+    });
+    const todo = createTodo(db, other.id, { content: 'theirs', position: 0 });
+    const res = await patch(repoId, todo.id, { done: true });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/repositories/:id/todos/:todoId', () => {
+  const del = async (id: string, todoId: string) => {
+    const { DELETE } = await import('@/app/api/repositories/[id]/todos/[todoId]/route');
+    return DELETE(
+      asReq(
+        new Request(`http://localhost/api/repositories/${id}/todos/${todoId}`, {
+          method: 'DELETE',
+        }),
+      ),
+      { params: Promise.resolve({ id, todoId }) },
+    );
+  };
+
+  it('deletes a todo', async () => {
+    const todo = createTodo(db, repoId, { content: 'gone', position: 0 });
+    const res = await del(repoId, todo.id);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(getTodosByRepositoryId(db, repoId)).toHaveLength(0);
+  });
+
+  it('returns 404 for a non-existent todo', async () => {
+    const res = await del(repoId, 'missing');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a non-existent repository', async () => {
+    const res = await del('nope', 'whatever');
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/db/todo-db.test.ts
+++ b/tests/unit/db/todo-db.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for repository_todos CRUD operations (todo-db.ts, migration v34).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { createRepository } from '@/lib/db/db-repository';
+import {
+  getTodosByRepositoryId,
+  getTodoById,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} from '@/lib/db';
+
+describe('todo-db', () => {
+  let db: Database.Database;
+  let repositoryId: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+
+    const repo = createRepository(db, {
+      name: 'TestRepo',
+      path: '/path/to/test-repo',
+      cloneSource: 'local',
+    });
+    repositoryId = repo.id;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates the repository_todos table via migration v34', () => {
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name)).toContain('repository_todos');
+  });
+
+  it('returns an empty list when no todos exist', () => {
+    expect(getTodosByRepositoryId(db, repositoryId)).toEqual([]);
+  });
+
+  it('creates a todo with done=false by default', () => {
+    const todo = createTodo(db, repositoryId, { content: 'Buy milk', position: 0 });
+    expect(todo.id).toBeTruthy();
+    expect(todo.repositoryId).toBe(repositoryId);
+    expect(todo.content).toBe('Buy milk');
+    expect(todo.done).toBe(false);
+    expect(todo.position).toBe(0);
+    expect(todo.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('lists todos sorted by position', () => {
+    createTodo(db, repositoryId, { content: 'C', position: 2 });
+    createTodo(db, repositoryId, { content: 'A', position: 0 });
+    createTodo(db, repositoryId, { content: 'B', position: 1 });
+
+    const todos = getTodosByRepositoryId(db, repositoryId);
+    expect(todos.map((t) => t.content)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('scopes list to the given repository', () => {
+    const other = createRepository(db, {
+      name: 'Other',
+      path: '/path/to/other',
+      cloneSource: 'local',
+    });
+    createTodo(db, repositoryId, { content: 'mine', position: 0 });
+    createTodo(db, other.id, { content: 'theirs', position: 0 });
+
+    expect(getTodosByRepositoryId(db, repositoryId).map((t) => t.content)).toEqual(['mine']);
+    expect(getTodosByRepositoryId(db, other.id).map((t) => t.content)).toEqual(['theirs']);
+  });
+
+  it('getTodoById returns null for a missing id', () => {
+    expect(getTodoById(db, 'nope')).toBeNull();
+  });
+
+  it('updates content', () => {
+    const todo = createTodo(db, repositoryId, { content: 'old', position: 0 });
+    updateTodo(db, todo.id, { content: 'new' });
+    expect(getTodoById(db, todo.id)?.content).toBe('new');
+  });
+
+  it('toggles done state', () => {
+    const todo = createTodo(db, repositoryId, { content: 'task', position: 0 });
+    updateTodo(db, todo.id, { done: true });
+    expect(getTodoById(db, todo.id)?.done).toBe(true);
+    updateTodo(db, todo.id, { done: false });
+    expect(getTodoById(db, todo.id)?.done).toBe(false);
+  });
+
+  it('updates content and done together', () => {
+    const todo = createTodo(db, repositoryId, { content: 'a', position: 0 });
+    updateTodo(db, todo.id, { content: 'b', done: true });
+    const updated = getTodoById(db, todo.id);
+    expect(updated?.content).toBe('b');
+    expect(updated?.done).toBe(true);
+  });
+
+  it('deletes a todo', () => {
+    const todo = createTodo(db, repositoryId, { content: 'gone', position: 0 });
+    deleteTodo(db, todo.id);
+    expect(getTodoById(db, todo.id)).toBeNull();
+    expect(getTodosByRepositoryId(db, repositoryId)).toHaveLength(0);
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 33 after Migration #33 (Issue #868: agent instances)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(33);
+    it('should be 34 after Migration #34 (repository_todos)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(34);
     });
   });
 


### PR DESCRIPTION
## 概要

Home（`http://localhost:3000`）に、対象リポジトリを選択して書けるチェックボックス形式の軽量 ToDo / 備忘録ウィジェットを追加します。ToDo はリポジトリ単位でスコープされ、全体で1つのウィジェットとして「Session Overview」と「Shortcut Cards」の間に配置されます。

Closes #894

## 変更内容

### 新規
| ファイル | 役割 |
|---|---|
| `src/lib/db/migrations/v34-repository-todos.ts` | `repository_todos` テーブル作成（FK→`repositories(id)` ON DELETE CASCADE、`(repository_id, position)` インデックス） |
| `src/config/todo-config.ts` | 上限定数（1リポジトリ 50 件 / 1件 2000 文字） |
| `src/lib/db/todo-db.ts` | CRUD（list/get/create/update/delete） |
| `src/app/api/repositories/[id]/todos/route.ts` | GET（一覧）/ POST（作成・自動 position・上限/バリデーション） |
| `src/app/api/repositories/[id]/todos/[todoId]/route.ts` | PATCH（content/done 部分更新）/ DELETE |
| `src/lib/api/todo-api.ts` | クライアント API ラッパ |
| `src/components/home/TodoWidget.tsx` | UI（リポジトリ選択を localStorage 永続、追加・完了トグル・削除、残数表示） |
| `tests/unit/db/todo-db.test.ts` | CRUD ユニット（10件） |
| `tests/integration/api/repository-todos.test.ts` | API 結合（18件） |

### 変更
- `src/lib/db/migrations/index.ts` — v34 を登録
- `src/lib/db/migrations/runner.ts` — `CURRENT_SCHEMA_VERSION` 33→34
- `src/lib/db/db.ts` — todo-db を barrel 再エクスポート
- `src/app/page.tsx` — ToDo セクション挿入
- `tests/unit/lib/db-migrations.test.ts` — スキーマバージョン期待値を 34 に更新

## 設計上の選択

- データモデルは `worktree_memos` を踏襲、API は memos ルートを踏襲して `/api/repositories/[id]/todos` にネスト
- リポジトリ識別は安定 UUID（`repositories.id`）を採用（Home の Assistant が repo id でキーする方式に合わせる）
- 部分更新のため PUT ではなく PATCH

## 品質チェック

| チェック | 結果 |
|---|---|
| `npm run lint` | ✅ 0 warnings/errors |
| `npx tsc --noEmit` | ✅ exit 0 |
| `npm run test:unit` | ✅ 7836 passed |
| `npm run build` | ✅ exit 0 |
| 結合テスト（todos API） | ✅ 18/18 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
