### PR TITLE
fix: 同一エージェントの複数インスタンスで Auto-Yes を個別有効化 (#896)

### DIFF
--- a/src/app/api/worktrees/[id]/auto-yes/route.ts
+++ b/src/app/api/worktrees/[id]/auto-yes/route.ts
@@ -17,10 +17,11 @@ import {
   buildCompositeKey,
   getCompositeKeysByWorktree,
   extractCliToolId,
+  extractInstanceId,
   type AutoYesState,
 } from '@/lib/polling/auto-yes-manager';
 import { isValidWorktreeId } from '@/lib/security/path-validator';
-import { CLI_TOOL_IDS, type CLIToolType } from '@/lib/cli-tools/types';
+import { CLI_TOOL_IDS, isValidInstanceId, type CLIToolType } from '@/lib/cli-tools/types';
 import { isAllowedDuration, DEFAULT_AUTO_YES_DURATION, validateStopPattern, type AutoYesDuration } from '@/config/auto-yes-config';
 import { createLogger } from '@/lib/logger';
 
@@ -92,8 +93,17 @@ export async function GET(
     if (notFound) return notFound;
 
     // Issue #525: cliToolId query parameter support
+    // Issue #896: optional instanceId query parameter for per-instance state
     const url = new URL(request.url);
     const cliToolIdParam = url.searchParams.get('cliToolId');
+    const instanceIdParam = url.searchParams.get('instanceId') ?? undefined;
+
+    if (instanceIdParam !== undefined && !isValidInstanceId(instanceIdParam)) {
+      return NextResponse.json(
+        { error: 'Invalid instanceId' },
+        { status: 400 }
+      );
+    }
 
     if (cliToolIdParam) {
       // Single agent query
@@ -103,18 +113,24 @@ export async function GET(
           { status: 400 }
         );
       }
-      const state = getAutoYesState(params.id, cliToolIdParam);
+      const state = getAutoYesState(params.id, cliToolIdParam, instanceIdParam);
       return NextResponse.json(buildAutoYesResponse(state));
     }
 
-    // No cliToolId: return map of all agents
+    // No cliToolId: return maps keyed by agent (cliToolId) and by instance (Issue #896).
     const compositeKeys = getCompositeKeysByWorktree(params.id);
     const agentStates: Record<string, ReturnType<typeof buildAutoYesResponse>> = {};
+    const instanceStates: Record<string, ReturnType<typeof buildAutoYesResponse>> = {};
     for (const key of compositeKeys) {
       const agentId = extractCliToolId(key);
       if (!agentId) continue;
-      const state = getAutoYesState(params.id, agentId);
-      agentStates[agentId] = buildAutoYesResponse(state);
+      const instanceId = extractInstanceId(key) ?? agentId;
+      const state = getAutoYesState(params.id, agentId, instanceId);
+      instanceStates[instanceId] = buildAutoYesResponse(state);
+      // Keep the cliTool-level map populated from the primary instance for backward compat.
+      if (instanceId === agentId) {
+        agentStates[agentId] = buildAutoYesResponse(state);
+      }
     }
 
     // For backward compatibility, also include top-level fields from default agent
@@ -122,6 +138,7 @@ export async function GET(
     return NextResponse.json({
       ...buildAutoYesResponse(defaultState),
       agents: agentStates,
+      instances: instanceStates,
     });
   } catch (error: unknown) {
     logger.error('error-getting-auto-yes-state:', { error: error instanceof Error ? error.message : String(error) });
@@ -203,7 +220,17 @@ export async function POST(
     }
     const cliToolId: CLIToolType = body.cliToolId ?? 'claude';
 
-    // Issue #138, #525: Start or stop server-side polling
+    // Issue #896: Validate optional instanceId (per-instance auto-yes).
+    if (body.instanceId !== undefined && !isValidInstanceId(body.instanceId)) {
+      return NextResponse.json(
+        { error: 'Invalid instanceId' },
+        { status: 400 }
+      );
+    }
+    // Effective instance: provided instanceId, else the primary (=== cliToolId).
+    const instanceId: string = body.instanceId ?? cliToolId;
+
+    // Issue #138, #525, #896: Start or stop server-side polling (per-instance)
     let pollingStarted = false;
     let state;
     if (body.enabled) {
@@ -212,26 +239,32 @@ export async function POST(
         cliToolId,
         true,
         duration,
-        stopPattern
+        stopPattern,
+        instanceId
       );
-      const result = startAutoYesPolling(params.id, cliToolId);
+      const result = startAutoYesPolling(params.id, cliToolId, instanceId);
       pollingStarted = result.started;
       if (!result.started) {
         logger.warn('polling-not-started:');
       }
     } else {
-      // Issue #525: cliToolId specified -> stop individual; not specified -> stop all
-      if (body.cliToolId) {
+      // Issue #525, #896: instanceId/cliToolId specified -> stop that instance;
+      // neither specified -> stop all instances for this worktree.
+      if (body.instanceId) {
+        state = setAutoYesEnabled(params.id, cliToolId, false, undefined, undefined, instanceId);
+        const compositeKey = buildCompositeKey(params.id, cliToolId, instanceId);
+        stopAutoYesPolling(compositeKey);
+      } else if (body.cliToolId) {
         state = setAutoYesEnabled(params.id, cliToolId, false);
         const compositeKey = buildCompositeKey(params.id, cliToolId);
         stopAutoYesPolling(compositeKey);
       } else {
-        // Disable all agents for this worktree
+        // Disable all agents/instances for this worktree
         const keys = getCompositeKeysByWorktree(params.id);
         for (const key of keys) {
           const toolId = extractCliToolId(key);
           if (toolId) {
-            setAutoYesEnabled(params.id, toolId, false);
+            setAutoYesEnabled(params.id, toolId, false, undefined, undefined, extractInstanceId(key) ?? undefined);
           }
         }
         stopAutoYesPollingByWorktree(params.id);

--- a/src/app/api/worktrees/[id]/current-output/route.ts
+++ b/src/app/api/worktrees/[id]/current-output/route.ts
@@ -95,8 +95,9 @@ export async function GET(
     const newLines = lines.slice(Math.max(0, lastCapturedLine));
     const newContent = newLines.join('\n');
 
-    // Issue #501, #525: Get last server response timestamp using compositeKey
-    const compositeKey = buildCompositeKey(params.id, cliToolId);
+    // Issue #501, #525, #896: Get last server response timestamp using the
+    // per-instance compositeKey (alias instances build a 3-part key).
+    const compositeKey = buildCompositeKey(params.id, cliToolId, instanceId);
     const lastServerResponseTimestamp = getLastServerResponseTimestamp(compositeKey);
     const lastOutputTimestamp = lastServerResponseTimestamp ? new Date(lastServerResponseTimestamp) : undefined;
 
@@ -124,8 +125,8 @@ export async function GET(
     // Extract realtime snippet (last 100 lines for better context)
     const realtimeSnippet = lines.slice(-100).join('\n');
 
-    // Get auto-yes state (Issue #525: per-agent)
-    const autoYesState = getAutoYesState(params.id, cliToolId);
+    // Get auto-yes state (Issue #525: per-agent, #896: per-instance)
+    const autoYesState = getAutoYesState(params.id, cliToolId, instanceId);
 
     return NextResponse.json({
       isRunning: true,

--- a/src/cli/commands/auto-yes.ts
+++ b/src/cli/commands/auto-yes.ts
@@ -6,7 +6,7 @@
 import { Command } from 'commander';
 import { ExitCode } from '../types';
 import type { AutoYesOptions } from '../types';
-import { ApiClient, isValidWorktreeId, MAX_STOP_PATTERN_LENGTH } from '../utils/api-client';
+import { ApiClient, isValidWorktreeId, isValidInstanceId, MAX_STOP_PATTERN_LENGTH } from '../utils/api-client';
 import { TOKEN_WARNING, handleCommandError } from '../utils/command-helpers';
 import { parseDurationToMs, ALLOWED_DURATIONS } from '../config/duration-constants';
 import { isCliToolId } from '../config/cli-tool-ids';
@@ -21,6 +21,7 @@ export function createAutoYesCommand(): Command {
     .option('--duration <duration>', `Duration (${ALLOWED_DURATIONS.join(', ')})`)
     .option('--stop-pattern <pattern>', 'Stop pattern (regex, max 500 chars)')
     .option('--agent <agent>', 'CLI tool agent (claude, codex, gemini, vibe-local, opencode, copilot)')
+    .option('--instance <id>', 'Agent instance ID (defaults to the agent\'s primary instance)')
     .option('--token <token>', TOKEN_WARNING)
     .action(async (worktreeId: string, options: AutoYesOptions) => {
       try {
@@ -43,6 +44,12 @@ export function createAutoYesCommand(): Command {
 
         if (options.agent && !isCliToolId(options.agent)) {
           console.error('Error: Invalid agent.');
+          process.exit(ExitCode.CONFIG_ERROR);
+        }
+
+        // Issue #896: Validate instance ID if provided
+        if (options.instance && !isValidInstanceId(options.instance)) {
+          console.error('Error: Invalid --instance. Must be an alphanumeric/underscore/hyphen identifier (max 64 chars).');
           process.exit(ExitCode.CONFIG_ERROR);
         }
 
@@ -78,6 +85,11 @@ export function createAutoYesCommand(): Command {
 
         if (options.agent) {
           body.cliToolId = options.agent;
+        }
+
+        // Issue #896: per-instance auto-yes
+        if (options.instance) {
+          body.instanceId = options.instance;
         }
 
         await client.post<void>(`/api/worktrees/${worktreeId}/auto-yes`, body);

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -42,9 +42,12 @@ async function enableAutoYes(
   if (options.agent) {
     autoYesBody.cliToolId = options.agent;
   }
-  // Issue #868: auto-yes is tool-scoped in this PR (the poller keys on
-  // worktreeId:cliToolId). Instance-level auto-yes is deferred with the UI
-  // work (#866-C), so --instance does not narrow auto-yes here.
+  // Issue #896: per-instance auto-yes. When --instance is given, the poller keys
+  // on worktreeId:cliToolId:instanceId so the targeted instance is auto-answered
+  // independently of other instances of the same agent.
+  if (options.instance) {
+    autoYesBody.instanceId = options.instance;
+  }
   if (options.stopPattern) {
     autoYesBody.stopPattern = options.stopPattern;
   }

--- a/src/cli/types/index.ts
+++ b/src/cli/types/index.ts
@@ -229,6 +229,8 @@ export interface AutoYesOptions {
   duration?: string;
   stopPattern?: string;
   agent?: string;
+  /** Issue #896: agent instance ID (defaults to the agent's primary instance) */
+  instance?: string;
   token?: string;
 }
 

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -88,9 +88,9 @@ export interface WorktreeDetailDesktopProps {
   handleInsertConsumed: (idx: number) => void;
   handleInsertToMessage: (text: string) => void;
 
-  // Auto-yes (per-CLI)
+  // Auto-yes (Issue #896: per-instance; map keyed by instanceId)
   autoYesStateMap: Map<string, { enabled: boolean; expiresAt: number | null }>;
-  makeAutoYesToggleHandler: (cliToolId: CLIToolType) => (params: AutoYesToggleParams) => Promise<void>;
+  makeAutoYesToggleHandler: (cliToolId: CLIToolType, instanceId?: string) => (params: AutoYesToggleParams) => Promise<void>;
 
   // History controls
   showArchived: boolean;
@@ -315,10 +315,10 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       onDropInstance: (instanceId: string) => void;
     }) => {
       const panePendingInsert = pendingInsertTextMap.get(splitIndex) ?? null;
-      // Issue #525 / #740: auto-yes state is per-CLI in autoYesStateMap; each
-      // split resolves its own enabled/expiresAt by its own cliToolId (the
-      // instance's backing CLI tool — auto-yes stays cliTool-keyed in #869).
-      const paneAutoYes = autoYesStateMap.get(paneCli);
+      // Issue #525 / #740 / #896: auto-yes state is per-INSTANCE in
+      // autoYesStateMap; each split resolves its own enabled/expiresAt by its own
+      // instanceId so multiple instances of the same CLI tool toggle independently.
+      const paneAutoYes = autoYesStateMap.get(paneInstanceId);
       const paneAutoYesEnabled = paneAutoYes?.enabled ?? false;
       const paneAutoYesExpiresAt = paneAutoYes?.expiresAt ?? null;
       // Issue #743/#875: derive THIS pane's AI agent status. Splits are
@@ -362,7 +362,9 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
             enabled: paneAutoYesEnabled,
             expiresAt: paneAutoYesExpiresAt,
             lastAutoResponse: lastAutoResponse,
-            onToggle: makeAutoYesToggleHandler(paneCli),
+            // Issue #896: bind the toggle to THIS pane's instance so each
+            // instance enables/disables its own auto-yes poller independently.
+            onToggle: makeAutoYesToggleHandler(paneCli, paneInstanceId),
           }}
           // Issue #756: History domain group. Issue #744: embedded per-split
           // HistoryPane. Each split fetches its OWN cliToolId's messages

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -197,7 +197,10 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   const [editorFilePath, setEditorFilePath] = useState<string | null>(null);
   // Issue #104: Track editor maximized state to disable Modal close handlers
   const [isEditorMaximized, setIsEditorMaximized] = useState(false);
-  // Issue #525: Per-agent auto-yes state management
+  // Issue #525: Per-agent auto-yes state management.
+  // Issue #896: re-keyed by *instanceId* so each agent instance has its own
+  // auto-yes state (the primary instance's id === its cliToolId, preserving the
+  // previous cliTool-keyed behavior for single-instance worktrees).
   const [autoYesStateMap, setAutoYesStateMap] = useState<Map<string, { enabled: boolean; expiresAt: number | null }>>(new Map());
   // Issue #501: Track last server-side auto-yes response timestamp for duplicate prevention
   const [lastServerResponseTimestamp, setLastServerResponseTimestamp] = useState<number | null>(null);
@@ -282,9 +285,10 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   // polls/tab switches from overwriting the active CLI tab state.
   const latestMessagesRequestIdRef = useRef(0);
   const latestCurrentOutputRequestIdRef = useRef(0);
-  // Issue #525: Derive active agent's auto-yes state from per-agent map
-  const autoYesEnabled = autoYesStateMap.get(activeCliTab)?.enabled ?? false;
-  const autoYesExpiresAt = autoYesStateMap.get(activeCliTab)?.expiresAt ?? null;
+  // Issue #525/#896: Derive the active instance's auto-yes state from the
+  // per-instance map (keyed by activeInstanceId; primary instance id === cliToolId).
+  const autoYesEnabled = autoYesStateMap.get(activeInstanceId)?.enabled ?? false;
+  const autoYesExpiresAt = autoYesStateMap.get(activeInstanceId)?.expiresAt ?? null;
   // Trigger to refresh FileTreeView after file operations
   const [fileTreeRefresh, setFileTreeRefresh] = useState(0);
 
@@ -561,13 +565,18 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
       setLastServerResponseTimestamp(data.lastServerResponseTimestamp ?? null);
       setServerPollerActive(data.serverPollerActive ?? false);
 
-      // Update auto-yes state from server (Issue #314: stopReason tracking, Issue #525: per-agent)
+      // Update auto-yes state from server (Issue #314: stopReason tracking,
+      // Issue #525: per-agent, Issue #896: per-instance).
+      // PC keeps the parent poll byte-identical (no `instance` param) so the
+      // server resolves the PRIMARY instance, whose id === requestedCliTool.
+      // Mobile sends `instance`, so the response is the requested instance's state.
       if (data.autoYes) {
         const wasEnabled = prevAutoYesEnabledRef.current;
         const autoYes = data.autoYes;
+        const seedInstanceId = onMobile ? requestedInstance : requestedCliTool;
         setAutoYesStateMap(prev => {
           const next = new Map(prev);
-          next.set(requestedCliTool, { enabled: autoYes.enabled, expiresAt: autoYes.expiresAt });
+          next.set(seedInstanceId, { enabled: autoYes.enabled, expiresAt: autoYes.expiresAt });
           return next;
         });
         prevAutoYesEnabledRef.current = autoYes.enabled;
@@ -891,12 +900,17 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
    * Issue #740: parameterized by cliToolId via a curried factory so each PC
    * split footer can toggle auto-yes for its OWN CLI independently. The factory
    * is stable per worktreeId (cliToolId is captured per call), keeping split
-   * re-renders down. `activeCliTabRef` is read inside so the stop-reason ref is
-   * only updated for the active CLI (preserving existing toast detection).
+   * re-renders down. `activeInstanceIdRef` is read inside so the stop-reason ref
+   * is only updated for the active instance (preserving existing toast detection).
+   *
+   * Issue #896: also parameterized by instanceId so each instance toggles its
+   * OWN auto-yes (a 3-part poller key for aliases). instanceId defaults to the
+   * primary (=== cliToolId) when omitted.
    */
   const makeAutoYesToggleHandler = useCallback(
-    (cliToolId: CLIToolType) =>
+    (cliToolId: CLIToolType, instanceId?: string) =>
       async (params: AutoYesToggleParams): Promise<void> => {
+        const effectiveInstanceId = instanceId ?? cliToolId;
         try {
           const response = await fetch(`/api/worktrees/${worktreeId}/auto-yes`, {
             method: 'POST',
@@ -904,21 +918,22 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
             body: JSON.stringify({
               enabled: params.enabled,
               cliToolId,
+              instanceId: effectiveInstanceId,
               duration: params.duration,
               stopPattern: params.stopPattern,
             }),
           });
           if (response.ok) {
             const data = await response.json();
-            // Issue #525: Store per-agent state keyed by the toggled CLI.
+            // Issue #525/#896: Store per-instance state keyed by the toggled instance.
             setAutoYesStateMap(prev => {
               const next = new Map(prev);
-              next.set(cliToolId, { enabled: data.enabled, expiresAt: data.expiresAt });
+              next.set(effectiveInstanceId, { enabled: data.enabled, expiresAt: data.expiresAt });
               return next;
             });
-            // Issue #740: the stop-reason ref tracks the ACTIVE CLI only; avoid
-            // clobbering it when a non-active split is toggled.
-            if (cliToolId === activeCliTabRef.current) {
+            // Issue #740/#896: the stop-reason ref tracks the ACTIVE instance only;
+            // avoid clobbering it when a non-active split is toggled.
+            if (effectiveInstanceId === activeInstanceIdRef.current) {
               prevAutoYesEnabledRef.current = data.enabled;
             }
           }
@@ -930,14 +945,15 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   );
 
   /**
-   * Mobile + active-CLI default handler (unchanged behavior). Issue #740: thin
-   * wrapper over the curried factory bound to the current activeCliTab so the
-   * Mobile AutoYesToggle call site stays untouched.
+   * Mobile + active-instance default handler (unchanged behavior). Issue #740:
+   * thin wrapper over the curried factory bound to the current active instance
+   * so the Mobile AutoYesToggle call site stays untouched. Issue #896: binds the
+   * active instance id so mobile toggles the active instance's auto-yes.
    */
   const handleAutoYesToggle = useCallback(
     (params: AutoYesToggleParams): Promise<void> =>
-      makeAutoYesToggleHandler(activeCliTab)(params),
-    [makeAutoYesToggleHandler, activeCliTab],
+      makeAutoYesToggleHandler(activeCliTab, activeInstanceId)(params),
+    [makeAutoYesToggleHandler, activeCliTab, activeInstanceId],
   );
 
   /** Issue #4: Kill session confirmation dialog state */

--- a/src/lib/auto-yes-poller.ts
+++ b/src/lib/auto-yes-poller.ts
@@ -34,6 +34,7 @@ import {
   buildCompositeKey,
   extractWorktreeId,
   extractCliToolId,
+  extractInstanceId,
   filterCompositeKeysByWorktree,
   getAutoYesState,
   disableAutoYes,
@@ -50,12 +51,14 @@ import {
 // Poller Types
 // =============================================================================
 
-/** Poller state for a worktree/agent (Issue #138, #525) */
+/** Poller state for a worktree/agent (Issue #138, #525, #896) */
 export interface AutoYesPollerState {
   /** setTimeout ID */
   timerId: ReturnType<typeof setTimeout> | null;
   /** CLI tool ID being polled */
   cliToolId: CLIToolType;
+  /** Agent instance ID being polled (Issue #896; equals cliToolId for the primary instance) */
+  instanceId: string;
   /** Consecutive error count */
   consecutiveErrors: number;
   /** Current polling interval (with backoff applied) */
@@ -191,7 +194,8 @@ function incrementErrorCount(compositeKey: string): void {
       const worktreeId = extractWorktreeId(compositeKey);
       const cliToolId = extractCliToolId(compositeKey);
       if (cliToolId) {
-        disableAutoYes(worktreeId, cliToolId, 'consecutive_errors');
+        // Issue #896: target the specific instance state (3-part keys carry instanceId).
+        disableAutoYes(worktreeId, cliToolId, 'consecutive_errors', extractInstanceId(compositeKey) ?? undefined);
       }
       stopAutoYesPolling(compositeKey);
     }
@@ -242,7 +246,9 @@ export function validatePollingContext(
     return 'expired';
   }
 
-  const autoYesState = getAutoYesState(worktreeId, cliToolId);
+  // Issue #896: resolve instanceId so per-instance enabled state is checked.
+  const instanceId = extractInstanceId(compositeKey) ?? undefined;
+  const autoYesState = getAutoYesState(worktreeId, cliToolId, instanceId);
   if (!autoYesState?.enabled) {
     stopAutoYesPolling(compositeKey);
     return 'expired';
@@ -257,15 +263,18 @@ export function validatePollingContext(
  * @internal Exported for testing purposes only.
  * @param worktreeId - Worktree identifier
  * @param cliToolId - CLI tool type being polled
+ * @param captureLines - Optional number of lines to capture
+ * @param instanceId - Optional agent instance ID (Issue #896; defaults to primary session)
  * @returns Cleaned output string (ANSI stripped)
  */
 export async function captureAndCleanOutput(
   worktreeId: string,
   cliToolId: CLIToolType,
-  captureLines?: number
+  captureLines?: number,
+  instanceId?: string
 ): Promise<string> {
   const lines = captureLines ?? FULL_CAPTURE_LINES;
-  const output = await captureSessionOutput(worktreeId, cliToolId, lines);
+  const output = await captureSessionOutput(worktreeId, cliToolId, lines, instanceId);
   return stripBoxDrawing(stripAnsi(output));
 }
 
@@ -310,6 +319,8 @@ export function processStopConditionDelta(
  * @param pollerState - Current poller state (mutated: lastAnsweredPromptKey updated)
  * @param cliToolId - CLI tool type
  * @param cleanOutput - ANSI-stripped terminal output
+ * @param precomputedLines - Optional pre-split lines to reuse
+ * @param instanceId - Optional agent instance ID (Issue #896; defaults to primary session)
  * @returns 'responded' | 'no_prompt' | 'duplicate' | 'no_answer' | 'error'
  */
 export async function detectAndRespondToPrompt(
@@ -317,9 +328,10 @@ export async function detectAndRespondToPrompt(
   pollerState: AutoYesPollerState,
   cliToolId: CLIToolType,
   cleanOutput: string,
-  precomputedLines?: string[]
+  precomputedLines?: string[],
+  instanceId?: string
 ): Promise<'responded' | 'no_prompt' | 'duplicate' | 'no_answer' | 'error'> {
-  const compositeKey = buildCompositeKey(worktreeId, cliToolId);
+  const compositeKey = buildCompositeKey(worktreeId, cliToolId, instanceId);
   try {
     // 1. Detect prompt
     const promptOptions = buildDetectPromptOptions(cliToolId);
@@ -346,10 +358,10 @@ export async function detectAndRespondToPrompt(
       return 'no_answer';
     }
 
-    // 4. Send answer to tmux
+    // 4. Send answer to tmux (Issue #896: resolve the instance-specific session)
     const manager = CLIToolManager.getInstance();
     const cliTool = manager.getTool(cliToolId);
-    const sessionName = cliTool.getSessionName(worktreeId);
+    const sessionName = cliTool.getSessionName(worktreeId, instanceId);
 
     try {
       await sendPromptAnswer({
@@ -370,12 +382,12 @@ export async function detectAndRespondToPrompt(
     pollerState.lastAnsweredPromptKey = promptKey;
     pollerState.lastAnsweredAt = Date.now();
 
-    logger.info('poller:response-sent', { worktreeId, cliToolId });
+    logger.info('poller:response-sent', { worktreeId, cliToolId, instanceId });
 
     return 'responded';
   } catch {
     incrementErrorCount(compositeKey);
-    logger.warn('poller:detect-respond-error', { worktreeId, cliToolId });
+    logger.warn('poller:detect-respond-error', { worktreeId, cliToolId, instanceId });
     return 'error';
   }
 }
@@ -385,9 +397,10 @@ export async function detectAndRespondToPrompt(
  *
  * @param worktreeId - Worktree identifier
  * @param cliToolId - CLI tool type being polled
+ * @param instanceId - Agent instance ID being polled (Issue #896; equals cliToolId for primary)
  */
-async function pollAutoYes(worktreeId: string, cliToolId: CLIToolType): Promise<void> {
-  const compositeKey = buildCompositeKey(worktreeId, cliToolId);
+async function pollAutoYes(worktreeId: string, cliToolId: CLIToolType, instanceId?: string): Promise<void> {
+  const compositeKey = buildCompositeKey(worktreeId, cliToolId, instanceId);
 
   // 1. Validate context
   const pollerState = getPollerState(compositeKey);
@@ -398,11 +411,11 @@ async function pollAutoYes(worktreeId: string, cliToolId: CLIToolType): Promise<
 
   try {
     // 2. Capture and clean output
-    const autoYesState = getAutoYesState(worktreeId, cliToolId);
+    const autoYesState = getAutoYesState(worktreeId, cliToolId, instanceId);
     const captureLines = autoYesState?.stopPattern
       ? FULL_CAPTURE_LINES
       : REDUCED_CAPTURE_LINES;
-    const cleanOutput = await captureAndCleanOutput(worktreeId, cliToolId, captureLines);
+    const cleanOutput = await captureAndCleanOutput(worktreeId, cliToolId, captureLines, instanceId);
 
     const lines = cleanOutput.split('\n');
 
@@ -412,9 +425,9 @@ async function pollAutoYes(worktreeId: string, cliToolId: CLIToolType): Promise<
     }
 
     // 4. Detect and respond to prompt
-    const result = await detectAndRespondToPrompt(worktreeId, pollerState!, cliToolId, cleanOutput, lines);
+    const result = await detectAndRespondToPrompt(worktreeId, pollerState!, cliToolId, cleanOutput, lines, instanceId);
     if (result === 'responded') {
-      scheduleNextPoll(worktreeId, cliToolId, COOLDOWN_INTERVAL_MS);
+      scheduleNextPoll(worktreeId, cliToolId, instanceId, COOLDOWN_INTERVAL_MS);
       return;
     }
 
@@ -422,33 +435,39 @@ async function pollAutoYes(worktreeId: string, cliToolId: CLIToolType): Promise<
     if (result === 'no_prompt') {
       const recentLines = lines.slice(-THINKING_CHECK_LINE_COUNT).join('\n');
       if (detectThinking(cliToolId, recentLines)) {
-        scheduleNextPoll(worktreeId, cliToolId, THINKING_POLLING_INTERVAL_MS);
+        scheduleNextPoll(worktreeId, cliToolId, instanceId, THINKING_POLLING_INTERVAL_MS);
         return;
       }
     }
   } catch (error) {
     incrementErrorCount(compositeKey);
-    logger.warn('poller:poll-error', { worktreeId, cliToolId, error: getErrorMessage(error) });
+    logger.warn('poller:poll-error', { worktreeId, cliToolId, instanceId, error: getErrorMessage(error) });
   }
 
-  scheduleNextPoll(worktreeId, cliToolId);
+  scheduleNextPoll(worktreeId, cliToolId, instanceId);
 }
 
 /**
  * Schedule the next polling iteration
+ *
+ * @param worktreeId - Worktree identifier
+ * @param cliToolId - CLI tool type being polled
+ * @param instanceId - Agent instance ID being polled (Issue #896)
+ * @param overrideInterval - Optional override for the next poll delay
  */
 function scheduleNextPoll(
   worktreeId: string,
   cliToolId: CLIToolType,
+  instanceId?: string,
   overrideInterval?: number
 ): void {
-  const compositeKey = buildCompositeKey(worktreeId, cliToolId);
+  const compositeKey = buildCompositeKey(worktreeId, cliToolId, instanceId);
   const pollerState = getPollerState(compositeKey);
   if (!pollerState) return;
 
   const interval = Math.max(overrideInterval ?? pollerState.currentInterval, POLLING_INTERVAL_MS);
   pollerState.timerId = setTimeout(() => {
-    pollAutoYes(worktreeId, cliToolId);
+    pollAutoYes(worktreeId, cliToolId, instanceId);
   }, interval);
 }
 
@@ -457,28 +476,37 @@ function scheduleNextPoll(
 // =============================================================================
 
 /**
- * Start server-side auto-yes polling for a worktree/agent.
+ * Start server-side auto-yes polling for a worktree/agent instance.
+ *
+ * Issue #896: per-instance polling. Each agent instance gets its own poller keyed
+ * by the (worktreeId, cliToolId, instanceId) composite key, so multiple instances
+ * of the same CLI tool on one worktree are polled independently.
  *
  * @param worktreeId - Worktree identifier (must match WORKTREE_ID_PATTERN)
  * @param cliToolId - CLI tool type to poll for
+ * @param instanceId - Optional agent instance ID (defaults to the primary instance)
  * @returns Result indicating whether the poller was started
  */
 export function startAutoYesPolling(
   worktreeId: string,
-  cliToolId: CLIToolType
+  cliToolId: CLIToolType,
+  instanceId?: string
 ): StartPollingResult {
   // Validate worktree ID (security)
   if (!isValidWorktreeId(worktreeId)) {
     return { started: false, reason: 'invalid worktree ID' };
   }
 
+  // Resolve the effective instance ID (primary === cliToolId).
+  const effectiveInstanceId = instanceId ?? cliToolId;
+
   // Check if auto-yes is enabled
-  const autoYesState = getAutoYesState(worktreeId, cliToolId);
+  const autoYesState = getAutoYesState(worktreeId, cliToolId, effectiveInstanceId);
   if (!autoYesState?.enabled) {
     return { started: false, reason: 'auto-yes not enabled' };
   }
 
-  const compositeKey = buildCompositeKey(worktreeId, cliToolId);
+  const compositeKey = buildCompositeKey(worktreeId, cliToolId, effectiveInstanceId);
 
   // Check concurrent poller limit (DoS protection)
   const existingPollerState = getPollerState(compositeKey);
@@ -486,7 +514,8 @@ export function startAutoYesPolling(
     return { started: false, reason: 'max concurrent pollers reached' };
   }
 
-  // Issue #501: Idempotency check
+  // Issue #501: Idempotency check (key already encodes the instance, so a matching
+  // poller is the same instance).
   if (existingPollerState && existingPollerState.cliToolId === cliToolId) {
     return { started: true, reason: 'already_running' };
   }
@@ -500,6 +529,7 @@ export function startAutoYesPolling(
   const pollerState: AutoYesPollerState = {
     timerId: null,
     cliToolId,
+    instanceId: effectiveInstanceId,
     consecutiveErrors: 0,
     currentInterval: POLLING_INTERVAL_MS,
     lastServerResponseTimestamp: null,
@@ -511,10 +541,10 @@ export function startAutoYesPolling(
 
   // Start polling immediately
   pollerState.timerId = setTimeout(() => {
-    pollAutoYes(worktreeId, cliToolId);
+    pollAutoYes(worktreeId, cliToolId, effectiveInstanceId);
   }, POLLING_INTERVAL_MS);
 
-  logger.info('poller:started', { worktreeId, cliToolId });
+  logger.info('poller:started', { worktreeId, cliToolId, instanceId: effectiveInstanceId });
   return { started: true };
 }
 

--- a/src/lib/auto-yes-state.ts
+++ b/src/lib/auto-yes-state.ts
@@ -25,50 +25,81 @@ const logger = createLogger('auto-yes-state');
 export const COMPOSITE_KEY_SEPARATOR = ':' as const;
 
 /**
- * Build a composite key from worktreeId and cliToolId.
+ * Build a composite key from worktreeId, cliToolId and (optionally) instanceId.
  *
- * @precondition worktreeId must not contain COMPOSITE_KEY_SEPARATOR (':').
- *   This precondition is guaranteed by isValidWorktreeId() which restricts
- *   to alphanumeric + hyphens + underscores. If isValidWorktreeId() allowed
- *   characters change, this function must be reviewed.
+ * Issue #896: per-instance auto-yes. A single worktree can run multiple instances
+ * of the same CLI tool (e.g. "claude" + "claude-2"). Each instance must have its
+ * own independent auto-yes state + poller.
  *
- * [SEC4-SF-004] Defensive assertion: throws if worktreeId contains separator.
+ * Key shape is backward-compatible:
+ * - Primary instance (instanceId omitted or === cliToolId): 2-part "worktreeId:cliToolId"
+ *   (unchanged from Issue #525, so existing state/tests are unaffected).
+ * - Alias instance (instanceId !== cliToolId): 3-part "worktreeId:cliToolId:instanceId".
+ *
+ * @precondition worktreeId / instanceId must not contain COMPOSITE_KEY_SEPARATOR (':').
+ *   Guaranteed by isValidWorktreeId() / isValidInstanceId() which restrict to
+ *   alphanumeric + hyphens + underscores. If those allowed characters change,
+ *   this function must be reviewed.
+ *
+ * [SEC4-SF-004] Defensive assertion: throws if worktreeId/instanceId contains separator.
  *
  * @param worktreeId - Worktree identifier
  * @param cliToolId - CLI tool type
- * @returns Composite key string "worktreeId:cliToolId"
+ * @param instanceId - Optional instance identifier (defaults to the primary, i.e. cliToolId)
+ * @returns Composite key string
  */
-export function buildCompositeKey(worktreeId: string, cliToolId: CLIToolType): string {
+export function buildCompositeKey(worktreeId: string, cliToolId: CLIToolType, instanceId?: string): string {
   if (worktreeId.includes(COMPOSITE_KEY_SEPARATOR)) {
     throw new Error(`worktreeId must not contain '${COMPOSITE_KEY_SEPARATOR}': ${worktreeId}`);
   }
-  return `${worktreeId}${COMPOSITE_KEY_SEPARATOR}${cliToolId}`;
+  // Primary instance keeps the 2-part key for backward compatibility.
+  if (!instanceId || instanceId === cliToolId) {
+    return `${worktreeId}${COMPOSITE_KEY_SEPARATOR}${cliToolId}`;
+  }
+  if (instanceId.includes(COMPOSITE_KEY_SEPARATOR)) {
+    throw new Error(`instanceId must not contain '${COMPOSITE_KEY_SEPARATOR}': ${instanceId}`);
+  }
+  return `${worktreeId}${COMPOSITE_KEY_SEPARATOR}${cliToolId}${COMPOSITE_KEY_SEPARATOR}${instanceId}`;
 }
 
 /**
  * Extract worktreeId from a composite key.
- * Uses lastIndexOf for safety (cliToolId may contain hyphens but not colons).
+ * worktreeId never contains a colon, so it is always the first segment.
  *
  * @param compositeKey - Composite key string
  * @returns worktreeId portion, or the full string if no separator found
  */
 export function extractWorktreeId(compositeKey: string): string {
-  const lastIndex = compositeKey.lastIndexOf(COMPOSITE_KEY_SEPARATOR);
-  return lastIndex === -1 ? compositeKey : compositeKey.substring(0, lastIndex);
+  const firstIndex = compositeKey.indexOf(COMPOSITE_KEY_SEPARATOR);
+  return firstIndex === -1 ? compositeKey : compositeKey.substring(0, firstIndex);
 }
 
 /**
  * Extract cliToolId from a composite key.
+ * cliToolId is always the second segment (it never contains a colon).
  * Validates the extracted value against known CLI tool IDs.
  *
  * @param compositeKey - Composite key string
  * @returns CLIToolType if valid, null otherwise
  */
 export function extractCliToolId(compositeKey: string): CLIToolType | null {
-  const lastIndex = compositeKey.lastIndexOf(COMPOSITE_KEY_SEPARATOR);
-  if (lastIndex === -1) return null;
-  const cliToolId = compositeKey.substring(lastIndex + 1);
+  const cliToolId = compositeKey.split(COMPOSITE_KEY_SEPARATOR)[1];
+  if (cliToolId === undefined) return null;
   return isCliToolType(cliToolId) ? cliToolId : null;
+}
+
+/**
+ * Extract instanceId from a composite key (Issue #896).
+ * - 3-part key "wt:cli:instance" -> "instance" (alias instance)
+ * - 2-part key "wt:cli"          -> "cli"      (primary instance id === cliToolId)
+ *
+ * @param compositeKey - Composite key string
+ * @returns instanceId portion, or null if the key has no cliToolId segment
+ */
+export function extractInstanceId(compositeKey: string): string | null {
+  const parts = compositeKey.split(COMPOSITE_KEY_SEPARATOR);
+  // parts[2] = alias instanceId; fall back to parts[1] (cliToolId) for primary keys.
+  return parts[2] ?? parts[1] ?? null;
 }
 
 // Re-export from shared config for backward compatibility (Issue #314)
@@ -133,16 +164,21 @@ export function isAutoYesExpired(state: AutoYesState): boolean {
  *
  * @param worktreeId - Worktree identifier
  * @param cliToolId - CLI tool type (default: 'claude')
+ * @param instanceId - Optional instance identifier (Issue #896; defaults to primary)
  * @returns Current auto-yes state, or null if no state exists
  */
-export function getAutoYesState(worktreeId: string, cliToolId: CLIToolType = 'claude'): AutoYesState | null {
-  const key = buildCompositeKey(worktreeId, cliToolId);
+export function getAutoYesState(
+  worktreeId: string,
+  cliToolId: CLIToolType = 'claude',
+  instanceId?: string
+): AutoYesState | null {
+  const key = buildCompositeKey(worktreeId, cliToolId, instanceId);
   const state = autoYesStates.get(key);
   if (!state) return null;
 
   // Auto-disable if expired (Issue #314: delegate to disableAutoYes)
   if (isAutoYesExpired(state)) {
-    return disableAutoYes(worktreeId, cliToolId, 'expired');
+    return disableAutoYes(worktreeId, cliToolId, 'expired', instanceId);
   }
 
   return state;
@@ -160,15 +196,17 @@ export function getAutoYesState(worktreeId: string, cliToolId: CLIToolType = 'cl
  * @param duration - Optional duration in milliseconds (must be an ALLOWED_DURATIONS value).
  *                   Defaults to DEFAULT_AUTO_YES_DURATION (1 hour) when omitted.
  * @param stopPattern - Optional regex pattern for stop condition (Issue #314).
+ * @param instanceId - Optional instance identifier (Issue #896; defaults to primary).
  */
 export function setAutoYesEnabled(
   worktreeId: string,
   cliToolId: CLIToolType,
   enabled: boolean,
   duration?: AutoYesDuration,
-  stopPattern?: string
+  stopPattern?: string,
+  instanceId?: string
 ): AutoYesState {
-  const key = buildCompositeKey(worktreeId, cliToolId);
+  const key = buildCompositeKey(worktreeId, cliToolId, instanceId);
   if (enabled) {
     const now = Date.now();
     const effectiveDuration = duration ?? DEFAULT_AUTO_YES_DURATION;
@@ -182,7 +220,7 @@ export function setAutoYesEnabled(
     return state;
   } else {
     // Issue #314: Delegate disable path to disableAutoYes()
-    return disableAutoYes(worktreeId, cliToolId);
+    return disableAutoYes(worktreeId, cliToolId, undefined, instanceId);
   }
 }
 
@@ -196,14 +234,16 @@ export function setAutoYesEnabled(
  * @param worktreeId - Worktree identifier
  * @param cliToolId - CLI tool type (default: 'claude')
  * @param reason - Optional reason for disabling ('expired' | 'stop_pattern_matched')
+ * @param instanceId - Optional instance identifier (Issue #896; defaults to primary)
  * @returns Updated auto-yes state
  */
 export function disableAutoYes(
   worktreeId: string,
   cliToolId: CLIToolType = 'claude',
-  reason?: AutoYesStopReason
+  reason?: AutoYesStopReason,
+  instanceId?: string
 ): AutoYesState {
-  const key = buildCompositeKey(worktreeId, cliToolId);
+  const key = buildCompositeKey(worktreeId, cliToolId, instanceId);
   const existing = autoYesStates.get(key);
   const state: AutoYesState = {
     enabled: false,
@@ -271,14 +311,17 @@ export function checkStopCondition(
   const worktreeId = extractWorktreeId(compositeKey);
   const cliToolId = extractCliToolId(compositeKey);
   if (!cliToolId) return false;
+  // Issue #896: alias instances carry a 3-part key; resolve their instanceId so
+  // the stop-condition disable targets the correct instance state.
+  const instanceId = extractInstanceId(compositeKey) ?? undefined;
 
-  const autoYesState = getAutoYesState(worktreeId, cliToolId);
+  const autoYesState = getAutoYesState(worktreeId, cliToolId, instanceId);
   if (!autoYesState?.stopPattern) return false;
 
   const validation = validateStopPattern(autoYesState.stopPattern);
   if (!validation.valid) {
     logger.warn('invalid-stop-pattern', { detail: String({ compositeKey }) });
-    disableAutoYes(worktreeId, cliToolId);
+    disableAutoYes(worktreeId, cliToolId, undefined, instanceId);
     return false;
   }
 
@@ -289,12 +332,12 @@ export function checkStopCondition(
     if (matched === null) {
       // Execution failed - disable to prevent future errors
       logger.warn('stop-condition-check', { detail: String({ compositeKey }) });
-      disableAutoYes(worktreeId, cliToolId);
+      disableAutoYes(worktreeId, cliToolId, undefined, instanceId);
       return false;
     }
 
     if (matched) {
-      disableAutoYes(worktreeId, cliToolId, 'stop_pattern_matched');
+      disableAutoYes(worktreeId, cliToolId, 'stop_pattern_matched', instanceId);
       if (onStopMatched) {
         onStopMatched(compositeKey);
       }

--- a/src/lib/polling/auto-yes-manager.ts
+++ b/src/lib/polling/auto-yes-manager.ts
@@ -18,11 +18,12 @@ export type { AutoYesStopReason } from '../auto-yes-state';
 export type { AutoYesState } from '../auto-yes-state';
 
 export {
-  // Composite key helpers (Issue #525)
+  // Composite key helpers (Issue #525, #896)
   COMPOSITE_KEY_SEPARATOR,
   buildCompositeKey,
   extractWorktreeId,
   extractCliToolId,
+  extractInstanceId,
 
   // State management
   isAutoYesExpired,

--- a/src/lib/session/worktree-status-helper.ts
+++ b/src/lib/session/worktree-status-helper.ts
@@ -119,10 +119,10 @@ async function detectInstanceSessionStatus(
     try {
       const captureLines = getStatusCaptureLines(cliToolId);
       const output = await captureSessionOutput(worktreeId, cliToolId, captureLines, instanceId);
-      // Issue #501, #525: Pass last server response timestamp using compositeKey.
-      // Auto-yes / last-response tracking stays cliTool-keyed (#869), so alias
-      // instances share the tool's composite key — acceptable as a status hint.
-      const compositeKey = buildCompositeKey(worktreeId, cliToolId);
+      // Issue #501, #525, #896: Pass last server response timestamp using the
+      // per-instance compositeKey. Auto-yes / last-response tracking is now
+      // per-instance, so alias instances read their own poller timestamp.
+      const compositeKey = buildCompositeKey(worktreeId, cliToolId, instanceId);
       const lastServerResponseTs = getLastServerResponseTimestamp(compositeKey);
       const lastOutputTimestamp = lastServerResponseTs ? new Date(lastServerResponseTs) : undefined;
       const statusResult = detectSessionStatus(output, cliToolId, lastOutputTimestamp);

--- a/tests/unit/lib/auto-yes-composite-key.test.ts
+++ b/tests/unit/lib/auto-yes-composite-key.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for composite key helper functions (Issue #525)
  * Phase 1: buildCompositeKey, extractWorktreeId, extractCliToolId
+ * Issue #896: per-instance keys (3-part) + extractInstanceId
  */
 
 import { describe, it, expect } from 'vitest';
@@ -8,6 +9,7 @@ import {
   buildCompositeKey,
   extractWorktreeId,
   extractCliToolId,
+  extractInstanceId,
   COMPOSITE_KEY_SEPARATOR,
 } from '@/lib/auto-yes-state';
 
@@ -38,6 +40,27 @@ describe('Composite Key Helpers (Issue #525)', () => {
         /worktreeId must not contain/
       );
     });
+
+    // Issue #896: per-instance keys
+    it('should keep the 2-part key for the primary instance (instanceId === cliToolId)', () => {
+      expect(buildCompositeKey('wt-1', 'claude', 'claude')).toBe('wt-1:claude');
+    });
+
+    it('should keep the 2-part key when instanceId is omitted', () => {
+      expect(buildCompositeKey('wt-1', 'claude')).toBe('wt-1:claude');
+      expect(buildCompositeKey('wt-1', 'claude', undefined)).toBe('wt-1:claude');
+    });
+
+    it('should create a 3-part key for an alias instance (instanceId !== cliToolId)', () => {
+      expect(buildCompositeKey('wt-1', 'claude', 'claude-2')).toBe('wt-1:claude:claude-2');
+      expect(buildCompositeKey('wt-2', 'codex', 'codex-review')).toBe('wt-2:codex:codex-review');
+    });
+
+    it('should throw if instanceId contains the separator [SEC4-SF-004]', () => {
+      expect(() => buildCompositeKey('wt-1', 'claude', 'bad:instance')).toThrow(
+        /instanceId must not contain/
+      );
+    });
   });
 
   describe('extractWorktreeId', () => {
@@ -54,9 +77,11 @@ describe('Composite Key Helpers (Issue #525)', () => {
       expect(extractWorktreeId('no-separator')).toBe('no-separator');
     });
 
-    it('should use lastIndexOf to handle edge cases', () => {
-      // cliToolId "vibe-local" does not contain ':', so lastIndexOf is correct
+    it('should use the first segment so multi-part keys still resolve the worktreeId', () => {
+      // worktreeId never contains ':', so the first segment is always the worktreeId
       expect(extractWorktreeId('wt-1:vibe-local')).toBe('wt-1');
+      // Issue #896: 3-part alias key still extracts the worktreeId (not the cliToolId)
+      expect(extractWorktreeId('wt-1:claude:claude-2')).toBe('wt-1');
     });
   });
 
@@ -77,6 +102,28 @@ describe('Composite Key Helpers (Issue #525)', () => {
       expect(extractCliToolId('wt-1:invalid-tool')).toBeNull();
       expect(extractCliToolId('wt-1:')).toBeNull();
     });
+
+    it('should extract cliToolId from a 3-part alias key (Issue #896)', () => {
+      expect(extractCliToolId('wt-1:claude:claude-2')).toBe('claude');
+      expect(extractCliToolId('wt-2:codex:codex-review')).toBe('codex');
+    });
+  });
+
+  // Issue #896: extractInstanceId
+  describe('extractInstanceId', () => {
+    it('should return the alias instanceId from a 3-part key', () => {
+      expect(extractInstanceId('wt-1:claude:claude-2')).toBe('claude-2');
+      expect(extractInstanceId('wt-2:codex:codex-review')).toBe('codex-review');
+    });
+
+    it('should fall back to the cliToolId for a 2-part primary key', () => {
+      expect(extractInstanceId('wt-1:claude')).toBe('claude');
+      expect(extractInstanceId('wt-1:vibe-local')).toBe('vibe-local');
+    });
+
+    it('should return null when the key has no cliToolId segment', () => {
+      expect(extractInstanceId('no-separator')).toBeNull();
+    });
   });
 
   describe('roundtrip consistency', () => {
@@ -86,6 +133,15 @@ describe('Composite Key Helpers (Issue #525)', () => {
       const cliToolId = extractCliToolId(original);
       expect(cliToolId).not.toBeNull();
       expect(buildCompositeKey(worktreeId, cliToolId!)).toBe(original);
+    });
+
+    it('should reconstruct an alias composite key from extracted parts (Issue #896)', () => {
+      const original = buildCompositeKey('my-wt', 'claude', 'claude-2');
+      const worktreeId = extractWorktreeId(original);
+      const cliToolId = extractCliToolId(original);
+      const instanceId = extractInstanceId(original);
+      expect(cliToolId).not.toBeNull();
+      expect(buildCompositeKey(worktreeId, cliToolId!, instanceId!)).toBe(original);
     });
   });
 });

--- a/tests/unit/lib/auto-yes-manager.test.ts
+++ b/tests/unit/lib/auto-yes-manager.test.ts
@@ -335,6 +335,36 @@ describe('auto-yes-manager', () => {
       expect(result.started).toBe(false);
       expect(result.reason).toBe('max concurrent pollers reached');
     });
+
+    // Issue #896: per-instance pollers
+    it('should run independent pollers for the primary and an alias of the same cliTool', () => {
+      setAutoYesEnabled('wt-1', 'claude', true);
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2');
+
+      const primary = startAutoYesPolling('wt-1', 'claude');
+      const alias = startAutoYesPolling('wt-1', 'claude', 'claude-2');
+
+      expect(primary.started).toBe(true);
+      expect(alias.started).toBe(true);
+      // Two distinct composite keys -> two distinct pollers
+      expect(getActivePollerCount()).toBe(2);
+    });
+
+    it('should stop only the targeted instance poller, leaving the other running', () => {
+      setAutoYesEnabled('wt-1', 'claude', true);
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2');
+      startAutoYesPolling('wt-1', 'claude');
+      startAutoYesPolling('wt-1', 'claude', 'claude-2');
+      expect(getActivePollerCount()).toBe(2);
+
+      // Stop just the alias (3-part composite key)
+      stopAutoYesPolling('wt-1:claude:claude-2');
+      expect(getActivePollerCount()).toBe(1);
+
+      // Primary poller is still active
+      stopAutoYesPolling('wt-1:claude');
+      expect(getActivePollerCount()).toBe(0);
+    });
   });
 
   describe('stopAutoYesPolling', () => {
@@ -1369,6 +1399,7 @@ describe('auto-yes-manager', () => {
     return {
       timerId: null,
       cliToolId: 'claude',
+      instanceId: 'claude',
       consecutiveErrors: 0,
       currentInterval: POLLING_INTERVAL_MS,
       lastServerResponseTimestamp: null,
@@ -1455,7 +1486,8 @@ describe('auto-yes-manager', () => {
       expect(result).toBe('Hello World');
 
       // Verify captureSessionOutput was called with 5000 line limit
-      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 5000);
+      // Issue #896: instanceId is passed as 4th arg (undefined for primary)
+      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 5000, undefined);
 
       vi.mocked(captureSessionOutput).mockReset();
     });
@@ -2091,15 +2123,16 @@ describe('auto-yes-manager', () => {
       vi.mocked(captureSessionOutput).mockResolvedValue('test output');
 
       // Call with explicit REDUCED_CAPTURE_LINES
+      // Issue #896: instanceId is passed as 4th arg (undefined for primary)
       await captureAndCleanOutput('test-wt', 'claude', REDUCED_CAPTURE_LINES);
-      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 300);
+      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 300, undefined);
 
       vi.mocked(captureSessionOutput).mockReset();
       vi.mocked(captureSessionOutput).mockResolvedValue('test output');
 
       // Call with explicit FULL_CAPTURE_LINES
       await captureAndCleanOutput('test-wt', 'claude', FULL_CAPTURE_LINES);
-      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 5000);
+      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 5000, undefined);
 
       vi.mocked(captureSessionOutput).mockReset();
     });

--- a/tests/unit/lib/auto-yes-state-composite.test.ts
+++ b/tests/unit/lib/auto-yes-state-composite.test.ts
@@ -247,4 +247,73 @@ describe('auto-yes-state composite key migration (Issue #525)', () => {
       expect(deleteAutoYesStateByWorktree('wt-nonexistent')).toBe(0);
     });
   });
+
+  // ==========================================================================
+  // Issue #896: per-instance state isolation
+  // Two instances of the SAME cliTool (primary "claude" + alias "claude-2")
+  // must own completely independent auto-yes states.
+  // ==========================================================================
+  describe('per-instance state isolation (Issue #896)', () => {
+    it('should keep primary and alias states independent for the same cliTool', () => {
+      setAutoYesEnabled('wt-1', 'claude', true);
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2');
+
+      expect(getAutoYesState('wt-1', 'claude')?.enabled).toBe(true);
+      expect(getAutoYesState('wt-1', 'claude', 'claude-2')?.enabled).toBe(true);
+
+      // Disabling the alias must NOT disable the primary
+      disableAutoYes('wt-1', 'claude', 'expired', 'claude-2');
+      expect(getAutoYesState('wt-1', 'claude', 'claude-2')?.enabled).toBe(false);
+      expect(getAutoYesState('wt-1', 'claude')?.enabled).toBe(true);
+    });
+
+    it('should treat instanceId === cliToolId as the primary (same 2-part key)', () => {
+      setAutoYesEnabled('wt-1', 'claude', true);
+      // Passing the primary instanceId resolves to the same state, not a new one
+      expect(getAutoYesState('wt-1', 'claude', 'claude')?.enabled).toBe(true);
+    });
+
+    it('should not leak the alias state when querying the primary before it exists', () => {
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2');
+
+      expect(getAutoYesState('wt-1', 'claude', 'claude-2')?.enabled).toBe(true);
+      // Primary was never enabled -> still null
+      expect(getAutoYesState('wt-1', 'claude')).toBeNull();
+    });
+
+    it('should include both primary and alias keys for the worktree', () => {
+      setAutoYesEnabled('wt-1', 'claude', true);
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2');
+
+      const keys = getCompositeKeysByWorktree('wt-1');
+      expect(keys).toContain('wt-1:claude');
+      expect(keys).toContain('wt-1:claude:claude-2');
+    });
+
+    it('should delete both primary and alias states by worktree', () => {
+      setAutoYesEnabled('wt-1', 'claude', true);
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2');
+
+      const count = deleteAutoYesStateByWorktree('wt-1');
+
+      expect(count).toBe(2);
+      expect(getAutoYesState('wt-1', 'claude')).toBeNull();
+      expect(getAutoYesState('wt-1', 'claude', 'claude-2')).toBeNull();
+    });
+
+    it('should auto-disable an expired alias independently of the primary', () => {
+      vi.useFakeTimers();
+      const now = 1700000000000;
+      vi.setSystemTime(now);
+
+      setAutoYesEnabled('wt-1', 'claude', true, 10800000); // primary: 3h
+      setAutoYesEnabled('wt-1', 'claude', true, undefined, undefined, 'claude-2'); // alias: 1h default
+
+      // Advance past the alias expiration but not the primary's
+      vi.setSystemTime(now + 3600001);
+
+      expect(getAutoYesState('wt-1', 'claude', 'claude-2')?.enabled).toBe(false);
+      expect(getAutoYesState('wt-1', 'claude')?.enabled).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

同一ブランチで同一コーディングエージェントの複数インスタンス（例: `claude` + エイリアス `claude-2`）を起動した際、Auto-Yes が**1セッション分しか有効にならない**不具合を修正します。

Closes #896

## 原因

Auto-Yes の state（`__autoYesStates`）と poller（`__autoYesPollerStates`）が `worktreeId:cliToolId` の 2-part composite key のみでキー付けされていました。さらに poller 内の `captureSessionOutput` / `getSessionName` が `instanceId` を渡しておらず、常にプライマリインスタンスの tmux セッションを解決していたため、エイリアスインスタンスは Auto-Yes 応答が一切行われませんでした。

## 対策

`instanceId` を以下の全レイヤーに通し、各インスタンスが**独立した Auto-Yes state と poller** を持つようにしました。

- **composite key**: プライマリは従来どおり 2-part `worktreeId:cliToolId`（後方互換）、エイリアスは 3-part `worktreeId:cliToolId:instanceId`
- **state** (`auto-yes-state.ts`): `get/set/disable` が `instanceId` を受け取り、`extractInstanceId` を追加
- **poller** (`auto-yes-poller.ts`): `AutoYesPollerState` に `instanceId` を保持し、capture / `getSessionName` / poll スケジュールへ伝播
- **API** (`auto-yes` / `current-output` ルート): `instanceId` の受け取り・検証、GET レスポンスに `instances` マップを追加、disable は instance/tool/all の3分岐
- **CLI** (`send` / `auto-yes`): `--instance` オプションで instance 指定可能に
- **フロントエンド** (`useWorktreeDetailController` / `WorktreeDetailDesktop`): state マップ・トグルハンドラを instanceId 単位に変更し、各セッションタブ／ペインが個別にトグル

## テスト

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅（415 files / 7853 tests passing）
- `npm run build` ✅

新規ユニットテスト:
- 3-part composite key の生成・分解、`extractInstanceId`
- 同一 cliTool のプライマリ／エイリアス state の独立性（個別 disable・期限切れ・worktree 単位削除）
- プライマリ／エイリアスの独立 poller（個別起動・個別停止）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
