### PR TITLE
fix: split 復帰時のターミナル選択リセットを解消（過渡 roster への reconcile 抑止）(#898)

### DIFF
--- a/src/components/worktree/TerminalSplitContainer.tsx
+++ b/src/components/worktree/TerminalSplitContainer.tsx
@@ -69,6 +69,15 @@ export interface TerminalSplitContainerProps {
   worktreeId: string;
   /** Issue #869: the worktree's agent-instance roster (drives split identity). */
   instances: AgentInstance[];
+  /**
+   * Issue #898: `true` once `instances` is the REAL roster for `worktreeId`
+   * (not the transient seed/default shown before the API responds or right
+   * after a sidebar worktree switch). Gates the split reconcile so persisted
+   * alias splits (`claude-2`) are not evicted against an incomplete roster.
+   * Optional (defaults to `true`) for callers/tests that always pass a concrete
+   * roster.
+   */
+  rosterReady?: boolean;
   /** Render a single split body. Caller wires sendMessage / TerminalDisplay. */
   renderPane: (args: RenderTerminalSplitPaneArgs) => ReactNode;
   /**
@@ -92,6 +101,7 @@ export interface TerminalSplitContainerProps {
 export const TerminalSplitContainer = memo(function TerminalSplitContainer({
   worktreeId,
   instances,
+  rosterReady = true,
   renderPane,
   onFocusedSplitChange,
   showToast,
@@ -108,7 +118,7 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
     availableInstanceIds,
     focusedSplitIndex,
     setFocusedSplitIndex,
-  } = useTerminalSplits(worktreeId, instances);
+  } = useTerminalSplits(worktreeId, instances, rosterReady);
 
   // Stable lookup from instanceId → AgentInstance for label / availability.
   const instanceById = useMemo(() => {

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -65,6 +65,13 @@ export interface WorktreeDetailDesktopProps {
   worktreeStatus: WorktreeStatus;
   /** Issue #869: agent instance roster (drives instance tabs / split selectors). */
   instances: AgentInstance[];
+  /**
+   * Issue #898: `true` once the real roster for this worktree has loaded.
+   * Forwarded to TerminalSplitContainer so the split reconcile is suppressed
+   * while the roster is still the transient seed/default (which would otherwise
+   * evict persisted alias splits like `claude-2`).
+   */
+  rosterReady: boolean;
   /** Issue #869: active agent instance id (tab/split identity). */
   activeInstanceId: string;
   /** Issue #869: set the active agent instance (also syncs activeCliTab). */
@@ -188,6 +195,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
   worktreeName,
   worktreeStatus,
   instances,
+  rosterReady,
   activeInstanceId,
   setActiveInstanceId,
   hasUpdate,
@@ -428,6 +436,8 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       <TerminalSplitContainer
         worktreeId={worktreeId}
         instances={instances}
+        // Issue #898: suppress split reconcile until the real roster is loaded.
+        rosterReady={rosterReady}
         renderPane={renderSplitPane}
         onFocusedSplitChange={setFocusedSplitIndex}
         // Issue #786 / #869: the container is the drop validation owner; it
@@ -440,7 +450,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
     // setFocusedSplitIndex / setActiveInstanceId are stable callbacks, and
     // showToast is a stable parent callback, so listing them does not
     // destabilize the memo beyond the existing per-render cadence.
-    [worktreeId, instances, renderSplitPane, setFocusedSplitIndex, showToast, setActiveInstanceId],
+    [worktreeId, instances, rosterReady, renderSplitPane, setFocusedSplitIndex, showToast, setActiveInstanceId],
   );
 
   /**

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -187,6 +187,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     pendingInsertText,
     pendingInsertTextMap,
     removeToast,
+    rosterReady,
     setActiveInstanceId,
     setEditorFilePath,
     setFocusedSplitIndex,
@@ -236,6 +237,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           worktreeName={worktreeName}
           worktreeStatus={worktreeStatus}
           instances={agentInstances}
+          rosterReady={rosterReady}
           activeInstanceId={activeInstanceId}
           setActiveInstanceId={setActiveInstanceId}
           hasUpdate={hasUpdate}

--- a/src/hooks/useTerminalSplits.ts
+++ b/src/hooks/useTerminalSplits.ts
@@ -150,29 +150,56 @@ function reconcileConfig(config: TerminalSplitConfig, instances: AgentInstance[]
   return { splits: newSplits, widths };
 }
 
-function readInitialState(worktreeId: string, instances: AgentInstance[]): TerminalSplitConfig {
-  if (typeof window === 'undefined') return reconcileConfig(defaultConfigFor(instances), instances);
+/**
+ * Load the persisted (or default) split config for a worktree WITHOUT
+ * reconciling it against the roster. Widths are self-healed (sum -> 1.0) so the
+ * value is render-safe, but instance assignments are preserved verbatim — alias
+ * instances (e.g. `claude-2`) survive even when the caller's roster does not yet
+ * contain them (Issue #898).
+ */
+function loadPersistedConfig(worktreeId: string, instances: AgentInstance[]): TerminalSplitConfig {
+  if (typeof window === 'undefined') return defaultConfigFor(instances);
   try {
     const raw = window.localStorage.getItem(getTerminalSplitsStorageKey(worktreeId));
-    if (!raw) return reconcileConfig(defaultConfigFor(instances), instances);
+    if (!raw) return defaultConfigFor(instances);
     const parsed: unknown = JSON.parse(raw);
     const normalized = normalizeSplitConfig(parsed);
     if (normalized) {
-      // Self-heal widths (sum -> 1.0) then reconcile against the live roster.
-      const healed = { ...normalized, widths: normalizeWidths(normalized.widths) };
-      return reconcileConfig(healed, instances);
+      // Self-heal widths (sum -> 1.0); leave splits untouched.
+      return { ...normalized, widths: normalizeWidths(normalized.widths) };
     }
     console.warn(
       `[useTerminalSplits] stale state for ${worktreeId}; falling back to default`,
     );
-    return reconcileConfig(defaultConfigFor(instances), instances);
+    return defaultConfigFor(instances);
   } catch (err) {
     console.warn(
       `[useTerminalSplits] failed to parse stored state for ${worktreeId}; using default`,
       err,
     );
-    return reconcileConfig(defaultConfigFor(instances), instances);
+    return defaultConfigFor(instances);
   }
+}
+
+/**
+ * Issue #898: derive the initial config, reconciling against the roster ONLY
+ * when `rosterReady` is true.
+ *
+ * Until the worktree's REAL agent-instance roster has loaded, the caller seeds a
+ * default primary-only roster (claude/codex/… — no aliases). Reconciling the
+ * persisted `[claude, claude-2]` against that transient roster would evict
+ * `claude-2` (it is absent) and back-fill an unrelated primary, which is exactly
+ * the split-reset bug. So while `rosterReady` is false we preserve the persisted
+ * config verbatim; a later reconcile pass (fired when `rosterReady` flips true)
+ * fixes it against the real roster.
+ */
+function readInitialState(
+  worktreeId: string,
+  instances: AgentInstance[],
+  rosterReady: boolean,
+): TerminalSplitConfig {
+  const loaded = loadPersistedConfig(worktreeId, instances);
+  return rosterReady ? reconcileConfig(loaded, instances) : loaded;
 }
 
 function pickUnusedInstance(
@@ -196,9 +223,18 @@ function widthsValid(widths: unknown): widths is number[] {
 export function useTerminalSplits(
   worktreeId: string,
   instances: AgentInstance[],
+  /**
+   * Issue #898: `true` once the REAL agent-instance roster for `worktreeId` has
+   * loaded (vs. the transient seed/default roster shown before the API responds
+   * or right after a sidebar worktree switch). While `false`, reconcile is
+   * suppressed so persisted alias instances (`claude-2`) are not evicted against
+   * an incomplete roster. Defaults to `true` for callers/tests that always pass
+   * a concrete roster (pre-#898 behavior).
+   */
+  rosterReady: boolean = true,
 ): UseTerminalSplitsReturn {
   const [config, setConfig] = useState<TerminalSplitConfig>(() =>
-    readInitialState(worktreeId, instances),
+    readInitialState(worktreeId, instances, rosterReady),
   );
   const [focusedSplitIndex, setFocusedSplitIndexRaw] = useState(0);
 
@@ -210,13 +246,17 @@ export function useTerminalSplits(
   configRef.current = config;
   const instancesRef = useRef(instances);
   instancesRef.current = instances;
+  // Issue #898: read the latest rosterReady inside the worktreeId-change effect
+  // without re-running it when only rosterReady flips.
+  const rosterReadyRef = useRef(rosterReady);
+  rosterReadyRef.current = rosterReady;
 
   // Re-read when worktreeId changes (worktree switching).
   const prevWorktreeIdRef = useRef(worktreeId);
   useEffect(() => {
     if (prevWorktreeIdRef.current === worktreeId) return;
     prevWorktreeIdRef.current = worktreeId;
-    setConfig(readInitialState(worktreeId, instancesRef.current));
+    setConfig(readInitialState(worktreeId, instancesRef.current, rosterReadyRef.current));
     setFocusedSplitIndexRaw(0);
   }, [worktreeId]);
 
@@ -224,19 +264,33 @@ export function useTerminalSplits(
   // removed). Keyed on a roster signature so the effect only runs on a real
   // roster change, not on every render. reconcileConfig returns the same
   // reference when nothing changed, so setConfig bails out (no re-render).
+  // Issue #898: also re-runs when `rosterReady` flips false→true so the first
+  // reconcile happens once the real roster is confirmed; while false the
+  // reconcile is skipped to preserve persisted alias assignments.
   const rosterSignature = useMemo(
     () => instances.map(i => `${i.id}:${i.cliTool}`).join('|'),
     [instances],
   );
   useEffect(() => {
+    if (!rosterReady) return;
     setConfig(prev => reconcileConfig(prev, instancesRef.current));
     // rosterSignature is the real dependency; instancesRef is read fresh.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rosterSignature]);
+  }, [rosterSignature, rosterReady]);
 
   // Persist on every change. Quota / unavailability is swallowed.
+  // Issue #898: skip the single transient render right after a worktree switch
+  // where `config` still reflects the PREVIOUS worktree (the worktreeId effect
+  // above re-derives it via a fresh setConfig → re-render, which then persists
+  // correctly). This avoids momentarily writing the old config under the new
+  // worktreeId's storage key.
+  const persistedWorktreeIdRef = useRef(worktreeId);
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (persistedWorktreeIdRef.current !== worktreeId) {
+      persistedWorktreeIdRef.current = worktreeId;
+      return;
+    }
     try {
       window.localStorage.setItem(
         getTerminalSplitsStorageKey(worktreeId),

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -226,6 +226,14 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   );
   const agentInstancesRef = useRef(agentInstances);
   agentInstancesRef.current = agentInstances;
+  // Issue #898: which worktreeId the current `agentInstances` roster was loaded
+  // for. `null` until the first real roster arrives. Until it equals the active
+  // `worktreeId`, the roster in hand is the transient seed/default (or a
+  // previous worktree's roster right after a sidebar switch), which lacks alias
+  // instances (claude-2). `rosterReady` gates the terminal-split reconcile so it
+  // never evicts persisted aliases against that incomplete roster.
+  const [rosterWorktreeId, setRosterWorktreeId] = useState<string | null>(null);
+  const rosterReady = rosterWorktreeId === worktreeId;
   // Issue #368: Vibe-local Ollama model state (initialized from API)
   const [vibeLocalModel, setVibeLocalModel] = useState<string | null>(null);
   // Issue #374: Vibe-local context window state (initialized from API)
@@ -454,6 +462,12 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
         if (!isSame) {
           setAgentInstances(next);
         }
+        // Issue #898: the real roster for THIS worktree is now confirmed (even
+        // when unchanged), so terminal-split reconcile may run. `worktreeId` is
+        // captured from this callback's closure, so a stale response for a
+        // previous worktree tags its own id — `rosterReady` stays false until the
+        // active worktree's roster arrives.
+        setRosterWorktreeId(worktreeId);
       }
       // Issue #368: Sync vibeLocalModel from API response
       if ('vibeLocalModel' in data) {
@@ -663,7 +677,11 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
    */
   const handleAgentInstancesChange = useCallback((instances: AgentInstance[]) => {
     setAgentInstances(instances);
-  }, []);
+    // Issue #898: a roster edit applies to the active worktree, so keep the
+    // roster tagged to it — reconcile must run against the edited roster (e.g.
+    // a removed alias should be evicted from splits as before).
+    setRosterWorktreeId(worktreeId);
+  }, [worktreeId]);
 
   /** Issue #368: Callback for AgentSettingsPane to update vibeLocalModel */
   const handleVibeLocalModelChange = useCallback((model: string | null) => {
@@ -1534,6 +1552,7 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     handleShowArchivedChange,
     handleUpload,
     handleVibeLocalContextWindowChange,
+    rosterReady,
     handleVibeLocalModelChange,
     handleWorktreeStatusChange,
     hasUpdate,

--- a/tests/unit/hooks/useTerminalSplits.test.ts
+++ b/tests/unit/hooks/useTerminalSplits.test.ts
@@ -528,4 +528,123 @@ describe('useTerminalSplits', () => {
       expect(stored?.widths[1]).toBeCloseTo(0.5);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #898: split restoration must NOT reconcile against the transient
+  // seed/default roster (primary-only, no aliases) shown before the real roster
+  // arrives or right after a sidebar worktree switch. Reconciling there evicts
+  // persisted alias splits (`claude-2`) and back-fills an unrelated primary,
+  // resetting the 2nd pane to the dropdown head. `rosterReady` gates reconcile.
+  // ---------------------------------------------------------------------------
+  describe('rosterReady gating (Issue #898)', () => {
+    // Real roster (alias included), as returned by the API for the worktree.
+    const REAL_A: AgentInstance[] = [
+      { id: 'claude', cliTool: 'claude', alias: 'Claude', order: 0 },
+      { id: 'claude-2', cliTool: 'claude', alias: 'Claude (review)', order: 1 },
+      { id: 'codex', cliTool: 'codex', alias: 'Codex', order: 2 },
+    ];
+    // Transient seed roster: primary-only, no `claude-2` (mirrors
+    // agentInstancesFromSelectedAgents(DEFAULT_SELECTED_AGENTS)).
+    const SEED: AgentInstance[] = [
+      { id: 'claude', cliTool: 'claude', alias: 'Claude', order: 0 },
+      { id: 'codex', cliTool: 'codex', alias: 'Codex', order: 1 },
+      { id: 'gemini', cliTool: 'gemini', alias: 'Gemini', order: 2 },
+    ];
+
+    const aliasConfig = {
+      splits: [
+        { cliToolId: 'claude', instanceId: 'claude' },
+        { cliToolId: 'claude', instanceId: 'claude-2' },
+      ],
+      widths: [0.5, 0.5],
+    };
+
+    // Test point 1: persisted [claude, claude-2] + transient seed roster +
+    // rosterReady=false → config preserved verbatim (no eviction).
+    it('preserves persisted alias splits while the roster is not ready', () => {
+      mockTerminalSplitsLocalStorage('w-a', aliasConfig);
+      const { result } = renderHook(() => useTerminalSplits('w-a', SEED, false));
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+    });
+
+    // Test point 2: once the real roster (with claude-2) arrives and
+    // rosterReady flips true, the alias assignment is still preserved.
+    it('keeps the alias assignment after the real roster arrives (false → true)', () => {
+      mockTerminalSplitsLocalStorage('w-a', aliasConfig);
+      const { result, rerender } = renderHook(
+        ({ roster, ready }: { roster: AgentInstance[]; ready: boolean }) =>
+          useTerminalSplits('w-a', roster, ready),
+        { initialProps: { roster: SEED, ready: false } },
+      );
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+
+      rerender({ roster: REAL_A, ready: true });
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+    });
+
+    // Test point 3: A → B → A sidebar round trip. The 2nd pane must return as
+    // `claude-2`, not morph into the alternate primary (codex) that B's roster
+    // would have back-filled during the transient reconcile.
+    it('keeps the 2nd pane as claude-2 across an A → B → A round trip', () => {
+      mockTerminalSplitsLocalStorage('w-a', aliasConfig);
+      // B's real roster (no claude-2; shares codex with the buggy back-fill).
+      const REAL_B: AgentInstance[] = [
+        { id: 'claude', cliTool: 'claude', alias: 'Claude', order: 0 },
+        { id: 'codex', cliTool: 'codex', alias: 'Codex', order: 1 },
+      ];
+
+      const { result, rerender } = renderHook(
+        ({ wid, roster, ready }: { wid: string; roster: AgentInstance[]; ready: boolean }) =>
+          useTerminalSplits(wid, roster, ready),
+        { initialProps: { wid: 'w-a', roster: REAL_A, ready: true } },
+      );
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+
+      // Navigate to B: transient roster (seed) then B's real roster.
+      rerender({ wid: 'w-b', roster: SEED, ready: false });
+      rerender({ wid: 'w-b', roster: REAL_B, ready: true });
+
+      // Navigate back to A. During the transient window the in-hand roster is
+      // still B's (no claude-2) and rosterReady is false → reconcile suppressed.
+      rerender({ wid: 'w-a', roster: REAL_B, ready: false });
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+
+      // A's real roster arrives → reconcile keeps claude-2 (it exists again).
+      rerender({ wid: 'w-a', roster: REAL_A, ready: true });
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+    });
+
+    // Test point 4: when the alias is genuinely gone from the REAL roster (and
+    // rosterReady=true), the pre-#898 eviction behavior is unchanged.
+    it('still evicts an alias that is truly absent from the real roster', () => {
+      mockTerminalSplitsLocalStorage('w-a', aliasConfig);
+      // ROSTER has no claude-2 → claude-2 evicted, slot back-filled with codex.
+      const { result } = renderHook(() => useTerminalSplits('w-a', ROSTER, true));
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'codex']);
+    });
+
+    // Test point 5 (persistence guard): switching worktrees must not write the
+    // previous worktree's config under the new worktreeId's storage key.
+    it('does not pollute the new worktree storage with the old config on switch', () => {
+      mockTerminalSplitsLocalStorage('w-a', aliasConfig);
+      const { result, rerender } = renderHook(
+        ({ wid, roster, ready }: { wid: string; roster: AgentInstance[]; ready: boolean }) =>
+          useTerminalSplits(wid, roster, ready),
+        { initialProps: { wid: 'w-a', roster: REAL_A, ready: true } },
+      );
+      expect(result.current.splits.map(s => s.instanceId)).toEqual(['claude', 'claude-2']);
+
+      // Switch to a fresh worktree with no stored config; its config must be the
+      // default single split — never the previous worktree's [claude, claude-2].
+      rerender({ wid: 'w-b', roster: SEED, ready: false });
+      const storedB = readTerminalSplitsLocalStorage('w-b');
+      expect(storedB?.splits.map(s => s.instanceId)).not.toEqual(['claude', 'claude-2']);
+      expect(storedB?.splits).toHaveLength(1);
+      // w-a's persisted config is untouched.
+      expect(readTerminalSplitsLocalStorage('w-a')?.splits.map(s => s.instanceId)).toEqual([
+        'claude',
+        'claude-2',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## 概要
Issue #898 の修正。split 分割時、サイドバーから他ブランチを選択して戻ると2個目以降のターミナル選択がドロップダウン先頭にリセットされる不具合を解消する。

## 根本原因
split 復帰時に `useTerminalSplits` が、永続化済みの正しい split 設定を **過渡 roster**（API応答前の primary-only シード/デフォルト、または A→B→A 直後に残る前ブランチ roster）に対して reconcile していた。reconcile が永続 alias split（例: `claude-2`）を退避させ、無関係な primary（codex）をバックフィルするため、2個目のペインがドロップダウン先頭に切り替わっていた。

## 修正（案A: 実 roster 確定まで reconcile を抑止）
1. **`useWorktreeDetailController.ts`** — `rosterWorktreeId` state を追加し、`fetchWorktree`/`handleAgentInstancesChange` で実 roster 反映時に active `worktreeId` をタグ付け。`rosterReady = rosterWorktreeId === worktreeId` を導出して返却。古い応答は自身のidをタグ付けするため、対象 worktree の roster 到着まで `rosterReady` は false のまま。
2. **`useTerminalSplits.ts`** — `rosterReady` パラメータを追加（後方互換でデフォルト `true`）。false の間は reconcile を抑止し永続設定をそのまま保持。`false→true` で実 roster に対して1度だけ reconcile。`readInitialState` を `loadPersistedConfig` + reconcile に分割。切替直後の過渡レンダーで旧設定を新 `worktreeId` のストレージキーに書き込む二次バグも永続化ガードで解消。
3. **配線** — `rosterReady` を `WorktreeDetailRefactored → WorktreeDetailDesktop → TerminalSplitContainer → useTerminalSplits` に伝搬。

## テスト
`useTerminalSplits.test.ts` に回帰テスト5件を追加（roster未確定時の alias 保持／実 roster 到着後の保持／A→B→A で `claude-2` が codex に化けない／alias が真に消えた場合の正当な退避は維持／切替時のストレージ汚染なし）。

## 品質ゲート（worktree で確認済み）
- `npm run lint` ✓ No ESLint warnings or errors
- `npx tsc --noEmit` ✓
- `npm run test:unit` ✓ 415 files / 7858 passed
- `npm run build` ✓

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)