### PR TITLE
fix(todo): リポジトリ別 ToDo にリポジトリ名を表示（#900）

### DIFF
--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -30,6 +30,11 @@ function repoLabel(repo: RepositoryOption): string {
   return repo.displayName?.trim() || repo.name;
 }
 
+/** Human-readable repository name for a todo (Issue #900). */
+function todoRepoLabel(todo: TodoItem): string {
+  return todo.repositoryDisplayName?.trim() || todo.repositoryName || '';
+}
+
 export function TodoWidget() {
   const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
   const [selectedRepoId, setSelectedRepoId] = useState('');
@@ -276,6 +281,15 @@ export function TodoWidget() {
                   >
                     {todo.content}
                   </span>
+                  {todoRepoLabel(todo) && (
+                    <span
+                      className="shrink-0 max-w-[8rem] truncate rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:text-gray-400"
+                      data-testid="todo-repo-badge"
+                      title={todoRepoLabel(todo)}
+                    >
+                      {todoRepoLabel(todo)}
+                    </span>
+                  )}
                   <button
                     type="button"
                     onClick={() => handleDelete(todo)}

--- a/src/lib/api/todo-api.ts
+++ b/src/lib/api/todo-api.ts
@@ -6,6 +6,10 @@
 export interface TodoItem {
   id: string;
   repositoryId: string;
+  /** Repository name resolved by the API via JOIN (Issue #900). */
+  repositoryName: string;
+  /** Optional repository display-name override. */
+  repositoryDisplayName?: string;
   content: string;
   done: boolean;
   position: number;

--- a/src/lib/db/todo-db.ts
+++ b/src/lib/db/todo-db.ts
@@ -11,10 +11,18 @@ import Database from 'better-sqlite3';
 
 /**
  * A single ToDo item scoped to a repository.
+ *
+ * `repositoryName` / `repositoryDisplayName` are resolved at read time by
+ * JOINing `repositories` (Issue #900). The table itself stays normalized
+ * (only `repository_id` is stored), so renames are reflected automatically.
  */
 export interface RepositoryTodo {
   id: string;
   repositoryId: string;
+  /** Repository `name` resolved via JOIN (always present, FK-guaranteed). */
+  repositoryName: string;
+  /** Repository `display_name` override; `undefined` when not set. */
+  repositoryDisplayName?: string;
   content: string;
   done: boolean;
   position: number;
@@ -24,10 +32,15 @@ export interface RepositoryTodo {
 
 /**
  * Database row type for repository todos.
+ *
+ * `repository_name` / `repository_display_name` come from the JOIN on
+ * `repositories`, not the `repository_todos` table itself.
  */
 type RepositoryTodoRow = {
   id: string;
   repository_id: string;
+  repository_name: string;
+  repository_display_name: string | null;
   content: string;
   done: number;
   position: number;
@@ -36,12 +49,34 @@ type RepositoryTodoRow = {
 };
 
 /**
+ * SELECT clause shared by todo read queries. Resolves the repository name at
+ * read time so consumers (widget, future cross-repo views, API/CLI) all get a
+ * human-readable name without denormalizing the table.
+ */
+const TODO_SELECT = `
+  SELECT
+    t.id,
+    t.repository_id,
+    r.name AS repository_name,
+    r.display_name AS repository_display_name,
+    t.content,
+    t.done,
+    t.position,
+    t.created_at,
+    t.updated_at
+  FROM repository_todos t
+  JOIN repositories r ON r.id = t.repository_id
+`;
+
+/**
  * Map database row to RepositoryTodo model.
  */
 function mapTodoRow(row: RepositoryTodoRow): RepositoryTodo {
   return {
     id: row.id,
     repositoryId: row.repository_id,
+    repositoryName: row.repository_name,
+    repositoryDisplayName: row.repository_display_name || undefined,
     content: row.content,
     done: row.done === 1,
     position: row.position,
@@ -58,10 +93,9 @@ export function getTodosByRepositoryId(
   repositoryId: string
 ): RepositoryTodo[] {
   const stmt = db.prepare(`
-    SELECT id, repository_id, content, done, position, created_at, updated_at
-    FROM repository_todos
-    WHERE repository_id = ?
-    ORDER BY position ASC, created_at ASC
+    ${TODO_SELECT}
+    WHERE t.repository_id = ?
+    ORDER BY t.position ASC, t.created_at ASC
   `);
 
   const rows = stmt.all(repositoryId) as RepositoryTodoRow[];
@@ -78,9 +112,8 @@ export function getTodoById(
   todoId: string
 ): RepositoryTodo | null {
   const stmt = db.prepare(`
-    SELECT id, repository_id, content, done, position, created_at, updated_at
-    FROM repository_todos
-    WHERE id = ?
+    ${TODO_SELECT}
+    WHERE t.id = ?
   `);
 
   const row = stmt.get(todoId) as RepositoryTodoRow | undefined;
@@ -108,15 +141,13 @@ export function createTodo(
 
   stmt.run(id, repositoryId, options.content, options.position, now, now);
 
-  return {
-    id,
-    repositoryId,
-    content: options.content,
-    done: false,
-    position: options.position,
-    createdAt: new Date(now),
-    updatedAt: new Date(now),
-  };
+  // Re-fetch so the returned todo carries the JOIN-resolved repository name
+  // (Issue #900), keeping POST responses consistent with GET.
+  const created = getTodoById(db, id);
+  if (!created) {
+    throw new Error(`Failed to load created todo '${id}'`);
+  }
+  return created;
 }
 
 /**

--- a/tests/integration/api/repository-todos.test.ts
+++ b/tests/integration/api/repository-todos.test.ts
@@ -93,6 +93,19 @@ describe('GET /api/repositories/:id/todos', () => {
     expect(data.todos.map((t: { content: string }) => t.content)).toEqual(['first', 'second']);
   });
 
+  it('includes the resolved repository name (Issue #900)', async () => {
+    createTodo(db, repoId, { content: 'task', position: 0 });
+
+    const { GET } = await import('@/app/api/repositories/[id]/todos/route');
+    const res = await GET(
+      asReq(new Request(`http://localhost/api/repositories/${repoId}/todos`)),
+      { params: Promise.resolve({ id: repoId }) },
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todos[0].repositoryName).toBe('TestRepo');
+  });
+
   it('returns 404 for a non-existent repository', async () => {
     const { GET } = await import('@/app/api/repositories/[id]/todos/route');
     const res = await GET(
@@ -137,6 +150,7 @@ describe('POST /api/repositories/:id/todos', () => {
     expect(data.todo.content).toBe('Write tests');
     expect(data.todo.done).toBe(false);
     expect(data.todo.repositoryId).toBe(repoId);
+    expect(data.todo.repositoryName).toBe('TestRepo');
     expect(data.todo.position).toBe(0);
   });
 

--- a/tests/unit/db/todo-db.test.ts
+++ b/tests/unit/db/todo-db.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { runMigrations } from '@/lib/db/db-migrations';
-import { createRepository } from '@/lib/db/db-repository';
+import { createRepository, updateRepository } from '@/lib/db/db-repository';
 import {
   getTodosByRepositoryId,
   getTodoById,
@@ -55,6 +55,36 @@ describe('todo-db', () => {
     expect(todo.done).toBe(false);
     expect(todo.position).toBe(0);
     expect(todo.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('resolves the repository name via JOIN (Issue #900)', () => {
+    const todo = createTodo(db, repositoryId, { content: 'task', position: 0 });
+    // createTodo re-fetches so the returned object carries the name.
+    expect(todo.repositoryName).toBe('TestRepo');
+    expect(todo.repositoryDisplayName).toBeUndefined();
+
+    const [listed] = getTodosByRepositoryId(db, repositoryId);
+    expect(listed.repositoryName).toBe('TestRepo');
+
+    const fetched = getTodoById(db, todo.id);
+    expect(fetched?.repositoryName).toBe('TestRepo');
+  });
+
+  it('returns the repository display name when set (Issue #900)', () => {
+    updateRepository(db, repositoryId, { displayName: 'My Repo' });
+    const todo = createTodo(db, repositoryId, { content: 'task', position: 0 });
+    expect(todo.repositoryName).toBe('TestRepo');
+    expect(todo.repositoryDisplayName).toBe('My Repo');
+  });
+
+  it('reflects the latest repository name after a rename (Issue #900)', () => {
+    const todo = createTodo(db, repositoryId, { content: 'task', position: 0 });
+    expect(getTodoById(db, todo.id)?.repositoryName).toBe('TestRepo');
+
+    updateRepository(db, repositoryId, { name: 'RenamedRepo' });
+
+    expect(getTodoById(db, todo.id)?.repositoryName).toBe('RenamedRepo');
+    expect(getTodosByRepositoryId(db, repositoryId)[0].repositoryName).toBe('RenamedRepo');
   });
 
   it('lists todos sorted by position', () => {


### PR DESCRIPTION
## 概要
リポジトリ別 ToDo 一覧で、登録された ToDo にリポジトリ名が表示されない問題を修正します（Issue #900 / 案2: DB/API 層で `repositoryName` を JOIN 提供）。

## 根本原因
ToDo データ取得時にリポジトリ名を JOIN しておらず、UI（`TodoWidget`）にリポジトリ名を渡す経路が存在しなかった。

## 修正内容
- `src/lib/db/todo-db.ts`: `repositories` を JOIN し、`RepositoryTodo` に `repositoryName` / `repositoryDisplayName` を付与（`mapTodoRow` 更新）。
- `src/lib/api/todo-api.ts`: `TodoItem` にリポジトリ名フィールドを反映。
- `src/components/home/TodoWidget.tsx`: リポジトリ名バッジを表示。
- テスト: `tests/unit/db/todo-db.test.ts` / `tests/integration/api/repository-todos.test.ts` に回帰テスト追加。

## 品質ゲート（オーケストレーター独立検証で全パス）
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅（415 files / 7861 tests）
- `npm run build` ✅

Refs #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
