### PR TITLE
fix(terminal-split): interrupt の別 instance 誤送信を解消（#901）

### DIFF
--- a/src/components/worktree/InterruptButton.tsx
+++ b/src/components/worktree/InterruptButton.tsx
@@ -13,6 +13,12 @@ import type { CLIToolType } from '@/lib/cli-tools/types';
 export interface InterruptButtonProps {
   worktreeId: string;
   cliToolId: CLIToolType;
+  /**
+   * Issue #901: agent instance id to target. Defaults to the primary instance
+   * (`=== cliToolId`) when omitted, so interrupt no longer broadcasts to other
+   * instances of the same cliTool (e.g. split `claude` vs `claude-2`).
+   */
+  instanceId?: string;
   disabled?: boolean;
   onInterrupt?: () => void;
 }
@@ -42,6 +48,7 @@ const DEBOUNCE_DELAY_MS = 1000;
 export const InterruptButton = memo(function InterruptButton({
   worktreeId,
   cliToolId,
+  instanceId,
   disabled = false,
   onInterrupt,
 }: InterruptButtonProps) {
@@ -58,12 +65,18 @@ export const InterruptButton = memo(function InterruptButton({
 
     setIsLoading(true);
     try {
+      // Issue #901: include instanceId so interrupt targets only this split's
+      // session. The primary instance (`=== cliToolId` or omitted) keeps sending
+      // `{ cliToolId }` only, preserving the CLI broadcast behavior.
+      const body = instanceId && instanceId !== cliToolId
+        ? { cliToolId, instanceId }
+        : { cliToolId };
       const response = await fetch(`/api/worktrees/${worktreeId}/interrupt`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ cliToolId }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
@@ -77,7 +90,7 @@ export const InterruptButton = memo(function InterruptButton({
     } finally {
       setIsLoading(false);
     }
-  }, [worktreeId, cliToolId, onInterrupt]);
+  }, [worktreeId, cliToolId, instanceId, onInterrupt]);
 
   return (
     <button

--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -480,6 +480,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             <InterruptButton
               worktreeId={worktreeId}
               cliToolId={cliToolId || 'claude'}
+              instanceId={instanceId}
               disabled={!isSessionRunning}
             />
           </div>
@@ -530,6 +531,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             <InterruptButton
               worktreeId={worktreeId}
               cliToolId={cliToolId || 'claude'}
+              instanceId={instanceId}
               disabled={!isSessionRunning}
             />
           )}

--- a/tests/unit/components/worktree/InterruptButton.test.tsx
+++ b/tests/unit/components/worktree/InterruptButton.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for InterruptButton component
+ *
+ * Issue #901: split 時に同一 cliTool の別 instance へ interrupt が誤送信される問題の
+ * 回帰テスト。interrupt の宛先キーに instanceId を含めることで、alias instance を
+ * 指定した split のみ対象になることを担保する。
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { InterruptButton } from '@/components/worktree/InterruptButton';
+
+describe('InterruptButton', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const clickInterrupt = () => {
+    fireEvent.click(screen.getByTestId('interrupt-button'));
+  };
+
+  const getRequestBody = (): Record<string, unknown> => {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/worktrees/wt-1/interrupt');
+    expect(init.method).toBe('POST');
+    return JSON.parse(init.body as string);
+  };
+
+  it('sends { cliToolId, instanceId } for an alias instance (split target)', async () => {
+    render(
+      <InterruptButton
+        worktreeId="wt-1"
+        cliToolId="claude"
+        instanceId="claude-2"
+      />
+    );
+
+    clickInterrupt();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(getRequestBody()).toEqual({ cliToolId: 'claude', instanceId: 'claude-2' });
+  });
+
+  it('sends only { cliToolId } for the primary instance (instanceId === cliToolId)', async () => {
+    render(
+      <InterruptButton
+        worktreeId="wt-1"
+        cliToolId="claude"
+        instanceId="claude"
+      />
+    );
+
+    clickInterrupt();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(getRequestBody()).toEqual({ cliToolId: 'claude' });
+  });
+
+  it('sends only { cliToolId } when instanceId is omitted (backward compatible)', async () => {
+    render(
+      <InterruptButton
+        worktreeId="wt-1"
+        cliToolId="claude"
+      />
+    );
+
+    clickInterrupt();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(getRequestBody()).toEqual({ cliToolId: 'claude' });
+  });
+
+  it('does not leak another instance id: alias B targets only its own instance', async () => {
+    render(
+      <InterruptButton
+        worktreeId="wt-1"
+        cliToolId="claude"
+        instanceId="claude-3"
+      />
+    );
+
+    clickInterrupt();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const body = getRequestBody();
+    expect(body.instanceId).toBe('claude-3');
+    expect(body.instanceId).not.toBe('claude');
+    expect(body.instanceId).not.toBe('claude-2');
+  });
+
+  it('does not send when disabled', () => {
+    render(
+      <InterruptButton
+        worktreeId="wt-1"
+        cliToolId="claude"
+        instanceId="claude-2"
+        disabled
+      />
+    );
+
+    clickInterrupt();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要
ターミナル split 時、interrupt が同一 cliTool の別 instance（alias）へ誤送信されるケースを解消します（Issue #901 / 案A: instanceId を InterruptButton まで伝搬）。

## 根本原因
`InterruptButton` が `instanceId` を持たず、interrupt API へ `{ cliToolId }` のみを送信していたため、同一 cliTool の alias instance が複数ある場合に API 側が全 instance へブロードキャストしていた。

## 修正内容
- `src/components/worktree/InterruptButton.tsx`: `instanceId?` を受け取り、`instanceId && instanceId !== cliToolId ? { cliToolId, instanceId } : { cliToolId }` を送信。
- `src/components/worktree/MessageInput.tsx`: `InterruptButton` へ `instanceId` を伝搬。
- テスト: `tests/unit/components/worktree/InterruptButton.test.tsx` に回帰テスト5件追加（alias は `{cliToolId, instanceId}` / primary・未指定は `{cliToolId}` のみ / 別 instance へ飛ばない / disabled 時は送信なし）。

## 品質ゲート（オーケストレーター独立検証で全パス）
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅（416 files / 7863 tests）
- `npm run build` ✅

Refs #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
