### PR TITLE
fix(auto-yes): 別ブランチ遷移→復帰で Auto-Yes 表示がリセットされる問題を解消（#902）

### DIFF
--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -293,6 +293,10 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   // polls/tab switches from overwriting the active CLI tab state.
   const latestMessagesRequestIdRef = useRef(0);
   const latestCurrentOutputRequestIdRef = useRef(0);
+  // Issue #902: Latest-request guard for the bulk per-instance auto-yes refetch
+  // so a slow reply for worktree A can't pollute worktree B's map during rapid
+  // A→B→A navigation (newest reply wins; the server is the source of truth).
+  const latestAutoYesRequestIdRef = useRef(0);
   // Issue #525/#896: Derive the active instance's auto-yes state from the
   // per-instance map (keyed by activeInstanceId; primary instance id === cliToolId).
   const autoYesEnabled = autoYesStateMap.get(activeInstanceId)?.enabled ?? false;
@@ -422,6 +426,11 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
       initialLoadCompletedRef.current = false;
       // Issue #736: terminal output reset is handled by the mobile terminal
       // tab's useTerminalPanePolling (self-resets on worktreeId change).
+      // Issue #902 (案2): discard the previous worktree's per-instance auto-yes
+      // map so B's values can never bleed onto A's same-named keys (e.g.
+      // "claude") during the transition. The 案1 bulk refetch below repopulates
+      // the map from the server an instant later (primary AND alias).
+      setAutoYesStateMap(new Map());
       // Update ref for next comparison
       prevWorktreeIdRef.current = worktreeId;
     }
@@ -612,6 +621,49 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
       console.error('[WorktreeDetailRefactored] Error fetching current output:', err);
     }
   }, [worktreeId, actions, state.prompt.visible]);
+
+  /**
+   * Issue #902: Re-fetch the FULL per-instance auto-yes map in one request.
+   *
+   * Root cause of the reset-on-return bug: the only UI re-seed path for auto-yes
+   * was the `current-output` poll, whose PC variant carries no `instance` query
+   * param and therefore re-seeds ONLY the primary instance (the server resolves
+   * `resolvedInstanceId === cliToolId`). After a sidebar branch switch and back,
+   * ALIAS instances (e.g. `claude-2`) had no re-seed path and stayed stuck OFF,
+   * while primary merely flickered until the next poll.
+   *
+   * This calls the existing (previously unused) GET `/api/worktrees/:id/auto-yes`
+   * with no `cliToolId`, which returns the full `instances` map, and reflects it
+   * into `autoYesStateMap` wholesale so primary AND alias instances are restored
+   * to the server's truth at once. The latest-request guard drops replies from
+   * older worktrees (rapid A→B→A) so a slow A reply can't pollute B's map.
+   */
+  const fetchAutoYesStates = useCallback(async (): Promise<void> => {
+    const requestId = ++latestAutoYesRequestIdRef.current;
+    try {
+      const response = await fetch(`/api/worktrees/${worktreeId}/auto-yes`);
+      if (!response.ok) return;
+      const data = await response.json();
+      // Latest-request guard: only the newest refetch may write the map.
+      if (latestAutoYesRequestIdRef.current !== requestId) return;
+      const instances = data?.instances;
+      if (!instances || typeof instances !== 'object') return;
+      const next = new Map<string, { enabled: boolean; expiresAt: number | null }>();
+      for (const [instanceId, raw] of Object.entries(instances)) {
+        if (raw && typeof raw === 'object') {
+          const s = raw as { enabled?: boolean; expiresAt?: number | null };
+          next.set(instanceId, {
+            enabled: s.enabled ?? false,
+            expiresAt: s.expiresAt ?? null,
+          });
+        }
+      }
+      setAutoYesStateMap(next);
+    } catch (err) {
+      if (latestAutoYesRequestIdRef.current !== requestId) return;
+      console.error('[WorktreeDetailRefactored] Error fetching auto-yes states:', err);
+    }
+  }, [worktreeId]);
 
   // Issue #874: Mobile now manages agent *instances* (折衷案). The shared roster
   // (agentInstances) lives in the DB; this hook owns ONLY the per-device "which
@@ -1431,6 +1483,20 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
 
     return () => clearInterval(intervalId);
   }, [loading, error, fetchCurrentOutput, fetchWorktree, fetchMessages, activeCliRunning, isMobile]);
+
+  /**
+   * Issue #902 (案1): re-seed the FULL per-instance auto-yes map whenever the
+   * active worktree changes OR its real instance roster becomes ready
+   * (`rosterReady`). `fetchAutoYesStates` is keyed to `worktreeId`, so this fires
+   * once on mount, once per branch switch (immediately, restoring primary +
+   * alias before the next poll), and once more when the worktree's true roster
+   * arrives. Paired with the 案2 map-clear in the worktreeId reset effect, the
+   * server stays the single source of truth and stale cross-worktree values
+   * never linger — fixing the alias-stuck-OFF reset and the primary flicker.
+   */
+  useEffect(() => {
+    void fetchAutoYesStates();
+  }, [worktreeId, rosterReady, fetchAutoYesStates]);
 
   /** Sync layout mode with viewport size */
   useEffect(() => {

--- a/tests/unit/hooks/useWorktreeDetailController.auto-yes-refetch.test.tsx
+++ b/tests/unit/hooks/useWorktreeDetailController.auto-yes-refetch.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * Regression tests for Issue #902 — Auto-Yes display reset on branch navigation.
+ *
+ * Bug: navigating away from a worktree and back made Auto-Yes appear reset (OFF),
+ * most severely for ALIAS instances (e.g. `claude-2`) which had NO re-seed path
+ * and stayed stuck OFF, while the primary merely flickered. Root cause: the only
+ * UI re-seed path was the `current-output` poll, whose PC variant re-seeds only
+ * the primary instance.
+ *
+ * Fix (案1 + 案2):
+ *  - 案1: on worktreeId change OR rosterReady, fetch GET /api/worktrees/:id/auto-yes
+ *         (no cliToolId) and reflect the full `instances` map into autoYesStateMap.
+ *  - 案2: clear autoYesStateMap on worktreeId change so a previous worktree's
+ *         values cannot bleed onto the new worktree's same-named keys.
+ *  - Latest-request guard so a slow reply for A cannot pollute B during A→B→A.
+ *
+ * These tests intentionally make the `current-output` mock return NO `autoYes`
+ * field, so the ONLY thing that can populate autoYesStateMap is the 案1 bulk GET.
+ * An assertion that primary/alias is ON after return therefore proves the fix
+ * (under the old code the map would never be seeded for these instances).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { Worktree } from '@/types/models';
+import type { AgentInstance } from '@/lib/cli-tools/types';
+import type { UseWorktreesCacheReturn } from '@/hooks/useWorktreesCache';
+
+// ---------------------------------------------------------------------------
+// Provider-dependent hook mocks (same shape as the cache-priming test) so the
+// controller runs under renderHook without the full app provider tree.
+// ---------------------------------------------------------------------------
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/worktrees/wt-a',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+  MOBILE_BREAKPOINT: 768,
+}));
+
+vi.mock('@/contexts/SidebarContext', () => ({
+  useSidebarContext: () => ({
+    isOpen: true,
+    width: 288,
+    isMobileDrawerOpen: false,
+    toggle: vi.fn(),
+    setWidth: vi.fn(),
+    openMobileDrawer: vi.fn(),
+    closeMobileDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useUpdateCheck', () => ({
+  useUpdateCheck: () => ({ data: null, loading: false, error: null }),
+}));
+
+const mockCache: { current: UseWorktreesCacheReturn | null } = { current: null };
+vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
+  useOptionalWorktreesCacheContext: () => mockCache.current,
+}));
+
+import { useWorktreeDetailController } from '@/hooks/useWorktreeDetailController';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+const ROSTER: AgentInstance[] = [
+  { id: 'claude', cliTool: 'claude', alias: 'Claude', order: 0 },
+  { id: 'claude-2', cliTool: 'claude', alias: 'Claude 2', order: 1 },
+];
+
+type AutoYesEntry = { enabled: boolean; expiresAt: number | null };
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-a',
+    name: 'feature/a',
+    path: '/path/to/wt',
+    repositoryPath: '/path/to/repo',
+    repositoryName: 'MyRepo',
+    agentInstances: ROSTER,
+    ...overrides,
+  } as Worktree;
+}
+
+function okJson(data: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+}
+
+/** Parse the worktreeId out of an /api/worktrees/:id... URL. */
+function parseWorktreeId(url: string): string {
+  const m = url.match(/\/api\/worktrees\/([^/?]+)/);
+  return m ? decodeURIComponent(m[1]) : 'wt-a';
+}
+
+const mockFetch = vi.fn();
+
+interface DetailControllerResult {
+  autoYesStateMap: Map<string, AutoYesEntry>;
+  autoYesEnabled: boolean;
+  activeInstanceId: string;
+}
+
+describe('useWorktreeDetailController — Issue #902 Auto-Yes refetch on navigation', () => {
+  beforeEach(() => {
+    mockCache.current = null;
+    mockFetch.mockReset();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    try {
+      window.localStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Build a fetch impl where GET /auto-yes returns the per-worktree instances
+   * map from `byWorktree`. `current-output` deliberately omits `autoYes`.
+   */
+  function installImmediateFetch(byWorktree: Record<string, Record<string, AutoYesEntry>>) {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (/\/auto-yes(\?|$)/.test(url) && method === 'GET') {
+        const wtId = parseWorktreeId(url);
+        return okJson({ enabled: false, expiresAt: null, agents: {}, instances: byWorktree[wtId] ?? {} });
+      }
+      if (url.includes('/messages')) return okJson([]);
+      if (url.includes('/current-output')) return okJson({ isRunning: false });
+      if (url.includes('/api/worktrees/')) {
+        return okJson(makeWorktree({ id: parseWorktreeId(url) }));
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+  }
+
+  it('案1+案2: alias instance ON → navigate away → return keeps it ON', async () => {
+    installImmediateFetch({
+      'wt-a': {
+        claude: { enabled: true, expiresAt: null },
+        'claude-2': { enabled: true, expiresAt: 1234 },
+      },
+      'wt-b': {}, // worktree B has no auto-yes state
+    });
+
+    const { result, rerender } = renderHook(
+      (props: { worktreeId: string }) =>
+        useWorktreeDetailController(props) as unknown as DetailControllerResult,
+      { initialProps: { worktreeId: 'wt-a' } },
+    );
+
+    // On wt-a the alias (claude-2) is restored ON by the bulk GET.
+    await waitFor(() => {
+      expect(result.current.autoYesStateMap.get('claude-2')?.enabled).toBe(true);
+    });
+    expect(result.current.autoYesStateMap.get('claude-2')?.expiresAt).toBe(1234);
+
+    // Navigate to wt-b: 案2 clears the map, 案1 repopulates from B (empty).
+    rerender({ worktreeId: 'wt-b' });
+    await waitFor(() => {
+      expect(result.current.autoYesStateMap.get('claude-2')?.enabled ?? false).toBe(false);
+    });
+
+    // Return to wt-a: alias must come back ON (not stuck OFF).
+    rerender({ worktreeId: 'wt-a' });
+    await waitFor(() => {
+      expect(result.current.autoYesStateMap.get('claude-2')?.enabled).toBe(true);
+    });
+  });
+
+  it('primary instance is restored ON after return (no flicker / poll-independent)', async () => {
+    installImmediateFetch({
+      'wt-a': { claude: { enabled: true, expiresAt: null } },
+      'wt-b': {},
+    });
+
+    const { result, rerender } = renderHook(
+      (props: { worktreeId: string }) =>
+        useWorktreeDetailController(props) as unknown as DetailControllerResult,
+      { initialProps: { worktreeId: 'wt-a' } },
+    );
+
+    // activeInstanceId defaults to the primary ('claude'); the bulk GET seeds it.
+    await waitFor(() => {
+      expect(result.current.activeInstanceId).toBe('claude');
+      expect(result.current.autoYesEnabled).toBe(true);
+    });
+
+    rerender({ worktreeId: 'wt-b' });
+    await waitFor(() => {
+      expect(result.current.autoYesEnabled).toBe(false);
+    });
+
+    rerender({ worktreeId: 'wt-a' });
+    // Primary returns ON immediately via the bulk GET — current-output carries no
+    // autoYes here, so this can only be the 案1 refetch (proves the flicker fix).
+    await waitFor(() => {
+      expect(result.current.autoYesStateMap.get('claude')?.enabled).toBe(true);
+      expect(result.current.autoYesEnabled).toBe(true);
+    });
+  });
+
+  it('latest-request guard: a stale A reply cannot pollute the new map (fast A→B→A)', async () => {
+    // Deferred auto-yes GETs so we control resolution order. Worktrees here have
+    // NO agentInstances, so rosterReady never flips and exactly one auto-yes GET
+    // fires per worktreeId change (mount, →b, →a) — three deferreds total.
+    const autoYesCalls: Array<{ worktreeId: string; resolve: (instances: Record<string, AutoYesEntry>) => void }> = [];
+
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (/\/auto-yes(\?|$)/.test(url) && method === 'GET') {
+        const wtId = parseWorktreeId(url);
+        return new Promise((resolve) => {
+          autoYesCalls.push({
+            worktreeId: wtId,
+            resolve: (instances) =>
+              resolve({ ok: true, json: () => Promise.resolve({ instances }) }),
+          });
+        });
+      }
+      if (url.includes('/messages')) return okJson([]);
+      if (url.includes('/current-output')) return okJson({ isRunning: false });
+      if (url.includes('/api/worktrees/')) {
+        // Omit agentInstances → rosterReady stays false → one GET per navigation.
+        return okJson({ id: parseWorktreeId(url), name: 'x', path: '/p', repositoryPath: '/r', repositoryName: 'R' });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const { result, rerender } = renderHook(
+      (props: { worktreeId: string }) =>
+        useWorktreeDetailController(props) as unknown as DetailControllerResult,
+      { initialProps: { worktreeId: 'wt-a' } },
+    );
+
+    // Wait for the mount GET (wt-a, request #1) to be issued.
+    await waitFor(() => expect(autoYesCalls.length).toBe(1));
+
+    // A→B→A in quick succession (none resolved yet).
+    rerender({ worktreeId: 'wt-b' });
+    await waitFor(() => expect(autoYesCalls.length).toBe(2));
+    rerender({ worktreeId: 'wt-a' });
+    await waitFor(() => expect(autoYesCalls.length).toBe(3));
+
+    const [firstA, , thirdA] = autoYesCalls;
+    expect(firstA.worktreeId).toBe('wt-a');
+    expect(thirdA.worktreeId).toBe('wt-a');
+
+    // Newest reply (request #3) lands first with the correct ON state.
+    await act(async () => {
+      thirdA.resolve({ claude: { enabled: true, expiresAt: null } });
+    });
+    await waitFor(() => {
+      expect(result.current.autoYesStateMap.get('claude')?.enabled).toBe(true);
+    });
+
+    // The STALE first-A reply arrives late with OFF — the guard must drop it.
+    await act(async () => {
+      firstA.resolve({ claude: { enabled: false, expiresAt: null } });
+    });
+    // The stale OFF must NOT have polluted the map.
+    expect(result.current.autoYesStateMap.get('claude')?.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
サイドバーから別ブランチ（worktree）へ遷移→復帰すると Auto-Yes 表示がリセットされる問題を修正します（Issue #902 / 案1（根本）＋案2（過渡汚染遮断）の併用）。特に alias instance（claude-2 等）が OFF 固定になる事象を解消します。

## 根本原因
UI の Auto-Yes 状態供給が `current-output` ポーリング1経路に依存しており、その PC 経路は primary instance しか再シードしなかった。全 instance を一括取得できる GET `/api/worktrees/[id]/auto-yes`（`instances` マップ）は実装済みだが UI から一度も呼ばれておらず、戻り後に alias の `autoYesStateMap` が `undefined` → OFF 表示になっていた。

## 修正内容
- **案1（根本）**: `worktreeId` 変更時 or `rosterReady` 成立時に、既存の未使用 GET `/api/worktrees/[id]/auto-yes`（cliToolId なし）を1回呼び、返る `instances` マップを `autoYesStateMap` 全体へ反映。primary も alias も一括でサーバ状態へ復元。
- **案2（過渡汚染遮断）**: `worktreeId` 変更リセット effect で `autoYesStateMap` を破棄し、旧 worktree の同名キー（例 `claude`）が新 worktree を汚染する過渡誤表示を遮断。案1の即時再フェッチで埋め直す。
- **最新リクエストガード**: `latestAutoYesRequestIdRef` を追加し、高速な A→B→A 遷移でも古いレスポンスが新しい map を汚染しないようにする。
- API 追加実装は不要（既存・テスト済みの `instances` マップを利用）。

## 変更ファイル（2件、dev-reports 除外）
- `src/hooks/useWorktreeDetailController.ts`
- `tests/unit/hooks/useWorktreeDetailController.auto-yes-refetch.test.tsx`（回帰テスト新規）

## 品質ゲート（オーケストレーター独立検証で全パス）
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅（417 files / 7869 tests）
- `npm run build` ✅

Refs #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)
