### PR TITLE
feat(todo): ホームToDoを全リポジトリ横断表示に（登録はドロップダウン選択を維持）（#907）

### DIFF
--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -1,0 +1,35 @@
+/**
+ * API Route: /api/todos
+ * GET: Returns every todo across all repositories (global Home ToDo widget).
+ *
+ * Issue #907: the Home ToDo widget shows a cross-repository list — all
+ * repositories' todos are displayed regardless of the dropdown selection,
+ * while creation stays scoped to the selected repository via
+ * /api/repositories/:id/todos. The `{ todos }` shape matches the per-repo GET.
+ */
+
+import { NextResponse } from 'next/server';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getAllTodos } from '@/lib/db';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('api/todos');
+
+/**
+ * GET /api/todos
+ * Returns all todos across every repository, ordered by repository then position.
+ */
+export async function GET() {
+  try {
+    const db = getDbInstance();
+    const todos = getAllTodos(db);
+
+    return NextResponse.json({ todos }, { status: 200 });
+  } catch (error) {
+    logger.error('error-fetching-all-todos:', { error: error instanceof Error ? error.message : String(error) });
+    return NextResponse.json(
+      { error: 'Failed to fetch todos' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -1,13 +1,15 @@
 /**
  * TodoWidget Component
  *
- * Home page lightweight ToDo widget. A single global widget where the user
- * picks a target repository and jots down checkbox-style ToDo / memo items
- * scoped to that repository.
+ * Home page lightweight ToDo widget. A single global widget that lists ToDo /
+ * memo items across all repositories (Issue #907). The dropdown selects only
+ * the *target* repository for newly added items; the displayed list is always
+ * the cross-repository set and is not filtered by the selection.
  *
  * Repository list is fetched from GET /api/worktrees (the same `repositories`
- * array used by the Home Assistant chat). ToDos are keyed by repository id and
- * persisted via /api/repositories/:id/todos.
+ * array used by the Home Assistant chat). The cross-repo list is loaded via
+ * GET /api/todos; creation/toggle/delete go through /api/repositories/:id/todos
+ * keyed by each todo's own repository id.
  */
 
 'use client';
@@ -87,15 +89,13 @@ export function TodoWidget() {
     void fetchRepos();
   }, []);
 
-  const loadTodos = useCallback(async (repositoryId: string) => {
-    if (!repositoryId) {
-      setTodos([]);
-      return;
-    }
+  // Load the cross-repository todo list (Issue #907): not scoped to the
+  // selected repository, so the dropdown never filters the displayed list.
+  const loadTodos = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const items = await todoApi.list(repositoryId);
+      const items = await todoApi.listAll();
       setTodos(items);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load todos');
@@ -105,7 +105,13 @@ export function TodoWidget() {
     }
   }, []);
 
-  // Reload todos whenever the selected repository changes.
+  // Load all todos once on mount; the list is repository-agnostic.
+  useEffect(() => {
+    void loadTodos();
+  }, [loadTodos]);
+
+  // Persist the selected target repository (used for new todos only). Changing
+  // it must NOT reload/filter the list — only the add target changes.
   useEffect(() => {
     if (!selectedRepoId) {
       return;
@@ -113,8 +119,7 @@ export function TodoWidget() {
     if (typeof window !== 'undefined') {
       localStorage.setItem(SELECTED_REPO_KEY, selectedRepoId);
     }
-    void loadTodos(selectedRepoId);
-  }, [selectedRepoId, loadTodos]);
+  }, [selectedRepoId]);
 
   const handleAdd = useCallback(async () => {
     const content = input.trim();
@@ -126,7 +131,7 @@ export function TodoWidget() {
     try {
       await todoApi.create(selectedRepoId, content);
       setInput('');
-      await loadTodos(selectedRepoId);
+      await loadTodos();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add todo');
     } finally {
@@ -136,39 +141,33 @@ export function TodoWidget() {
 
   const handleToggle = useCallback(
     async (todo: TodoItem) => {
-      if (!selectedRepoId) {
-        return;
-      }
       // Optimistic update for snappy checkbox feedback.
       setTodos((prev) =>
         prev.map((t) => (t.id === todo.id ? { ...t, done: !t.done } : t)),
       );
       setError(null);
       try {
-        await todoApi.update(selectedRepoId, todo.id, { done: !todo.done });
+        // Operate on the todo's own repository, not the dropdown selection,
+        // so cross-repo todos toggle correctly (Issue #907).
+        await todoApi.update(todo.repositoryId, todo.id, { done: !todo.done });
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to update todo');
-        void loadTodos(selectedRepoId);
+        void loadTodos();
       }
     },
-    [selectedRepoId, loadTodos],
+    [loadTodos],
   );
 
-  const handleDelete = useCallback(
-    async (todo: TodoItem) => {
-      if (!selectedRepoId) {
-        return;
-      }
-      setError(null);
-      try {
-        await todoApi.remove(selectedRepoId, todo.id);
-        setTodos((prev) => prev.filter((t) => t.id !== todo.id));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to delete todo');
-      }
-    },
-    [selectedRepoId],
-  );
+  const handleDelete = useCallback(async (todo: TodoItem) => {
+    setError(null);
+    try {
+      // Use the todo's own repository id so cross-repo deletes don't 404.
+      await todoApi.remove(todo.repositoryId, todo.id);
+      setTodos((prev) => prev.filter((t) => t.id !== todo.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete todo');
+    }
+  }, []);
 
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/lib/api/todo-api.ts
+++ b/src/lib/api/todo-api.ts
@@ -32,6 +32,19 @@ export const todoApi = {
     return data.todos ?? [];
   },
 
+  /**
+   * List todos across all repositories (Issue #907). Used by the Home widget
+   * to show a cross-repository list regardless of the selected target repo.
+   */
+  async listAll(): Promise<TodoItem[]> {
+    const res = await fetch('/api/todos');
+    if (!res.ok) {
+      return parseError(res, 'Failed to load todos');
+    }
+    const data = (await res.json()) as { todos: TodoItem[] };
+    return data.todos ?? [];
+  },
+
   async create(repositoryId: string, content: string): Promise<TodoItem> {
     const res = await fetch(
       `/api/repositories/${encodeURIComponent(repositoryId)}/todos`,

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -90,6 +90,7 @@ export {
 // todo-db (repository-scoped Home ToDo widget)
 export {
   getTodosByRepositoryId,
+  getAllTodos,
   getTodoById,
   createTodo,
   updateTodo,

--- a/src/lib/db/todo-db.ts
+++ b/src/lib/db/todo-db.ts
@@ -103,6 +103,30 @@ export function getTodosByRepositoryId(
 }
 
 /**
+ * Get every todo across all repositories, for the global Home ToDo widget
+ * (Issue #907). Unlike {@link getTodosByRepositoryId}, this is not scoped to a
+ * single repository — the widget displays all repositories' todos at once.
+ *
+ * Ordered by the effective repository label (display name, falling back to
+ * name, case-insensitive) so the cross-repo list is grouped per repository,
+ * then by `position` / `created_at` within a repository, with `id` as a final
+ * tiebreaker for fully deterministic ordering.
+ */
+export function getAllTodos(db: Database.Database): RepositoryTodo[] {
+  const stmt = db.prepare(`
+    ${TODO_SELECT}
+    ORDER BY
+      COALESCE(NULLIF(TRIM(r.display_name), ''), r.name) COLLATE NOCASE ASC,
+      t.position ASC,
+      t.created_at ASC,
+      t.id ASC
+  `);
+
+  const rows = stmt.all() as RepositoryTodoRow[];
+  return rows.map(mapTodoRow);
+}
+
+/**
  * Get a todo by ID.
  *
  * @returns Todo or null if not found.

--- a/tests/integration/api/todos.test.ts
+++ b/tests/integration/api/todos.test.ts
@@ -1,0 +1,99 @@
+/**
+ * API Routes Integration Tests - Global Todos (cross-repository, Issue #907)
+ *
+ * Tests for:
+ * - GET /api/todos - List todos across all repositories
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { createRepository } from '@/lib/db/db-repository';
+import { createTodo } from '@/lib/db';
+
+declare module '@/lib/db/db-instance' {
+  export function setMockDb(db: Database.Database): void;
+}
+
+vi.mock('@/lib/db/db-instance', () => {
+  let mockDb: Database.Database | null = null;
+  return {
+    getDbInstance: () => {
+      if (!mockDb) {
+        throw new Error('Mock database not initialized');
+      }
+      return mockDb;
+    },
+    setMockDb: (db: Database.Database) => {
+      mockDb = db;
+    },
+    closeDbInstance: () => {
+      if (mockDb) {
+        mockDb.close();
+        mockDb = null;
+      }
+    },
+  };
+});
+
+let db: Database.Database;
+
+beforeEach(async () => {
+  db = new Database(':memory:');
+  runMigrations(db);
+
+  const { setMockDb } = await import('@/lib/db/db-instance');
+  setMockDb(db);
+});
+
+afterEach(async () => {
+  const { closeDbInstance } = await import('@/lib/db/db-instance');
+  closeDbInstance();
+});
+
+describe('GET /api/todos', () => {
+  it('returns an empty array when no todos exist', async () => {
+    const { GET } = await import('@/app/api/todos/route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todos).toEqual([]);
+  });
+
+  it('returns todos across all repositories with resolved repository names', async () => {
+    const alpha = createRepository(db, {
+      name: 'Alpha',
+      path: '/path/to/alpha',
+      cloneSource: 'local',
+    });
+    const beta = createRepository(db, {
+      name: 'Beta',
+      path: '/path/to/beta',
+      cloneSource: 'local',
+    });
+    createTodo(db, beta.id, { content: 'beta task', position: 0 });
+    createTodo(db, alpha.id, { content: 'alpha task', position: 0 });
+
+    const { GET } = await import('@/app/api/todos/route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    // Ordered by repository label (Alpha before Beta).
+    expect(data.todos.map((t: { content: string }) => t.content)).toEqual([
+      'alpha task',
+      'beta task',
+    ]);
+    expect(data.todos[0].repositoryName).toBe('Alpha');
+    expect(data.todos[1].repositoryName).toBe('Beta');
+  });
+
+  it('returns 500 on database error', async () => {
+    db.close();
+    const { GET } = await import('@/app/api/todos/route');
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/components/home/TodoWidget.test.tsx
+++ b/tests/unit/components/home/TodoWidget.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for the Home TodoWidget (Issue #907).
+ *
+ * Verifies the cross-repository behavior:
+ * - the list is loaded via todoApi.listAll() (not scoped to the dropdown),
+ * - changing the dropdown does NOT refetch/filter the list,
+ * - toggle/delete operate on each todo's own repositoryId,
+ * - add uses the selected dropdown repository and refreshes via listAll().
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TodoWidget } from '@/components/home/TodoWidget';
+import { todoApi, type TodoItem } from '@/lib/api/todo-api';
+
+vi.mock('@/lib/api/todo-api', () => ({
+  todoApi: {
+    list: vi.fn(),
+    listAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(todoApi);
+
+const REPOS = [
+  { id: 'repo-a', path: '/path/a', name: 'Alpha' },
+  { id: 'repo-b', path: '/path/b', name: 'Beta' },
+];
+
+const TODOS: TodoItem[] = [
+  {
+    id: 't1',
+    repositoryId: 'repo-a',
+    repositoryName: 'Alpha',
+    content: 'alpha task',
+    done: false,
+    position: 0,
+  },
+  {
+    id: 't2',
+    repositoryId: 'repo-b',
+    repositoryName: 'Beta',
+    content: 'beta task',
+    done: false,
+    position: 0,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/worktrees')) {
+      return { ok: true, json: async () => ({ repositories: REPOS }) } as Response;
+    }
+    return { ok: false, json: async () => ({}) } as Response;
+  }) as unknown as typeof fetch;
+  mockedApi.listAll.mockResolvedValue(TODOS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TodoWidget (Issue #907)', () => {
+  it('loads all todos via listAll and shows todos from every repository', async () => {
+    render(<TodoWidget />);
+
+    await waitFor(() => expect(mockedApi.listAll).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('alpha task')).toBeInTheDocument();
+    expect(screen.getByText('beta task')).toBeInTheDocument();
+    expect(mockedApi.list).not.toHaveBeenCalled();
+
+    // Each row carries a repository badge for cross-repo disambiguation.
+    const badges = screen
+      .getAllByTestId('todo-repo-badge')
+      .map((b) => b.textContent);
+    expect(badges).toContain('Alpha');
+    expect(badges).toContain('Beta');
+  });
+
+  it('does not refetch/filter the list when the target repository dropdown changes', async () => {
+    render(<TodoWidget />);
+    await waitFor(() => expect(mockedApi.listAll).toHaveBeenCalledTimes(1));
+    await screen.findByText('alpha task');
+
+    const select = screen.getByTestId('todo-repo-select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'repo-b' } });
+
+    // The list stays fully populated and listAll is not called again.
+    expect(mockedApi.listAll).toHaveBeenCalledTimes(1);
+    expect(mockedApi.list).not.toHaveBeenCalled();
+    expect(screen.getByText('alpha task')).toBeInTheDocument();
+    expect(screen.getByText('beta task')).toBeInTheDocument();
+  });
+
+  it('toggles a todo using its own repositoryId', async () => {
+    mockedApi.update.mockResolvedValue(TODOS[1]);
+    render(<TodoWidget />);
+    await screen.findByText('beta task');
+
+    // Second checkbox corresponds to the Beta (repo-b) todo.
+    const checkboxes = screen.getAllByTestId('todo-checkbox');
+    fireEvent.click(checkboxes[1]);
+
+    await waitFor(() =>
+      expect(mockedApi.update).toHaveBeenCalledWith('repo-b', 't2', { done: true }),
+    );
+  });
+
+  it('deletes a todo using its own repositoryId', async () => {
+    mockedApi.remove.mockResolvedValue(undefined);
+    render(<TodoWidget />);
+    await screen.findByText('alpha task');
+
+    // First delete button corresponds to the Alpha (repo-a) todo.
+    const deleteButtons = screen.getAllByTestId('todo-delete');
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() =>
+      expect(mockedApi.remove).toHaveBeenCalledWith('repo-a', 't1'),
+    );
+  });
+
+  it('creates a todo for the selected dropdown repository and refreshes via listAll', async () => {
+    mockedApi.create.mockResolvedValue(TODOS[1]);
+    render(<TodoWidget />);
+    await waitFor(() => expect(mockedApi.listAll).toHaveBeenCalledTimes(1));
+    await screen.findByText('alpha task');
+
+    const select = screen.getByTestId('todo-repo-select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'repo-b' } });
+
+    const input = screen.getByTestId('todo-input');
+    fireEvent.change(input, { target: { value: 'new task' } });
+    fireEvent.click(screen.getByTestId('todo-add-button'));
+
+    await waitFor(() =>
+      expect(mockedApi.create).toHaveBeenCalledWith('repo-b', 'new task'),
+    );
+    // The post-add refresh re-uses the cross-repo listAll, never the per-repo list.
+    await waitFor(() => expect(mockedApi.listAll).toHaveBeenCalledTimes(2));
+    expect(mockedApi.list).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/db/todo-db.test.ts
+++ b/tests/unit/db/todo-db.test.ts
@@ -10,6 +10,7 @@ import { runMigrations } from '@/lib/db/db-migrations';
 import { createRepository, updateRepository } from '@/lib/db/db-repository';
 import {
   getTodosByRepositoryId,
+  getAllTodos,
   getTodoById,
   createTodo,
   updateTodo,
@@ -111,6 +112,46 @@ describe('todo-db', () => {
 
   it('getTodoById returns null for a missing id', () => {
     expect(getTodoById(db, 'nope')).toBeNull();
+  });
+
+  describe('getAllTodos (cross-repository, Issue #907)', () => {
+    it('returns an empty list when no todos exist', () => {
+      expect(getAllTodos(db)).toEqual([]);
+    });
+
+    it('returns todos from every repository ordered by repo label then position', () => {
+      // 'Alpha' sorts before 'TestRepo' (the beforeEach repo) case-insensitively.
+      const alpha = createRepository(db, {
+        name: 'Alpha',
+        path: '/path/to/alpha',
+        cloneSource: 'local',
+      });
+      createTodo(db, repositoryId, { content: 'b', position: 1 });
+      createTodo(db, repositoryId, { content: 'a', position: 0 });
+      createTodo(db, alpha.id, { content: 'z', position: 0 });
+
+      const all = getAllTodos(db);
+      // Alpha first (z), then TestRepo by position (a, b).
+      expect(all.map((t) => t.content)).toEqual(['z', 'a', 'b']);
+      expect(all[0].repositoryId).toBe(alpha.id);
+      expect(all[0].repositoryName).toBe('Alpha');
+      expect(all[1].repositoryId).toBe(repositoryId);
+      expect(all[1].repositoryName).toBe('TestRepo');
+    });
+
+    it('orders by the repository display name when set', () => {
+      // Give TestRepo a display name that sorts before a repo named 'Bbb'.
+      updateRepository(db, repositoryId, { displayName: 'Aaa' });
+      const bbb = createRepository(db, {
+        name: 'Bbb',
+        path: '/path/to/bbb',
+        cloneSource: 'local',
+      });
+      createTodo(db, bbb.id, { content: 'bbb-todo', position: 0 });
+      createTodo(db, repositoryId, { content: 'aaa-todo', position: 0 });
+
+      expect(getAllTodos(db).map((t) => t.content)).toEqual(['aaa-todo', 'bbb-todo']);
+    });
   });
 
   it('updates content', () => {


### PR DESCRIPTION
## 概要

Issue #907（案A）。ホーム ToDo ウィジェットの一覧を選択中リポジトリでフィルタせず、**全リポジトリ横断で表示**するよう変更。登録時のリポジトリ選択（ドロップダウン）は維持。

## 変更内容

- **DB**: `getAllTodos(db)` を追加（`TODO_SELECT` の WHERE 無し版、リポジトリ名→position→created_at→id の安定順）。barrel から export。
- **API**: `GET /api/todos` を新規追加（全リポジトリ横断、`{ todos }` 形式）。
- **API client**: `todoApi.listAll()` を追加。
- **TodoWidget**: 一覧取得を `listAll()` に変更（ドロップダウン変更で再フィルタしない）。ドロップダウンは追加先選択専用（localStorage 永続化は維持）。`handleToggle`/`handleDelete` を `selectedRepoId` → `todo.repositoryId` に変更（横断操作で 404 回避）。追加後リフレッシュも `listAll()`。
- **test**: `getAllTodos` / `GET /api/todos`（integration）/ `TodoWidget`（unit）を追加。

## 受入基準

- [x] 全リポジトリの ToDo が選択中リポジトリに関わらず表示される
- [x] 各行にリポジトリ名バッジ（#900 既存）
- [x] ドロップダウン選択リポジトリへ新規登録でき、全件一覧に即時反映
- [x] 他リポジトリ ToDo のチェック・削除が 404 にならず動作
- [x] ドロップダウン切替で一覧がフィルタされない

## 品質チェック（worktree 独立検証）

| チェック | 結果 |
|---------|------|
| npm run lint | ✅ Pass |
| npx tsc --noEmit | ✅ Pass |
| npm run test:unit | ✅ Pass（418 files / 7877） |
| npm run build | ✅ Pass |

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
