### PR TITLE
feat(todo): ホームToDoウィジェットのモバイル向けレイアウト最適化（#909）

### DIFF
--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -187,8 +187,14 @@ export function TodoWidget() {
       className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
       data-testid="home-todo-widget"
     >
-      {/* Repository selector + remaining count */}
-      <div className="flex items-center justify-between gap-3 mb-3">
+      {/* Repository selector + remaining count.
+          Mobile: stack vertically so the select can use the full width; the
+          `N open` count drops to its own line. Desktop (>= sm): unchanged
+          single-row layout with the select capped at 16rem (Issue #909). */}
+      <div
+        className="flex flex-col gap-2 mb-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
+        data-testid="todo-selector-row"
+      >
         <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 min-w-0">
           <span className="shrink-0">Repository</span>
           <select
@@ -196,7 +202,7 @@ export function TodoWidget() {
             onChange={(e) => setSelectedRepoId(e.target.value)}
             disabled={!hasRepositories}
             data-testid="todo-repo-select"
-            className="min-w-0 max-w-[16rem] truncate rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-50"
+            className="min-w-0 flex-1 truncate rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-50 sm:flex-initial sm:max-w-[16rem]"
           >
             {repositories.map((repo) => (
               <option key={repo.id} value={repo.id}>
@@ -260,46 +266,60 @@ export function TodoWidget() {
               {todos.map((todo) => (
                 <li
                   key={todo.id}
-                  className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/40 group"
+                  className="flex flex-col gap-1 rounded-md px-1 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/40 group sm:flex-row sm:items-center sm:gap-2"
                   data-testid="todo-item"
                 >
-                  <input
-                    type="checkbox"
-                    checked={todo.done}
-                    onChange={() => handleToggle(todo)}
-                    data-testid="todo-checkbox"
-                    aria-label={todo.done ? 'Mark as not done' : 'Mark as done'}
-                    className="shrink-0 h-4 w-4 rounded border-gray-300 text-cyan-600 focus:ring-cyan-400"
-                  />
-                  <span
-                    className={`flex-1 min-w-0 break-words text-sm ${
-                      todo.done
-                        ? 'line-through text-gray-400 dark:text-gray-500'
-                        : 'text-gray-800 dark:text-gray-200'
-                    }`}
-                  >
-                    {todo.content}
-                  </span>
-                  {todoRepoLabel(todo) && (
+                  {/* Top row (mobile) / left section (desktop): checkbox + content.
+                      The checkbox is wrapped in a label that provides a ~44px
+                      touch target on mobile while the box itself stays small
+                      (Issue #909). */}
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <label className="shrink-0 inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center sm:min-h-0 sm:min-w-0">
+                      <input
+                        type="checkbox"
+                        checked={todo.done}
+                        onChange={() => handleToggle(todo)}
+                        data-testid="todo-checkbox"
+                        aria-label={todo.done ? 'Mark as not done' : 'Mark as done'}
+                        className="h-4 w-4 rounded border-gray-300 text-cyan-600 focus:ring-cyan-400"
+                      />
+                    </label>
                     <span
-                      className="shrink-0 max-w-[8rem] truncate rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:text-gray-400"
-                      data-testid="todo-repo-badge"
-                      title={todoRepoLabel(todo)}
+                      className={`min-w-0 flex-1 break-words text-sm ${
+                        todo.done
+                          ? 'line-through text-gray-400 dark:text-gray-500'
+                          : 'text-gray-800 dark:text-gray-200'
+                      }`}
                     >
-                      {todoRepoLabel(todo)}
+                      {todo.content}
                     </span>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(todo)}
-                    aria-label="Delete todo"
-                    data-testid="todo-delete"
-                    className="shrink-0 text-gray-300 hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
+                  </div>
+                  {/* Bottom row (mobile) / right section (desktop): repo badge +
+                      delete. On mobile the delete button is always visible with
+                      a ~44px touch target; on desktop the original hover-reveal
+                      (sm:opacity-0 → sm:group-hover) is restored (Issue #909). */}
+                  <div className="flex shrink-0 items-center justify-end gap-2">
+                    {todoRepoLabel(todo) && (
+                      <span
+                        className="shrink-0 max-w-[8rem] truncate rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:text-gray-400"
+                        data-testid="todo-repo-badge"
+                        title={todoRepoLabel(todo)}
+                      >
+                        {todoRepoLabel(todo)}
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(todo)}
+                      aria-label="Delete todo"
+                      data-testid="todo-delete"
+                      className="inline-flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center text-gray-300 opacity-100 transition-opacity hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400 sm:min-h-0 sm:min-w-0 sm:opacity-0 sm:group-hover:opacity-100"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/tests/unit/components/home/TodoWidget.test.tsx
+++ b/tests/unit/components/home/TodoWidget.test.tsx
@@ -149,3 +149,83 @@ describe('TodoWidget (Issue #907)', () => {
     expect(mockedApi.list).not.toHaveBeenCalled();
   });
 });
+
+describe('TodoWidget mobile layout (Issue #909)', () => {
+  it('keeps the delete button visible on mobile and hover-reveal only on desktop', async () => {
+    render(<TodoWidget />);
+    await screen.findByText('alpha task');
+
+    for (const btn of screen.getAllByTestId('todo-delete')) {
+      const classes = btn.className.split(/\s+/);
+      // Always visible on touch screens (no :hover available).
+      expect(classes).toContain('opacity-100');
+      // Hover-reveal restored only at >= sm so desktop is unchanged.
+      expect(classes).toContain('sm:opacity-0');
+      expect(classes).toContain('sm:group-hover:opacity-100');
+      // Must NOT carry the pre-#909 mobile-hiding tokens.
+      expect(classes).not.toContain('opacity-0');
+      expect(classes).not.toContain('group-hover:opacity-100');
+    }
+  });
+
+  it('renders rows as a responsive two-row (mobile) / single-row (desktop) layout', async () => {
+    render(<TodoWidget />);
+    await screen.findByText('alpha task');
+
+    for (const item of screen.getAllByTestId('todo-item')) {
+      const classes = item.className.split(/\s+/);
+      expect(classes).toContain('flex-col'); // stacked on mobile
+      expect(classes).toContain('sm:flex-row'); // single row on desktop
+    }
+  });
+
+  it('gives the checkbox and delete button a ~44px touch target on mobile', async () => {
+    render(<TodoWidget />);
+    await screen.findByText('alpha task');
+
+    for (const btn of screen.getAllByTestId('todo-delete')) {
+      const classes = btn.className.split(/\s+/);
+      expect(classes).toContain('min-h-[44px]');
+      expect(classes).toContain('min-w-[44px]');
+      // Compact again on desktop so the single row stays tight.
+      expect(classes).toContain('sm:min-h-0');
+      expect(classes).toContain('sm:min-w-0');
+    }
+
+    for (const cb of screen.getAllByTestId('todo-checkbox')) {
+      const label = cb.closest('label');
+      expect(label).not.toBeNull();
+      const classes = label!.className.split(/\s+/);
+      expect(classes).toContain('min-h-[44px]');
+      expect(classes).toContain('min-w-[44px]');
+      expect(classes).toContain('sm:min-h-0');
+      expect(classes).toContain('sm:min-w-0');
+    }
+  });
+
+  it('stacks the repository selector row on mobile and aligns it on desktop', async () => {
+    render(<TodoWidget />);
+    await screen.findByText('alpha task');
+
+    const classes = screen.getByTestId('todo-selector-row').className.split(/\s+/);
+    expect(classes).toContain('flex-col');
+    expect(classes).toContain('sm:flex-row');
+  });
+
+  it('still toggles and deletes via each todo own repositoryId after the layout change', async () => {
+    mockedApi.update.mockResolvedValue(TODOS[1]);
+    mockedApi.remove.mockResolvedValue(undefined);
+    render(<TodoWidget />);
+    await screen.findByText('beta task');
+
+    fireEvent.click(screen.getAllByTestId('todo-checkbox')[1]);
+    await waitFor(() =>
+      expect(mockedApi.update).toHaveBeenCalledWith('repo-b', 't2', { done: true }),
+    );
+
+    fireEvent.click(screen.getAllByTestId('todo-delete')[0]);
+    await waitFor(() =>
+      expect(mockedApi.remove).toHaveBeenCalledWith('repo-a', 't1'),
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Issue #909（案B）。ホーム ToDo ウィジェット（`TodoWidget`）の**モバイル向けレイアウト最適化**。`sm:` ブレークポイントでデスクトップ（現状維持）／モバイル（最適化）を出し分け、`hover` 依存だった削除ボタンをタッチ端末で常時表示にし、タッチUXを改善。機能ロジック（#907 の横断表示）は非変更。

## 変更内容

- **リスト行の2段組化**: モバイル（`< sm`）は上段にチェックボックス＋コンテンツ、下段にリポジトリバッジ＋削除ボタン。デスクトップ（`>= sm`）は現状の1行レイアウト（hover-reveal 削除）を維持。
- **削除ボタンの hover 依存解消**: タッチ端末では削除ボタンを常時表示、デスクトップのみ hover-reveal。
- **タップ領域の拡大**: チェックボックス／削除ボタンのヒット領域を 40–44px 確保。
- **セレクタ行のレスポンシブ化**: 狭幅で縦積みに切替え。
- **test**: レスポンシブ表示・削除ボタン可視性の unit テストを追加。

## 受入基準

- [x] スマホ幅で削除ボタンが常時見えてタップできる（hover 不要）
- [x] スマホ幅でチェック・削除のタップ領域が十分（目安44px）
- [x] スマホ幅でリスト行が窮屈にならない
- [x] セレクタ行がスマホ幅で破綻しない
- [x] デスクトップ幅は従来どおり（hover-reveal 削除含む）リグレッションなし

## 品質チェック（worktree 独立検証）

| チェック | 結果 |
|---------|------|
| npm run lint | ✅ Pass |
| npx tsc --noEmit | ✅ Pass |
| npm run test:unit | ✅ Pass（418 files / 7882） |
| npm run build | ✅ Pass |

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
