### PR TITLE
fix(todo): /api/todos を force-dynamic 化しホームToDoの即時反映を担保（#911）

### DIFF
--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -13,6 +13,11 @@ import { getDbInstance } from '@/lib/db/db-instance';
 import { getAllTodos } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
 
+// Issue #911: Force dynamic rendering so the route reads the live DB on every
+// request instead of being statically prerendered at build time. Without this,
+// ToDo add/done/delete mutations would not reflect until a hard reload.
+export const dynamic = 'force-dynamic';
+
 const logger = createLogger('api/todos');
 
 /**

--- a/tests/unit/api/todos-route-config.test.ts
+++ b/tests/unit/api/todos-route-config.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Unit test for /api/todos route configuration (Issue #911)
+ *
+ * Regression guard: the global Home ToDo widget reads /api/todos, which must be
+ * dynamically rendered so each request hits the live DB. If the route is
+ * statically prerendered at build time, ToDo add/done/delete mutations are not
+ * reflected until a hard reload. Mirrors the update-check route config test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { dynamic } from '@/app/api/todos/route';
+
+describe('Route configuration: /api/todos', () => {
+  it('exports dynamic as force-dynamic to prevent static prerendering', () => {
+    // Issue #911: ensures Next.js treats this route as dynamic (ƒ), not a
+    // build-time static snapshot (○), so the live DB is read per request.
+    expect(dynamic).toBe('force-dynamic');
+  });
+});


### PR DESCRIPTION
## 概要

ホーム ToDo ウィジェットで ToDo を登録/更新しても一覧に反映されない不具合（#911）を修正。

## 根本原因

`/api/todos`（#907 で追加した横断一覧取得ルート）に `export const dynamic = 'force-dynamic'` が無く、リクエスト引数も使わないため、Next.js 14 がビルド時に静的プリレンダリング（`○`）していた。結果としてビルド時点の DB スナップショットを毎回返し、登録/done切替/削除（動的 POST/PATCH/DELETE で DB には反映される）が画面に出なかった。PC/スマホ共通。

## 変更内容

- `src/app/api/todos/route.ts`: `export const dynamic = 'force-dynamic';` を追加（`/api/worktrees` と同じ idiom）。リクエスト毎にライブ DB を読む。
- `tests/unit/api/todos-route-config.test.ts`: 当該ルートが `dynamic === 'force-dynamic'` を export することを保証する回帰テストを追加。

## 検証

- lint / tsc --noEmit / test:unit（419 files / 7883 tests）/ build 全 Pass。
- `npm run build` 後の出力で `/api/todos` が `○`(Static) ではなく **`ƒ`(Dynamic)** になることを確認。

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)