### PR TITLE
feat(display): PC版に表示サイズ切替（大/中/小/極小）を追加（既定=中・remカスケード）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,26 @@
 @tailwind utilities;
 
 @layer base {
+  /*
+   * [Issue #915] PC display size (案A: rem カスケード).
+   * Applied to <html data-pc-size> on PC only (see PcDisplaySizeProvider).
+   * rem-based Tailwind spacing/typography scales with the root font-size;
+   * fixed-px surfaces (sidebar width, xterm fontSize) are scaled separately via
+   * PC_DISPLAY_SIZE_META in src/hooks/usePcDisplaySize.ts (keep values in sync).
+   */
+  html[data-pc-size='large'] {
+    font-size: 18px;
+  }
+  html[data-pc-size='medium'] {
+    font-size: 16px;
+  }
+  html[data-pc-size='small'] {
+    font-size: 14px;
+  }
+  html[data-pc-size='xsmall'] {
+    font-size: 12.5px;
+  }
+
   body {
     @apply text-gray-900 dark:text-gray-100 antialiased;
   }

--- a/src/app/worktrees/[id]/terminal/page.tsx
+++ b/src/app/worktrees/[id]/terminal/page.tsx
@@ -10,6 +10,8 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { ArrowLeft, Terminal, Monitor, Code, Loader2 } from 'lucide-react';
 import { isTmuxControlModeEnabledForClient } from '@/lib/tmux/tmux-control-mode-flags';
+import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
+import { getTerminalFontSize } from '@/hooks/usePcDisplaySize';
 
 /**
  * Dynamic import of TerminalComponent with SSR disabled.
@@ -39,6 +41,9 @@ export default function TerminalPage({
 }) {
   const [selectedTool, setSelectedTool] = useState<string>('claude');
   const controlModeEnabled = isTmuxControlModeEnabledForClient();
+  // Issue #915: terminal font size follows the PC display size selection.
+  const { size: pcDisplaySize } = usePcDisplaySizeContext();
+  const terminalFontSize = getTerminalFontSize(pcDisplaySize);
 
   const cliTools = [
     { id: 'claude', name: 'Claude', icon: '🤖', color: 'bg-purple-600' },
@@ -105,6 +110,7 @@ export default function TerminalPage({
             cliToolId={selectedTool}
             className="h-full"
             controlModeEnabled={controlModeEnabled}
+            fontSize={terminalFontSize}
           />
         </div>
       </div>

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -17,7 +17,12 @@ interface TerminalComponentProps {
   cliToolId: string;
   className?: string;
   controlModeEnabled?: boolean;
+  /** xterm.js font size in px (Issue #915 — driven by PC display size). */
+  fontSize?: number;
 }
+
+/** Default xterm.js font size (matches PC display size "medium"). */
+const DEFAULT_TERMINAL_FONT_SIZE = 14;
 
 type ConnectionStatus =
   | 'disabled'
@@ -33,9 +38,18 @@ export function TerminalComponent({
   cliToolId,
   className = '',
   controlModeEnabled,
+  fontSize = DEFAULT_TERMINAL_FONT_SIZE,
 }: TerminalComponentProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Refs to the live xterm instance + fit addon so font size can be updated
+  // without tearing down the WebSocket connection (Issue #915).
+  const termRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  // Keep the latest fontSize available to the connection effect without making
+  // it a dependency (avoids reconnecting when only the size changes).
+  const fontSizeRef = useRef(fontSize);
+  fontSizeRef.current = fontSize;
   const [terminal, setTerminal] = useState<Terminal | null>(null);
   const [socket, setSocket] = useState<WebSocket | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
@@ -69,7 +83,7 @@ export function TerminalComponent({
         brightWhite: '#ffffff',
       },
       fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-      fontSize: 14,
+      fontSize: fontSizeRef.current,
       cursorBlink: true,
       convertEol: true,
     });
@@ -78,6 +92,10 @@ export function TerminalComponent({
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
+
+    // Track the live instances so the font-size effect can update them.
+    termRef.current = term;
+    fitAddonRef.current = fitAddon;
 
     // Open terminal in the DOM
     term.open(terminalRef.current);
@@ -113,6 +131,8 @@ export function TerminalComponent({
           reconnectTimerRef.current = null;
         }
         term.dispose();
+        termRef.current = null;
+        fitAddonRef.current = null;
       };
     }
 
@@ -203,8 +223,28 @@ export function TerminalComponent({
       }
       ws?.close();
       term.dispose();
+      termRef.current = null;
+      fitAddonRef.current = null;
     };
   }, [worktreeId, cliToolId, controlModeEnabled, reconnectAttempt]);
+
+  // Issue #915: react to font-size changes without reconnecting. Updates the live
+  // xterm fontSize, re-fits, and notifies the server of the new dimensions.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    if (term.options) {
+      term.options.fontSize = fontSize;
+    }
+    fitAddonRef.current?.fit();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({
+        type: 'terminal_resize',
+        cols: term.cols,
+        rows: term.rows,
+      }));
+    }
+  }, [fontSize, socket]);
 
   const statusMeta: Record<ConnectionStatus, { dot: string; label: string; detail: string }> = {
     disabled: {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -14,6 +14,7 @@ import React, { memo, useCallback, useRef, type ReactNode } from 'react';
 import { useSidebarContext } from '@/contexts/SidebarContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useLayoutConfig } from '@/hooks/useLayoutConfig';
+import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
@@ -71,15 +72,27 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
   const { isOpen, isMobileDrawerOpen, closeMobileDrawer, width, setWidth } = useSidebarContext();
   const isMobile = useIsMobile();
   const { showSidebar, showGlobalNav } = useLayoutConfig();
+  // Issue #915: scale fixed-px sidebar width by the PC display-size factor.
+  const { factor } = usePcDisplaySizeContext();
+
+  // Stored width is kept in medium-base px; the displayed width (and clamps) are
+  // scaled by the current size factor so the sidebar roughly follows the UI scale.
+  const minWidth = Math.round(MIN_SIDEBAR_WIDTH * factor);
+  const maxWidth = Math.round(MAX_SIDEBAR_WIDTH * factor);
+  const displayWidth = Math.round(
+    Math.min(maxWidth, Math.max(minWidth, width * factor))
+  );
 
   // Refs for direct DOM manipulation during drag (avoids React re-render lag)
   const sidebarRef = useRef<HTMLElement>(null);
   const mainRef = useRef<HTMLElement>(null);
 
-  // Called only on mouseup — persists final width to React state + localStorage
+  // Called only on mouseup — persists final width to React state + localStorage.
+  // newWidth is in display space; convert back to medium-base before storing so
+  // it survives size changes without compounding the factor.
   const handleWidthChange = useCallback((newWidth: number) => {
-    setWidth(newWidth); // already clamped by ResizeHandle
-  }, [setWidth]);
+    setWidth(Math.round(newWidth / factor)); // already clamped by ResizeHandle
+  }, [setWidth, factor]);
 
   // Mobile layout with drawer
   if (isMobile) {
@@ -141,13 +154,15 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
               ${SIDEBAR_TRANSITION}
               ${isOpen ? 'translate-x-0' : '-translate-x-full'}
             `}
-            style={{ width: `${width}px`, zIndex: Z_INDEX.SIDEBAR }}
+            style={{ width: `${displayWidth}px`, zIndex: Z_INDEX.SIDEBAR }}
             role="complementary"
             aria-hidden={!isOpen}
           >
             <Sidebar />
             <ResizeHandle
-              currentWidth={width}
+              currentWidth={displayWidth}
+              minWidth={minWidth}
+              maxWidth={maxWidth}
               sidebarRef={sidebarRef}
               mainRef={mainRef}
               onWidthChange={handleWidthChange}
@@ -159,7 +174,7 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
         <main
           ref={mainRef}
           className="flex-1 min-w-0 h-full overflow-hidden transition-[padding] duration-300 ease-out"
-          style={{ paddingLeft: showSidebar && isOpen ? `${width}px` : 0 }}
+          style={{ paddingLeft: showSidebar && isOpen ? `${displayWidth}px` : 0 }}
           role="main"
         >
           {children}
@@ -182,11 +197,15 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
  */
 function ResizeHandle({
   currentWidth,
+  minWidth,
+  maxWidth,
   sidebarRef,
   mainRef,
   onWidthChange,
 }: {
   currentWidth: number;
+  minWidth: number;
+  maxWidth: number;
   sidebarRef: { current: HTMLElement | null };
   mainRef: { current: HTMLElement | null };
   onWidthChange: (width: number) => void;
@@ -204,7 +223,7 @@ function ResizeHandle({
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       const raw = startWidth + (moveEvent.clientX - startX);
-      finalWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, raw));
+      finalWidth = Math.max(minWidth, Math.min(maxWidth, raw));
       // Direct DOM writes — bypasses React state for lag-free tracking
       if (sidebarRef.current) {
         sidebarRef.current.style.width = `${finalWidth}px`;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { PcDisplaySizeSelector } from './PcDisplaySizeSelector';
 
 export interface HeaderProps {
   title?: string;
@@ -84,6 +85,8 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
                 </Link>
               );
             })}
+            {/* PC display size selector (Issue #915) - hidden on mobile */}
+            <PcDisplaySizeSelector />
             <a
               href="https://github.com/kewton/MyCodeBranchDesk"
               target="_blank"

--- a/src/components/layout/PcDisplaySizeSelector.tsx
+++ b/src/components/layout/PcDisplaySizeSelector.tsx
@@ -1,0 +1,57 @@
+/**
+ * PcDisplaySizeSelector (Issue #915)
+ *
+ * PC-only dropdown for choosing the UI display size (大 / 中 / 小 / 極小).
+ * Hidden on mobile. Two-way bound to the persisted size via the context.
+ */
+
+'use client';
+
+import React from 'react';
+import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
+import {
+  PC_DISPLAY_SIZE_ORDER,
+  PC_DISPLAY_SIZE_META,
+  isPcDisplaySize,
+} from '@/hooks/usePcDisplaySize';
+
+/**
+ * Accessible display-size selector rendered in the PC header.
+ * Returns `null` on mobile so scaling stays PC-only.
+ */
+export function PcDisplaySizeSelector() {
+  const { size, setSize, isMobile } = usePcDisplaySizeContext();
+
+  if (isMobile) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center">
+      <label htmlFor="pc-display-size" className="sr-only">
+        表示サイズ
+      </label>
+      <select
+        id="pc-display-size"
+        data-testid="pc-display-size-select"
+        aria-label="表示サイズ"
+        value={size}
+        onChange={(event) => {
+          const next = event.target.value;
+          if (isPcDisplaySize(next)) {
+            setSize(next);
+          }
+        }}
+        className="text-sm bg-transparent text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+      >
+        {PC_DISPLAY_SIZE_ORDER.map((option) => (
+          <option key={option} value={option}>
+            {PC_DISPLAY_SIZE_META[option].label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default PcDisplaySizeSelector;

--- a/src/components/providers/AppProviders.tsx
+++ b/src/components/providers/AppProviders.tsx
@@ -15,6 +15,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { ThemeProvider } from 'next-themes';
 import { SidebarProvider } from '@/contexts/SidebarContext';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { PcDisplaySizeProvider } from '@/contexts/PcDisplaySizeContext';
 import { WorktreesCacheProvider } from '@/components/providers/WorktreesCacheProvider';
 
 interface AppProvidersProps {
@@ -40,11 +41,13 @@ export function AppProviders({ children, locale, messages, timeZone, authEnabled
     <NextIntlClientProvider locale={locale} messages={messages} timeZone={timeZone}>
       <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
         <AuthProvider authEnabled={authEnabled}>
-          <SidebarProvider>
-            <WorktreesCacheProvider>
-              {children}
-            </WorktreesCacheProvider>
-          </SidebarProvider>
+          <PcDisplaySizeProvider>
+            <SidebarProvider>
+              <WorktreesCacheProvider>
+                {children}
+              </WorktreesCacheProvider>
+            </SidebarProvider>
+          </PcDisplaySizeProvider>
         </AuthProvider>
       </ThemeProvider>
     </NextIntlClientProvider>

--- a/src/contexts/PcDisplaySizeContext.tsx
+++ b/src/contexts/PcDisplaySizeContext.tsx
@@ -1,0 +1,108 @@
+/**
+ * PcDisplaySizeContext (Issue #915)
+ *
+ * Single source of truth for the PC display size so that the header selector,
+ * the AppShell sidebar-width scaling, and the `<html data-pc-size>` cascade stay
+ * in sync within the same tab (separate `usePcDisplaySize()` instances would not).
+ *
+ * The provider applies the size to `document.documentElement` as `data-pc-size`
+ * for the rem cascade (案A) — PC only. On mobile (`useIsMobile()`) or unmount the
+ * attribute is removed so rem resolves to the browser default (16px = medium).
+ *
+ * The context has a non-throwing default (medium, factor 1) so components remain
+ * usable without an explicit provider (e.g. isolated unit tests).
+ */
+
+'use client';
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import {
+  usePcDisplaySize,
+  DEFAULT_PC_DISPLAY_SIZE,
+  PC_DISPLAY_SIZE_META,
+  type PcDisplaySize,
+} from '@/hooks/usePcDisplaySize';
+
+/** Attribute applied to `<html>` to drive the rem cascade. */
+export const PC_DISPLAY_SIZE_ATTRIBUTE = 'data-pc-size';
+
+/** Context value. */
+export interface PcDisplaySizeContextValue {
+  /** Current display size. */
+  size: PcDisplaySize;
+  /** Update and persist the display size. */
+  setSize: (size: PcDisplaySize) => void;
+  /** True when the viewport is mobile — selector hidden, scaling disabled. */
+  isMobile: boolean;
+  /** Scale factor (relative to medium) for the current size. */
+  factor: number;
+  /** Whether localStorage is available. */
+  isAvailable: boolean;
+}
+
+const DEFAULT_CONTEXT_VALUE: PcDisplaySizeContextValue = {
+  size: DEFAULT_PC_DISPLAY_SIZE,
+  setSize: () => {},
+  isMobile: false,
+  factor: PC_DISPLAY_SIZE_META[DEFAULT_PC_DISPLAY_SIZE].factor,
+  isAvailable: false,
+};
+
+const PcDisplaySizeContext = createContext<PcDisplaySizeContextValue>(
+  DEFAULT_CONTEXT_VALUE
+);
+
+/**
+ * Provider that owns the persisted size and applies the rem cascade attribute.
+ */
+export function PcDisplaySizeProvider({ children }: { children: ReactNode }) {
+  const { size, setSize, isAvailable } = usePcDisplaySize();
+  const isMobile = useIsMobile();
+
+  // Apply `<html data-pc-size>` on PC only; remove on mobile / unmount.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+
+    if (isMobile) {
+      root.removeAttribute(PC_DISPLAY_SIZE_ATTRIBUTE);
+      return;
+    }
+
+    root.setAttribute(PC_DISPLAY_SIZE_ATTRIBUTE, size);
+    return () => {
+      root.removeAttribute(PC_DISPLAY_SIZE_ATTRIBUTE);
+    };
+  }, [size, isMobile]);
+
+  const value = useMemo<PcDisplaySizeContextValue>(
+    () => ({
+      size,
+      setSize,
+      isMobile,
+      factor: PC_DISPLAY_SIZE_META[size].factor,
+      isAvailable,
+    }),
+    [size, setSize, isMobile, isAvailable]
+  );
+
+  return (
+    <PcDisplaySizeContext.Provider value={value}>
+      {children}
+    </PcDisplaySizeContext.Provider>
+  );
+}
+
+/** Consume the PC display size context. */
+export function usePcDisplaySizeContext(): PcDisplaySizeContextValue {
+  return useContext(PcDisplaySizeContext);
+}
+
+export default PcDisplaySizeContext;

--- a/src/hooks/usePcDisplaySize.ts
+++ b/src/hooks/usePcDisplaySize.ts
@@ -1,0 +1,104 @@
+/**
+ * usePcDisplaySize Hook (Issue #915)
+ *
+ * PC-only display-size preference (大 / 中 / 小 / 極小) persisted per browser via
+ * localStorage. The selected size drives the `rem` cascade (案A): the value is
+ * applied as `<html data-pc-size>` (see {@link PcDisplaySizeProvider}) so that
+ * rem-based Tailwind spacing/typography scales automatically. Fixed-px surfaces
+ * (sidebar width, xterm.js terminal fontSize) scale separately via the factor /
+ * terminalFontSize metadata exported here.
+ *
+ * @module hooks/usePcDisplaySize
+ */
+
+'use client';
+
+import { useLocalStorageState } from './useLocalStorageState';
+
+/** PC display size identifiers (大 / 中 / 小 / 極小). */
+export type PcDisplaySize = 'large' | 'medium' | 'small' | 'xsmall';
+
+/** localStorage key (follows the `mcbd-*` convention). */
+export const PC_DISPLAY_SIZE_STORAGE_KEY = 'mcbd-pc-display-size';
+
+/** Default size when nothing is stored or the stored value is invalid. */
+export const DEFAULT_PC_DISPLAY_SIZE: PcDisplaySize = 'medium';
+
+/** Display order for the selector UI (大 → 極小). */
+export const PC_DISPLAY_SIZE_ORDER: readonly PcDisplaySize[] = [
+  'large',
+  'medium',
+  'small',
+  'xsmall',
+];
+
+/** Per-size metadata. */
+export interface PcDisplaySizeMeta {
+  /** Stored value. */
+  value: PcDisplaySize;
+  /** Accessible Japanese label (大 / 中 / 小 / 極小). */
+  label: string;
+  /** `<html>` font-size in px applied via the globals.css cascade. */
+  rootFontSizePx: number;
+  /** Scale factor relative to medium, for fixed-px surfaces (e.g. sidebar width). */
+  factor: number;
+  /** xterm.js terminal fontSize for this size. */
+  terminalFontSize: number;
+}
+
+/**
+ * Size factor table (Issue #915 採用方針: 案A rem カスケード).
+ * Keep in sync with the `html[data-pc-size=...]` rules in `globals.css`.
+ */
+export const PC_DISPLAY_SIZE_META: Record<PcDisplaySize, PcDisplaySizeMeta> = {
+  large: { value: 'large', label: '大', rootFontSizePx: 18, factor: 1.125, terminalFontSize: 16 },
+  medium: { value: 'medium', label: '中', rootFontSizePx: 16, factor: 1, terminalFontSize: 14 },
+  small: { value: 'small', label: '小', rootFontSizePx: 14, factor: 0.875, terminalFontSize: 12 },
+  xsmall: { value: 'xsmall', label: '極小', rootFontSizePx: 12.5, factor: 0.78, terminalFontSize: 11 },
+};
+
+/** Type guard / validator for stored values. */
+export function isPcDisplaySize(value: unknown): value is PcDisplaySize {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(PC_DISPLAY_SIZE_META, value)
+  );
+}
+
+/** Scale factor (relative to medium) for the given size. */
+export function getPcDisplaySizeFactor(size: PcDisplaySize): number {
+  return PC_DISPLAY_SIZE_META[size].factor;
+}
+
+/** xterm.js terminal fontSize for the given size. */
+export function getTerminalFontSize(size: PcDisplaySize): number {
+  return PC_DISPLAY_SIZE_META[size].terminalFontSize;
+}
+
+/** Return type for {@link usePcDisplaySize}. */
+export interface UsePcDisplaySizeReturn {
+  /** Current persisted size. */
+  size: PcDisplaySize;
+  /** Update and persist the size. */
+  setSize: (size: PcDisplaySize) => void;
+  /** Whether localStorage is available. */
+  isAvailable: boolean;
+}
+
+/**
+ * Hook exposing the persisted PC display size preference.
+ *
+ * Out-of-range / corrupted stored values fall back to {@link DEFAULT_PC_DISPLAY_SIZE}
+ * via the validator.
+ */
+export function usePcDisplaySize(): UsePcDisplaySizeReturn {
+  const { value, setValue, isAvailable } = useLocalStorageState<PcDisplaySize>({
+    key: PC_DISPLAY_SIZE_STORAGE_KEY,
+    defaultValue: DEFAULT_PC_DISPLAY_SIZE,
+    validate: isPcDisplaySize,
+  });
+
+  return { size: value, setSize: setValue, isAvailable };
+}
+
+export default usePcDisplaySize;

--- a/tests/unit/components/TerminalComponent-fontSize.test.tsx
+++ b/tests/unit/components/TerminalComponent-fontSize.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for TerminalComponent fontSize prop (Issue #915)
+ *
+ * Verifies the xterm.js terminal font size is driven by the `fontSize` prop and
+ * updates live when the prop changes (without tearing down the connection).
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+const constructorOptions: Array<Record<string, unknown>> = [];
+let lastTerminal: MockTerminal | null = null;
+const mockFit = vi.fn();
+
+class MockTerminal {
+  cols = 80;
+  rows = 24;
+  options: Record<string, unknown>;
+  open = vi.fn();
+  write = vi.fn();
+  clear = vi.fn();
+  dispose = vi.fn();
+  loadAddon = vi.fn();
+  onData = vi.fn();
+
+  constructor(opts: Record<string, unknown>) {
+    this.options = { ...opts };
+    constructorOptions.push(opts);
+    lastTerminal = this;
+  }
+}
+
+class MockFitAddon {
+  fit = mockFit;
+}
+
+class MockWebLinksAddon {}
+
+vi.mock('xterm', () => ({ Terminal: MockTerminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: MockFitAddon }));
+vi.mock('xterm-addon-web-links', () => ({ WebLinksAddon: MockWebLinksAddon }));
+vi.mock('xterm/css/xterm.css', () => ({}));
+vi.mock('@/lib/tmux/tmux-control-mode-flags', () => ({
+  isTmuxControlModeEnabledForClient: () => false,
+}));
+
+describe('TerminalComponent fontSize (Issue #915)', () => {
+  beforeEach(() => {
+    constructorOptions.length = 0;
+    lastTerminal = null;
+    mockFit.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('passes the fontSize prop to the xterm Terminal constructor', async () => {
+    const { TerminalComponent } = await import('@/components/Terminal');
+    render(
+      <TerminalComponent
+        worktreeId="w1"
+        cliToolId="claude"
+        controlModeEnabled={false}
+        fontSize={16}
+      />
+    );
+    expect(constructorOptions[0]?.fontSize).toBe(16);
+  });
+
+  it('defaults to 14 when no fontSize prop is provided', async () => {
+    const { TerminalComponent } = await import('@/components/Terminal');
+    render(
+      <TerminalComponent worktreeId="w1" cliToolId="claude" controlModeEnabled={false} />
+    );
+    expect(constructorOptions[0]?.fontSize).toBe(14);
+  });
+
+  it('updates the live terminal fontSize when the prop changes', async () => {
+    const { TerminalComponent } = await import('@/components/Terminal');
+    const { rerender } = render(
+      <TerminalComponent
+        worktreeId="w1"
+        cliToolId="claude"
+        controlModeEnabled={false}
+        fontSize={16}
+      />
+    );
+    const term = lastTerminal;
+    expect(term?.options.fontSize).toBe(16);
+
+    mockFit.mockClear();
+    rerender(
+      <TerminalComponent
+        worktreeId="w1"
+        cliToolId="claude"
+        controlModeEnabled={false}
+        fontSize={11}
+      />
+    );
+
+    // Same instance updated in place (no reconnect/dispose).
+    expect(lastTerminal).toBe(term);
+    expect(term?.options.fontSize).toBe(11);
+    expect(mockFit).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/layout/PcDisplaySizeSelector.test.tsx
+++ b/tests/unit/components/layout/PcDisplaySizeSelector.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for PcDisplaySizeSelector (Issue #915)
+ *
+ * Verifies the PC-only display-size dropdown: rendering, persistence, and that
+ * it is hidden on mobile.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+const mockIsMobile = vi.fn(() => false);
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+  MOBILE_BREAKPOINT: 768,
+}));
+
+import { PcDisplaySizeProvider } from '@/contexts/PcDisplaySizeContext';
+import { PcDisplaySizeSelector } from '@/components/layout/PcDisplaySizeSelector';
+import { PC_DISPLAY_SIZE_STORAGE_KEY } from '@/hooks/usePcDisplaySize';
+
+describe('PcDisplaySizeSelector (Issue #915)', () => {
+  let mockStorage: Record<string, string>;
+
+  beforeEach(() => {
+    mockStorage = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => mockStorage[key] ?? null,
+        setItem: (key: string, value: string) => {
+          mockStorage[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete mockStorage[key];
+        },
+        clear: () => {
+          mockStorage = {};
+        },
+      },
+      writable: true,
+    });
+    mockIsMobile.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const renderSelector = () =>
+    render(
+      <PcDisplaySizeProvider>
+        <PcDisplaySizeSelector />
+      </PcDisplaySizeProvider>
+    );
+
+  it('renders the selector with all four sizes on PC, defaulting to medium', () => {
+    renderSelector();
+    const select = screen.getByTestId('pc-display-size-select') as HTMLSelectElement;
+    expect(select).toBeDefined();
+    expect(select.options).toHaveLength(4);
+    expect(select.value).toBe('medium');
+    expect(screen.getByLabelText('表示サイズ')).toBeDefined();
+  });
+
+  it('persists the chosen size to localStorage on change', () => {
+    renderSelector();
+    const select = screen.getByTestId('pc-display-size-select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'small' } });
+    expect(select.value).toBe('small');
+    expect(mockStorage[PC_DISPLAY_SIZE_STORAGE_KEY]).toBe(JSON.stringify('small'));
+  });
+
+  it('is hidden on mobile', () => {
+    mockIsMobile.mockReturnValue(true);
+    renderSelector();
+    expect(screen.queryByTestId('pc-display-size-select')).toBeNull();
+  });
+});

--- a/tests/unit/hooks/usePcDisplaySize.test.ts
+++ b/tests/unit/hooks/usePcDisplaySize.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for usePcDisplaySize hook (Issue #915)
+ *
+ * @module tests/unit/hooks/usePcDisplaySize
+ * @vitest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  usePcDisplaySize,
+  isPcDisplaySize,
+  getPcDisplaySizeFactor,
+  getTerminalFontSize,
+  PC_DISPLAY_SIZE_STORAGE_KEY,
+  DEFAULT_PC_DISPLAY_SIZE,
+  PC_DISPLAY_SIZE_ORDER,
+  PC_DISPLAY_SIZE_META,
+} from '@/hooks/usePcDisplaySize';
+
+describe('usePcDisplaySize (Issue #915)', () => {
+  let mockStorage: Record<string, string>;
+
+  beforeEach(() => {
+    mockStorage = {};
+    const localStorageMock = {
+      getItem: vi.fn((key: string) => mockStorage[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        mockStorage[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete mockStorage[key];
+      }),
+      clear: vi.fn(() => {
+        mockStorage = {};
+      }),
+      get length() {
+        return Object.keys(mockStorage).length;
+      },
+      key: vi.fn((index: number) => Object.keys(mockStorage)[index] ?? null),
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('metadata', () => {
+    it('defaults to medium', () => {
+      expect(DEFAULT_PC_DISPLAY_SIZE).toBe('medium');
+    });
+
+    it('orders sizes 大 → 極小', () => {
+      expect(PC_DISPLAY_SIZE_ORDER).toEqual(['large', 'medium', 'small', 'xsmall']);
+    });
+
+    it('validates known sizes and rejects others', () => {
+      expect(isPcDisplaySize('large')).toBe(true);
+      expect(isPcDisplaySize('medium')).toBe(true);
+      expect(isPcDisplaySize('small')).toBe(true);
+      expect(isPcDisplaySize('xsmall')).toBe(true);
+      expect(isPcDisplaySize('huge')).toBe(false);
+      expect(isPcDisplaySize(123)).toBe(false);
+      expect(isPcDisplaySize(null)).toBe(false);
+      expect(isPcDisplaySize(undefined)).toBe(false);
+      expect(isPcDisplaySize({})).toBe(false);
+    });
+
+    it('exposes factor and terminal font size per size', () => {
+      expect(getPcDisplaySizeFactor('medium')).toBe(1);
+      expect(getPcDisplaySizeFactor('large')).toBe(1.125);
+      expect(getPcDisplaySizeFactor('small')).toBe(0.875);
+      expect(getPcDisplaySizeFactor('xsmall')).toBe(0.78);
+      expect(getTerminalFontSize('large')).toBe(16);
+      expect(getTerminalFontSize('medium')).toBe(14);
+      expect(getTerminalFontSize('small')).toBe(12);
+      expect(getTerminalFontSize('xsmall')).toBe(11);
+      expect(PC_DISPLAY_SIZE_META.large.rootFontSizePx).toBe(18);
+      expect(PC_DISPLAY_SIZE_META.medium.rootFontSizePx).toBe(16);
+      expect(PC_DISPLAY_SIZE_META.small.rootFontSizePx).toBe(14);
+      expect(PC_DISPLAY_SIZE_META.xsmall.rootFontSizePx).toBe(12.5);
+    });
+  });
+
+  describe('hook', () => {
+    it('returns medium by default when nothing is stored', () => {
+      const { result } = renderHook(() => usePcDisplaySize());
+      expect(result.current.size).toBe('medium');
+    });
+
+    it('reads a valid persisted size', () => {
+      mockStorage[PC_DISPLAY_SIZE_STORAGE_KEY] = JSON.stringify('small');
+      const { result } = renderHook(() => usePcDisplaySize());
+      expect(result.current.size).toBe('small');
+    });
+
+    it('falls back to medium for an invalid persisted value', () => {
+      mockStorage[PC_DISPLAY_SIZE_STORAGE_KEY] = JSON.stringify('huge');
+      const { result } = renderHook(() => usePcDisplaySize());
+      expect(result.current.size).toBe('medium');
+    });
+
+    it('persists the selected size to localStorage', () => {
+      const { result } = renderHook(() => usePcDisplaySize());
+      act(() => {
+        result.current.setSize('xsmall');
+      });
+      expect(result.current.size).toBe('xsmall');
+      expect(mockStorage[PC_DISPLAY_SIZE_STORAGE_KEY]).toBe(JSON.stringify('xsmall'));
+    });
+  });
+});


### PR DESCRIPTION
## 概要

PC版で UI 全体の表示サイズを **4段階（大 / 中 / 小 / 極小）** から選択できるようにしました。既定は **中（medium）**。設定はブラウザごとに localStorage で永続化し、モバイル（< 768px）には適用しません（PC専用）。

採用方針は **案A（rem カスケード）**: `<html>` に `data-pc-size` を付与して font-size を切替え、Tailwind の rem ベース spacing/typography を一括スケールさせます。rem が効かない箇所（xterm.js ターミナル fontSize / 固定px のサイドバー幅）はサイズ係数で個別連動させます。

Closes #915

## 変更内容

| # | 項目 | 対応 |
|---|------|------|
| 1 | 設定永続化フック | `src/hooks/usePcDisplaySize.ts`（新規）— key `mcbd-pc-display-size`、既定 `medium`、`validate` で範囲外→medium。サイズ係数 / ターミナル fontSize / root フォントサイズのメタ表を集約 |
| 2 | スケール適用 | `src/contexts/PcDisplaySizeContext.tsx`（新規）— 単一の真実源。PC（`!isMobile`）時のみ `<html data-pc-size>` を付与、モバイル/アンマウント時は除去。`AppProviders` に組込 |
| 3 | CSS | `globals.css` の `@layer base` に `html[data-pc-size=...]` で 18/16/14/12.5px を定義 |
| 4 | ターミナル連動 | `Terminal.tsx` の `fontSize` を prop 化（既定14）。変更時は `term.options.fontSize` 更新＋`fit()` 再フィット（再接続なし）。`terminal/page.tsx` が選択サイズの値を配線 |
| 5 | サイドバー幅連動 | `AppShell.tsx` の MIN/MAX/表示幅をサイズ係数で連動（clamp 維持・係数往復で非破壊。medium=factor1 で従来と完全一致） |
| 6 | セレクタUI | `PcDisplaySizeSelector.tsx`（新規）を Header 右 nav に追加。PC専用（モバイル非表示）、アクセシブルラベル付き、双方向バインド |

### サイズ係数表

| サイズ | `<html>` font-size | 係数(対 中) | ターミナル fontSize |
|--------|--------------------|-------------|---------------------|
| 大 large | 18px | 1.125 | 16 |
| 中 medium | 16px | 1.0（既定） | 14 |
| 小 small | 14px | 0.875 | 12 |
| 極小 xsmall | 12.5px | 0.78 | 11 |

## テスト（新規3ファイル）

- `tests/unit/hooks/usePcDisplaySize.test.ts`（既定/検証/永続化/メタ）
- `tests/unit/components/layout/PcDisplaySizeSelector.test.tsx`（PC表示/永続化/モバイル非表示）
- `tests/unit/components/TerminalComponent-fontSize.test.tsx`（prop反映/既定14/動的更新）

## 品質チェック（オーケストレーター独立検証）

| チェック | 結果 |
|---------|------|
| `npm run lint` | ✅ No ESLint warnings or errors |
| `npx tsc --noEmit` | ✅ Pass |
| `npm run test:unit` | ✅ 7897 passed（422 files） |
| `npm run build` | ✅ 成功 |

## 受入観点

- PC版で 大/中/小/極小 切替がフォント・余白・主要コンポーネントに即時反映
- 既定=中。未設定の新規ブラウザは中表示。リロード後も保持
- ターミナル文字サイズも連動・リサイズ崩れ無し。サイドバー幅も追従
- モバイル（< 768px）ではセレクタ非表示・スケール非適用（従来通り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
