### PR TITLE
fix(display): PC表示サイズセレクタを詳細ページに表示＋ラベルをロケール連動（#917 #918）

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -22,5 +22,12 @@
     "sort": "Sort branches",
     "sync": "Sync worktrees",
     "repositories": "Manage repositories (add / sync)"
+  },
+  "displaySize": {
+    "ariaLabel": "Display size",
+    "large": "Large",
+    "medium": "Medium",
+    "small": "Small",
+    "xsmall": "Extra small"
   }
 }

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -22,5 +22,12 @@
     "sort": "ブランチの並び替え",
     "sync": "worktree を同期",
     "repositories": "リポジトリを管理（追加・同期）"
+  },
+  "displaySize": {
+    "ariaLabel": "表示サイズ",
+    "large": "大",
+    "medium": "中",
+    "small": "小",
+    "xsmall": "極小"
   }
 }

--- a/src/components/layout/PcDisplaySizeSelector.tsx
+++ b/src/components/layout/PcDisplaySizeSelector.tsx
@@ -1,17 +1,20 @@
 /**
  * PcDisplaySizeSelector (Issue #915)
  *
- * PC-only dropdown for choosing the UI display size (大 / 中 / 小 / 極小).
+ * PC-only dropdown for choosing the UI display size (large / medium / small / xsmall).
  * Hidden on mobile. Two-way bound to the persisted size via the context.
+ *
+ * Labels and the accessible label are localized via next-intl (`common.displaySize.*`)
+ * so they follow the active locale instead of being hard-coded Japanese (Issue #918).
  */
 
 'use client';
 
 import React from 'react';
+import { useTranslations } from 'next-intl';
 import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
 import {
   PC_DISPLAY_SIZE_ORDER,
-  PC_DISPLAY_SIZE_META,
   isPcDisplaySize,
 } from '@/hooks/usePcDisplaySize';
 
@@ -21,20 +24,23 @@ import {
  */
 export function PcDisplaySizeSelector() {
   const { size, setSize, isMobile } = usePcDisplaySizeContext();
+  const t = useTranslations('common');
 
   if (isMobile) {
     return null;
   }
 
+  const ariaLabel = t('displaySize.ariaLabel');
+
   return (
     <div className="flex items-center">
       <label htmlFor="pc-display-size" className="sr-only">
-        表示サイズ
+        {ariaLabel}
       </label>
       <select
         id="pc-display-size"
         data-testid="pc-display-size-select"
-        aria-label="表示サイズ"
+        aria-label={ariaLabel}
         value={size}
         onChange={(event) => {
           const next = event.target.value;
@@ -46,7 +52,7 @@ export function PcDisplaySizeSelector() {
       >
         {PC_DISPLAY_SIZE_ORDER.map((option) => (
           <option key={option} value={option}>
-            {PC_DISPLAY_SIZE_META[option].label}
+            {t(`displaySize.${option}`)}
           </option>
         ))}
       </select>

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -28,6 +28,7 @@ import type { Worktree, ChatMessage, GitStatus } from '@/types/models';
 import { getInstanceLabel, type AgentInstance, type CLIToolType } from '@/lib/cli-tools/types';
 import { COPY_FEEDBACK_RESET_MS } from '@/config/ui-feedback-config';
 import { AGENT_INSTANCE_DND_MIME } from '@/components/worktree/TerminalSplitPane';
+import { PcDisplaySizeSelector } from '@/components/layout/PcDisplaySizeSelector';
 
 // ============================================================================
 // Constants
@@ -735,6 +736,11 @@ export const DesktopHeader = memo(function DesktopHeader({
             ))}
           </select>
         )}
+        {/* Issue #917: PC display-size selector. The global Header (where it
+            also lives) is suppressed on /worktrees/[id] (useLayoutConfig
+            showGlobalNav:false), so it is surfaced here too. PC only — the
+            selector returns null on mobile. */}
+        <PcDisplaySizeSelector />
       <button
         type="button"
         onClick={onInfoClick}

--- a/src/hooks/usePcDisplaySize.ts
+++ b/src/hooks/usePcDisplaySize.ts
@@ -36,8 +36,6 @@ export const PC_DISPLAY_SIZE_ORDER: readonly PcDisplaySize[] = [
 export interface PcDisplaySizeMeta {
   /** Stored value. */
   value: PcDisplaySize;
-  /** Accessible Japanese label (大 / 中 / 小 / 極小). */
-  label: string;
   /** `<html>` font-size in px applied via the globals.css cascade. */
   rootFontSizePx: number;
   /** Scale factor relative to medium, for fixed-px surfaces (e.g. sidebar width). */
@@ -49,12 +47,16 @@ export interface PcDisplaySizeMeta {
 /**
  * Size factor table (Issue #915 採用方針: 案A rem カスケード).
  * Keep in sync with the `html[data-pc-size=...]` rules in `globals.css`.
+ *
+ * Display labels are intentionally NOT stored here — they live in the i18n
+ * dictionaries (`common.displaySize.*`) so the selector follows the active
+ * locale instead of hard-coded Japanese (Issue #918).
  */
 export const PC_DISPLAY_SIZE_META: Record<PcDisplaySize, PcDisplaySizeMeta> = {
-  large: { value: 'large', label: '大', rootFontSizePx: 18, factor: 1.125, terminalFontSize: 16 },
-  medium: { value: 'medium', label: '中', rootFontSizePx: 16, factor: 1, terminalFontSize: 14 },
-  small: { value: 'small', label: '小', rootFontSizePx: 14, factor: 0.875, terminalFontSize: 12 },
-  xsmall: { value: 'xsmall', label: '極小', rootFontSizePx: 12.5, factor: 0.78, terminalFontSize: 11 },
+  large: { value: 'large', rootFontSizePx: 18, factor: 1.125, terminalFontSize: 16 },
+  medium: { value: 'medium', rootFontSizePx: 16, factor: 1, terminalFontSize: 14 },
+  small: { value: 'small', rootFontSizePx: 14, factor: 0.875, terminalFontSize: 12 },
+  xsmall: { value: 'xsmall', rootFontSizePx: 12.5, factor: 0.78, terminalFontSize: 11 },
 };
 
 /** Type guard / validator for stored values. */

--- a/tests/unit/components/layout/PcDisplaySizeSelector.test.tsx
+++ b/tests/unit/components/layout/PcDisplaySizeSelector.test.tsx
@@ -62,7 +62,25 @@ describe('PcDisplaySizeSelector (Issue #915)', () => {
     expect(select).toBeDefined();
     expect(select.options).toHaveLength(4);
     expect(select.value).toBe('medium');
-    expect(screen.getByLabelText('表示サイズ')).toBeDefined();
+    // Issue #918: the accessible label is localized via next-intl
+    // (`common.displaySize.ariaLabel`) rather than a hard-coded Japanese string.
+    // The global next-intl mock (tests/setup.ts) echoes the full key.
+    expect(screen.getByLabelText('common.displaySize.ariaLabel')).toBeDefined();
+  });
+
+  it('labels each size option from the i18n dictionary, not hard-coded Japanese (Issue #918)', () => {
+    renderSelector();
+    const select = screen.getByTestId('pc-display-size-select') as HTMLSelectElement;
+    const optionText = Array.from(select.options).map((o) => o.textContent);
+    expect(optionText).toEqual([
+      'common.displaySize.large',
+      'common.displaySize.medium',
+      'common.displaySize.small',
+      'common.displaySize.xsmall',
+    ]);
+    // No raw Japanese label should leak through (regression guard for the bug).
+    expect(optionText).not.toContain('大');
+    expect(optionText).not.toContain('極小');
   });
 
   it('persists the chosen size to localStorage on change', () => {

--- a/tests/unit/components/worktree/WorktreeDetailSubComponents.test.tsx
+++ b/tests/unit/components/worktree/WorktreeDetailSubComponents.test.tsx
@@ -648,4 +648,22 @@ describe('DesktopHeader agent indicator drag source (Issue #786 / #869)', () => 
     expect(screen.queryByTestId('desktop-agent-status-row')).toBeNull();
     expect(container.querySelector('[draggable="true"]')).toBeNull();
   });
+
+  // Issue #917: the PC display-size selector must be reachable from the worktree
+  // detail page. The global Header is suppressed on /worktrees/[id] (useLayoutConfig
+  // showGlobalNav:false), so DesktopHeader surfaces the selector in its top bar.
+  // PcDisplaySizeContext has a non-throwing default (isMobile:false) so it renders
+  // without an explicit provider.
+  describe('PC display-size selector (Issue #917)', () => {
+    it('renders the display-size selector in the desktop top bar', () => {
+      render(<DesktopHeader {...baseProps} />);
+      expect(screen.getByTestId('pc-display-size-select')).toBeDefined();
+    });
+
+    it('keeps the selector present alongside the per-instance status row', () => {
+      render(<DesktopHeader {...baseProps} instances={mkInstances(['claude', 'codex'])} />);
+      expect(screen.getByTestId('desktop-agent-status-row')).toBeDefined();
+      expect(screen.getByTestId('pc-display-size-select')).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Issue #915 で追加した PC 表示サイズセレクタの 2 件のフォローアップ修正です。

- **#917**: worktree 詳細ページ（`/worktrees/[id]`）にセレクタが表示されない
- **#918**: セレクタのラベルが言語設定（en）に追従せず日本語固定（大/中/小/極小）

## 原因

| Issue | 原因 |
|-------|------|
| #917 | `/worktrees/[id]` は `useLayoutConfig` で `showGlobalNav:false` のためグローバル `Header`（#915 でセレクタを追加した場所）が描画されず、詳細ページからセレクタに到達できなかった |
| #918 | `PcDisplaySizeSelector` がハードコードの日本語ラベル（`PC_DISPLAY_SIZE_META[size].label`）と日本語 `aria-label`（"表示サイズ"）を直接描画しており、next-intl のロケールを経由していなかった |

## 変更内容

| # | 項目 | 対応 |
|---|------|------|
| 1 | 詳細ページ表示（#917） | `WorktreeDetailSubComponents.tsx` の `DesktopHeader` 右アクション群に `<PcDisplaySizeSelector />` を追加（PC専用・モバイルは `null`）。詳細ページの上部バーから到達可能に |
| 2 | i18n 化（#918） | `locales/{en,ja}/common.json` に `displaySize`（ariaLabel / large / medium / small / xsmall）を追加。`PcDisplaySizeSelector` で `useTranslations('common')` を用い、ラベル・aria-label をロケール連動に変更 |
| 3 | 単一の真実源化 | 未使用となった日本語固定の `label` フィールドを `PC_DISPLAY_SIZE_META` / `PcDisplaySizeMeta` から削除（表示文言は i18n 辞書を単一の真実源に） |

### ロケール別の表示

| size | en | ja |
|------|-----|----|
| large | Large | 大 |
| medium | Medium | 中 |
| small | Small | 小 |
| xsmall | Extra small | 極小 |
| aria-label | Display size | 表示サイズ |

## テスト（回帰ガード追加）

- `PcDisplaySizeSelector.test.tsx`: aria-label・各オプションが i18n 辞書（`common.displaySize.*`）由来であること、生の日本語が混入しないこと
- `WorktreeDetailSubComponents.test.tsx`: `DesktopHeader` がセレクタを描画すること（単独 / インスタンスステータス行と併存）

## 品質チェック（worktree 独立検証）

| チェック | 結果 |
|---------|------|
| `npm run lint` | ✅ No ESLint warnings or errors |
| `npx tsc --noEmit` | ✅ Pass |
| `npm run test:unit` | ✅ 7900 passed（422 files） |
| `npm run build` | ✅ 成功 |

## 受入観点

- PC の worktree 詳細ページ上部バーに表示サイズセレクタが表示される
- 言語設定が en のとき Large/Medium/Small/Extra small、ja のとき 大/中/小/極小 で表示される
- モバイルではセレクタ非表示（従来通り）

Closes #917
Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
