### PR TITLE
docs: fix stale repo name Kewton/MyCodeBranchDesk in .claude/commands

### DIFF
--- a/.claude/commands/cause-analysis.md
+++ b/.claude/commands/cause-analysis.md
@@ -35,7 +35,7 @@ Issueに記載されている不具合事象を元に、他のコーディング
 
 ```bash
 ISSUE_NUM="$ARGUMENTS"
-gh issue view "$ISSUE_NUM" --repo Kewton/MyCodeBranchDesk --json number,title,body,labels,comments
+gh issue view "$ISSUE_NUM" --repo Kewton/CommandMate --json number,title,body,labels,comments
 ```
 
 Issue本文から以下を抽出：
@@ -66,7 +66,7 @@ WORKTREE_ID="mycodebranchdesk-develop"
 ANALYSIS_PROMPT="Issue #${ISSUE_NUM} の根本原因分析を実施してください。
 
 ## Issue内容
-$(gh issue view ${ISSUE_NUM} --repo Kewton/MyCodeBranchDesk --json body -q '.body')
+$(gh issue view ${ISSUE_NUM} --repo Kewton/CommandMate --json body -q '.body')
 
 ## 分析要求
 
@@ -162,7 +162,7 @@ ${推奨する対策とその理由}
 ```
 
 ```bash
-gh issue edit "$ISSUE_NUM" --repo Kewton/MyCodeBranchDesk --body "$UPDATED_BODY"
+gh issue edit "$ISSUE_NUM" --repo Kewton/CommandMate --body "$UPDATED_BODY"
 ```
 
 ### Step 7: 結果報告

--- a/.claude/commands/current-situation.md
+++ b/.claude/commands/current-situation.md
@@ -62,7 +62,7 @@ sqlite3 db.sqlite "SELECT COUNT(*) FROM chat_messages;" 2>/dev/null
 
 ```bash
 # 類似のオープンIssueがないか確認
-gh issue list --repo Kewton/MyCodeBranchDesk --state open --json number,title --limit 30
+gh issue list --repo Kewton/CommandMate --state open --json number,title --limit 30
 ```
 
 類似Issueが存在する場合はユーザーに報告し、新規作成か既存への追記かを確認します。
@@ -121,7 +121,7 @@ ${会話中に判明したその他の情報}
 ### Step 6: Issue登録
 
 ```bash
-gh issue create --repo Kewton/MyCodeBranchDesk \
+gh issue create --repo Kewton/CommandMate \
   --title "[Bug] ${タイトル}" \
   --body "${Issue本文}"
 ```

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -63,7 +63,7 @@ TodoWriteツールで作業計画を作成：
 
 ```bash
 for issue_num in {issue_numbers}; do
-  gh issue view "$issue_num" --repo Kewton/MyCodeBranchDesk --json number,title,body,labels
+  gh issue view "$issue_num" --repo Kewton/CommandMate --json number,title,body,labels
 done
 ```
 
@@ -73,7 +73,7 @@ done
 
 ```bash
 for issue_num in {issue_numbers}; do
-  labels=$(gh issue view "$issue_num" --repo Kewton/MyCodeBranchDesk --json labels -q '[.labels[].name] | join(",")')
+  labels=$(gh issue view "$issue_num" --repo Kewton/CommandMate --json labels -q '[.labels[].name] | join(",")')
   if echo "$labels" | grep -q "bug"; then
     echo "BUG: #${issue_num}"
   else
@@ -164,7 +164,7 @@ develop worktree上でバグIssueごとに根本原因分析を実行する：
 WORKTREE_ID="mycodebranchdesk-develop"
 
 for bug_issue in $BUG_ISSUES; do
-  ISSUE_BODY=$(gh issue view "$bug_issue" --repo Kewton/MyCodeBranchDesk --json body -q '.body')
+  ISSUE_BODY=$(gh issue view "$bug_issue" --repo Kewton/CommandMate --json body -q '.body')
 
   # 必ず --agent copilot 等でclaude以外のエージェントを指定
   commandmatedev send "$WORKTREE_ID" "Issue #${bug_issue} の根本原因分析を実施してください。コードを変更せず分析のみ行い、結果をテキストで出力してください。
@@ -188,7 +188,7 @@ done
 分析結果をオーケストレーターが検証し、Issue本文に追記する：
 
 ```bash
-gh issue edit "$bug_issue" --repo Kewton/MyCodeBranchDesk --body "${CURRENT_BODY}${ANALYSIS_SECTION}"
+gh issue edit "$bug_issue" --repo Kewton/CommandMate --body "${CURRENT_BODY}${ANALYSIS_SECTION}"
 ```
 
 ### 2.5-3. 複数バグIssueの場合

--- a/.claude/commands/pr-merge-pipeline.md
+++ b/.claude/commands/pr-merge-pipeline.md
@@ -59,7 +59,7 @@ commandmatedev ls --json
 
 ```bash
 for issue_num in {issue_numbers}; do
-  gh pr list --repo Kewton/MyCodeBranchDesk --head "feature/${issue_num}-worktree" --json number,title,state
+  gh pr list --repo Kewton/CommandMate --head "feature/${issue_num}-worktree" --json number,title,state
 done
 ```
 
@@ -90,7 +90,7 @@ for each worktree:
 
 ```bash
 for issue_num in {issue_numbers}; do
-  PR_NUM=$(gh pr list --repo Kewton/MyCodeBranchDesk --head "feature/${issue_num}-worktree" --json number -q '.[0].number')
+  PR_NUM=$(gh pr list --repo Kewton/CommandMate --head "feature/${issue_num}-worktree" --json number -q '.[0].number')
   echo "Issue #${issue_num} → PR #${PR_NUM}"
 done
 ```
@@ -105,7 +105,7 @@ PR番号を記録し、以降のステップで使用する。
 
 ```bash
 for each PR:
-  gh pr checks <PR_NUM> --repo Kewton/MyCodeBranchDesk
+  gh pr checks <PR_NUM> --repo Kewton/CommandMate
 ```
 
 ### 3-2. CI完了待ち
@@ -114,7 +114,7 @@ CIが実行中の場合は完了を待つ。定期的にステータスを確認
 
 ```bash
 for each PR:
-  gh pr checks <PR_NUM> --repo Kewton/MyCodeBranchDesk --watch
+  gh pr checks <PR_NUM> --repo Kewton/CommandMate --watch
 ```
 
 ### 3-3. CI失敗時のリカバリ
@@ -123,7 +123,7 @@ CI失敗を検出した場合:
 
 1. 失敗内容を取得：
    ```bash
-   gh pr checks <PR_NUM> --repo Kewton/MyCodeBranchDesk
+   gh pr checks <PR_NUM> --repo Kewton/CommandMate
    ```
 
 2. ワーカーに修正を指示：
@@ -151,7 +151,7 @@ CI失敗を検出した場合:
 1. **各PRの変更規模を取得**:
    ```bash
    for each PR:
-     gh pr diff <PR_NUM> --repo Kewton/MyCodeBranchDesk --stat
+     gh pr diff <PR_NUM> --repo Kewton/CommandMate --stat
    ```
 
 2. **共通変更ファイルの特定**:
@@ -185,7 +185,7 @@ CI失敗を検出した場合:
 #### 5-1. マージ可能性の確認
 
 ```bash
-gh pr view <PR_NUM> --repo Kewton/MyCodeBranchDesk --json mergeable,mergeStateStatus
+gh pr view <PR_NUM> --repo Kewton/CommandMate --json mergeable,mergeStateStatus
 ```
 
 - **mergeable**: マージ可能 → 5-3 へ
@@ -211,7 +211,7 @@ commandmatedev wait <worktree-id> --timeout 3600
 #### 5-3. マージ実行
 
 ```bash
-gh pr merge <PR_NUM> --merge --repo Kewton/MyCodeBranchDesk
+gh pr merge <PR_NUM> --merge --repo Kewton/CommandMate
 ```
 
 #### 5-4. develop更新・ビルド検証

--- a/.claude/commands/uat-fix-loop.md
+++ b/.claude/commands/uat-fix-loop.md
@@ -166,7 +166,7 @@ commandmatedev send <worktree-id> \
 
 ```bash
 for issue_num in {issue_numbers}; do
-  gh pr list --repo Kewton/MyCodeBranchDesk \
+  gh pr list --repo Kewton/CommandMate \
     --head "feature/${issue_num}-worktree" \
     --state all --json number,state -q '.[0] | "\(.number) \(.state)"'
 done
@@ -176,7 +176,7 @@ done
 
 - **OPEN**: pushで自動更新済み。CIの通過を待つ。
   ```bash
-  gh pr checks <PR_NUM> --repo Kewton/MyCodeBranchDesk --watch
+  gh pr checks <PR_NUM> --repo Kewton/CommandMate --watch
   ```
 
 - **MERGED**: 修正コミットのための新規PR作成が必要。
@@ -195,7 +195,7 @@ done
 
 ```bash
 for each PR:
-  gh pr checks <PR_NUM> --repo Kewton/MyCodeBranchDesk --watch
+  gh pr checks <PR_NUM> --repo Kewton/CommandMate --watch
 ```
 
 CI失敗時はワーカーに修正指示（最大3回）。
@@ -205,13 +205,13 @@ CI失敗時はワーカーに修正指示（最大3回）。
 ```bash
 for each PR:
   # コンフリクト確認
-  gh pr view <PR_NUM> --repo Kewton/MyCodeBranchDesk --json mergeable
+  gh pr view <PR_NUM> --repo Kewton/CommandMate --json mergeable
 
   # コンフリクト時はワーカーに rebase 指示
   # （必要に応じて）
 
   # マージ
-  gh pr merge <PR_NUM> --merge --repo Kewton/MyCodeBranchDesk
+  gh pr merge <PR_NUM> --merge --repo Kewton/CommandMate
 
   # develop更新・ビルド検証
   git pull origin develop


### PR DESCRIPTION
## 概要
Issue #924 の対応（/orchestrate 自動開発フロー）。

docs: fix stale repo name Kewton/MyCodeBranchDesk in .claude/commands

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)