### PR TITLE
refactor: split useWorktreeDetailController god-hook into sub-hooks

### DIFF
--- a/src/hooks/useDiffViewerState.ts
+++ b/src/hooks/useDiffViewerState.ts
@@ -1,0 +1,68 @@
+/**
+ * useDiffViewerState hook (Issue #923)
+ *
+ * Owns the PC right-pane diff viewer state extracted from
+ * `useWorktreeDetailController` as a pure structural refactor (no behavior
+ * change). One of the Phase 1 "low-risk, no cross-concern coupling" sub-hooks:
+ * the diff content/path is set by `handleDiffSelect` (from GitPane, PC only)
+ * and cleared by `handleCloseDiff`, with no other coupling to the controller's
+ * terminal/auto-yes concerns (Issue #447).
+ *
+ * `handleDiffSelect` no-ops on mobile (the diff is rendered inline within
+ * GitPane there), so `isMobile` is passed in to preserve that exact behavior.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+
+/** Public API returned by {@link useDiffViewerState}. */
+export interface UseDiffViewerStateReturn {
+  /** Diff text shown in the PC right pane, or null when no diff is open. */
+  diffContent: string | null;
+  /** Path of the file whose diff is shown, or null when no diff is open. */
+  diffFilePath: string | null;
+  /**
+   * Show a diff in the PC right pane (Issue #447). No-op on mobile, where the
+   * diff is rendered inline within GitPane instead.
+   */
+  handleDiffSelect: (diff: string, filePath: string) => void;
+  /** Close the diff view in the PC right pane. */
+  handleCloseDiff: () => void;
+}
+
+/**
+ * State management for the PC right-pane diff viewer.
+ *
+ * @param isMobile - When true, {@link handleDiffSelect} is a no-op (mobile
+ *   renders the diff inline within GitPane).
+ * @returns The diff content/path plus open/close handlers.
+ */
+export function useDiffViewerState(isMobile: boolean): UseDiffViewerStateReturn {
+  // [Issue #447] Diff content for right pane display (PC only)
+  const [diffContent, setDiffContent] = useState<string | null>(null);
+  const [diffFilePath, setDiffFilePath] = useState<string | null>(null);
+
+  /** Handle diff selection from GitPane (Issue #447) */
+  const handleDiffSelect = useCallback((diff: string, filePath: string) => {
+    if (!isMobile) {
+      // PC: show diff in right pane file panel area
+      setDiffContent(diff);
+      setDiffFilePath(filePath);
+    }
+    // Mobile: diff is shown inline within GitPane
+  }, [isMobile]);
+
+  /** Close diff view in right pane (Issue #447) */
+  const handleCloseDiff = useCallback(() => {
+    setDiffContent(null);
+    setDiffFilePath(null);
+  }, []);
+
+  return {
+    diffContent,
+    diffFilePath,
+    handleDiffSelect,
+    handleCloseDiff,
+  };
+}

--- a/src/hooks/useHistoryFilters.ts
+++ b/src/hooks/useHistoryFilters.ts
@@ -1,0 +1,125 @@
+/**
+ * useHistoryFilters hook (Issue #923)
+ *
+ * Owns the History pane's filter/display state extracted from
+ * `useWorktreeDetailController` as a pure structural refactor (no behavior
+ * change). This is one of the Phase 1 "low-risk, no cross-concern coupling"
+ * sub-hooks — it manages only self-contained state with localStorage sync:
+ *  - `historySubTab`        : 'message' (default) | 'git'           (Issue #447)
+ *  - `showArchived`         : include archived messages toggle      (Issue #168)
+ *  - `historyUserOnly`      : HistoryPane "User only" filter toggle (Issue #725)
+ *  - `historyDisplayLimit`  : how many messages to request          (Issue #701)
+ *
+ * Ownership boundary: this hook covers the filter *values* and their
+ * localStorage persistence only. The ref mirrors (`showArchivedRef` /
+ * `historyDisplayLimitRef`) that keep the controller's `fetchMessages` a stable
+ * closure stay in the controller — they belong to the polling/fetch concern
+ * (deferred to Issue #923 Phase 2/3), not to this filter-state concern.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import {
+  HISTORY_DISPLAY_LIMIT_STORAGE_KEY,
+  HISTORY_USER_ONLY_STORAGE_KEY,
+  DEFAULT_MESSAGES_LIMIT,
+  isHistoryDisplayLimit,
+  type HistoryDisplayLimit,
+} from '@/config/history-display-config';
+
+/** localStorage key for the "show archived messages" toggle (Issue #168). */
+const SHOW_ARCHIVED_STORAGE_KEY = 'commandmate:showArchived';
+
+/** Public API returned by {@link useHistoryFilters}. */
+export interface UseHistoryFiltersReturn {
+  /** History sub-tab: 'message' (default) or 'git' (Issue #447). */
+  historySubTab: 'message' | 'git';
+  /** Setter for {@link historySubTab}. */
+  setHistorySubTab: Dispatch<SetStateAction<'message' | 'git'>>;
+  /** Whether archived messages are included in the History pane (Issue #168). */
+  showArchived: boolean;
+  /** Update {@link showArchived} and persist it to localStorage. */
+  handleShowArchivedChange: (show: boolean) => void;
+  /** HistoryPane "User only" filter toggle (Issue #725). */
+  historyUserOnly: boolean;
+  /** Update {@link historyUserOnly} and persist it to localStorage. */
+  handleHistoryUserOnlyChange: (next: boolean) => void;
+  /** How many messages to request from the History API (Issue #701). */
+  historyDisplayLimit: HistoryDisplayLimit;
+  /** Update {@link historyDisplayLimit} and persist it to localStorage. */
+  handleHistoryDisplayLimitChange: (limit: HistoryDisplayLimit) => void;
+}
+
+/**
+ * State management for the History pane's filter/display toggles.
+ *
+ * @returns The filter state and their localStorage-synced change handlers.
+ */
+export function useHistoryFilters(): UseHistoryFiltersReturn {
+  // [Issue #447] History sub-tab: 'message' (default) or 'git'
+  const [historySubTab, setHistorySubTab] = useState<'message' | 'git'>('message');
+
+  // Issue #168: showArchived toggle state with localStorage persistence
+  const [showArchived, setShowArchived] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(SHOW_ARCHIVED_STORAGE_KEY) === 'true';
+  });
+  const handleShowArchivedChange = useCallback((show: boolean) => {
+    setShowArchived(show);
+    localStorage.setItem(SHOW_ARCHIVED_STORAGE_KEY, String(show));
+  }, []);
+
+  // Issue #725: HistoryPane "User only" filter toggle with localStorage persistence.
+  // Value representation: 'true' / 'false' (matches commandmate:showArchived).
+  // Any other value (including legacy '1'/'0') is treated as false (safe-off fallback).
+  const [historyUserOnly, setHistoryUserOnly] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return localStorage.getItem(HISTORY_USER_ONLY_STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+  const handleHistoryUserOnlyChange = useCallback((next: boolean) => {
+    setHistoryUserOnly(next);
+    try {
+      localStorage.setItem(HISTORY_USER_ONLY_STORAGE_KEY, String(next));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, []);
+
+  // Issue #701: history display limit state with localStorage persistence
+  const [historyDisplayLimit, setHistoryDisplayLimit] = useState<HistoryDisplayLimit>(() => {
+    if (typeof window === 'undefined') return DEFAULT_MESSAGES_LIMIT;
+    try {
+      const stored = localStorage.getItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY);
+      if (stored === null) return DEFAULT_MESSAGES_LIMIT;
+      const parsed = parseInt(stored, 10);
+      return isHistoryDisplayLimit(parsed) ? parsed : DEFAULT_MESSAGES_LIMIT;
+    } catch {
+      return DEFAULT_MESSAGES_LIMIT;
+    }
+  });
+  const handleHistoryDisplayLimitChange = useCallback((limit: HistoryDisplayLimit) => {
+    setHistoryDisplayLimit(limit);
+    try {
+      localStorage.setItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY, String(limit));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, []);
+
+  return {
+    historySubTab,
+    setHistorySubTab,
+    showArchived,
+    handleShowArchivedChange,
+    historyUserOnly,
+    handleHistoryUserOnlyChange,
+    historyDisplayLimit,
+    handleHistoryDisplayLimitChange,
+  };
+}

--- a/src/hooks/useVisibilityRecovery.ts
+++ b/src/hooks/useVisibilityRecovery.ts
@@ -1,0 +1,157 @@
+/**
+ * useVisibilityRecovery hook (Issue #923)
+ *
+ * Owns the page-visibility background recovery extracted from
+ * `useWorktreeDetailController` as a pure structural refactor (no behavior
+ * change). One of the Phase 1 "low-risk, no cross-concern coupling" sub-hooks:
+ * it fully encapsulates the throttle ref, the `visibilitychange` handler, and
+ * the listener registration effect (Issue #246, Issue #266).
+ *
+ * The controller passes in its data fetchers, error state, and recovery
+ * handler; the hook registers the listener and drives recovery, returning
+ * nothing (the controller never consumed `handleVisibilityChange` directly).
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { Worktree } from '@/types/models';
+
+/**
+ * Throttle interval for visibilitychange recovery (ms).
+ * Prevents excessive API calls when the page rapidly transitions between
+ * visible and hidden states.
+ * Same value as IDLE_POLLING_INTERVAL_MS but semantically independent:
+ * - IDLE_POLLING_INTERVAL_MS: steady-state polling frequency
+ * - RECOVERY_THROTTLE_MS: visibilitychange burst prevention threshold
+ * (Issue #246, SF-001)
+ */
+const RECOVERY_THROTTLE_MS = 5000;
+
+/** Dependencies injected by the controller into {@link useVisibilityRecovery}. */
+export interface UseVisibilityRecoveryParams {
+  /** Current error state; when set, recovery defers to {@link handleRetry}. */
+  error: string | null;
+  /** Full recovery (resets loading state and rebuilds the UI from error). */
+  handleRetry: () => void;
+  /** Re-fetch worktree metadata. */
+  fetchWorktree: () => Promise<Worktree | null>;
+  /** Re-fetch message history. */
+  fetchMessages: () => Promise<void>;
+  /** Re-fetch current terminal output / prompt status. */
+  fetchCurrentOutput: () => Promise<void>;
+  /** Clear the error state (counters internal setError from fetchWorktree). */
+  setError: (error: string | null) => void;
+}
+
+/**
+ * Register a `visibilitychange` listener that re-syncs data when the page
+ * returns to the foreground (e.g. smartphone foreground restoration).
+ */
+export function useVisibilityRecovery({
+  error,
+  handleRetry,
+  fetchWorktree,
+  fetchMessages,
+  fetchCurrentOutput,
+  setError,
+}: UseVisibilityRecoveryParams): void {
+  /**
+   * Timestamp of the last visibilitychange recovery to prevent rapid re-fetches.
+   * Used as a throttle guard: if less than RECOVERY_THROTTLE_MS has elapsed
+   * since the last recovery, the handler skips execution.
+   */
+  const lastRecoveryTimestampRef = useRef<number>(0);
+
+  /**
+   * Handle page visibility change for background recovery.
+   * When the page becomes visible again (e.g., smartphone foreground restoration),
+   * performs data re-fetch to synchronize stale state.
+   *
+   * Design rationale (Issue #246, Issue #266):
+   *
+   * [SF-001] SRP: handleVisibilityChange is responsible for "background recovery
+   *   data sync" only. Full recovery (handleRetry) is a separate concern.
+   *
+   * [SF-002] KISS: Simple error guard - error state uses handleRetry (full recovery),
+   *   normal state uses lightweight recovery (no loading state change).
+   *
+   * [IA-002] Overlap: When the page becomes visible, up to 3 data-fetch
+   *   sources may fire concurrently:
+   *   1. This visibilitychange handler (lightweight recovery)
+   *   2. The setInterval polling timer (if it fires during the same tick)
+   *   3. WebSocket reconnection triggering a broadcast-based fetch
+   *   All fetches are idempotent GET requests, so concurrent execution is
+   *   safe -- it may cause redundant network calls but no data corruption.
+   */
+  const handleVisibilityChange = useCallback(async () => {
+    if (document.visibilityState !== 'visible') return;
+
+    const now = Date.now();
+    if (now - lastRecoveryTimestampRef.current < RECOVERY_THROTTLE_MS) {
+      return;
+    }
+    lastRecoveryTimestampRef.current = now;
+
+    // [SF-001] Error state requires full recovery (handleRetry) to reset
+    // loading state and rebuild the UI from ErrorDisplay back to normal.
+    if (error) {
+      handleRetry();
+      return;
+    }
+
+    // [SF-002] Normal state uses lightweight recovery (loading state unchanged).
+    // This preserves the component tree, preventing MessageInput/PromptPanel
+    // content from being cleared by unmount/remount caused by setLoading(true/false).
+    //
+    // [SF-DRY-001] Note: These fetch calls duplicate the data retrieval done by
+    // handleRetry(). handleRetry uses setLoading(true/false) for full recovery,
+    // while this path intentionally omits loading state changes for lightweight
+    // recovery. When adding/changing fetch functions, update handleRetry() as well.
+    //
+    // [SF-CONS-001] handleRetry uses a sequential pattern (fetchWorktree first,
+    // then conditionally fetchMessages/fetchCurrentOutput). Lightweight recovery
+    // uses Promise.all for parallel execution because: failure is silently ignored
+    // (next polling cycle recovers), all requests are idempotent GETs (no data
+    // corruption risk), and parallel execution improves response time.
+    try {
+      await Promise.all([
+        fetchWorktree(),
+        fetchMessages(),
+        fetchCurrentOutput(),
+      ]);
+    } finally {
+      // [SF-IMP-001] fetchWorktree() internally catches errors and calls
+      // setError(message) without rethrowing. This means Promise.all resolves
+      // successfully even when fetchWorktree fails, but error state has already
+      // been set internally. Call setError(null) unconditionally to counter any
+      // internal setError() calls and maintain the component tree.
+      // On success, this is a no-op (error is already null).
+      // On failure, this prevents ErrorDisplay from replacing the normal UI,
+      // allowing the next polling cycle to recover naturally.
+      setError(null);
+    }
+    // [SF-IMP-002] Note: error in the dependency array causes useCallback to
+    // regenerate when error state changes, triggering useEffect listener
+    // re-registration (removeEventListener/addEventListener). Performance impact
+    // is negligible as these are synchronous lightweight operations.
+  }, [error, handleRetry, fetchWorktree, fetchMessages, fetchCurrentOutput, setError]);
+
+  /**
+   * Register visibilitychange event listener for background recovery (Issue #246, #266).
+   * When the page becomes visible, performs lightweight recovery (normal state)
+   * or full recovery via handleRetry() (error state) to re-fetch all data.
+   * This handles the case where the browser suspended network requests while
+   * the page was in the background (common on mobile browsers).
+   *
+   * Unlike WorktreeList.tsx (SF-003), this component needs:
+   * - Error state branching: full recovery (handleRetry) vs lightweight recovery
+   * - Throttle guard (RECOVERY_THROTTLE_MS) to prevent rapid re-fetches
+   */
+  useEffect(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [handleVisibilityChange]);
+}

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -56,13 +56,9 @@ import { useMobileSelectedInstances } from '@/hooks/useMobileSelectedInstances';
 import { useTranslations } from 'next-intl';
 import { useFileOperations } from '@/hooks/useFileOperations';
 import { encodePathForUrl } from '@/lib/url-path-encoder';
-import {
-  HISTORY_DISPLAY_LIMIT_STORAGE_KEY,
-  HISTORY_USER_ONLY_STORAGE_KEY,
-  DEFAULT_MESSAGES_LIMIT,
-  isHistoryDisplayLimit,
-  type HistoryDisplayLimit,
-} from '@/config/history-display-config';
+import { useHistoryFilters } from '@/hooks/useHistoryFilters';
+import { useDiffViewerState } from '@/hooks/useDiffViewerState';
+import { useVisibilityRecovery } from '@/hooks/useVisibilityRecovery';
 
 // ============================================================================
 // Constants
@@ -118,17 +114,6 @@ const ACTIVE_POLLING_INTERVAL_MS = 2000;
 
 /** Polling interval when terminal is idle (ms) */
 const IDLE_POLLING_INTERVAL_MS = 5000;
-
-/**
- * Throttle interval for visibilitychange recovery (ms).
- * Prevents excessive API calls when the page rapidly transitions between
- * visible and hidden states.
- * Same value as IDLE_POLLING_INTERVAL_MS but semantically independent:
- * - IDLE_POLLING_INTERVAL_MS: steady-state polling frequency
- * - RECOVERY_THROTTLE_MS: visibilitychange burst prevention threshold
- * (Issue #246, SF-001)
- */
-const RECOVERY_THROTTLE_MS = 5000;
 
 /** Default worktree name when not loaded */
 const DEFAULT_WORKTREE_NAME = 'Unknown';
@@ -325,65 +310,28 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   // just the root). The controller only retains `fileTreeRefresh` to force an
   // explicit refresh after local file operations (create/rename/delete/upload).
 
-  // [Issue #447] History sub-tab: 'message' (default) or 'git'
-  const [historySubTab, setHistorySubTab] = useState<'message' | 'git'>('message');
-
-  // Issue #168: showArchived toggle state with localStorage persistence
-  const [showArchived, setShowArchived] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    return localStorage.getItem('commandmate:showArchived') === 'true';
-  });
-  const handleShowArchivedChange = useCallback((show: boolean) => {
-    setShowArchived(show);
-    localStorage.setItem('commandmate:showArchived', String(show));
-  }, []);
-  // Ref for showArchived to avoid callback recreation
+  // [Issue #447 / #168 / #725 / #701] History pane filter/display state.
+  // Issue #923: extracted to the useHistoryFilters hook (former inline state +
+  // localStorage-synced handlers). The hook owns the filter values; the ref
+  // mirrors below (read by fetchMessages to stay a stable closure) and the
+  // re-fetch-on-change effects remain here as part of the fetch/polling concern.
+  const {
+    historySubTab,
+    setHistorySubTab,
+    showArchived,
+    handleShowArchivedChange,
+    historyUserOnly,
+    handleHistoryUserOnlyChange,
+    historyDisplayLimit,
+    handleHistoryDisplayLimitChange,
+  } = useHistoryFilters();
+  // Ref mirrors so fetchMessages reads the latest filter values without being
+  // recreated on toggle (kept local: refs from a hook return would trip
+  // react-hooks/exhaustive-deps since ESLint can't see them as stable).
   const showArchivedRef = useRef(showArchived);
   useEffect(() => {
     showArchivedRef.current = showArchived;
   }, [showArchived]);
-
-  // Issue #725: HistoryPane "User only" filter toggle with localStorage persistence.
-  // Value representation: 'true' / 'false' (matches commandmate:showArchived).
-  // Any other value (including legacy '1'/'0') is treated as false (safe-off fallback).
-  const [historyUserOnly, setHistoryUserOnly] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    try {
-      return localStorage.getItem(HISTORY_USER_ONLY_STORAGE_KEY) === 'true';
-    } catch {
-      return false;
-    }
-  });
-  const handleHistoryUserOnlyChange = useCallback((next: boolean) => {
-    setHistoryUserOnly(next);
-    try {
-      localStorage.setItem(HISTORY_USER_ONLY_STORAGE_KEY, String(next));
-    } catch {
-      /* localStorage unavailable */
-    }
-  }, []);
-
-  // Issue #701: history display limit state with localStorage persistence
-  const [historyDisplayLimit, setHistoryDisplayLimit] = useState<HistoryDisplayLimit>(() => {
-    if (typeof window === 'undefined') return DEFAULT_MESSAGES_LIMIT;
-    try {
-      const stored = localStorage.getItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY);
-      if (stored === null) return DEFAULT_MESSAGES_LIMIT;
-      const parsed = parseInt(stored, 10);
-      return isHistoryDisplayLimit(parsed) ? parsed : DEFAULT_MESSAGES_LIMIT;
-    } catch {
-      return DEFAULT_MESSAGES_LIMIT;
-    }
-  });
-  const handleHistoryDisplayLimitChange = useCallback((limit: HistoryDisplayLimit) => {
-    setHistoryDisplayLimit(limit);
-    try {
-      localStorage.setItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY, String(limit));
-    } catch {
-      /* localStorage unavailable */
-    }
-  }, []);
-  // Ref for historyDisplayLimit to avoid fetchMessages callback recreation
   const historyDisplayLimitRef = useRef(historyDisplayLimit);
   useEffect(() => {
     historyDisplayLimitRef.current = historyDisplayLimit;
@@ -403,9 +351,15 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     handleInsertConsumedSingle,
   } = usePendingInsertText();
 
-  // [Issue #447] Diff content for right pane display (PC only)
-  const [diffContent, setDiffContent] = useState<string | null>(null);
-  const [diffFilePath, setDiffFilePath] = useState<string | null>(null);
+  // [Issue #447] Diff content for right pane display (PC only).
+  // Issue #923: extracted to the useDiffViewerState hook (state + open/close
+  // handlers). handleDiffSelect no-ops on mobile, so isMobile is passed in.
+  const {
+    diffContent,
+    diffFilePath,
+    handleDiffSelect,
+    handleCloseDiff,
+  } = useDiffViewerState(isMobile);
 
   // [Issue #21] File search state
   const fileSearch = useFileSearch({ worktreeId });
@@ -862,22 +816,6 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     router.push('/');
   }, [router]);
 
-  /** Handle diff selection from GitPane (Issue #447) */
-  const handleDiffSelect = useCallback((diff: string, filePath: string) => {
-    if (!isMobile) {
-      // PC: show diff in right pane file panel area
-      setDiffContent(diff);
-      setDiffFilePath(filePath);
-    }
-    // Mobile: diff is shown inline within GitPane
-  }, [isMobile]);
-
-  /** Close diff view in right pane (Issue #447) */
-  const handleCloseDiff = useCallback(() => {
-    setDiffContent(null);
-    setDiffFilePath(null);
-  }, []);
-
   /** Handle worktree status change via dropdown */
   const handleWorktreeStatusChange = useCallback(async (newStatus: 'ready' | 'in_progress' | 'in_review' | 'done' | null) => {
     try {
@@ -1307,86 +1245,18 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   // Visibility Change Recovery (Issue #246, Issue #266)
   // ========================================================================
 
-  /**
-   * Timestamp of the last visibilitychange recovery to prevent rapid re-fetches.
-   * Used as a throttle guard: if less than RECOVERY_THROTTLE_MS has elapsed
-   * since the last recovery, the handler skips execution.
-   */
-  const lastRecoveryTimestampRef = useRef<number>(0);
-
-  /**
-   * Handle page visibility change for background recovery.
-   * When the page becomes visible again (e.g., smartphone foreground restoration),
-   * performs data re-fetch to synchronize stale state.
-   *
-   * Design rationale (Issue #246, Issue #266):
-   *
-   * [SF-001] SRP: handleVisibilityChange is responsible for "background recovery
-   *   data sync" only. Full recovery (handleRetry) is a separate concern.
-   *
-   * [SF-002] KISS: Simple error guard - error state uses handleRetry (full recovery),
-   *   normal state uses lightweight recovery (no loading state change).
-   *
-   * [IA-002] Overlap: When the page becomes visible, up to 3 data-fetch
-   *   sources may fire concurrently:
-   *   1. This visibilitychange handler (lightweight recovery)
-   *   2. The setInterval polling timer (if it fires during the same tick)
-   *   3. WebSocket reconnection triggering a broadcast-based fetch
-   *   All fetches are idempotent GET requests, so concurrent execution is
-   *   safe -- it may cause redundant network calls but no data corruption.
-   */
-  const handleVisibilityChange = useCallback(async () => {
-    if (document.visibilityState !== 'visible') return;
-
-    const now = Date.now();
-    if (now - lastRecoveryTimestampRef.current < RECOVERY_THROTTLE_MS) {
-      return;
-    }
-    lastRecoveryTimestampRef.current = now;
-
-    // [SF-001] Error state requires full recovery (handleRetry) to reset
-    // loading state and rebuild the UI from ErrorDisplay back to normal.
-    if (error) {
-      handleRetry();
-      return;
-    }
-
-    // [SF-002] Normal state uses lightweight recovery (loading state unchanged).
-    // This preserves the component tree, preventing MessageInput/PromptPanel
-    // content from being cleared by unmount/remount caused by setLoading(true/false).
-    //
-    // [SF-DRY-001] Note: These fetch calls duplicate the data retrieval done by
-    // handleRetry(). handleRetry uses setLoading(true/false) for full recovery,
-    // while this path intentionally omits loading state changes for lightweight
-    // recovery. When adding/changing fetch functions, update handleRetry() as well.
-    //
-    // [SF-CONS-001] handleRetry uses a sequential pattern (fetchWorktree first,
-    // then conditionally fetchMessages/fetchCurrentOutput). Lightweight recovery
-    // uses Promise.all for parallel execution because: failure is silently ignored
-    // (next polling cycle recovers), all requests are idempotent GETs (no data
-    // corruption risk), and parallel execution improves response time.
-    try {
-      await Promise.all([
-        fetchWorktree(),
-        fetchMessages(),
-        fetchCurrentOutput(),
-      ]);
-    } finally {
-      // [SF-IMP-001] fetchWorktree() internally catches errors and calls
-      // setError(message) without rethrowing. This means Promise.all resolves
-      // successfully even when fetchWorktree fails, but error state has already
-      // been set internally. Call setError(null) unconditionally to counter any
-      // internal setError() calls and maintain the component tree.
-      // On success, this is a no-op (error is already null).
-      // On failure, this prevents ErrorDisplay from replacing the normal UI,
-      // allowing the next polling cycle to recover naturally.
-      setError(null);
-    }
-    // [SF-IMP-002] Note: error in the dependency array causes useCallback to
-    // regenerate when error state changes, triggering useEffect listener
-    // re-registration (removeEventListener/addEventListener). Performance impact
-    // is negligible as these are synchronous lightweight operations.
-  }, [error, handleRetry, fetchWorktree, fetchMessages, fetchCurrentOutput]);
+  // Issue #923: extracted to the useVisibilityRecovery hook (throttle ref +
+  // visibilitychange handler + listener registration effect). It re-syncs data
+  // when the page returns to the foreground: full recovery (handleRetry) on
+  // error, lightweight parallel re-fetch otherwise.
+  useVisibilityRecovery({
+    error,
+    handleRetry,
+    fetchWorktree,
+    fetchMessages,
+    fetchCurrentOutput,
+    setError,
+  });
 
   // ========================================================================
   // Effects
@@ -1427,24 +1297,6 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
       isMounted = false;
     };
   }, [fetchWorktree, fetchMessages, fetchCurrentOutput]);
-
-  /**
-   * Register visibilitychange event listener for background recovery (Issue #246, #266).
-   * When the page becomes visible, performs lightweight recovery (normal state)
-   * or full recovery via handleRetry() (error state) to re-fetch all data.
-   * This handles the case where the browser suspended network requests while
-   * the page was in the background (common on mobile browsers).
-   *
-   * Unlike WorktreeList.tsx (SF-003), this component needs:
-   * - Error state branching: full recovery (handleRetry) vs lightweight recovery
-   * - Throttle guard (RECOVERY_THROTTLE_MS) to prevent rapid re-fetches
-   */
-  useEffect(() => {
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [handleVisibilityChange]);
 
   /**
    * Poll for current output and worktree status at adaptive intervals.

--- a/tests/unit/hooks/useDiffViewerState.test.tsx
+++ b/tests/unit/hooks/useDiffViewerState.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for useDiffViewerState (Issue #923).
+ *
+ * Verifies the PC right-pane diff viewer state extracted from
+ * useWorktreeDetailController: open/close on PC, and the mobile no-op (mobile
+ * renders the diff inline within GitPane instead).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDiffViewerState } from '@/hooks/useDiffViewerState';
+
+describe('useDiffViewerState (Issue #923)', () => {
+  it('starts with no diff open', () => {
+    const { result } = renderHook(() => useDiffViewerState(false));
+
+    expect(result.current.diffContent).toBeNull();
+    expect(result.current.diffFilePath).toBeNull();
+  });
+
+  it('PC: handleDiffSelect sets content and path', () => {
+    const { result } = renderHook(() => useDiffViewerState(false));
+
+    act(() => result.current.handleDiffSelect('diff text', 'src/a.ts'));
+
+    expect(result.current.diffContent).toBe('diff text');
+    expect(result.current.diffFilePath).toBe('src/a.ts');
+  });
+
+  it('PC: handleCloseDiff clears content and path', () => {
+    const { result } = renderHook(() => useDiffViewerState(false));
+
+    act(() => result.current.handleDiffSelect('diff text', 'src/a.ts'));
+    act(() => result.current.handleCloseDiff());
+
+    expect(result.current.diffContent).toBeNull();
+    expect(result.current.diffFilePath).toBeNull();
+  });
+
+  it('mobile: handleDiffSelect is a no-op (diff shown inline in GitPane)', () => {
+    const { result } = renderHook(() => useDiffViewerState(true));
+
+    act(() => result.current.handleDiffSelect('diff text', 'src/a.ts'));
+
+    expect(result.current.diffContent).toBeNull();
+    expect(result.current.diffFilePath).toBeNull();
+  });
+
+  it('handleCloseDiff keeps a stable identity across renders', () => {
+    const { result, rerender } = renderHook(
+      ({ isMobile }: { isMobile: boolean }) => useDiffViewerState(isMobile),
+      { initialProps: { isMobile: false } },
+    );
+
+    const first = result.current.handleCloseDiff;
+    rerender({ isMobile: false });
+    expect(result.current.handleCloseDiff).toBe(first);
+  });
+});

--- a/tests/unit/hooks/useHistoryFilters.test.tsx
+++ b/tests/unit/hooks/useHistoryFilters.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for useHistoryFilters (Issue #923).
+ *
+ * Verifies the History pane filter/display state extracted from
+ * useWorktreeDetailController: defaults, localStorage initialization, and that
+ * each change handler updates state AND persists to localStorage.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHistoryFilters } from '@/hooks/useHistoryFilters';
+import {
+  DEFAULT_MESSAGES_LIMIT,
+  HISTORY_DISPLAY_LIMIT_STORAGE_KEY,
+  HISTORY_USER_ONLY_STORAGE_KEY,
+} from '@/config/history-display-config';
+
+const SHOW_ARCHIVED_KEY = 'commandmate:showArchived';
+
+describe('useHistoryFilters (Issue #923)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('defaults when localStorage is empty', () => {
+    const { result } = renderHook(() => useHistoryFilters());
+
+    expect(result.current.historySubTab).toBe('message');
+    expect(result.current.showArchived).toBe(false);
+    expect(result.current.historyUserOnly).toBe(false);
+    expect(result.current.historyDisplayLimit).toBe(DEFAULT_MESSAGES_LIMIT);
+  });
+
+  it('initializes from localStorage', () => {
+    window.localStorage.setItem(SHOW_ARCHIVED_KEY, 'true');
+    window.localStorage.setItem(HISTORY_USER_ONLY_STORAGE_KEY, 'true');
+    window.localStorage.setItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY, '100');
+
+    const { result } = renderHook(() => useHistoryFilters());
+
+    expect(result.current.showArchived).toBe(true);
+    expect(result.current.historyUserOnly).toBe(true);
+    expect(result.current.historyDisplayLimit).toBe(100);
+  });
+
+  it('falls back to default for an invalid stored display limit', () => {
+    window.localStorage.setItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY, '999');
+
+    const { result } = renderHook(() => useHistoryFilters());
+
+    expect(result.current.historyDisplayLimit).toBe(DEFAULT_MESSAGES_LIMIT);
+  });
+
+  it('setHistorySubTab updates the sub-tab', () => {
+    const { result } = renderHook(() => useHistoryFilters());
+
+    act(() => result.current.setHistorySubTab('git'));
+
+    expect(result.current.historySubTab).toBe('git');
+  });
+
+  it('handleShowArchivedChange updates state and persists', () => {
+    const { result } = renderHook(() => useHistoryFilters());
+
+    act(() => result.current.handleShowArchivedChange(true));
+
+    expect(result.current.showArchived).toBe(true);
+    expect(window.localStorage.getItem(SHOW_ARCHIVED_KEY)).toBe('true');
+  });
+
+  it('handleHistoryUserOnlyChange updates state and persists', () => {
+    const { result } = renderHook(() => useHistoryFilters());
+
+    act(() => result.current.handleHistoryUserOnlyChange(true));
+
+    expect(result.current.historyUserOnly).toBe(true);
+    expect(window.localStorage.getItem(HISTORY_USER_ONLY_STORAGE_KEY)).toBe('true');
+  });
+
+  it('handleHistoryDisplayLimitChange updates state and persists', () => {
+    const { result } = renderHook(() => useHistoryFilters());
+
+    act(() => result.current.handleHistoryDisplayLimitChange(150));
+
+    expect(result.current.historyDisplayLimit).toBe(150);
+    expect(window.localStorage.getItem(HISTORY_DISPLAY_LIMIT_STORAGE_KEY)).toBe('150');
+  });
+
+  it('change handlers keep a stable identity across renders', () => {
+    const { result, rerender } = renderHook(() => useHistoryFilters());
+
+    const first = result.current.handleShowArchivedChange;
+    rerender();
+    expect(result.current.handleShowArchivedChange).toBe(first);
+  });
+});

--- a/tests/unit/hooks/useVisibilityRecovery.test.tsx
+++ b/tests/unit/hooks/useVisibilityRecovery.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for useVisibilityRecovery (Issue #923).
+ *
+ * Verifies the page-visibility background recovery extracted from
+ * useWorktreeDetailController (Issue #246, #266):
+ *  - visible + no error  -> lightweight parallel re-fetch, then setError(null)
+ *  - visible + error     -> full recovery via handleRetry only
+ *  - hidden              -> no-op
+ *  - rapid re-fire       -> throttled (RECOVERY_THROTTLE_MS = 5000ms)
+ *  - unmount             -> listener removed
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVisibilityRecovery } from '@/hooks/useVisibilityRecovery';
+import type { Worktree } from '@/types/models';
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+async function fireVisibilityChange() {
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    // Flush the async handler's Promise.all + finally.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function makeParams(overrides: Partial<Parameters<typeof useVisibilityRecovery>[0]> = {}) {
+  return {
+    error: null as string | null,
+    handleRetry: vi.fn(),
+    fetchWorktree: vi.fn<() => Promise<Worktree | null>>().mockResolvedValue(null),
+    fetchMessages: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    fetchCurrentOutput: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    setError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useVisibilityRecovery (Issue #923)', () => {
+  beforeEach(() => {
+    setVisibility('visible');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('visible + no error: parallel re-fetch then setError(null)', async () => {
+    const params = makeParams();
+    renderHook(() => useVisibilityRecovery(params));
+
+    await fireVisibilityChange();
+
+    expect(params.fetchWorktree).toHaveBeenCalledTimes(1);
+    expect(params.fetchMessages).toHaveBeenCalledTimes(1);
+    expect(params.fetchCurrentOutput).toHaveBeenCalledTimes(1);
+    expect(params.setError).toHaveBeenCalledWith(null);
+    expect(params.handleRetry).not.toHaveBeenCalled();
+  });
+
+  it('visible + error: full recovery via handleRetry only', async () => {
+    const params = makeParams({ error: 'boom' });
+    renderHook(() => useVisibilityRecovery(params));
+
+    await fireVisibilityChange();
+
+    expect(params.handleRetry).toHaveBeenCalledTimes(1);
+    expect(params.fetchWorktree).not.toHaveBeenCalled();
+    expect(params.fetchMessages).not.toHaveBeenCalled();
+    expect(params.fetchCurrentOutput).not.toHaveBeenCalled();
+  });
+
+  it('hidden: no-op', async () => {
+    setVisibility('hidden');
+    const params = makeParams();
+    renderHook(() => useVisibilityRecovery(params));
+
+    await fireVisibilityChange();
+
+    expect(params.fetchWorktree).not.toHaveBeenCalled();
+    expect(params.handleRetry).not.toHaveBeenCalled();
+    expect(params.setError).not.toHaveBeenCalled();
+  });
+
+  it('throttles a rapid second fire within RECOVERY_THROTTLE_MS', async () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    const params = makeParams();
+    renderHook(() => useVisibilityRecovery(params));
+
+    // First fire at t=10000 runs.
+    nowSpy.mockReturnValue(10000);
+    await fireVisibilityChange();
+    expect(params.fetchWorktree).toHaveBeenCalledTimes(1);
+
+    // Second fire at t=12000 (2000ms < 5000ms) is throttled.
+    nowSpy.mockReturnValue(12000);
+    await fireVisibilityChange();
+    expect(params.fetchWorktree).toHaveBeenCalledTimes(1);
+
+    // Third fire at t=16000 (6000ms > 5000ms) runs again.
+    nowSpy.mockReturnValue(16000);
+    await fireVisibilityChange();
+    expect(params.fetchWorktree).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes the listener on unmount', async () => {
+    const params = makeParams();
+    const { unmount } = renderHook(() => useVisibilityRecovery(params));
+
+    unmount();
+    await fireVisibilityChange();
+
+    expect(params.fetchWorktree).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要
Issue #923 の対応（/orchestrate 自動開発フロー）。

refactor: split useWorktreeDetailController god-hook into sub-hooks

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)