### PR TITLE
feat(timer): select registered agent instances in Timer and Schedule (#942)

### DIFF
--- a/src/app/api/worktrees/[id]/timers/route.ts
+++ b/src/app/api/worktrees/[id]/timers/route.ts
@@ -14,10 +14,11 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { isCliToolType } from '@/lib/cli-tools/types';
+import { isCliToolType, isValidInstanceId, isPrimaryInstance } from '@/lib/cli-tools/types';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import { CLIToolManager } from '@/lib/cli-tools/manager';
 import { getWorktreeById } from '@/lib/db';
+import { getAgentInstances } from '@/lib/db/agent-instances-db';
 import { getDbInstance } from '@/lib/db/db-instance';
 import {
   createTimer,
@@ -57,11 +58,35 @@ export async function POST(
     }
 
     const body = await req.json();
-    const { cliToolId, message, delayMs } = body;
+    const { cliToolId, message, delayMs, instanceId } = body;
 
-    // Validate cliToolId
+    // Validate cliToolId (the backing CLI tool is always a real tool type)
     if (!cliToolId || typeof cliToolId !== 'string' || !isCliToolType(cliToolId)) {
       return NextResponse.json({ error: 'Invalid agent' }, { status: 400 });
+    }
+
+    // [Issue #942] Resolve the target agent instance. When omitted (legacy
+    // clients) the primary instance anchor (instanceId === cliToolId) is used.
+    let resolvedInstanceId: string = cliToolId;
+    if (instanceId !== undefined && instanceId !== null) {
+      if (typeof instanceId !== 'string' || !isValidInstanceId(instanceId)) {
+        return NextResponse.json({ error: 'Invalid agent instance' }, { status: 400 });
+      }
+      const registered = getAgentInstances(db, id);
+      const match = registered.find((inst) => inst.id === instanceId);
+      if (match) {
+        // The instance must be backed by the declared CLI tool.
+        if (match.cliTool !== cliToolId) {
+          return NextResponse.json({ error: 'Invalid agent instance' }, { status: 400 });
+        }
+        resolvedInstanceId = instanceId;
+      } else if (isPrimaryInstance(instanceId, cliToolId as CLIToolType)) {
+        // Primary anchor (id === cliTool) is always valid even if no explicit
+        // agent_instances row exists (backward compatibility).
+        resolvedInstanceId = instanceId;
+      } else {
+        return NextResponse.json({ error: 'Invalid agent instance' }, { status: 400 });
+      }
     }
 
     // Validate message
@@ -87,7 +112,7 @@ export async function POST(
     let warning: string | undefined;
     try {
       const cliTool = CLIToolManager.getInstance().getTool(cliToolId as CLIToolType);
-      const running = await cliTool.isRunning(id);
+      const running = await cliTool.isRunning(id, resolvedInstanceId);
       if (!running) {
         warning = 'session_not_running';
       }
@@ -99,6 +124,7 @@ export async function POST(
     const timer = createTimer(db, {
       worktreeId: id,
       cliToolId,
+      instanceId: resolvedInstanceId,
       message,
       delayMs,
     });
@@ -111,6 +137,7 @@ export async function POST(
       id: timer.id,
       worktreeId: timer.worktreeId,
       cliToolId: timer.cliToolId,
+      instanceId: timer.instanceId,
       message: timer.message,
       delayMs: timer.delayMs,
       scheduledSendTime: timer.scheduledSendTime,
@@ -180,6 +207,7 @@ export async function GET(
       timers: timers.map(t => ({
         id: t.id,
         cliToolId: t.cliToolId,
+        instanceId: t.instanceId,
         message: t.message,
         delayMs: t.delayMs,
         scheduledSendTime: t.scheduledSendTime,

--- a/src/components/worktree/ExecutionLogPane.tsx
+++ b/src/components/worktree/ExecutionLogPane.tsx
@@ -18,6 +18,7 @@ import { ExecutionLogsView, type ExecutionLog } from '@/components/worktree/sche
 import { formatTimestamp } from '@/components/worktree/schedules/format';
 import { parseCmateContent } from '@/lib/cmate-validator';
 import { parseCliToolColumn } from '@/lib/cmate-cli-tool-parser';
+import type { AgentInstance } from '@/lib/cli-tools/types';
 
 // ============================================================================
 // Types
@@ -61,6 +62,12 @@ export interface ExecutionLogPaneProps {
    * when omitted the buttons are hidden (graceful degradation).
    */
   onInsertToMessage?: (text: string) => void;
+  /**
+   * Issue #942: registered agent instances. Forwarded to ScheduleEditDialog so
+   * its agent selector shows registered instance aliases. Schedule execution
+   * still routes by the selected instance's backing CLI tool (UI-label only).
+   */
+  instances?: AgentInstance[];
 }
 
 // ============================================================================
@@ -91,6 +98,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
   worktreeId,
   className = '',
   onInsertToMessage,
+  instances,
 }: ExecutionLogPaneProps) {
   const t = useTranslations('schedule');
   const [logs, setLogs] = useState<ExecutionLog[]>([]);
@@ -485,6 +493,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
         initialValues={dialogInitial}
         originalName={dialogOriginalName}
         onInsertToMessage={onInsertToMessage}
+        instances={instances}
         onClose={() => setDialogOpen(false)}
         onSaved={() => { void fetchData(); }}
       />

--- a/src/components/worktree/NotesAndLogsPane.tsx
+++ b/src/components/worktree/NotesAndLogsPane.tsx
@@ -151,6 +151,7 @@ export const NotesAndLogsPane = memo(function NotesAndLogsPane({
             worktreeId={worktreeId}
             className="h-full"
             onInsertToMessage={onInsertToMessage}
+            instances={instances}
           />
         )}
         {activeSubTab === 'agent' && (
@@ -186,6 +187,7 @@ export const NotesAndLogsPane = memo(function NotesAndLogsPane({
         {activeSubTab === 'timer' && (
           <TimerPane
             worktreeId={worktreeId}
+            instances={instances}
             selectedAgents={selectedAgents}
           />
         )}

--- a/src/components/worktree/TimerPane.tsx
+++ b/src/components/worktree/TimerPane.tsx
@@ -13,7 +13,7 @@
 
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef, memo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import {
   TIMER_DELAYS,
@@ -23,8 +23,8 @@ import {
   DEFAULT_TIMER_HISTORY_LIMIT,
 } from '@/config/timer-constants';
 import { formatTimeRemaining } from '@/config/auto-yes-config';
-import type { CLIToolType } from '@/lib/cli-tools/types';
-import { CLI_TOOL_IDS, getCliToolDisplayName } from '@/lib/cli-tools/types';
+import type { CLIToolType, AgentInstance } from '@/lib/cli-tools/types';
+import { CLI_TOOL_IDS, agentInstancesFromSelectedAgents } from '@/lib/cli-tools/types';
 
 // =============================================================================
 // Types
@@ -32,13 +32,21 @@ import { CLI_TOOL_IDS, getCliToolDisplayName } from '@/lib/cli-tools/types';
 
 interface TimerPaneProps {
   worktreeId: string;
-  /** @deprecated No longer used — CLI_TOOL_IDS is used directly */
+  /**
+   * Registered agent instances (Issue #942). Drives the agent selector so the
+   * timer can target a specific instance session. Falls back to the primary
+   * instance of every CLI tool when omitted/empty (legacy behavior).
+   */
+  instances?: AgentInstance[];
+  /** @deprecated No longer used — instances drives the selector */
   selectedAgents?: CLIToolType[];
 }
 
 interface TimerItem {
   id: string;
   cliToolId: string;
+  /** Target agent instance (Issue #942). Legacy rows fall back to cliToolId. */
+  instanceId: string;
   message: string;
   delayMs: number;
   scheduledSendTime: number;
@@ -81,11 +89,23 @@ function getStatusColor(status: string): string {
 // Component
 // =============================================================================
 
-export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps) {
+export const TimerPane = memo(function TimerPane({ worktreeId, instances }: TimerPaneProps) {
   const t = useTranslations('schedule');
+
+  // Resolve the agent roster: explicit instances when configured, otherwise the
+  // primary instance of every CLI tool (legacy behavior, byte-for-byte compat).
+  const resolvedInstances = useMemo<AgentInstance[]>(
+    () => (instances && instances.length > 0
+      ? instances
+      : agentInstancesFromSelectedAgents([...CLI_TOOL_IDS])),
+    [instances]
+  );
+
   const [timers, setTimers] = useState<TimerItem[]>([]);
   const [message, setMessage] = useState('');
-  const [selectedAgent, setSelectedAgent] = useState<CLIToolType>(CLI_TOOL_IDS[0]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string>(
+    () => resolvedInstances[0]?.id ?? CLI_TOOL_IDS[0]
+  );
   const [selectedDelay, setSelectedDelay] = useState(TIMER_DELAYS[0]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasMore, setHasMore] = useState(false);
@@ -95,6 +115,14 @@ export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps)
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastCreatedAtRef = useRef<number | null>(null);
+
+  // Keep the selection valid when the instance roster changes (e.g. an instance
+  // is renamed/removed in the Agents panel while the Timer tab is open).
+  useEffect(() => {
+    if (!resolvedInstances.some((inst) => inst.id === selectedInstanceId)) {
+      setSelectedInstanceId(resolvedInstances[0]?.id ?? CLI_TOOL_IDS[0]);
+    }
+  }, [resolvedInstances, selectedInstanceId]);
 
   // ==========================================================================
   // Fetch timers
@@ -190,6 +218,9 @@ export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps)
   const handleRegister = useCallback(async () => {
     if (!message.trim() || isSubmitting) return;
 
+    const selected = resolvedInstances.find((inst) => inst.id === selectedInstanceId);
+    if (!selected) return;
+
     setWarning(null);
     setIsSubmitting(true);
     try {
@@ -197,7 +228,8 @@ export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps)
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          cliToolId: selectedAgent,
+          cliToolId: selected.cliTool,
+          instanceId: selected.id,
           message: message.trim(),
           delayMs: selectedDelay,
         }),
@@ -216,7 +248,7 @@ export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps)
     } finally {
       setIsSubmitting(false);
     }
-  }, [worktreeId, selectedAgent, message, selectedDelay, isSubmitting, fetchTimers]);
+  }, [worktreeId, resolvedInstances, selectedInstanceId, message, selectedDelay, isSubmitting, fetchTimers]);
 
   const handleCancel = useCallback(async (timerId: string) => {
     try {
@@ -265,15 +297,15 @@ export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps)
           {t('timer.title')}
         </div>
 
-        {/* Agent selector */}
+        {/* Agent instance selector (Issue #942) */}
         <select
-          value={selectedAgent}
-          onChange={(e) => setSelectedAgent(e.target.value as CLIToolType)}
+          value={selectedInstanceId}
+          onChange={(e) => setSelectedInstanceId(e.target.value)}
           className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-cyan-500"
         >
-          {CLI_TOOL_IDS.map((agent) => (
-            <option key={agent} value={agent}>
-              {getCliToolDisplayName(agent)}
+          {resolvedInstances.map((inst) => (
+            <option key={inst.id} value={inst.id}>
+              {inst.alias}
             </option>
           ))}
         </select>
@@ -343,7 +375,7 @@ export const TimerPane = memo(function TimerPane({ worktreeId }: TimerPaneProps)
                 </div>
                 <div className="flex items-center gap-2 text-xs">
                   <span className="text-cyan-600 dark:text-cyan-400 font-medium">
-                    {timer.cliToolId}
+                    {resolvedInstances.find((inst) => inst.id === timer.instanceId)?.alias ?? timer.cliToolId}
                   </span>
                   <span className={getStatusColor(timer.status)}>
                     {t(`timer.status.${timer.status}`)}

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -569,6 +569,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
           worktreeId={worktreeId}
           className="h-full"
           onInsertToMessage={handleInsertToMessage}
+          instances={instances}
         />
       ),
       agent: (
@@ -582,7 +583,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
           onVibeLocalContextWindowChange={onVibeLocalContextWindowChange}
         />
       ),
-      timer: <TimerPane worktreeId={worktreeId} />,
+      timer: <TimerPane worktreeId={worktreeId} instances={instances} />,
     }),
     [
       worktreeId,

--- a/src/components/worktree/schedules/ScheduleEditDialog.tsx
+++ b/src/components/worktree/schedules/ScheduleEditDialog.tsx
@@ -27,8 +27,9 @@ import { FullScreenModal } from '@/components/common/FullScreenModal';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import {
   CLI_TOOL_IDS,
-  getCliToolDisplayName,
   getCliToolDisplayNameSafe,
+  agentInstancesFromSelectedAgents,
+  type AgentInstance,
 } from '@/lib/cli-tools/types';
 import {
   getPermissionOptionsForTool,
@@ -67,6 +68,15 @@ export interface ScheduleEditDialogProps {
    * hidden (graceful degradation, same as the GitPane #817 pattern).
    */
   onInsertToMessage?: (text: string) => void;
+  /**
+   * Issue #942: registered agent instances. Drives the agent selector so it
+   * lists registered instance aliases instead of the raw CLI tool names. The
+   * schedule is persisted/executed by the selected instance's backing CLI tool
+   * (UI-label only — Schedule runs a fresh `claude -p` process, so per-instance
+   * session routing is not meaningful here). Falls back to the primary instance
+   * of every CLI tool when omitted/empty.
+   */
+  instances?: AgentInstance[];
   onClose: () => void;
   onSaved: () => void;
 }
@@ -214,12 +224,24 @@ export function ScheduleEditDialog({
   initialValues,
   originalName,
   onInsertToMessage,
+  instances,
   onClose,
   onSaved,
 }: ScheduleEditDialogProps) {
   const t = useTranslations('schedule');
   const isMobile = useIsMobile();
+
+  // Resolve the agent roster: explicit instances when configured, otherwise the
+  // primary instance of every CLI tool (legacy behavior).
+  const resolvedInstances = useMemo<AgentInstance[]>(
+    () => (instances && instances.length > 0
+      ? instances
+      : agentInstancesFromSelectedAgents([...CLI_TOOL_IDS])),
+    [instances]
+  );
+
   const [form, setForm] = useState<ScheduleFormValues>(DEFAULT_FORM);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string>('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   // Accordion: desktop shows every section open; mobile opens only the first.
@@ -232,16 +254,21 @@ export function ScheduleEditDialog({
     if (!isOpen) return;
     setSubmitError(null);
     setSubmitting(false);
+    const cliToolId = initialValues?.cliToolId ?? DEFAULT_FORM.cliToolId;
     setForm({
       name: initialValues?.name ?? DEFAULT_FORM.name,
       cronExpression: initialValues?.cronExpression ?? DEFAULT_FORM.cronExpression,
       message: initialValues?.message ?? DEFAULT_FORM.message,
-      cliToolId: initialValues?.cliToolId ?? DEFAULT_FORM.cliToolId,
+      cliToolId,
       enabled: initialValues?.enabled ?? DEFAULT_FORM.enabled,
       permission: initialValues?.permission ?? DEFAULT_FORM.permission,
       model: initialValues?.model ?? DEFAULT_FORM.model,
     });
-  }, [isOpen, initialValues]);
+    // Issue #942: pick the instance backing the seeded CLI tool. The modal is
+    // blocking, so the roster cannot change while it is open.
+    const match = resolvedInstances.find((inst) => inst.cliTool === cliToolId);
+    setSelectedInstanceId(match?.id ?? resolvedInstances[0]?.id ?? cliToolId);
+  }, [isOpen, initialValues, resolvedInstances]);
 
   // Reset which sections are open whenever the dialog opens or the layout changes.
   useEffect(() => {
@@ -308,6 +335,15 @@ export function ScheduleEditDialog({
     }));
   }, []);
 
+  // Issue #942: the agent selector picks an instance (by alias); the schedule is
+  // still keyed by the instance's backing CLI tool (UI-label only).
+  const handleInstanceChange = useCallback((instanceId: string) => {
+    const selected = resolvedInstances.find((inst) => inst.id === instanceId);
+    if (!selected) return;
+    setSelectedInstanceId(instanceId);
+    handleToolChange(selected.cliTool);
+  }, [resolvedInstances, handleToolChange]);
+
   const cronPresetValue = CRON_PRESETS.some((p) => p.value === form.cronExpression)
     ? form.cronExpression
     : 'custom';
@@ -373,7 +409,10 @@ export function ScheduleEditDialog({
   ]);
 
   // ----- Accordion header summaries -----
-  const cliToolName = getCliToolDisplayNameSafe(form.cliToolId);
+  // Show the selected instance alias, falling back to the CLI tool name.
+  const cliToolName =
+    resolvedInstances.find((inst) => inst.id === selectedInstanceId)?.alias
+    ?? getCliToolDisplayNameSafe(form.cliToolId);
   const basicSummary = form.name.trim()
     ? `${form.name.trim()} · ${form.cronExpression}`
     : form.cronExpression;
@@ -476,13 +515,13 @@ export function ScheduleEditDialog({
         <select
           id="schedule-cli-tool-select"
           data-testid="schedule-cli-tool-select"
-          value={form.cliToolId}
-          onChange={(e) => handleToolChange(e.target.value)}
+          value={selectedInstanceId}
+          onChange={(e) => handleInstanceChange(e.target.value)}
           className={INPUT_CLASS}
         >
-          {CLI_TOOL_IDS.map((tool) => (
-            <option key={tool} value={tool}>
-              {getCliToolDisplayName(tool)}
+          {resolvedInstances.map((inst) => (
+            <option key={inst.id} value={inst.id}>
+              {inst.alias}
             </option>
           ))}
         </select>

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -17,6 +17,7 @@ import { v31_migrations } from './v31-repository-visible';
 import { v32_migrations } from './v32-add-messages-role-composite-index';
 import { v33_migrations } from './v33-agent-instances';
 import { v34_migrations } from './v34-repository-todos';
+import { v35_migrations } from './v35-timer-instance-id';
 
 /**
  * Complete ordered list of all migrations.
@@ -39,4 +40,5 @@ export const migrations: Migration[] = [
   ...v32_migrations,
   ...v33_migrations,
   ...v34_migrations,
+  ...v35_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 34;
+export const CURRENT_SCHEMA_VERSION = 35;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v35-timer-instance-id.ts
+++ b/src/lib/db/migrations/v35-timer-instance-id.ts
@@ -1,0 +1,39 @@
+/** Migration v35: Add instance_id column to timer_messages (Issue #942).
+ *
+ * Timer (Issue #534) predates the AgentInstance system (Issue #869) and only
+ * stored the backing CLI tool (`cli_tool_id`). To let a timer target a specific
+ * registered agent instance — and route to that instance's tmux session via
+ * `getSessionName(worktreeId, instanceId)` — we add a nullable `instance_id`
+ * column.
+ *
+ * Backward compatibility: existing rows are backfilled with
+ * `instance_id = cli_tool_id`, which is exactly the primary instance anchor
+ * (`instanceId === cliTool`). New rows without an explicit instance also default
+ * to the primary, so legacy single-session behavior is preserved byte-for-byte.
+ */
+
+import type { Migration } from './runner';
+
+export const v35_migrations: Migration[] = [
+  {
+    version: 35,
+    name: 'add-instance-id-to-timer-messages',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE timer_messages ADD COLUMN instance_id TEXT;
+      `);
+
+      // Backfill existing timers: primary instance anchor (id === cli_tool_id).
+      db.exec(`
+        UPDATE timer_messages SET instance_id = cli_tool_id WHERE instance_id IS NULL;
+      `);
+
+      console.log('Added instance_id column to timer_messages table');
+    },
+    down: () => {
+      // SQLite cannot drop a column without a table rebuild; no-op rollback
+      // (mirrors the v22 archived-column migration).
+      console.log('No rollback for instance_id column (SQLite limitation)');
+    },
+  },
+];

--- a/src/lib/db/timer-db.ts
+++ b/src/lib/db/timer-db.ts
@@ -20,6 +20,11 @@ export interface TimerMessage {
   id: string;
   worktreeId: string;
   cliToolId: string;
+  /**
+   * Agent instance the timer targets (Issue #942). For the primary instance and
+   * legacy rows this equals `cliToolId` (the primary anchor: `id === cliTool`).
+   */
+  instanceId: string;
   message: string;
   delayMs: number;
   scheduledSendTime: number;
@@ -32,6 +37,8 @@ export interface TimerMessage {
 export interface CreateTimerParams {
   worktreeId: string;
   cliToolId: string;
+  /** Target agent instance (Issue #942). Defaults to the primary (`cliToolId`). */
+  instanceId?: string;
   message: string;
   delayMs: number;
 }
@@ -53,6 +60,8 @@ interface TimerMessageRow {
   id: string;
   worktree_id: string;
   cli_tool_id: string;
+  /** Nullable for rows created before the v35 migration (Issue #942). */
+  instance_id: string | null;
   message: string;
   delay_ms: number;
   scheduled_send_time: number;
@@ -66,7 +75,7 @@ interface TimerMessageRow {
 // =============================================================================
 
 /** SELECT column list for timer_messages queries */
-const TIMER_COLUMNS = 'id, worktree_id, cli_tool_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at';
+const TIMER_COLUMNS = 'id, worktree_id, cli_tool_id, instance_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at';
 
 // =============================================================================
 // Row Mapping
@@ -78,6 +87,9 @@ function mapRow(row: TimerMessageRow): TimerMessage {
     id: row.id,
     worktreeId: row.worktree_id,
     cliToolId: row.cli_tool_id,
+    // Legacy rows (pre-v35) have NULL instance_id → fall back to the primary
+    // instance anchor (instanceId === cliToolId).
+    instanceId: row.instance_id ?? row.cli_tool_id,
     message: row.message,
     delayMs: row.delay_ms,
     scheduledSendTime: row.scheduled_send_time,
@@ -102,16 +114,19 @@ export function createTimer(
   const id = randomUUID();
   const now = Date.now();
   const scheduledSendTime = now + params.delayMs;
+  // Default to the primary instance anchor when no instance is specified.
+  const instanceId = params.instanceId ?? params.cliToolId;
 
   const stmt = db.prepare(`
-    INSERT INTO timer_messages (id, worktree_id, cli_tool_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at)
-    VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
+    INSERT INTO timer_messages (id, worktree_id, cli_tool_id, instance_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
   `);
 
   stmt.run(
     id,
     params.worktreeId,
     params.cliToolId,
+    instanceId,
     params.message,
     params.delayMs,
     scheduledSendTime,
@@ -122,6 +137,7 @@ export function createTimer(
     id,
     worktreeId: params.worktreeId,
     cliToolId: params.cliToolId,
+    instanceId,
     message: params.message,
     delayMs: params.delayMs,
     scheduledSendTime,

--- a/src/lib/timer-manager.ts
+++ b/src/lib/timer-manager.ts
@@ -79,15 +79,20 @@ async function executeTimer(timerId: string): Promise<void> {
     // [DP-004/CON-MF-001] Resolve session name via CLIToolManager singleton
     const cliTool = CLIToolManager.getInstance().getTool(timer.cliToolId as CLIToolType);
 
+    // [Issue #942] Target the specific agent instance session. Legacy timers
+    // (and primary instances) have instanceId === cliToolId, preserving the
+    // original single-session behavior.
+    const instanceId = timer.instanceId;
+
     // [Issue #539] Check if session is running before sending
-    const isRunning = await cliTool.isRunning(timer.worktreeId);
+    const isRunning = await cliTool.isRunning(timer.worktreeId, instanceId);
     if (!isRunning) {
-      logger.warn('timer:no-session', { timerId, worktreeId: timer.worktreeId });
+      logger.warn('timer:no-session', { timerId, worktreeId: timer.worktreeId, instanceId });
       updateTimerStatus(db, timerId, TIMER_STATUS.NO_SESSION);
       return;
     }
 
-    const sessionName = cliTool.getSessionName(timer.worktreeId);
+    const sessionName = cliTool.getSessionName(timer.worktreeId, instanceId);
 
     updateTimerStatus(db, timerId, 'sending');
     await sendKeys(sessionName, timer.message, true);

--- a/tests/unit/components/schedules/ScheduleEditDialog.test.tsx
+++ b/tests/unit/components/schedules/ScheduleEditDialog.test.tsx
@@ -256,6 +256,62 @@ describe('ScheduleEditDialog', () => {
     });
   });
 
+  // --- Issue #942: agent instance selector (alias-driven, UI-label only) ---
+
+  describe('agent instance selector (Issue #942)', () => {
+    const instances = [
+      { id: 'claude', cliTool: 'claude' as const, alias: 'Main Claude', order: 0 },
+      { id: 'claude-reviewer', cliTool: 'claude' as const, alias: 'Reviewer', order: 1 },
+      { id: 'codex', cliTool: 'codex' as const, alias: 'My Codex', order: 2 },
+    ];
+
+    it('lists registered instance aliases in the agent selector', () => {
+      renderDialog({ instances });
+      const select = screen.getByTestId('schedule-cli-tool-select') as HTMLSelectElement;
+      const labels = Array.from(select.options).map((o) => o.textContent);
+      expect(labels).toEqual(['Main Claude', 'Reviewer', 'My Codex']);
+      // The option values are the instance ids.
+      expect(Array.from(select.options).map((o) => o.value)).toEqual([
+        'claude',
+        'claude-reviewer',
+        'codex',
+      ]);
+    });
+
+    it('persists the backing CLI tool of the selected instance on save (UI-label only)', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+      vi.stubGlobal('fetch', fetchMock);
+
+      renderDialog({
+        worktreeId: 'wt-9',
+        instances,
+        initialValues: { name: 'task-a', message: 'hello' },
+      });
+
+      // Pick the second instance, which is a *non-primary* claude instance.
+      fireEvent.change(screen.getByTestId('schedule-cli-tool-select'), {
+        target: { value: 'claude-reviewer' },
+      });
+      fireEvent.click(screen.getByTestId('schedule-save-button'));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      // No instanceId is persisted — only the backing CLI tool.
+      expect(body.cliToolId).toBe('claude');
+      expect(body.instanceId).toBeUndefined();
+    });
+
+    it('selects the instance backing the seeded CLI tool in edit mode', () => {
+      renderDialog({
+        instances,
+        originalName: 'task-a',
+        initialValues: { name: 'task-a', message: 'do it', cliToolId: 'codex' },
+      });
+      const select = screen.getByTestId('schedule-cli-tool-select') as HTMLSelectElement;
+      expect(select.value).toBe('codex');
+    });
+  });
+
   // --- Phase 4 (Issue #827): "Ask AI" buttons for cron / message drafting ---
 
   describe('Ask AI buttons (Issue #827)', () => {

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 34 after Migration #34 (repository_todos)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(34);
+    it('should be 35 after Migration #35 (timer instance_id)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(35);
     });
   });
 
@@ -515,6 +515,58 @@ describe('db-migrations', () => {
 
       const msg = db.prepare('SELECT archived FROM chat_messages WHERE id = ?').get('msg-archived-test') as { archived: number };
       expect(msg.archived).toBe(0);
+    });
+  });
+
+  describe('Migration #35: add-instance-id-to-timer-messages (Issue #942)', () => {
+    beforeEach(() => {
+      runMigrations(db);
+    });
+
+    it('should add a nullable instance_id column to timer_messages', () => {
+      const columns = db.prepare("PRAGMA table_info('timer_messages')").all() as Array<{
+        name: string;
+        type: string;
+        notnull: number;
+        dflt_value: string | null;
+      }>;
+
+      const instanceCol = columns.find(col => col.name === 'instance_id');
+      expect(instanceCol).toBeDefined();
+      expect(instanceCol?.type).toBe('TEXT');
+      // Nullable so pre-v35 rows are accepted; the app layer falls back to cli_tool_id.
+      expect(instanceCol?.notnull).toBe(0);
+    });
+
+    it('should backfill instance_id = cli_tool_id for rows created before the migration', async () => {
+      // Build a pre-v35 timer_messages table (no instance_id) in an isolated DB,
+      // seed a row, then run only the v35 up() to verify the backfill UPDATE.
+      const legacyDb = new Database(':memory:');
+      try {
+        legacyDb.exec(`
+          CREATE TABLE timer_messages (
+            id TEXT PRIMARY KEY,
+            worktree_id TEXT NOT NULL,
+            cli_tool_id TEXT NOT NULL,
+            message TEXT NOT NULL,
+            delay_ms INTEGER NOT NULL,
+            scheduled_send_time INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            created_at INTEGER NOT NULL,
+            sent_at INTEGER
+          );
+          INSERT INTO timer_messages (id, worktree_id, cli_tool_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at)
+          VALUES ('legacy-1', 'wt-1', 'codex', 'hi', 300000, 9999999999999, 'pending', 1, NULL);
+        `);
+
+        const { v35_migrations } = await import('../../../src/lib/db/migrations/v35-timer-instance-id');
+        v35_migrations[0].up(legacyDb);
+
+        const row = legacyDb.prepare('SELECT instance_id FROM timer_messages WHERE id = ?').get('legacy-1') as { instance_id: string };
+        expect(row.instance_id).toBe('codex');
+      } finally {
+        legacyDb.close();
+      }
     });
   });
 

--- a/tests/unit/lib/db/timer-db.test.ts
+++ b/tests/unit/lib/db/timer-db.test.ts
@@ -37,12 +37,13 @@ function setupTestDb(): Database.Database {
     );
   `);
 
-  // Create timer_messages table (v23 migration)
+  // Create timer_messages table (v23 migration + v35 instance_id, Issue #942)
   testDb.exec(`
     CREATE TABLE timer_messages (
       id TEXT PRIMARY KEY,
       worktree_id TEXT NOT NULL,
       cli_tool_id TEXT NOT NULL,
+      instance_id TEXT,
       message TEXT NOT NULL,
       delay_ms INTEGER NOT NULL,
       scheduled_send_time INTEGER NOT NULL,
@@ -113,6 +114,47 @@ describe('timer-db', () => {
       const timer = createTimer(db, params);
 
       expect(timer.scheduledSendTime).toBe(timer.createdAt + timer.delayMs);
+    });
+
+    // Issue #942: instance_id routing
+    it('should default instanceId to cliToolId when omitted', () => {
+      const timer = createTimer(db, {
+        worktreeId: 'wt-1',
+        cliToolId: 'claude',
+        message: 'Hello',
+        delayMs: 300000,
+      });
+
+      expect(timer.instanceId).toBe('claude');
+      // Persisted value also defaults to the primary anchor.
+      const fetched = getTimerById(db, timer.id);
+      expect(fetched!.instanceId).toBe('claude');
+    });
+
+    it('should persist an explicit instanceId distinct from cliToolId', () => {
+      const timer = createTimer(db, {
+        worktreeId: 'wt-1',
+        cliToolId: 'claude',
+        instanceId: 'claude-reviewer',
+        message: 'Hello',
+        delayMs: 300000,
+      });
+
+      expect(timer.cliToolId).toBe('claude');
+      expect(timer.instanceId).toBe('claude-reviewer');
+      const fetched = getTimerById(db, timer.id);
+      expect(fetched!.instanceId).toBe('claude-reviewer');
+    });
+
+    it('should fall back to cliToolId for legacy rows with NULL instance_id', () => {
+      // Simulate a pre-v35 row by inserting NULL instance_id directly.
+      db.prepare(`
+        INSERT INTO timer_messages (id, worktree_id, cli_tool_id, instance_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at)
+        VALUES ('legacy-1', 'wt-1', 'codex', NULL, 'legacy', 300000, 9999999999999, 'pending', 1, NULL)
+      `).run();
+
+      const fetched = getTimerById(db, 'legacy-1');
+      expect(fetched!.instanceId).toBe('codex');
     });
   });
 

--- a/tests/unit/lib/timer-manager.test.ts
+++ b/tests/unit/lib/timer-manager.test.ts
@@ -236,6 +236,7 @@ describe('timer-manager', () => {
         id: timerId,
         worktreeId: 'wt-1',
         cliToolId: 'claude',
+        instanceId: 'claude',
         message: 'Hello',
         delayMs: 300000,
         scheduledSendTime: Date.now() + 300000,
@@ -258,7 +259,7 @@ describe('timer-manager', () => {
       // Advance timers to trigger callback
       await vi.advanceTimersByTimeAsync(200);
 
-      expect(mockIsRunning).toHaveBeenCalledWith('wt-1');
+      expect(mockIsRunning).toHaveBeenCalledWith('wt-1', 'claude');
       expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
         expect.anything(),
         timerId,
@@ -273,12 +274,48 @@ describe('timer-manager', () => {
       );
     });
 
+    // Issue #942: route to the specific agent instance session
+    it('should resolve the instance session when timer targets a non-primary instance', async () => {
+      const timerId = 'timer-instance-1';
+      const timer = {
+        id: timerId,
+        worktreeId: 'wt-1',
+        cliToolId: 'claude',
+        instanceId: 'claude-reviewer',
+        message: 'Hello',
+        delayMs: 300000,
+        scheduledSendTime: Date.now() + 300000,
+        status: 'pending',
+        createdAt: Date.now(),
+        sentAt: null,
+      };
+
+      const mockGetSessionName = vi.fn().mockReturnValue('session-wt-1-reviewer');
+      mockGetPendingTimers.mockReturnValueOnce([]);
+      mockGetTimerById.mockReturnValue(timer);
+      mockIsRunning.mockResolvedValue(true);
+      mockGetTool.mockReturnValue({
+        getSessionName: mockGetSessionName,
+        isRunning: mockIsRunning,
+      });
+
+      initTimerManager();
+      scheduleTimer(timerId, 'wt-1', 100);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(mockIsRunning).toHaveBeenCalledWith('wt-1', 'claude-reviewer');
+      expect(mockGetSessionName).toHaveBeenCalledWith('wt-1', 'claude-reviewer');
+      expect(mockSendKeys).toHaveBeenCalledWith('session-wt-1-reviewer', 'Hello', true);
+    });
+
     it('should set status to no_session when session is not running', async () => {
       const timerId = 'timer-nosession-1';
       const timer = {
         id: timerId,
         worktreeId: 'wt-1',
         cliToolId: 'claude',
+        instanceId: 'claude',
         message: 'Hello',
         delayMs: 300000,
         scheduledSendTime: Date.now() + 300000,
@@ -300,7 +337,7 @@ describe('timer-manager', () => {
 
       await vi.advanceTimersByTimeAsync(200);
 
-      expect(mockIsRunning).toHaveBeenCalledWith('wt-1');
+      expect(mockIsRunning).toHaveBeenCalledWith('wt-1', 'claude');
       expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
         expect.anything(),
         timerId,
@@ -316,6 +353,7 @@ describe('timer-manager', () => {
         id: timerId,
         worktreeId: 'wt-1',
         cliToolId: 'claude',
+        instanceId: 'claude',
         message: 'Hello',
         delayMs: 300000,
         scheduledSendTime: Date.now() + 300000,


### PR DESCRIPTION
## 概要

Activity Bar の **Timer** および **Schedule** で、Agents パネル（Issue #869 の AgentInstance）に登録した AI エージェントを選択できない問題を修正します（Issue #942）。

Timer (#534) / Schedule (#824-827) は AgentInstance システムより前の実装で、エージェント選択が静的な `CLI_TOOL_IDS` に束縛されており、登録済みインスタンスを指定できませんでした。

## Timer — インスタンス完全対応

送信は live tmux セッションへの送信のため、インスタンスのルーティングが意味を持ちます。

- **v35 migration**: `timer_messages.instance_id`（nullable）を追加。既存行は `cli_tool_id`（= primary anchor `instanceId === cliTool`）でバックフィル。
- **timer-db / timers API**: `instanceId` を伝搬。API は登録済みインスタンス＋ primary anchor に対して検証。
- **timer-manager**: `isRunning` / `getSessionName(worktreeId, instanceId)` で対象インスタンスのセッションへ送信。
- **TimerPane**: 登録済みインスタンス（エイリアス表示）からセレクタを構築・記録・表示。未登録時は全 CLI ツールの primary instance にフォールバック（従来動作を byte-for-byte 維持）。

## Schedule — UI ラベルのみ

Schedule は `claude -p` の新規プロセスを起動する（セッション送信ではない）ため、インスタンス単位のルーティングは意味を持ちません。

- **ScheduleEditDialog**: インスタンスのエイリアスを表示しつつ、保存・実行は選択インスタンスの **backing CLI tool** で行う。CMATE.md のスキーマ変更なし。

## prop の伝搬

`instances` を `WorktreeDetailDesktop`（PC）/ `NotesAndLogsPane`（モバイル）経由で TimerPane・ExecutionLogPane・ScheduleEditDialog へ受け渡し。

## 後方互換

- `instance_id` は nullable、バックフィル = primary anchor。
- `instanceId` 省略時はサーバ側で primary に既定化。
- 既存タイマー／スケジュールの挙動は変わりません。

## テスト

- `npx tsc --noEmit`: pass
- `eslint`（変更ファイル）: pass
- `npm run test:unit`: **7948 passed / 441 files**
  - 追加: v35 migration（カラム追加・バックフィル）、timer-db（instanceId 既定化・NULL フォールバック）、timer-manager（非 primary インスタンスのセッション解決）、ScheduleEditDialog（エイリアス表示・backing tool 永続化）
- build は本ローカルで稼働中サーバの `.next` と競合するため PR CI に委譲

## 関連

Issue #942

> Note: base が `develop` のため Issue は自動クローズされません。マージ後に手動クローズします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)