### PR TITLE
feat(sidebar): サイドバー上段の5アイコンを拡大して視認性を改善 (#946)

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -65,6 +65,13 @@ const SIDEBAR_SCROLL_TOP_STORAGE_KEY = 'mcbd-sidebar-scroll-top';
 /** LocalStorage key for repository group order cache */
 const SIDEBAR_GROUP_ORDER_CACHE_STORAGE_KEY = 'mcbd-sidebar-group-order-cache';
 
+/**
+ * Shared Tailwind size for the sidebar header action icons (Issue #946).
+ * Applied to the view-mode toggle, sync button, sort selector and Repositories
+ * link so the five header icons share a single, easily-tunable size (16px).
+ */
+const HEADER_ICON_CLASS = 'w-4 h-4';
+
 /** In-memory cache used across client-side remounts */
 let lastSidebarScrollTop = 0;
 let lastRepositoryOrder: string[] | null = null;
@@ -441,7 +448,7 @@ export const Sidebar = memo(function Sidebar() {
                   focus:outline-none focus:ring-2 focus:ring-blue-500
                   transition-colors inline-flex items-center"
               >
-                <Database className="w-3 h-3" aria-hidden="true" />
+                <Database className={HEADER_ICON_CLASS} aria-hidden="true" />
               </Link>
             </Tooltip>
           </div>
@@ -715,9 +722,9 @@ function ViewModeToggle({
         "
       >
         {viewMode === 'grouped' ? (
-          <FlatListIcon className="w-3 h-3" />
+          <FlatListIcon className={HEADER_ICON_CLASS} />
         ) : (
-          <GroupIcon className="w-3 h-3" />
+          <GroupIcon className={HEADER_ICON_CLASS} />
         )}
       </button>
     </Tooltip>
@@ -797,7 +804,7 @@ function GripVerticalIcon() {
 function SyncIcon({ className = '' }: { className?: string }) {
   return (
     <svg
-      className={`w-3 h-3 ${className}`}
+      className={`${HEADER_ICON_CLASS} ${className}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"

--- a/src/components/sidebar/SortSelector.tsx
+++ b/src/components/sidebar/SortSelector.tsx
@@ -62,6 +62,7 @@ export const SortSelector = memo(function SortSelector() {
       defaultDirections={SIDEBAR_DEFAULT_DIRECTIONS}
       compact
       tooltip={t('tooltips.sort')}
+      iconClassName="w-4 h-4"
     />
   );
 });

--- a/src/components/sidebar/SortSelectorBase.tsx
+++ b/src/components/sidebar/SortSelectorBase.tsx
@@ -45,6 +45,12 @@ export interface SortSelectorBaseProps {
    * Omitted callers (e.g. Sessions page) keep the plain button.
    */
   tooltip?: string;
+  /**
+   * Tailwind size classes for the sort / direction icons (Issue #946). Defaults
+   * to `w-3 h-3`. The sidebar header passes `w-4 h-4` for better visibility,
+   * while other consumers (e.g. Sessions page) omit it and keep the original size.
+   */
+  iconClassName?: string;
 }
 
 // ============================================================================
@@ -68,6 +74,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
   defaultDirections,
   compact,
   tooltip,
+  iconClassName = 'w-3 h-3',
 }: SortSelectorBaseProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -140,7 +147,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
         transition-colors
       "
     >
-      <SortIcon className="w-3 h-3" />
+      <SortIcon className={iconClassName} />
       <span className={compact ? 'hidden' : 'hidden sm:inline'}>{currentLabel}</span>
     </button>
   );
@@ -169,9 +176,9 @@ export const SortSelectorBase = memo(function SortSelectorBase({
           "
         >
           {sortDirection === 'asc' ? (
-            <ArrowUpIcon className="w-3 h-3" />
+            <ArrowUpIcon className={iconClassName} />
           ) : (
-            <ArrowDownIcon className="w-3 h-3" />
+            <ArrowDownIcon className={iconClassName} />
           )}
         </button>
       </div>

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -560,6 +560,48 @@ describe('Sidebar', () => {
       // The link lives inside the sidebar header alongside the other actions
       expect(screen.getByTestId('sidebar-header')).toContainElement(link);
     });
+
+    // Issue #946: enlarge the header action icons from w-3 h-3 (12px) to w-4 h-4 (16px)
+    describe('header icon sizing (Issue #946)', () => {
+      it('renders the Repositories icon at w-4 h-4', async () => {
+        render(
+          <Wrapper>
+            <Sidebar />
+          </Wrapper>
+        );
+
+        const link = await screen.findByRole('link', { name: 'Repositories' });
+        const svg = link.querySelector('svg');
+        expect(svg?.getAttribute('class')).toContain('w-4');
+        expect(svg?.getAttribute('class')).toContain('h-4');
+      });
+
+      it('renders the view-mode-toggle icon at w-4 h-4', async () => {
+        render(
+          <Wrapper>
+            <Sidebar />
+          </Wrapper>
+        );
+
+        const toggle = await screen.findByTestId('view-mode-toggle');
+        const svg = toggle.querySelector('svg');
+        expect(svg?.getAttribute('class')).toContain('w-4');
+        expect(svg?.getAttribute('class')).toContain('h-4');
+      });
+
+      it('renders the sync icon at w-4 h-4', async () => {
+        render(
+          <Wrapper>
+            <Sidebar />
+          </Wrapper>
+        );
+
+        const syncButton = await screen.findByLabelText('common.syncButtonLabel');
+        const svg = syncButton.querySelector('svg');
+        expect(svg?.getAttribute('class')).toContain('w-4');
+        expect(svg?.getAttribute('class')).toContain('h-4');
+      });
+    });
   });
 
   // Issue #882: unify hover tooltips on the four header action buttons via the

--- a/tests/unit/components/sidebar/SortSelectorBase.test.tsx
+++ b/tests/unit/components/sidebar/SortSelectorBase.test.tsx
@@ -29,6 +29,7 @@ function renderSelector(overrides: Partial<{
   options: ReadonlyArray<SortOption>;
   defaultDirections: Partial<Record<SortKey, SortDirection>>;
   tooltip: string;
+  iconClassName: string;
 }> = {}) {
   const props = {
     sortKey: 'lastSent' as SortKey,
@@ -187,6 +188,37 @@ describe('SortSelectorBase', () => {
       });
 
       expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull();
+    });
+  });
+
+  // Issue #946: the sort/direction icon size must be controllable per-consumer so
+  // the sidebar header can enlarge them WITHOUT affecting the Sessions page, which
+  // shares this component and must keep the original w-3 h-3 size.
+  describe('icon sizing (Issue #946)', () => {
+    it('defaults the sort and direction icons to w-3 h-3 when iconClassName is omitted (Sessions regression guard)', () => {
+      const { container } = renderSelector();
+
+      const svgs = Array.from(container.querySelectorAll('svg'));
+      // Trigger SortIcon + direction Arrow icon are rendered when the dropdown is closed
+      expect(svgs.length).toBeGreaterThanOrEqual(2);
+      svgs.forEach((svg) => {
+        const cls = svg.getAttribute('class') ?? '';
+        expect(cls).toContain('w-3');
+        expect(cls).toContain('h-3');
+      });
+    });
+
+    it('applies a custom iconClassName to the sort and direction icons (sidebar header enlargement)', () => {
+      const { container } = renderSelector({ iconClassName: 'w-4 h-4' });
+
+      const svgs = Array.from(container.querySelectorAll('svg'));
+      expect(svgs.length).toBeGreaterThanOrEqual(2);
+      svgs.forEach((svg) => {
+        const cls = svg.getAttribute('class') ?? '';
+        expect(cls).toContain('w-4');
+        expect(cls).toContain('h-4');
+        expect(cls).not.toContain('w-3');
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

サイドバー上段（ヘッダー部）の 5 つのアクションアイコンが小さく視認しづらいため、`w-3 h-3`（12px）→ `w-4 h-4`（16px）に拡大しました。

Closes #946

## 変更内容

- `Sidebar.tsx` に共通定数 `HEADER_ICON_CLASS = 'w-4 h-4'` を導入し、以下に適用:
  - ビューモード切替（FlatList/Group）
  - 同期（Sync）
  - Repositories リンク（Database）
- `SortSelectorBase` に optional な `iconClassName` prop を追加（デフォルト `w-3 h-3`）。サイドバーの `SortSelector` のみ `w-4 h-4` を渡し、ソート/方向アイコンを拡大。
- 他の利用箇所（Sessions ページ等）は prop 未指定で従来サイズ（12px）を維持 → **波及なし**。

## 品質チェック（worktree ローカル）

| チェック | 結果 |
|---|---|
| npx tsc --noEmit | ✅ Pass |
| npm run lint | ✅ No warnings/errors |
| npm run test:unit | ✅ 7953 passed |
| npm run build | ✅ 成功 |

PC 専用 UI 変更（モバイルの GlobalMobileNav は独立実装で影響なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
