### PR TITLE
fix(timer): codex の Timer メッセージが Enter 確定されず未送信になる不具合を修正 (#947)

### DIFF
--- a/src/lib/timer-manager.ts
+++ b/src/lib/timer-manager.ts
@@ -16,7 +16,6 @@ import {
   cleanupOldTimers,
   recoverStuckSendingTimers,
 } from './db/timer-db';
-import { sendKeys } from './tmux/tmux';
 import { CLIToolManager } from './cli-tools/manager';
 import { getDbInstance } from '@/lib/db/db-instance';
 import { createLogger } from '@/lib/logger';
@@ -92,10 +91,14 @@ async function executeTimer(timerId: string): Promise<void> {
       return;
     }
 
-    const sessionName = cliTool.getSessionName(timer.worktreeId, instanceId);
-
     updateTimerStatus(db, timerId, 'sending');
-    await sendKeys(sessionName, timer.message, true);
+    // [Issue #947] Delegate to the CLI tool's sendMessage so timer sends take the
+    // exact same path as manual sends: per-tool text/Enter separation and waits.
+    // The previous direct sendKeys(sessionName, message, true) batched text+Enter
+    // in a single send-keys; codex's TUI never confirmed the input, leaving the
+    // message typed but unsent. sendMessage resolves the session name from
+    // (worktreeId, instanceId) internally, so claude/codex/gemini all work.
+    await cliTool.sendMessage(timer.worktreeId, timer.message, instanceId);
     updateTimerStatus(db, timerId, 'sent', Date.now());
 
     logger.info('timer:sent', { timerId, worktreeId: timer.worktreeId });

--- a/tests/unit/lib/timer-manager.test.ts
+++ b/tests/unit/lib/timer-manager.test.ts
@@ -47,15 +47,13 @@ vi.mock('@/lib/db/timer-db', () => ({
   recoverStuckSendingTimers: (...args: unknown[]) => mockRecoverStuckSendingTimers(...args),
 }));
 
-// Mock tmux sendKeys
-const mockSendKeys = vi.fn().mockResolvedValue(undefined);
-vi.mock('@/lib/tmux/tmux', () => ({
-  sendKeys: (...args: unknown[]) => mockSendKeys(...args),
-}));
-
 // Mock CLIToolManager
+// Issue #947: timer-manager now delegates sending to cliTool.sendMessage()
+// (which performs the per-tool text/Enter separation) instead of calling tmux
+// sendKeys() directly.
 const mockGetTool = vi.fn();
 const mockIsRunning = vi.fn().mockResolvedValue(true);
+const mockSendMessage = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/lib/cli-tools/manager', () => ({
   CLIToolManager: {
     getInstance: vi.fn().mockReturnValue({
@@ -249,8 +247,8 @@ describe('timer-manager', () => {
       mockGetTimerById.mockReturnValue(timer);
       mockIsRunning.mockResolvedValue(true);
       mockGetTool.mockReturnValue({
-        getSessionName: vi.fn().mockReturnValue('session-wt-1'),
         isRunning: mockIsRunning,
+        sendMessage: mockSendMessage,
       });
 
       initTimerManager();
@@ -265,7 +263,9 @@ describe('timer-manager', () => {
         timerId,
         'sending'
       );
-      expect(mockSendKeys).toHaveBeenCalledWith('session-wt-1', 'Hello', true);
+      // Issue #947: delegates to cliTool.sendMessage (worktreeId, message,
+      // instanceId) rather than calling tmux sendKeys directly.
+      expect(mockSendMessage).toHaveBeenCalledWith('wt-1', 'Hello', 'claude');
       expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
         expect.anything(),
         timerId,
@@ -290,13 +290,12 @@ describe('timer-manager', () => {
         sentAt: null,
       };
 
-      const mockGetSessionName = vi.fn().mockReturnValue('session-wt-1-reviewer');
       mockGetPendingTimers.mockReturnValueOnce([]);
       mockGetTimerById.mockReturnValue(timer);
       mockIsRunning.mockResolvedValue(true);
       mockGetTool.mockReturnValue({
-        getSessionName: mockGetSessionName,
         isRunning: mockIsRunning,
+        sendMessage: mockSendMessage,
       });
 
       initTimerManager();
@@ -305,8 +304,9 @@ describe('timer-manager', () => {
       await vi.advanceTimersByTimeAsync(200);
 
       expect(mockIsRunning).toHaveBeenCalledWith('wt-1', 'claude-reviewer');
-      expect(mockGetSessionName).toHaveBeenCalledWith('wt-1', 'claude-reviewer');
-      expect(mockSendKeys).toHaveBeenCalledWith('session-wt-1-reviewer', 'Hello', true);
+      // Issue #947: the instanceId is forwarded to sendMessage, which resolves
+      // the instance session internally (same path as manual sends).
+      expect(mockSendMessage).toHaveBeenCalledWith('wt-1', 'Hello', 'claude-reviewer');
     });
 
     it('should set status to no_session when session is not running', async () => {
@@ -328,8 +328,8 @@ describe('timer-manager', () => {
       mockGetTimerById.mockReturnValue(timer);
       mockIsRunning.mockResolvedValue(false);
       mockGetTool.mockReturnValue({
-        getSessionName: vi.fn().mockReturnValue('session-wt-1'),
         isRunning: mockIsRunning,
+        sendMessage: mockSendMessage,
       });
 
       initTimerManager();
@@ -343,8 +343,8 @@ describe('timer-manager', () => {
         timerId,
         'no_session'
       );
-      // Should NOT call sendKeys
-      expect(mockSendKeys).not.toHaveBeenCalled();
+      // Should NOT attempt to send when no session is running
+      expect(mockSendMessage).not.toHaveBeenCalled();
     });
 
     it('should set status to failed on send error when session is running', async () => {
@@ -366,10 +366,10 @@ describe('timer-manager', () => {
       mockGetTimerById.mockReturnValue(timer);
       mockIsRunning.mockResolvedValue(true);
       mockGetTool.mockReturnValue({
-        getSessionName: vi.fn().mockReturnValue('session-wt-1'),
         isRunning: mockIsRunning,
+        sendMessage: mockSendMessage,
       });
-      mockSendKeys.mockRejectedValueOnce(new Error('tmux session not found'));
+      mockSendMessage.mockRejectedValueOnce(new Error('tmux session not found'));
 
       initTimerManager();
       scheduleTimer(timerId, 'wt-1', 100);


### PR DESCRIPTION
## 概要
Timer で codex を選択して遅延送信したメッセージが、ターミナルに入力された状態のまま **Enter 確定（送信）されない**不具合を修正します。Issue #947。

## 根本原因
`src/lib/timer-manager.ts` の `executeTimer` が tmux へ `sendKeys(sessionName, message, true)` で**テキスト+Enter を一括投入**しており、CLI ツール固有の送信手順（codex: text → 100ms 待機 → `C-m` → 200ms 待機）をスキップしていた。codex の TUI はテキスト確定前に Enter が届くと確定が間に合わず、メッセージが入力欄に残ったまま送信されなかった。

## 修正内容（恒久対策）
- `executeTimer` の送信を `cliTool.sendMessage(timer.worktreeId, timer.message, instanceId)` に**委譲**。手動送信と完全に同一のコードパス（ツールごとのテキスト/Enter 分離・待機）を通るため、claude/codex/gemini すべてで Enter 確定が保証される。
- session 名は `sendMessage` 内部で `(worktreeId, instanceId)` から解決されるため、`getSessionName` 呼び出しと未使用の `sendKeys` import を削除。
- `isRunning`（`no_session` 判定）チェックは従来どおり維持。

## テスト
`tests/unit/lib/timer-manager.test.ts` を更新:
- `sendMessage` 委譲（呼び出し引数 `(worktreeId, message, instanceId)`）の検証
- 非プライマリ instanceId の伝播検証
- `no_session` 時に送信しない検証
- 送信失敗時に `failed` ステータスになる検証

## 品質チェック（worker 実行・全パス）
- `npm run lint` ✅ / `npx tsc --noEmit` ✅ / `npm run test:unit` ✅（7992、timer-manager 16/16） / `npm run build` ✅

## 補足
※ base=develop のため `Closes #947` では自動クローズされません。マージ後に手動 close します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)