### PR TITLE
fix: セッションクローズ確認ダイアログにインスタンスのエイリアスを表示 (#956)

### DIFF
--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -60,7 +60,7 @@ import { ToastContainer } from '@/components/common/Toast';
 import { Modal } from '@/components/ui/Modal';
 import { AutoYesToggle } from '@/components/worktree/AutoYesToggle';
 import { BranchMismatchAlert } from '@/components/worktree/BranchMismatchAlert';
-import { getCliToolDisplayName, getInstanceLabel } from '@/lib/cli-tools/types';
+import { getCliToolDisplayName, getInstanceLabel, getActiveInstanceLabel } from '@/lib/cli-tools/types';
 import { deriveCliStatus } from '@/types/sidebar';
 import { MoveDialog } from '@/components/worktree/MoveDialog';
 import { NewFileDialog } from '@/components/worktree/NewFileDialog';
@@ -226,6 +226,12 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     return <ErrorDisplay message={error} onRetry={handleRetry} />;
   }
 
+  // Issue #956: the kill-session confirmation dialog must show the active
+  // instance's user-defined alias (e.g. "レビュー担当"), not the bare CLI tool
+  // name. Resolve via getActiveInstanceLabel (alias-aware; falls back to the CLI
+  // display name when no alias is set or the active instance is stale).
+  const activeInstanceLabel = getActiveInstanceLabel(agentInstances, activeInstanceId, activeCliTab);
+
   // Render desktop layout
   if (!isMobile) {
     return (
@@ -308,7 +314,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           onNewFileCancel={handleNewFileCancel}
           toasts={toasts}
           onToastClose={removeToast}
-          killDialogTitle={tWorktree('session.confirmEnd', { tool: getCliToolDisplayName(activeCliTab) })}
+          killDialogTitle={tWorktree('session.confirmEnd', { tool: activeInstanceLabel })}
           killDialogWarning={tWorktree('session.endWarning')}
           cancelLabel={tCommon('cancel')}
           endLabel={tCommon('end')}
@@ -590,7 +596,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         <Modal
           isOpen={showKillConfirm}
           onClose={handleKillCancel}
-          title={tWorktree('session.confirmEnd', { tool: getCliToolDisplayName(activeCliTab) })}
+          title={tWorktree('session.confirmEnd', { tool: activeInstanceLabel })}
           size="sm"
           showCloseButton={true}
         >

--- a/src/lib/cli-tools/types.ts
+++ b/src/lib/cli-tools/types.ts
@@ -268,6 +268,32 @@ export function getInstanceLabel(instance: { cliTool: CLIToolType; alias?: strin
 }
 
 /**
+ * Resolve the alias-aware display label for the *active* agent instance within
+ * a roster (Issue #956).
+ *
+ * Finds the instance whose id matches `activeInstanceId` and returns its label
+ * via {@link getInstanceLabel} (alias-first). When no instance matches — e.g. a
+ * stale `activeInstanceId` or an empty roster — falls back to the bare CLI tool
+ * display name so callers still render something sensible.
+ *
+ * Used by the kill-session confirmation dialog so it shows the user-defined
+ * alias (e.g. "レビュー担当") instead of the raw CLI tool name (e.g. "Claude").
+ *
+ * @param instances - Agent instance roster
+ * @param activeInstanceId - Id of the currently active instance
+ * @param fallbackCliTool - CLI tool used when no instance matches
+ * @returns Non-empty display label
+ */
+export function getActiveInstanceLabel(
+  instances: ReadonlyArray<{ id: string; cliTool: CLIToolType; alias?: string }>,
+  activeInstanceId: string,
+  fallbackCliTool: CLIToolType,
+): string {
+  const active = instances.find((inst) => inst.id === activeInstanceId);
+  return active ? getInstanceLabel(active) : getCliToolDisplayName(fallbackCliTool);
+}
+
+/**
  * Build the default set of agent instances from a worktree's selectedAgents
  * (Issue #868 migration / fallback).
  *

--- a/tests/unit/cli-tools/display-name.test.ts
+++ b/tests/unit/cli-tools/display-name.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getCliToolDisplayName,
   getCliToolDisplayNameSafe,
+  getActiveInstanceLabel,
   isCliToolType,
   CLI_TOOL_DISPLAY_NAMES,
   CLI_TOOL_IDS,
@@ -115,5 +116,35 @@ describe('getCliToolDisplayNameSafe()', () => {
     expect(getCliToolDisplayNameSafe(undefined, '')).toBe('');
     expect(getCliToolDisplayNameSafe('', 'N/A')).toBe('N/A');
     expect(getCliToolDisplayNameSafe('unknown', 'Custom')).toBe('Custom');
+  });
+});
+
+describe('getActiveInstanceLabel() (Issue #956)', () => {
+  const roster = [
+    { id: 'claude', cliTool: 'claude' as CLIToolType, alias: 'Claude' },
+    { id: 'claude-2', cliTool: 'claude' as CLIToolType, alias: 'レビュー担当' },
+    { id: 'codex', cliTool: 'codex' as CLIToolType, alias: '' },
+  ];
+
+  it('should return the active instance alias when set', () => {
+    expect(getActiveInstanceLabel(roster, 'claude-2', 'claude')).toBe('レビュー担当');
+  });
+
+  it('should fall back to the CLI display name when the active instance has no alias', () => {
+    // codex instance has an empty alias -> getInstanceLabel falls back to "Codex"
+    expect(getActiveInstanceLabel(roster, 'codex', 'codex')).toBe('Codex');
+  });
+
+  it('should fall back to the fallback CLI tool when activeInstanceId is not found (stale)', () => {
+    expect(getActiveInstanceLabel(roster, 'missing-instance', 'codex')).toBe('Codex');
+  });
+
+  it('should fall back to the fallback CLI tool when the roster is empty', () => {
+    expect(getActiveInstanceLabel([], 'claude', 'claude')).toBe('Claude');
+  });
+
+  it('should treat whitespace-only alias as no alias', () => {
+    const ws = [{ id: 'claude', cliTool: 'claude' as CLIToolType, alias: '   ' }];
+    expect(getActiveInstanceLabel(ws, 'claude', 'claude')).toBe('Claude');
   });
 });


### PR DESCRIPTION
## 概要

Closes #956

アクティビティバーの **Agent** でインスタンスにエイリアス（別名）を付与しても、ヘッダーの「**✕ End**」によるセッションクローズ確認ダイアログのタイトルにはエイリアスではなく CLI ツール名（**Claude / Codex** 等）が表示されていた不具合を修正します。同画面のインスタンスタブはエイリアスを表示しており、ダイアログだけが不整合でした。

| | 修正前 | 修正後 |
|---|--------|--------|
| エイリアス「レビュー担当」を付与 | 「**Claude** セッションを終了しますか？」 | 「**レビュー担当** セッションを終了しますか？」 |
| エイリアス未設定 | 「Claude セッションを終了しますか？」 | 「Claude セッションを終了しますか？」（従来通り） |

## 原因

確認ダイアログのタイトルだけがエイリアスを解決せず、`getCliToolDisplayName(activeCliTab)`（CLI ツール名）を直接使っていた（`WorktreeDetailRefactored.tsx` の PC L311 / モバイル L593）。タブ表示（L411）は既に `getInstanceLabel` でエイリアスを表示しており、ダイアログだけ取り残されていた。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `src/lib/cli-tools/types.ts` | `getActiveInstanceLabel(instances, activeInstanceId, fallbackCliTool)` を新規追加。`activeInstanceId` に一致するインスタンスを `getInstanceLabel`（エイリアス優先）で解決し、未一致/stale 時は CLI 表示名へフォールバック |
| `src/components/worktree/WorktreeDetailRefactored.tsx` | `confirmEnd` ダイアログ（PC / モバイル）のタイトルを `activeInstanceLabel` に差し替え |
| `tests/unit/cli-tools/display-name.test.ts` | `getActiveInstanceLabel` のユニットテストを追加（エイリアス有/無/空白/stale/空ロスター） |

- エイリアス未設定時はフォールバックにより**従来挙動を維持**（後方互換）。
- ロケール `worktree.session.confirmEnd` は `{tool}` プレースホルダのみで**文言修正は不要**。

## テスト

| チェック | 結果 |
|---------|------|
| `getActiveInstanceLabel` ユニットテスト（5 ケース） | ✅ Pass |
| npm run lint | ✅ Pass |
| npx tsc --noEmit | ✅ Pass |
| npm run test:unit（7,997 件） | ✅ Pass |
| npm run build | ✅ Pass |

エイリアス解決ロジックはユニットテストで担保。ダイアログへの受け渡しは既存 `{tool}` プレースホルダへの値差し替えのみ（build で型・コンパイル確認済み）のため、実機 UAT は省略。

## 受入条件

- [x] エイリアス付与インスタンスで確認ダイアログにエイリアスが表示される（PC / モバイル両方）
- [x] エイリアス未設定インスタンスでは従来どおり CLI ツール名が表示される
- [x] lint / tsc / test:unit / build が全て pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
