### PR TITLE
fix: Auto Yes のカウントダウンが 00:00 到達時に無効化されない問題を修正

### DIFF
--- a/src/components/worktree/AutoYesToggle.tsx
+++ b/src/components/worktree/AutoYesToggle.tsx
@@ -36,6 +36,13 @@ export interface AutoYesToggleProps {
   cliToolName?: string;
   /** If true, render without outer container styles (for inline embedding) */
   inline?: boolean;
+  /**
+   * Optional callback fired once when the countdown reaches 00:00 (Issue #959).
+   * Lets a parent proactively disable auto-yes the instant the timer expires
+   * instead of waiting for the next server poll. Optional so existing callers
+   * need not change.
+   */
+  onExpire?: () => void;
 }
 
 export const AutoYesToggle = memo(function AutoYesToggle({
@@ -45,27 +52,54 @@ export const AutoYesToggle = memo(function AutoYesToggle({
   lastAutoResponse,
   cliToolName,
   inline = false,
+  onExpire,
 }: AutoYesToggleProps) {
   const [timeRemaining, setTimeRemaining] = useState<string>('');
   const [notification, setNotification] = useState<string | null>(null);
   const [toggling, setToggling] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  // Issue #959: latch that flips the UI to OFF the instant the countdown hits
+  // 00:00, so the toggle no longer shows ON while the server-side state catches
+  // up on the next poll.
+  const [hasExpired, setHasExpired] = useState(false);
 
   // Countdown timer
   useEffect(() => {
     if (!enabled || !expiresAt) {
       setTimeRemaining('');
+      setHasExpired(false);
       return;
     }
 
-    const updateTime = () => {
+    // Fresh enable window: clear any stale expiry latch from a previous run.
+    setHasExpired(false);
+
+    let expiredNotified = false;
+
+    // Refresh the displayed time. Returns true once the countdown has reached
+    // zero (Issue #959): at that point the UI proactively reflects expiry and
+    // notifies the parent once, instead of waiting for the next polling cycle.
+    const tick = (): boolean => {
       setTimeRemaining(formatTimeRemaining(expiresAt));
+      if (expiresAt - Date.now() <= 0 && !expiredNotified) {
+        expiredNotified = true;
+        setHasExpired(true);
+        onExpire?.();
+        return true;
+      }
+      return false;
     };
 
-    updateTime();
-    const interval = setInterval(updateTime, AUTO_YES_COUNTDOWN_INTERVAL_MS);
+    // Already past expiry at mount: no interval needed.
+    if (tick()) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (tick()) clearInterval(interval);
+    }, AUTO_YES_COUNTDOWN_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [enabled, expiresAt]);
+  }, [enabled, expiresAt, onExpire]);
 
   // Auto-response notification (2 second display)
   useEffect(() => {
@@ -76,8 +110,13 @@ export const AutoYesToggle = memo(function AutoYesToggle({
     return () => clearTimeout(timeout);
   }, [lastAutoResponse]);
 
+  // Issue #959: the UI presents as OFF the moment the countdown expires, even
+  // before the parent's polled `enabled` prop catches up. Derive a single source
+  // of truth so the visual state, click behaviour and countdown all agree.
+  const displayEnabled = enabled && !hasExpired;
+
   const handleToggle = useCallback(() => {
-    if (enabled) {
+    if (displayEnabled) {
       // OFF: execute directly
       setToggling(true);
       onToggle({ enabled: false }).finally(() => setToggling(false));
@@ -85,7 +124,7 @@ export const AutoYesToggle = memo(function AutoYesToggle({
       // ON: show confirmation dialog
       setShowConfirmDialog(true);
     }
-  }, [enabled, onToggle]);
+  }, [displayEnabled, onToggle]);
 
   const handleConfirm = useCallback((duration: AutoYesDuration, stopPattern?: string) => {
     setShowConfirmDialog(false);
@@ -103,17 +142,17 @@ export const AutoYesToggle = memo(function AutoYesToggle({
       <button
         type="button"
         role="switch"
-        aria-checked={enabled}
+        aria-checked={displayEnabled}
         aria-label="Auto Yes mode"
         disabled={toggling}
         onClick={handleToggle}
         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
-          enabled ? 'bg-cyan-600' : 'bg-gray-300 dark:bg-gray-600'
+          displayEnabled ? 'bg-cyan-600' : 'bg-gray-300 dark:bg-gray-600'
         } ${toggling ? 'opacity-50' : ''}`}
       >
         <span
           className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-            enabled ? 'translate-x-6' : 'translate-x-1'
+            displayEnabled ? 'translate-x-6' : 'translate-x-1'
           }`}
         />
       </button>
@@ -127,7 +166,7 @@ export const AutoYesToggle = memo(function AutoYesToggle({
       )}
 
       {/* Countdown timer */}
-      {enabled && timeRemaining && (
+      {displayEnabled && timeRemaining && (
         <span className="text-sm text-gray-500 dark:text-gray-400" aria-label="Time remaining">
           {timeRemaining}
         </span>

--- a/src/lib/auto-yes-state.ts
+++ b/src/lib/auto-yes-state.ts
@@ -145,11 +145,16 @@ const autoYesStates = globalThis.__autoYesStates ??
  * Check if an auto-yes state has expired.
  * Compares current time against the expiresAt timestamp.
  *
+ * Issue #959: Uses `>=` so the state expires exactly when the countdown reaches
+ * 00:00 (the moment `Date.now() === expiresAt`). This matches the display side
+ * (`formatTimeRemaining`), which clamps to 0 at that same instant. A strict `>`
+ * left the state enabled for one extra polling tick after the timer hit zero.
+ *
  * @param state - Auto-yes state to check
- * @returns true if the current time is past the expiration time
+ * @returns true if the current time is at or past the expiration time
  */
 export function isAutoYesExpired(state: AutoYesState): boolean {
-  return Date.now() > state.expiresAt;
+  return Date.now() >= state.expiresAt;
 }
 
 // =============================================================================

--- a/tests/unit/components/worktree/AutoYesToggle.test.tsx
+++ b/tests/unit/components/worktree/AutoYesToggle.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { AutoYesToggle, type AutoYesToggleParams } from '@/components/worktree/AutoYesToggle';
-import { DEFAULT_AUTO_YES_DURATION } from '@/config/auto-yes-config';
+import { DEFAULT_AUTO_YES_DURATION, AUTO_YES_COUNTDOWN_INTERVAL_MS } from '@/config/auto-yes-config';
 
 describe('AutoYesToggle', () => {
   const defaultProps = {
@@ -25,6 +25,7 @@ describe('AutoYesToggle', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   describe('OFF to ON (should show dialog)', () => {
@@ -199,6 +200,63 @@ describe('AutoYesToggle', () => {
 
       // Dialog should show tool-specific title
       expect(screen.getByText(/autoYes\.enableTitleWithTool/)).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Issue #959: UI reflects expiry the instant the countdown reaches 00:00
+  // ==========================================================================
+  describe('Issue #959: countdown reaching zero disables the toggle in the UI', () => {
+    it('flips the toggle to OFF and hides the countdown when expiresAt is reached', () => {
+      vi.useFakeTimers();
+      const now = 1_700_000_000_000;
+      vi.setSystemTime(now);
+
+      render(
+        <AutoYesToggle {...defaultProps} enabled={true} expiresAt={now + 2000} />
+      );
+
+      // Initially ON with a visible countdown.
+      expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
+      expect(screen.getByLabelText('Time remaining')).toBeDefined();
+
+      // Advance to the exact expiration instant and let the 1s tick fire.
+      act(() => {
+        vi.setSystemTime(now + 2000);
+        vi.advanceTimersByTime(AUTO_YES_COUNTDOWN_INTERVAL_MS);
+      });
+
+      // UI now presents as OFF and the countdown is gone.
+      expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('false');
+      expect(screen.queryByLabelText('Time remaining')).toBeNull();
+    });
+
+    it('invokes onExpire exactly once when the countdown reaches zero', () => {
+      vi.useFakeTimers();
+      const now = 1_700_000_000_000;
+      vi.setSystemTime(now);
+      const onExpire = vi.fn();
+
+      render(
+        <AutoYesToggle
+          {...defaultProps}
+          enabled={true}
+          expiresAt={now + 1000}
+          onExpire={onExpire}
+        />
+      );
+
+      act(() => {
+        vi.setSystemTime(now + 1000);
+        vi.advanceTimersByTime(AUTO_YES_COUNTDOWN_INTERVAL_MS);
+      });
+      expect(onExpire).toHaveBeenCalledTimes(1);
+
+      // Subsequent ticks must not re-fire the callback.
+      act(() => {
+        vi.advanceTimersByTime(AUTO_YES_COUNTDOWN_INTERVAL_MS * 3);
+      });
+      expect(onExpire).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/lib/auto-yes-manager.test.ts
+++ b/tests/unit/lib/auto-yes-manager.test.ts
@@ -222,8 +222,9 @@ describe('auto-yes-manager', () => {
       vi.useFakeTimers();
       vi.setSystemTime(2000);
 
-      // At exact expiration, Date.now() === expiresAt, so not expired (> not >=)
-      expect(isAutoYesExpired(state)).toBe(false);
+      // Issue #959: at exact expiration Date.now() === expiresAt, which is the
+      // instant the countdown shows 00:00, so it must already be expired (>=).
+      expect(isAutoYesExpired(state)).toBe(true);
     });
   });
 

--- a/tests/unit/lib/auto-yes-state-composite.test.ts
+++ b/tests/unit/lib/auto-yes-state-composite.test.ts
@@ -15,6 +15,8 @@ import {
   getCompositeKeysByWorktree,
   deleteAutoYesStateByWorktree,
   buildCompositeKey,
+  isAutoYesExpired,
+  type AutoYesState,
 } from '@/lib/auto-yes-state';
 import { DEFAULT_AUTO_YES_DURATION } from '@/config/auto-yes-config';
 
@@ -314,6 +316,43 @@ describe('auto-yes-state composite key migration (Issue #525)', () => {
 
       expect(getAutoYesState('wt-1', 'claude', 'claude-2')?.enabled).toBe(false);
       expect(getAutoYesState('wt-1', 'claude')?.enabled).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Issue #959: exact-expiry boundary (now === expiresAt)
+  // The countdown shows 00:00 the instant Date.now() === expiresAt, so the
+  // state must already be treated as expired/disabled at that exact moment.
+  // Existing tests used a +1ms offset and therefore missed this off-by-one.
+  // ==========================================================================
+  describe('exact-expiry boundary (Issue #959)', () => {
+    it('isAutoYesExpired returns true when now === expiresAt exactly', () => {
+      vi.useFakeTimers();
+      const expiresAt = 1700000000000;
+      vi.setSystemTime(expiresAt);
+
+      const state: AutoYesState = {
+        enabled: true,
+        enabledAt: expiresAt - DEFAULT_AUTO_YES_DURATION,
+        expiresAt,
+      };
+
+      expect(isAutoYesExpired(state)).toBe(true);
+    });
+
+    it('getAutoYesState auto-disables at the exact expiration instant', () => {
+      vi.useFakeTimers();
+      const now = 1700000000000;
+      vi.setSystemTime(now);
+
+      setAutoYesEnabled('wt-1', 'claude', true); // expiresAt = now + DEFAULT_AUTO_YES_DURATION
+
+      // Jump to the exact expiration instant (countdown reads 00:00).
+      vi.setSystemTime(now + DEFAULT_AUTO_YES_DURATION);
+
+      const state = getAutoYesState('wt-1', 'claude');
+      expect(state?.enabled).toBe(false);
+      expect(state?.stopReason).toBe('expired');
     });
   });
 });


### PR DESCRIPTION
## 概要
Closes #959（base=develop のため自動クローズされない。マージ後に手動close）

Auto Yes のカウントダウンが `00:00` になっても無効化（リセット）されず、トグルがONのまま／応答が続く問題を修正。

## 変更内容
- **サーバ側オフバイワン修正** `src/lib/auto-yes-state.ts`: `isAutoYesExpired` を `Date.now() >= state.expiresAt` に変更（従来 `>`）。表示側 `formatTimeRemaining` の 0 クランプと判定基準を一致させ、`00:00` 表示の瞬間に失効する。
- **UI 即時反映** `src/components/worktree/AutoYesToggle.tsx`: `hasExpired` ラッチでカウントダウンが 0 到達と同時にトグルをOFF表示・カウントダウン非表示にする（次回ポーリングを待たない）。optional `onExpire` prop 追加。`WorktreeDetailRefactored.tsx` は未変更（#958 との衝突回避）。
- **テスト追加**: `now === expiresAt` 境界、トグルの0到達OFF、`onExpire` 発火、既存のオフバイワン前提アサーション修正。

## 品質ゲート（worker実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（8001 passed）
- ✅ npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)