### PR TITLE
fix: スマホ版ヘッダーの横スクロールバーを非表示にする

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,6 +231,16 @@
     background-color: rgb(148 163 184);
   }
 
+  /* スクロールバー非表示・スワイプ/スクロールは維持 */
+  .scrollbar-hide {
+    -ms-overflow-style: none; /* IE/旧Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none; /* Chrome/Safari/WebKit */
+  }
+
   .assistant-md > *:first-child {
     margin-top: 0;
   }

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -401,7 +401,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               per-instance優先（PC版と整合, Issue #960）so closing one instance
               of a duplicated CLI tool no longer leaves a sibling's status. */}
           <nav
-            className="flex gap-2 flex-1 min-w-0 overflow-x-auto scrollbar-thin"
+            className="flex gap-2 flex-1 min-w-0 overflow-x-auto scrollbar-hide"
             aria-label="Agent Instance Selection"
           >
             {displayedInstances.map((inst) => {


### PR DESCRIPTION
## 概要
Closes #964（base=develop のため自動クローズされない。マージ後に手動close）

スマホ版ヘッダー（#958で横スクロール化）の横スクロールバーが表示領域を圧迫していたため、スクロールバーを非表示にしつつ横スワイプ/スクロールは維持する。

## 変更内容
- `src/app/globals.css`: `@layer utilities` 内に `.scrollbar-hide` を新規追加（`scrollbar-width: none` / `-ms-overflow-style: none` / `::-webkit-scrollbar { display: none }`）。`.scrollbar-thin` は未変更（他3箇所で意図的に使用中のため）。
- `src/components/worktree/WorktreeDetailRefactored.tsx`: モバイルヘッダー nav の className を `scrollbar-thin` → `scrollbar-hide` に変更（`overflow-x-auto flex gap-2 flex-1 min-w-0` は維持＝横スワイプ/スクロールは残存）。

PC版・他のスクロール領域（テキストエリア/ログ）は不変。

## 品質ゲート（worker実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（8001 passed）
- ✅ npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)