### PR TITLE
perf: サイドバークリック→worktree詳細表示の体感遅延を低減（クイックウィン）

### DIFF
--- a/src/app/api/worktrees/[id]/route.ts
+++ b/src/app/api/worktrees/[id]/route.ts
@@ -44,26 +44,34 @@ export async function GET(
       );
     }
 
-    // Issue #405: Batch query all tmux sessions once (N+1 elimination)
-    const tmuxSessions = await listSessions();
-    const sessionNameSet = new Set(tmuxSessions.map(s => s.name));
-
-    // Parallel: session status detection + git status (independent operations)
     const initialBranch = getInitialBranch(db, params.id);
-    const [sessionStatus, gitStatus] = await Promise.all([
-      detectWorktreeSessionStatus(
+
+    // Issue #965: git status is independent of the tmux session list, so start
+    // it immediately instead of waiting for listSessions() to resolve first.
+    const gitStatusPromise = getGitStatus(worktree.path, initialBranch).catch((gitError) => {
+      // Log but don't fail - git status is non-critical
+      logger.error('get-apiworktrees:id-failed-to-get-git-status', { error: gitError instanceof Error ? gitError.message : String(gitError) });
+      return undefined as GitStatus | undefined;
+    });
+
+    // Issue #405: Batch query all tmux sessions once (N+1 elimination). Only the
+    // session status detection depends on the session name set, so it chains off
+    // listSessions() while git status runs concurrently above.
+    const sessionStatusPromise = listSessions().then((tmuxSessions) => {
+      const sessionNameSet = new Set(tmuxSessions.map(s => s.name));
+      return detectWorktreeSessionStatus(
         params.id,
         sessionNameSet,
         db,
         getMessages,
         markPendingPromptsAsAnswered,
         getAgentInstances,
-      ),
-      getGitStatus(worktree.path, initialBranch).catch((gitError) => {
-        // Log but don't fail - git status is non-critical
-        logger.error('get-apiworktrees:id-failed-to-get-git-status', { error: gitError instanceof Error ? gitError.message : String(gitError) });
-        return undefined as GitStatus | undefined;
-      }),
+      );
+    });
+
+    const [sessionStatus, gitStatus] = await Promise.all([
+      sessionStatusPromise,
+      gitStatusPromise,
     ]);
 
     // Issue #368: selectedAgents is already included in worktree from getWorktreeById

--- a/src/config/status-capture-config.ts
+++ b/src/config/status-capture-config.ts
@@ -1,10 +1,29 @@
 /**
- * Default capture line count for session status detection.
- * Used by both worktree-status-helper.ts and current-output/route.ts
- * to ensure consistent status detection across APIs.
+ * Capture line count for the display path (current-output/route.ts).
  *
  * Issue #604: Previously, worktree-status-helper used 100 lines while
  * current-output used 10000, causing status inconsistency when tmux
  * buffer had 150+ trailing blank lines after a prompt.
+ *
+ * Issue #965: detection no longer shares this large value — see
+ * STATUS_DETECTION_CAPTURE_LINES below. The display path keeps 10000 so the
+ * full terminal scrollback remains available to the UI.
  */
 export const STATUS_CAPTURE_LINES = 10000;
+
+/**
+ * Capture line count for the status DETECTION path (worktree-status-helper.ts).
+ *
+ * Issue #965: Status detection only needs enough trailing lines to find the
+ * active prompt/spinner. The detector (status-detector.ts) trims trailing blank
+ * padding before windowing, so it just needs the captured slice to reach past
+ * that padding to the real content. Capturing the full 10000 lines on every
+ * sidebar→detail status probe makes the tmux capture-pane call needlessly slow.
+ *
+ * 1000 lines keeps a large margin above the worst observed trailing-blank
+ * padding (Issue #604: ~150+ blank lines after a prompt), so detection still
+ * sees the prompt/status after trimming — no regression of the #604 case —
+ * while cutting the capture cost. Tools with their own fixed pane height
+ * (OpenCode, Gemini) keep using that height instead.
+ */
+export const STATUS_DETECTION_CAPTURE_LINES = 1000;

--- a/src/contexts/WorktreeSelectionContext.tsx
+++ b/src/contexts/WorktreeSelectionContext.tsx
@@ -169,8 +169,20 @@ function worktreeSelectionReducer(
       return { ...state, worktrees: action.worktrees, isLoading: false };
     case 'SET_REPOSITORIES':
       return { ...state, repositories: action.repositories };
-    case 'SELECT_WORKTREE':
-      return { ...state, selectedWorktreeId: action.id };
+    case 'SELECT_WORKTREE': {
+      // Issue #965: Stale-while-revalidate. The sidebar already holds the
+      // worktree list (with per-instance session status, agent instances, etc.),
+      // so seed the detail pane from that cache immediately instead of blocking
+      // on getById(). Only fall back to the loading state on a cache miss; the
+      // background getById() in selectWorktree() overwrites with the fresh detail.
+      const cached = state.worktrees.find((wt) => wt.id === action.id) ?? null;
+      return {
+        ...state,
+        selectedWorktreeId: action.id,
+        selectedWorktreeDetail: cached ?? state.selectedWorktreeDetail,
+        isLoadingDetail: cached === null,
+      };
+    }
     case 'SET_WORKTREE_DETAIL':
       return { ...state, selectedWorktreeDetail: action.detail };
     case 'SET_LOADING':
@@ -245,9 +257,11 @@ export function WorktreeSelectionProvider({
 
   // Select a worktree with optimistic update
   const selectWorktree = useCallback(async (id: string) => {
-    // Optimistic update: immediately set selected ID
+    // Optimistic update: immediately set selected ID and seed the detail from
+    // the list cache (Issue #965). SELECT_WORKTREE sets isLoadingDetail only on
+    // a cache miss, so the detail pane renders instantly when the worktree is
+    // already in the sidebar list (the common path for external access).
     dispatch({ type: 'SELECT_WORKTREE', id });
-    dispatch({ type: 'SET_LOADING_DETAIL', isLoadingDetail: true });
     dispatch({ type: 'SET_ERROR', error: null });
 
     try {

--- a/src/lib/session/worktree-status-helper.ts
+++ b/src/lib/session/worktree-status-helper.ts
@@ -18,7 +18,7 @@ import { captureSessionOutput } from './cli-session';
 import { detectSessionStatus } from '@/lib/detection/status-detector';
 import { OPENCODE_PANE_HEIGHT } from '@/lib/cli-tools/opencode';
 import { GEMINI_PANE_HEIGHT } from '@/lib/cli-tools/gemini';
-import { STATUS_CAPTURE_LINES } from '@/config/status-capture-config';
+import { STATUS_DETECTION_CAPTURE_LINES } from '@/config/status-capture-config';
 import { isSessionHealthy } from './claude-session';
 import { getLastServerResponseTimestamp, buildCompositeKey } from '@/lib/polling/auto-yes-manager';
 import { GLOBAL_SESSION_WORKTREE_ID } from '@/lib/session/global-session-constants';
@@ -33,7 +33,10 @@ function getStatusCaptureLines(cliToolId: CLIToolType): number {
     return GEMINI_PANE_HEIGHT;
   }
 
-  return STATUS_CAPTURE_LINES;
+  // Issue #965: detection uses a smaller capture than the display path. The
+  // status detector trims trailing blank padding before windowing, so this is
+  // enough to find the prompt/status while keeping capture-pane fast.
+  return STATUS_DETECTION_CAPTURE_LINES;
 }
 
 /** Per-CLI-tool session status */

--- a/src/lib/tmux/tmux-capture-cache.ts
+++ b/src/lib/tmux/tmux-capture-cache.ts
@@ -7,7 +7,7 @@
  *
  * Cache key: sessionName (mcbd-{cliToolId}-{worktreeId} format)
  * Cache value: CacheEntry (output + metadata)
- * TTL: 2 seconds (CACHE_TTL_MS)
+ * TTL: 5 seconds (CACHE_TTL_MS)
  *
  * [SEC4-001] Trust Boundary: sessionName is validated by the caller chain
  * (CLIToolManager.getTool(cliToolId).getSessionName()). This module does not
@@ -35,8 +35,14 @@ interface CacheEntry {
 // Constants
 // =========================================================================
 
-/** Cache TTL in milliseconds (Issue #499 Item 6: extended from 2000 to 3000 for improved cache hit rate) */
-export const CACHE_TTL_MS = 3000;
+/**
+ * Cache TTL in milliseconds.
+ * Issue #499 Item 6: extended from 2000 to 3000 for improved cache hit rate.
+ * Issue #965: extended from 3000 to 5000 to further cut redundant tmux
+ * capture-pane invocations during sidebar→detail status probes. Kept modest to
+ * preserve real-time responsiveness of the terminal/status UI.
+ */
+export const CACHE_TTL_MS = 5000;
 
 /** Maximum number of cache entries */
 export const CACHE_MAX_ENTRIES = 100;

--- a/tests/unit/config/status-capture-config.test.ts
+++ b/tests/unit/config/status-capture-config.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { STATUS_CAPTURE_LINES } from '@/config/status-capture-config';
+import { STATUS_CAPTURE_LINES, STATUS_DETECTION_CAPTURE_LINES } from '@/config/status-capture-config';
 
 describe('status-capture-config', () => {
   describe('STATUS_CAPTURE_LINES', () => {
@@ -18,6 +18,23 @@ describe('status-capture-config', () => {
 
     it('should be a positive number', () => {
       expect(STATUS_CAPTURE_LINES).toBeGreaterThan(0);
+    });
+  });
+
+  // Issue #965: detection uses a smaller capture than the display path.
+  describe('STATUS_DETECTION_CAPTURE_LINES', () => {
+    it('should be 1000', () => {
+      expect(STATUS_DETECTION_CAPTURE_LINES).toBe(1000);
+    });
+
+    it('should be a positive number', () => {
+      expect(STATUS_DETECTION_CAPTURE_LINES).toBeGreaterThan(0);
+    });
+
+    it('should be smaller than the display capture (perf) yet large enough to clear #604 trailing-blank padding', () => {
+      expect(STATUS_DETECTION_CAPTURE_LINES).toBeLessThan(STATUS_CAPTURE_LINES);
+      // #604 observed ~150+ trailing blank lines after a prompt; keep a wide margin.
+      expect(STATUS_DETECTION_CAPTURE_LINES).toBeGreaterThan(150);
     });
   });
 });

--- a/tests/unit/contexts/WorktreeSelectionContext.test.tsx
+++ b/tests/unit/contexts/WorktreeSelectionContext.test.tsx
@@ -53,6 +53,7 @@ function TestConsumer() {
   return (
     <div>
       <span data-testid="selectedWorktreeId">{context.selectedWorktreeId ?? 'null'}</span>
+      <span data-testid="selectedWorktreeDetailId">{context.selectedWorktreeDetail?.id ?? 'null'}</span>
       <span data-testid="worktreeCount">{context.worktrees.length}</span>
       <span data-testid="isLoadingDetail">{String(context.isLoadingDetail)}</span>
       <span data-testid="error">{context.error ?? 'null'}</span>
@@ -61,6 +62,12 @@ function TestConsumer() {
         onClick={() => context.selectWorktree('feature-test-1')}
       >
         Select
+      </button>
+      <button
+        data-testid="selectWorktreeMissing"
+        onClick={() => context.selectWorktree('not-in-cache')}
+      >
+        Select Missing
       </button>
       <button
         data-testid="refreshWorktrees"
@@ -151,8 +158,11 @@ describe('WorktreeSelectionContext', () => {
         expect(screen.getByTestId('worktreeCount').textContent).toBe('2');
       });
 
+      // Issue #965: the loading state only applies on a cache miss now (a cached
+      // worktree is seeded immediately). Select one not in the list cache so the
+      // loading path is still exercised.
       act(() => {
-        screen.getByTestId('selectWorktree').click();
+        screen.getByTestId('selectWorktreeMissing').click();
       });
 
       // Should show loading immediately
@@ -249,9 +259,50 @@ describe('WorktreeSelectionContext', () => {
 
       // Should immediately update the selected ID (optimistic update)
       expect(screen.getByTestId('selectedWorktreeId').textContent).toBe('feature-test-1');
+
+      // Issue #965: stale-while-revalidate. The worktree is in the list cache,
+      // so the detail is seeded immediately and the loading state is NOT shown
+      // while getById() runs in the background.
+      expect(screen.getByTestId('isLoadingDetail').textContent).toBe('false');
+      expect(screen.getByTestId('selectedWorktreeDetailId').textContent).toBe('feature-test-1');
+
+      // Now resolve the API call (fresh detail overwrites the seeded value)
+      act(() => {
+        resolveGetById!(mockWorktrees[0]);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoadingDetail').textContent).toBe('false');
+      });
+      expect(screen.getByTestId('selectedWorktreeDetailId').textContent).toBe('feature-test-1');
+    });
+
+    it('should show the loading state only when the worktree is NOT in the list cache (Issue #965)', async () => {
+      // Make the getById call take some time
+      let resolveGetById: (value: Worktree) => void;
+      (worktreeApi.getById as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise((resolve) => { resolveGetById = resolve; })
+      );
+
+      render(
+        <WorktreeSelectionProvider>
+          <TestConsumer />
+        </WorktreeSelectionProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('worktreeCount').textContent).toBe('2');
+      });
+
+      act(() => {
+        screen.getByTestId('selectWorktreeMissing').click();
+      });
+
+      // Cache miss: fall back to the previous blocking behavior (loading shown).
+      expect(screen.getByTestId('selectedWorktreeId').textContent).toBe('not-in-cache');
       expect(screen.getByTestId('isLoadingDetail').textContent).toBe('true');
 
-      // Now resolve the API call
+      // Resolve the API call - loading clears once the detail arrives.
       act(() => {
         resolveGetById!(mockWorktrees[0]);
       });

--- a/tests/unit/lib/auto-yes-manager.test.ts
+++ b/tests/unit/lib/auto-yes-manager.test.ts
@@ -2178,10 +2178,10 @@ describe('auto-yes-manager', () => {
       vi.mocked(captureSessionOutput).mockReset();
     });
 
-    // Item 6: Cache TTL constant value
-    it('Item 6: CACHE_TTL_MS should be 3000', async () => {
+    // Item 6: Cache TTL constant value (Issue #965: extended 3000 -> 5000)
+    it('Item 6: CACHE_TTL_MS should be 5000', async () => {
       const { CACHE_TTL_MS } = await import('@/lib/tmux/tmux-capture-cache');
-      expect(CACHE_TTL_MS).toBe(3000);
+      expect(CACHE_TTL_MS).toBe(5000);
     });
 
     // Item 7: validatePollingContext should not call isAutoYesExpired

--- a/tests/unit/lib/tmux-capture-cache.test.ts
+++ b/tests/unit/lib/tmux-capture-cache.test.ts
@@ -48,8 +48,8 @@ describe('tmux-capture-cache', () => {
   // =========================================================================
 
   describe('constants', () => {
-    it('should export CACHE_TTL_MS as 3000 (Issue #499 Item 6)', () => {
-      expect(CACHE_TTL_MS).toBe(3000);
+    it('should export CACHE_TTL_MS as 5000 (Issue #965)', () => {
+      expect(CACHE_TTL_MS).toBe(5000);
     });
 
     it('should export CACHE_MAX_ENTRIES as 100', () => {


### PR DESCRIPTION
## 概要
Closes #965（base=develop のため自動クローズされない。マージ後に手動close）

外部アクセス時のサイドバークリック→worktree詳細表示の体感遅延を、低リスクなクイックウィン4件で低減する。

## 変更内容
1. **詳細の楽観的即描画**（`src/contexts/WorktreeSelectionContext.tsx`）
   `SELECT_WORKTREE` で一覧キャッシュから `selectedWorktreeDetail` をシードし、`isLoadingDetail` はキャッシュミス時のみ true。`getById()` はバックグラウンドで実行し最新で上書き（stale-while-revalidate）。キャッシュミス時は従来のローディング挙動にフォールバック。`WorktreeDetailRefactored.tsx` は非変更。
2. **検出用キャプチャ行数の分離**（`src/config/status-capture-config.ts`, `src/lib/session/worktree-status-helper.ts`）
   検出経路用に `STATUS_DETECTION_CAPTURE_LINES = 1000` を追加（表示/current-output は `STATUS_CAPTURE_LINES = 10000` を維持）。検出器が末尾空行をトリムしてから判定するため、#604（末尾空行150+）ケースは余裕で回避＝検出退行なし。
3. **git status の並走**（`src/app/api/worktrees/[id]/route.ts`）
   `getGitStatus()` を即時開始し `listSessions()` と並走。session検出は listSessions に連鎖。git status の .catch は維持。
4. **キャプチャキャッシュ TTL 延長**（`src/lib/tmux/tmux-capture-cache.ts`）
   `CACHE_TTL_MS` 3000 → 5000。

## スコープ外（別Issue）
一覧APIの並列度制限・遷移時ポーリング停止・検出結果メモ化・WebSocket/SSE移行。

## テスト
Context テストにキャッシュヒット（即時・ローディングなし）/ミス（ローディング）両経路を追加。auto-yes-manager・tmux-capture-cache の TTL 期待値を 5000 に更新。`STATUS_DETECTION_CAPTURE_LINES` テスト追加。

## 品質ゲート（worker実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（8005 passed）
- ✅ npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)