### PR TITLE
fix: サイドバー横スクロールバーを撤廃しtruncate＋ホバー全文表示にする

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -36,6 +36,7 @@ import { useSidebarContext } from '@/contexts/SidebarContext';
 import { BranchListItem } from '@/components/sidebar/BranchListItem';
 import { SortSelector } from '@/components/sidebar/SortSelector';
 import { Tooltip } from '@/components/common/Tooltip';
+import { TruncationTooltip } from '@/components/common/TruncationTooltip';
 import { LocaleSwitcher } from '@/components/common/LocaleSwitcher';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import { LogoutButton } from '@/components/common/LogoutButton';
@@ -478,7 +479,7 @@ export const Sidebar = memo(function Sidebar() {
         onScroll={saveBranchListScroll}
         onMouseEnter={handleListMouseEnter}
         onMouseLeave={handleListMouseLeave}
-        className="flex-1 overflow-y-auto"
+        className="flex-1 overflow-y-auto overflow-x-hidden"
       >
         {isEmpty ? (
           <div className="px-4 py-8 text-center text-gray-400">
@@ -575,7 +576,7 @@ function SortableGroupItem({
   };
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} className="w-full min-w-0">
       <GroupHeader
         repositoryName={group.repositoryName}
         branchCount={group.branches.length}
@@ -680,7 +681,7 @@ function GroupHeader({
         onClick={onClick}
         aria-expanded={isExpanded}
         className="
-          flex-1 flex items-center gap-2 px-2 py-2
+          flex-1 min-w-0 flex items-center gap-2 px-2 py-2
           text-xs font-semibold text-gray-300 uppercase tracking-wider
           focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500
           transition-colors
@@ -688,7 +689,9 @@ function GroupHeader({
       >
         <ChevronIcon isExpanded={isExpanded} />
         <GroupIcon color={generateRepositoryColor(repositoryName)} />
-        <span className="flex-1 text-left truncate">{repositoryName}</span>
+        <TruncationTooltip content={repositoryName} className="flex-1 min-w-0 text-left truncate">
+          {repositoryName}
+        </TruncationTooltip>
         <span className="text-gray-500 font-normal pr-2">{branchCount}</span>
       </button>
     </div>

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -837,6 +837,67 @@ describe('Sidebar', () => {
     });
   });
 
+  describe('Horizontal scrollbar suppression (Issue #971)', () => {
+    const longNameWorktrees: Worktree[] = [
+      {
+        id: 'long-repo-feature',
+        name: 'feature/some-work',
+        path: '/path/to/long',
+        repositoryPath: '/path/to/very-long-repo',
+        repositoryName: 'a-very-long-repository-name-that-overflows-the-sidebar-width',
+      },
+    ];
+
+    beforeEach(() => {
+      (worktreeApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        worktrees: longNameWorktrees,
+        repositories: [],
+      });
+    });
+
+    it('disables horizontal scrolling on the branch list container', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      await waitFor(() => {
+        const branchList = screen.getByTestId('branch-list');
+        expect(branchList.className).toMatch(/overflow-x-hidden/);
+      });
+    });
+
+    it('makes the group header a min-w-0 flex container so truncate can apply', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const groupHeader = await screen.findByTestId('group-header');
+      expect(groupHeader.className).toMatch(/min-w-0/);
+    });
+
+    it('truncates the repository name without a native title attribute', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const repoName = await screen.findByText(
+        'a-very-long-repository-name-that-overflows-the-sidebar-width'
+      );
+      // Truncation is enabled so the long name is clipped rather than overflowing.
+      expect(repoName).toHaveClass('truncate');
+      expect(repoName).toHaveClass('min-w-0');
+      // TruncationTooltip controls the hover delay in JS; it must not fall back
+      // to a native title attribute (Issue #971 / #859).
+      expect(repoName).not.toHaveAttribute('title');
+    });
+  });
+
   describe('Flat view', () => {
     it('should show flat list when view mode is flat', async () => {
       // Set localStorage to flat mode before rendering


### PR DESCRIPTION
## 概要
Closes #971

サイドバーの横スクロールバーを撤廃し、はみ出すテキストは truncate＋ホバー全文表示に:
- GroupHeader の `<button>` に `min-w-0` 追加 → リポジトリ名の truncate を有効化（はみ出しの根本対策）。
- repositoryName を `TruncationTooltip` でラップ → 省略時のみホバーで全文表示。
- ブランチ一覧コンテナに `overflow-x-hidden` 追加 → 横スクロールバーを物理的に撤廃。
- SortableGroupItem wrapper の幅制約を確認・付与（DnD ドラッグ中のはみ出し防止）。

幅が狭い場合はホバー全文表示 or 既存のサイドバーリサイズで対応可能。

## 変更ファイル
`src/components/layout/Sidebar.tsx` + 単体テスト（`TruncationTooltip` は流用のみ）

## 品質ゲート（ワーカー実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（8008 tests / 446 files・Sidebar 60 tests pass）
- ✅ npm run build
