### PR TITLE
feat: ファイルツリーのツールチップ（メタデータ＋ファイル名）を1つに共通化

### DIFF
--- a/src/components/common/TruncationTooltip.tsx
+++ b/src/components/common/TruncationTooltip.tsx
@@ -1,16 +1,23 @@
 /**
- * TruncationTooltip Component (Issue #859)
+ * TruncationTooltip Component (Issue #859, #975)
  *
  * A hover-delayed tooltip for text that is visually truncated (CSS
  * `text-overflow: ellipsis`). It replaces the native `title` attribute on
  * file names in the file tree, whose show-delay is browser-controlled and
  * sluggish (~0.5–1s in Chrome) and cannot be tuned from JS/CSS.
  *
+ * [Issue #975] An optional `metadata` prop lets a caller surface extra
+ * formatted info (e.g. a file's size / created / modified lines) inside the
+ * SAME bubble as the name, so a single styled tooltip replaces the previous
+ * two independent ones (native `title` metadata + this name tooltip).
+ *
  * Design notes:
  *   - The trigger is the truncating element itself (the caller passes the
  *     same `truncate`/`overflow-hidden` className it used before), so we can
  *     measure `scrollWidth > clientWidth` to decide whether the text is
- *     actually clipped. Short names that fit never show a tooltip.
+ *     actually clipped. Short names that fit never show a tooltip — unless
+ *     `metadata` is supplied, in which case the bubble always appears on hover
+ *     so the metadata is reachable even for short, non-clipped names.
  *   - The tooltip is rendered through a React portal to `document.body` with
  *     `position: fixed`, mirroring `BranchListItem`'s approach, so it is never
  *     clipped by the file tree's `overflow-y: auto` scroll container.
@@ -55,6 +62,14 @@ export interface TruncationTooltipProps {
    * `content` when omitted.
    */
   children?: React.ReactNode;
+  /**
+   * [Issue #975] Optional pre-formatted metadata (newline-separated lines)
+   * rendered below the name inside the same bubble. When present, the tooltip
+   * shows on hover even if the name is not truncated, so callers can attach
+   * always-available info (e.g. file size / created / modified). Omit it for a
+   * name-only tooltip (the default truncation behavior is unchanged).
+   */
+  metadata?: string;
 }
 
 /**
@@ -73,6 +88,7 @@ export function TruncationTooltip({
   delay = TRUNCATION_TOOLTIP_DELAY_MS,
   className,
   children,
+  metadata,
 }: TruncationTooltipProps): React.ReactElement {
   const triggerRef = useRef<HTMLSpanElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -91,8 +107,11 @@ export function TruncationTooltip({
   const handleMouseEnter = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
-    // Only show a tooltip when the name is actually clipped.
-    if (el.scrollWidth <= el.clientWidth) return;
+    // Show when the name is actually clipped OR when there is metadata to
+    // surface (file rows attach metadata so their info is reachable on hover
+    // even when the name itself fits). [Issue #975]
+    const isTruncated = el.scrollWidth > el.clientWidth;
+    if (!isTruncated && !metadata) return;
 
     clearTimer();
     timerRef.current = setTimeout(() => {
@@ -109,7 +128,7 @@ export function TruncationTooltip({
       setVisible(true);
       timerRef.current = null;
     }, delay);
-  }, [clearTimer, delay]);
+  }, [clearTimer, delay, metadata]);
 
   const handleMouseLeave = useCallback(() => {
     clearTimer();
@@ -133,10 +152,15 @@ export function TruncationTooltip({
           <span
             role="tooltip"
             aria-hidden="true"
-            className="fixed z-[9999] max-w-md px-2 py-1 text-xs font-medium rounded bg-gray-900 text-gray-100 shadow-lg pointer-events-none break-all"
+            className="fixed z-[9999] max-w-md px-2 py-1 text-xs font-medium rounded bg-gray-900 text-gray-100 shadow-lg pointer-events-none"
             style={{ top: coords.top, left: coords.left }}
           >
-            {content}
+            <span className="block break-all">{content}</span>
+            {metadata && (
+              <span className="mt-0.5 block whitespace-pre-line font-normal text-gray-300">
+                {metadata}
+              </span>
+            )}
           </span>,
           document.body
         )}

--- a/src/components/worktree/TreeNode.tsx
+++ b/src/components/worktree/TreeNode.tsx
@@ -280,12 +280,15 @@ export const TreeNode = memo(function TreeNode({
   );
 
   /**
-   * [Issue #969] Formatted, locale-aware metadata tooltip for file rows.
-   * Built into the row's `title` attribute (newline-separated) so the
-   * created/modified/size info is always available on hover, even when the
-   * inline columns are toggled off. Directories get no tooltip.
+   * [Issue #969, #975] Formatted, locale-aware metadata for file rows,
+   * newline-separated. Passed to `TruncationTooltip` so the size/created/
+   * modified info shows in the SAME bubble as the file name (one unified
+   * tooltip instead of the old native `title`). The full set is always
+   * surfaced on hover regardless of which inline columns are toggled, so the
+   * created/modified data stays reachable even in the default size-only view.
+   * Directories get no metadata (undefined → name-only tooltip when clipped).
    */
-  const metadataTitle = useMemo(() => {
+  const metadataTooltip = useMemo(() => {
     if (isDirectory) return undefined;
     const lines: string[] = [];
     if (item.size !== undefined) {
@@ -380,7 +383,6 @@ export const TreeNode = memo(function TreeNode({
         tabIndex={0}
         className="flex items-center gap-2 py-1.5 pr-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors"
         style={combinedStyle}
-        title={metadataTitle}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         onContextMenu={handleContextMenu}
@@ -410,10 +412,12 @@ export const TreeNode = memo(function TreeNode({
         )}
 
         {/* Name - with highlight for name search */}
-        {/* [Issue #859] JS tooltip (Portal) shows full name on hover when truncated,
-            replacing the native `title` whose show-delay is browser-controlled and slow */}
+        {/* [Issue #859/#975] One JS tooltip (Portal) shows the full name plus the
+            file's metadata (size/created/modified) on hover, replacing both the
+            slow native `title` and the previous separate metadata tooltip. */}
         <TruncationTooltip
           content={item.name}
+          metadata={metadataTooltip}
           className="flex-1 truncate text-sm text-gray-700 dark:text-gray-300"
         >
           {searchMode === 'name' && searchQuery ? (

--- a/tests/unit/components/common/TruncationTooltip.test.tsx
+++ b/tests/unit/components/common/TruncationTooltip.test.tsx
@@ -213,6 +213,74 @@ describe('TruncationTooltip (Issue #859)', () => {
     expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument();
   });
 
+  // [Issue #975] Metadata is folded into the same bubble as the name so a
+  // single styled tooltip replaces the old native `title` + name tooltip pair.
+  it('shows the tooltip with name + metadata even when the text is NOT truncated', () => {
+    render(
+      <TruncationTooltip
+        content="app.ts"
+        metadata={'Size: 2.0 KB\nModified: yesterday'}
+        className="truncate"
+      >
+        app.ts
+      </TruncationTooltip>
+    );
+    const trigger = screen.getByText('app.ts');
+    setTruncation(trigger, false);
+
+    fireEvent.mouseEnter(trigger);
+    act(() => {
+      vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS);
+    });
+
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+    expect(tooltip).toBeInTheDocument();
+    // One bubble carries both the name and the formatted metadata lines.
+    expect(tooltip).toHaveTextContent('app.ts');
+    expect(tooltip).toHaveTextContent('Size: 2.0 KB');
+    expect(tooltip).toHaveTextContent('Modified: yesterday');
+  });
+
+  it('still shows name + metadata together when the name IS truncated', () => {
+    render(
+      <TruncationTooltip
+        content="a-very-long-file-name.tsx"
+        metadata={'Size: 3.5 MB'}
+        className="truncate"
+      >
+        a-very-long-file-name.tsx
+      </TruncationTooltip>
+    );
+    const trigger = screen.getByText('a-very-long-file-name.tsx');
+    setTruncation(trigger, true);
+
+    fireEvent.mouseEnter(trigger);
+    act(() => {
+      vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS);
+    });
+
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+    expect(tooltip).toHaveTextContent('a-very-long-file-name.tsx');
+    expect(tooltip).toHaveTextContent('Size: 3.5 MB');
+  });
+
+  it('does NOT show a tooltip when there is no metadata and the text is not truncated', () => {
+    render(
+      <TruncationTooltip content="short.ts" className="truncate">
+        short.ts
+      </TruncationTooltip>
+    );
+    const trigger = screen.getByText('short.ts');
+    setTruncation(trigger, false);
+
+    fireEvent.mouseEnter(trigger);
+    act(() => {
+      vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS + 50);
+    });
+
+    expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+  });
+
   it('clears the scheduled timer on unmount (no tooltip flash after unmount)', () => {
     const { unmount } = render(
       <TruncationTooltip content="a-very-long-file-name.tsx" className="truncate">

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -1371,10 +1371,10 @@ describe('FileTreeView', () => {
       expect(fetchCount).toBeLessThan(10);
     });
 
-    it('hides the created column inline by default and exposes metadata via the row title [Issue #969]', async () => {
+    it('hides the created column inline by default and exposes metadata via the hover tooltip [Issue #969, #975]', async () => {
       // [Issue #162 -> #969] birthtime is no longer rendered inline by default
-      // (default = size only). The created/modified/size data is instead
-      // available via the row's formatted `title` tooltip.
+      // (default = size only). [Issue #975] The created/modified/size data is
+      // instead surfaced through the unified hover tooltip (no native `title`).
       window.localStorage.clear();
       const birthtimeData: TreeResponse = {
         path: '',
@@ -1411,13 +1411,15 @@ describe('FileTreeView', () => {
 
       // The raw ISO string is no longer used as a title (it is now formatted).
       expect(screen.queryByTitle('2026-02-10T10:00:00Z')).not.toBeInTheDocument();
-
-      // The row carries a formatted, multi-line metadata title for hover.
+      // No native `title` remains on the row — metadata moved to the tooltip.
       const row = screen.getByTestId('tree-item-test-file.ts');
-      const title = row.getAttribute('title');
-      expect(title).toBeTruthy();
-      expect(title).toContain('512 B');
-      expect(title!.split('\n').length).toBe(3);
+      expect(row.getAttribute('title')).toBeNull();
+
+      // Hovering the file name surfaces the formatted metadata in one bubble.
+      fireEvent.mouseEnter(screen.getByText('test-file.ts'));
+      const tooltip = await screen.findByRole('tooltip', { hidden: true });
+      expect(tooltip).toHaveTextContent('test-file.ts');
+      expect(tooltip).toHaveTextContent('512 B');
     });
 
     it('toggles inline metadata columns via the toolbar gear [Issue #969]', async () => {

--- a/tests/unit/components/worktree/TreeNode.test.tsx
+++ b/tests/unit/components/worktree/TreeNode.test.tsx
@@ -1,14 +1,16 @@
 /**
- * Tests for TreeNode metadata display (Issue #969)
+ * Tests for TreeNode metadata display (Issue #969, #975)
  *
  * Covers the toggleable inline columns (size / created / modified) and the
- * formatted hover tooltip built into the row's `title` attribute.
+ * unified hover tooltip (file name + metadata) rendered by TruncationTooltip
+ * — replacing the previous native `title` metadata tooltip (Issue #975).
  * @vitest-environment jsdom
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { TreeNode } from '@/components/worktree/TreeNode';
+import { TRUNCATION_TOOLTIP_DELAY_MS } from '@/components/common/TruncationTooltip';
 import type { TreeItem } from '@/types/models';
 import type { FileMetadataDisplaySettings } from '@/hooks/useFileMetadataDisplay';
 
@@ -65,26 +67,58 @@ describe('TreeNode metadata display [Issue #969]', () => {
     expect(screen.getByTestId('tree-item-modified')).toBeInTheDocument();
   });
 
-  it('builds a formatted, multi-line title tooltip on file rows', () => {
-    renderNode(FILE);
-    const row = screen.getByTestId('tree-item-app.ts');
-    const title = row.getAttribute('title');
-    expect(title).toBeTruthy();
-    // Size line (formatFileSize(2048) === '2.0 KB')
-    expect(title).toContain('2.0 KB');
-    // Localized labels resolve via the mocked useTranslations (key passthrough)
-    expect(title).toContain('worktree.fileTree.metadata.size');
-    expect(title).toContain('worktree.fileTree.metadata.created');
-    expect(title).toContain('worktree.fileTree.metadata.modified');
-    // Multi-line (newline-separated)
-    expect(title!.split('\n').length).toBe(3);
-  });
+  describe('unified hover tooltip [Issue #975]', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
 
-  it('does not set a metadata title on directory rows', () => {
-    const dir: TreeItem = { name: 'src', type: 'directory', itemCount: 3 };
-    renderNode(dir);
-    const row = screen.getByTestId('tree-item-src');
-    expect(row.getAttribute('title')).toBeNull();
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('no longer sets a native title attribute on file rows', () => {
+      renderNode(FILE);
+      const row = screen.getByTestId('tree-item-app.ts');
+      // Metadata moved out of the native `title` into the custom tooltip.
+      expect(row.getAttribute('title')).toBeNull();
+    });
+
+    it('shows name + formatted metadata in a single bubble on hover', () => {
+      renderNode(FILE);
+      // The name trigger carries metadata, so the bubble appears on hover
+      // even though jsdom reports the name as non-truncated.
+      const trigger = screen.getByText('app.ts');
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS);
+      });
+
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      // File name is part of the same bubble.
+      expect(tooltip).toHaveTextContent('app.ts');
+      // Size line (formatFileSize(2048) === '2.0 KB')
+      expect(tooltip).toHaveTextContent('2.0 KB');
+      // Localized labels resolve via the mocked useTranslations (key passthrough)
+      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.size');
+      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.created');
+      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.modified');
+    });
+
+    it('does not show a metadata tooltip on directory rows', () => {
+      const dir: TreeItem = { name: 'src', type: 'directory', itemCount: 3 };
+      renderNode(dir);
+      const row = screen.getByTestId('tree-item-src');
+      expect(row.getAttribute('title')).toBeNull();
+
+      // Directories pass no metadata; with a non-truncated name (jsdom) the
+      // bubble never appears.
+      const trigger = screen.getByText('src');
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS + 50);
+      });
+      expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+    });
   });
 
   it('shows item count for directories when size column is on', () => {


### PR DESCRIPTION
## 概要
Closes #975

アクティビティバーの Files（ファイルツリー）で別々に出ていた2つのツールチップ（メタデータ用ネイティブ `title` ＋ ファイル名用 `TruncationTooltip`）を **1つの吹き出しに共通化**:
- `TruncationTooltip` に `metadata` を渡せるよう拡張し、ファイル名＋作成/更新/サイズを1つの整形済み吹き出しで表示。
- `TreeNode.tsx` の行から native `title` 属性を撤廃し、メタデータ文字列を `TruncationTooltip` に渡す形へ統一。

## 変更ファイル
`src/components/common/TruncationTooltip.tsx`, `src/components/worktree/TreeNode.tsx` + 単体テスト3本（TruncationTooltip / TreeNode / FileTreeView）

## 品質ゲート（ワーカー実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（448 files / 8038 tests pass）
- ✅ npm run build
