### PR TITLE
fix: サイドバー狭幅時の上段ボタン重なりを折り返しで防ぐ

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -435,9 +435,14 @@ export const Sidebar = memo(function Sidebar() {
         data-testid="sidebar-header"
         className="flex-shrink-0 px-4 py-4 border-b border-gray-700"
       >
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-white">Branches</h2>
-          <div className="flex items-center gap-1">
+        {/* Issue #976: wrap the heading + actions when the sidebar is narrow so
+            the button group drops to a new line instead of overflowing
+            horizontally into the adjacent ActivityBar. flex-wrap on both the row
+            and the actions group keeps everything within the sidebar width
+            without an overflow clip (which would crop the Sort dropdown). */}
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
+          <h2 className="min-w-0 truncate text-lg font-semibold text-white">Branches</h2>
+          <div className="flex flex-wrap items-center gap-1">
             <ViewModeToggle viewMode={viewMode} onToggle={setViewMode} />
             <SortSelector />
             <SyncButton refreshWorktrees={refreshWorktrees} />

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -898,6 +898,50 @@ describe('Sidebar', () => {
     });
   });
 
+  // Issue #976: when the sidebar is narrowed, the header's heading + action
+  // buttons must wrap onto multiple lines instead of overflowing horizontally
+  // and overlapping the adjacent ActivityBar.
+  describe('Responsive header wrapping (Issue #976)', () => {
+    it('lets the header row wrap so the action buttons drop to a new line when narrow', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const header = await screen.findByTestId('sidebar-header');
+      const row = header.firstElementChild as HTMLElement;
+      expect(row.className).toMatch(/flex-wrap/);
+    });
+
+    it('lets the action button group itself wrap so icons stay within the sidebar width', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      // The Repositories link lives inside the action button group; walk up to
+      // that group container and assert it can wrap internally as a last resort.
+      const link = await screen.findByRole('link', { name: 'Repositories' });
+      const actions = link.closest('div.flex.flex-wrap') as HTMLElement;
+      expect(actions).not.toBeNull();
+      expect(actions.className).toMatch(/flex-wrap/);
+    });
+
+    it('keeps the Branches heading shrinkable (min-w-0) and truncatable so it never pushes the buttons out', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const heading = await screen.findByText('Branches');
+      expect(heading).toHaveClass('min-w-0');
+      expect(heading).toHaveClass('truncate');
+    });
+  });
+
   describe('Flat view', () => {
     it('should show flat list when view mode is flat', async () => {
       // Set localStorage to flat mode before rendering


### PR DESCRIPTION
## 概要
Closes #976

サイドバーの横幅を狭めたとき、上段ボタン群（Sync worktree 等）がアクティビティバー領域に重なる問題を修正:
- ヘッダー行に `flex-wrap` を付与 → 幅が狭いときボタン群が見出しの下へ複数行で折り返す。
- 見出しに `min-w-0 truncate` を付与 → 見出しがボタンを押し出すのを防止。
- 横方向オーバーフローを排除し、領域跨ぎの重なりを解消。通常幅では従来の1行レイアウトを維持。

## 変更ファイル
`src/components/layout/Sidebar.tsx` + 単体テスト（折り返し検証3ケース）

## 品質ゲート（ワーカー実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（448 files / 8037 tests pass）
- ✅ npm run build
