### PR TITLE
feat: PC版ターミナルヘッダーのボタンを左寄せ統一・並び替え

### DIFF
--- a/src/components/worktree/TerminalSplitContainer.tsx
+++ b/src/components/worktree/TerminalSplitContainer.tsx
@@ -285,6 +285,57 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
         </span>
 
         {/*
+          Issue #977: all action-bar buttons are left-aligned in a single
+          group, ordered +Split → -Split → Equal widths → History → Files.
+          The `ml-auto` that previously pushed +Split (and everything after)
+          to the right has been removed so the bar reads left-to-right.
+        */}
+        <button
+          type="button"
+          onClick={addSplit}
+          disabled={!canAdd}
+          aria-disabled={!canAdd}
+          aria-label="Add terminal split"
+          data-testid="add-terminal-split"
+          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          + Split
+        </button>
+        <button
+          type="button"
+          onClick={removeSplit}
+          disabled={!canRemove}
+          aria-disabled={!canRemove}
+          aria-label="Remove last terminal split"
+          data-testid="remove-terminal-split"
+          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          - Split
+        </button>
+
+        {/*
+          Issue #861: equalize terminal split widths (each → 1/n) and reset the
+          Message History width to default in one action. Disabled only when
+          there is nothing to equalize (single split AND History hidden).
+        */}
+        <button
+          type="button"
+          onClick={handleEqualizeWidths}
+          disabled={!canEqualize}
+          aria-disabled={!canEqualize}
+          aria-label={t('terminal.equalizeWidthsHint')}
+          title={t('terminal.equalizeWidthsHint')}
+          data-testid="equalize-split-widths"
+          className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <AlignHorizontalDistributeCenter
+            className="w-3.5 h-3.5 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span>{t('terminal.equalizeWidths')}</span>
+        </button>
+
+        {/*
           Issue #841 (Phase 2): History / Files visibility toggles. Always
           shown (split-count independent). Active = cyan accent, inactive =
           gray. `aria-pressed` reflects current visibility. The existing
@@ -333,51 +384,6 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
         >
           <Files className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
           <span>{t('terminal.filesLabel')}</span>
-        </button>
-
-        <button
-          type="button"
-          onClick={addSplit}
-          disabled={!canAdd}
-          aria-disabled={!canAdd}
-          aria-label="Add terminal split"
-          data-testid="add-terminal-split"
-          className="ml-auto text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          + Split
-        </button>
-        <button
-          type="button"
-          onClick={removeSplit}
-          disabled={!canRemove}
-          aria-disabled={!canRemove}
-          aria-label="Remove last terminal split"
-          data-testid="remove-terminal-split"
-          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          - Split
-        </button>
-
-        {/*
-          Issue #861: equalize terminal split widths (each → 1/n) and reset the
-          Message History width to default in one action. Disabled only when
-          there is nothing to equalize (single split AND History hidden).
-        */}
-        <button
-          type="button"
-          onClick={handleEqualizeWidths}
-          disabled={!canEqualize}
-          aria-disabled={!canEqualize}
-          aria-label={t('terminal.equalizeWidthsHint')}
-          title={t('terminal.equalizeWidthsHint')}
-          data-testid="equalize-split-widths"
-          className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <AlignHorizontalDistributeCenter
-            className="w-3.5 h-3.5 flex-shrink-0"
-            aria-hidden="true"
-          />
-          <span>{t('terminal.equalizeWidths')}</span>
         </button>
       </div>
 

--- a/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
@@ -479,3 +479,37 @@ describe('TerminalSplitContainer drop validation (Issue #786 / #869)', () => {
     expect(screen.getByTestId('pane-cli-0')).toHaveTextContent('gemini');
   });
 });
+
+// ===========================================================================
+// Issue #977: the action-bar buttons are all left-aligned in a single group,
+// ordered +Split → -Split → Equal widths → History → Files. The `ml-auto` that
+// previously split the bar into left/right groups has been removed.
+// ===========================================================================
+describe('TerminalSplitContainer action-bar layout (Issue #977)', () => {
+  it('renders the action buttons in DOM order +Split → -Split → Equal widths → History → Files', () => {
+    setup();
+    const order = [
+      'add-terminal-split',
+      'remove-terminal-split',
+      'equalize-split-widths',
+      'toggle-history-pane',
+      'toggle-file-panel',
+    ];
+    // Each button must precede the next in document order (left-to-right bar).
+    for (let i = 0; i < order.length - 1; i++) {
+      const current = screen.getByTestId(order[i]);
+      const next = screen.getByTestId(order[i + 1]);
+      expect(
+        current.compareDocumentPosition(next) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+  });
+
+  it('does not push +Split to the right with ml-auto (left-aligned bar)', () => {
+    setup();
+    expect(screen.getByTestId('add-terminal-split').className).not.toContain(
+      'ml-auto',
+    );
+  });
+});


### PR DESCRIPTION
## 概要
Closes #977

PC版ターミナル表示領域ヘッダーのボタンを **左寄せに統一** し、並び順を次のとおりに変更:

**+Split → -Split → Equal widths → History → Files**

- 右寄せの原因だった `ml-auto` を撤廃。
- アクションバー内の JSX を上記順に並べ替え。
- 機能・活性条件（canAdd/canRemove/canEqualize）・aria 状態は不変。PC専用変更のためモバイル影響なし。

## 変更ファイル
`src/components/worktree/TerminalSplitContainer.tsx` + 単体テスト（並び順保証2件追加）

## 品質ゲート（ワーカー実行・全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（8036 tests pass・新規2件含む）
- ✅ npm run build
