### PR TITLE
feat(markdown): プレビュー時にコードブロックをコピー可能にする（PC/スマホ）

### DIFF
--- a/src/app/worktrees/[id]/files/[...path]/page.tsx
+++ b/src/app/worktrees/[id]/files/[...path]/page.tsx
@@ -15,6 +15,7 @@ import rehypeHighlight from 'rehype-highlight';
 import { FileContent } from '@/types/models';
 import { ImageViewer } from '@/components/worktree/ImageViewer';
 import { VideoViewer } from '@/components/worktree/VideoViewer';
+import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 
 export default function FileViewerPage() {
   const router = useRouter();
@@ -167,10 +168,15 @@ export default function FileViewerPage() {
                           </code>
                         );
                       },
+                      // Issue #981: wrap code blocks with a copy button. The
+                      // wrapper sits outside the scrollable <pre> so the button
+                      // stays pinned to the top-right while code scrolls.
                       pre: ({ children }: { children?: React.ReactNode }) => (
-                        <pre className="overflow-x-auto">
-                          {children}
-                        </pre>
+                        <CodeBlockWithCopy>
+                          <pre className="overflow-x-auto">
+                            {children}
+                          </pre>
+                        </CodeBlockWithCopy>
                       ),
                       table: ({ children }: { children?: React.ReactNode }) => (
                         <div className="overflow-x-auto">

--- a/src/components/common/CodeBlockWithCopy.tsx
+++ b/src/components/common/CodeBlockWithCopy.tsx
@@ -1,0 +1,98 @@
+/**
+ * CodeBlockWithCopy Component
+ *
+ * Issue #981: Wraps a rendered markdown code block (a `<code>` or `<pre>`
+ * element) in a `relative group` container and overlays a {@link CopyButton}
+ * in the top-right corner.
+ *
+ * Used by the markdown *file preview* render paths only:
+ * - `MermaidCodeBlock` (the `code` renderer used by MarkdownPreview) wraps the
+ *   non-mermaid `<code>` element, passing `as="span"` so the wrapper is valid
+ *   phrasing content inside the parent `<pre>`.
+ * - The file viewer page wraps the `<pre>` element from its `pre` renderer
+ *   (default `as="div"`, sitting outside the scrollable `<pre>` so the button
+ *   stays pinned while code scrolls horizontally).
+ *
+ * The button is hidden by default on pointer/desktop widths and revealed on
+ * hover/focus; on small (touch) widths it is always visible since hover is
+ * unavailable. The copy target is the plain text content of the code block
+ * (highlight.js decoration markup stripped), extracted via
+ * {@link extractCodeText}.
+ *
+ * @module components/common/CodeBlockWithCopy
+ */
+
+'use client';
+
+import React from 'react';
+import { CopyButton } from './CopyButton';
+
+/**
+ * Recursively extract the plain text content from a React node tree.
+ *
+ * rehype-highlight rewrites code children into nested `<span>` elements, so a
+ * naive `String(children)` yields `[object Object]`. This walks the tree and
+ * concatenates string/number leaves, mirroring DOM `textContent`.
+ */
+export function extractCodeText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractCodeText).join('');
+  }
+  if (React.isValidElement(node)) {
+    return extractCodeText((node.props as { children?: React.ReactNode }).children);
+  }
+  return '';
+}
+
+export interface CodeBlockWithCopyProps {
+  /** Rendered code block content (a `<code>` or `<pre>` element) */
+  children: React.ReactNode;
+  /**
+   * Wrapper element tag. Use `'span'` when rendered inside a `<pre>` (phrasing
+   * context); `'div'` otherwise. Defaults to `'div'`.
+   */
+  as?: 'div' | 'span';
+  /** Extra classes for the wrapper */
+  className?: string;
+}
+
+/**
+ * Wraps a code block and overlays a copy button. Renders the children
+ * unchanged (no button) when the block has no copyable text.
+ */
+export function CodeBlockWithCopy({
+  children,
+  as = 'div',
+  className = '',
+}: CodeBlockWithCopyProps): JSX.Element {
+  const Wrapper = as;
+  const text = extractCodeText(children);
+
+  // Nothing meaningful to copy: render the block as-is without a button.
+  if (!text || text.trim().length === 0) {
+    return <Wrapper className={className || undefined}>{children}</Wrapper>;
+  }
+
+  const wrapperClass = `relative group ${as === 'span' ? 'block ' : ''}${className}`.trim();
+
+  return (
+    <Wrapper className={wrapperClass} data-testid="code-block-with-copy">
+      {children}
+      <CopyButton
+        text={text}
+        className="absolute right-2 top-2 z-10 opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 focus:opacity-100"
+      />
+    </Wrapper>
+  );
+}
+
+export default CodeBlockWithCopy;

--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,0 +1,88 @@
+/**
+ * CopyButton Component
+ *
+ * Issue #981: Extracted from AssistantMessageList for reuse across the app
+ * (assistant chat message bubbles + markdown file preview code blocks).
+ *
+ * Behavior is preserved verbatim from the original AssistantMessageList
+ * implementation: copies `text` via `copyToClipboard`, shows a Check icon for
+ * `COPY_FEEDBACK_RESET_SHORT_MS` (1.5s), then reverts to the Copy icon. The
+ * timer is cleared on unmount and de-duplicated on rapid clicks.
+ *
+ * @module components/common/CopyButton
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { copyToClipboard } from '@/lib/clipboard-utils';
+import { COPY_FEEDBACK_RESET_SHORT_MS } from '@/config/ui-feedback-config';
+
+function IconCopy() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+export interface CopyButtonProps {
+  /** Text copied to the clipboard when the button is pressed */
+  text: string;
+  /** Extra classes appended to the button (e.g. absolute positioning) */
+  className?: string;
+  /** Accessible label / visible caption shown next to the icon */
+  label?: string;
+}
+
+/**
+ * Compact copy-to-clipboard button with transient "Copied" feedback.
+ */
+export function CopyButton({ text, className = '', label = 'Copy' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    try {
+      await copyToClipboard(text);
+      setCopied(true);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_RESET_SHORT_MS);
+    } catch {
+      // ignore - copyToClipboard handles fallback
+    }
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/70 px-2 py-0.5 text-[11px] font-medium text-slate-300 transition-colors hover:bg-slate-800 ${className}`}
+      aria-label={copied ? 'Copied' : label}
+      title={copied ? 'Copied!' : label}
+    >
+      {copied ? <IconCheck /> : <IconCopy />}
+      <span>{copied ? 'Copied' : label}</span>
+    </button>
+  );
+}
+
+export default CopyButton;

--- a/src/components/home/AssistantMessageList.tsx
+++ b/src/components/home/AssistantMessageList.tsx
@@ -7,8 +7,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import type { AssistantMessage } from '@/lib/db/assistant-conversation-db';
-import { copyToClipboard } from '@/lib/clipboard-utils';
-import { COPY_FEEDBACK_RESET_SHORT_MS } from '@/config/ui-feedback-config';
+import { CopyButton } from '@/components/common/CopyButton';
 
 interface AssistantMessageListProps {
   messages: AssistantMessage[];
@@ -23,72 +22,11 @@ function formatTimestamp(timestamp: Date): string {
   return timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-function IconCopy() {
-  return (
-    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-    </svg>
-  );
-}
-
-function IconCheck() {
-  return (
-    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-    </svg>
-  );
-}
-
 function IconPencil() {
   return (
     <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
     </svg>
-  );
-}
-
-interface CopyButtonProps {
-  text: string;
-  className?: string;
-  label?: string;
-}
-
-function CopyButton({ text, className = '', label = 'Copy' }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, []);
-
-  const handleClick = useCallback(async () => {
-    try {
-      await copyToClipboard(text);
-      setCopied(true);
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-      timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_RESET_SHORT_MS);
-    } catch {
-      // ignore - copyToClipboard handles fallback
-    }
-  }, [text]);
-
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className={`inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/70 px-2 py-0.5 text-[11px] font-medium text-slate-300 transition-colors hover:bg-slate-800 ${className}`}
-      aria-label={copied ? 'Copied' : label}
-      title={copied ? 'Copied!' : label}
-    >
-      {copied ? <IconCheck /> : <IconCopy />}
-      <span>{copied ? 'Copied' : label}</span>
-    </button>
   );
 }
 

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -12,6 +12,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { Loader2 } from 'lucide-react';
+import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 
 /**
  * Dynamic import of MermaidDiagram with SSR disabled
@@ -130,10 +131,14 @@ export function MermaidCodeBlock({
     return <MermaidDiagram code={code} />;
   }
 
-  // Non-mermaid code blocks are rendered as regular code elements
+  // Non-mermaid code blocks are rendered as regular code elements, wrapped with
+  // a copy button (Issue #981). The wrapper is a <span> so it stays valid
+  // phrasing content inside the parent <pre>.
   return (
-    <code className={className}>
-      {children}
-    </code>
+    <CodeBlockWithCopy as="span">
+      <code className={className}>
+        {children}
+      </code>
+    </CodeBlockWithCopy>
   );
 }

--- a/tests/unit/components/MermaidCodeBlock.test.tsx
+++ b/tests/unit/components/MermaidCodeBlock.test.tsx
@@ -10,8 +10,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MermaidCodeBlock } from '@/components/worktree/MermaidCodeBlock';
+
+// Hoisted clipboard mock for the copy button (Issue #981)
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
 
 // Mock MermaidDiagram component
 vi.mock('@/components/worktree/MermaidDiagram', () => ({
@@ -192,6 +201,61 @@ describe('MermaidCodeBlock', () => {
 
       // Should still render (empty diagram will show error)
       expect(screen.getByTestId('mermaid-diagram-mock')).toBeInTheDocument();
+    });
+  });
+
+  describe('Copy button (Issue #981)', () => {
+    beforeEach(() => {
+      mockCopyToClipboard.mockResolvedValue(undefined);
+    });
+
+    it('renders a copy button for non-mermaid block code', () => {
+      render(
+        <MermaidCodeBlock className="language-javascript">
+          const x = 1;
+        </MermaidCodeBlock>
+      );
+
+      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+      // The underlying code element is preserved
+      const codeElement = screen.getByText('const x = 1;');
+      expect(codeElement.tagName).toBe('CODE');
+      expect(codeElement).toHaveClass('language-javascript');
+    });
+
+    it('copies the code text when the copy button is clicked', async () => {
+      render(
+        <MermaidCodeBlock className="language-javascript">
+          const x = 1;
+        </MermaidCodeBlock>
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+      });
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
+    });
+
+    it('does not render a copy button for mermaid diagrams', () => {
+      render(
+        <MermaidCodeBlock className="language-mermaid">
+          graph TD
+        </MermaidCodeBlock>
+      );
+
+      expect(screen.getByTestId('mermaid-diagram-mock')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    });
+
+    it('does not render a copy button for inline code', () => {
+      render(
+        <MermaidCodeBlock inline={true} className="language-javascript">
+          inline code
+        </MermaidCodeBlock>
+      );
+
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/components/common/CodeBlockWithCopy.test.tsx
+++ b/tests/unit/components/common/CodeBlockWithCopy.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * CodeBlockWithCopy Component Tests (Issue #981)
+ *
+ * Covers:
+ * - extractCodeText: plain text extraction from React node trees (the shape
+ *   rehype-highlight produces) and primitive/edge inputs
+ * - Wrapper rendering: relative group container, span vs div tag
+ * - Copy button presence + copying the extracted plain text
+ * - No button rendered for empty / whitespace-only code blocks
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CodeBlockWithCopy, extractCodeText } from '@/components/common/CodeBlockWithCopy';
+
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
+
+describe('extractCodeText', () => {
+  it('returns a plain string unchanged', () => {
+    expect(extractCodeText('const x = 1;')).toBe('const x = 1;');
+  });
+
+  it('stringifies numbers', () => {
+    expect(extractCodeText(42)).toBe('42');
+  });
+
+  it('joins arrays of strings', () => {
+    expect(extractCodeText(['graph TD', '\n', 'A-->B'])).toBe('graph TD\nA-->B');
+  });
+
+  it('returns empty string for null / undefined / boolean', () => {
+    expect(extractCodeText(null)).toBe('');
+    expect(extractCodeText(undefined)).toBe('');
+    expect(extractCodeText(true)).toBe('');
+    expect(extractCodeText(false)).toBe('');
+  });
+
+  it('walks a nested React element tree (highlight.js shape) and concatenates text', () => {
+    const tree = (
+      <code className="hljs language-js">
+        <span className="hljs-keyword">const</span>
+        <span> x = </span>
+        <span className="hljs-number">1</span>
+        <span>;</span>
+      </code>
+    );
+    expect(extractCodeText(tree)).toBe('const x = 1;');
+  });
+});
+
+describe('CodeBlockWithCopy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders its children', () => {
+    render(
+      <CodeBlockWithCopy>
+        <pre>
+          <code>echo hi</code>
+        </pre>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.getByText('echo hi')).toBeInTheDocument();
+  });
+
+  it('renders a copy button for non-empty code blocks', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('wraps content in a relative group container', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    const wrapper = screen.getByTestId('code-block-with-copy');
+    expect(wrapper).toHaveClass('relative', 'group');
+  });
+
+  it('renders a div wrapper by default', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    const wrapper = screen.getByTestId('code-block-with-copy');
+    expect(wrapper.tagName).toBe('DIV');
+  });
+
+  it('renders a span wrapper (block) when as="span"', () => {
+    render(
+      <CodeBlockWithCopy as="span">
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    const wrapper = screen.getByTestId('code-block-with-copy');
+    expect(wrapper.tagName).toBe('SPAN');
+    expect(wrapper).toHaveClass('block');
+  });
+
+  it('copies the extracted plain text (not highlight markup) when clicked', async () => {
+    render(
+      <CodeBlockWithCopy>
+        <code className="hljs">
+          <span className="hljs-keyword">const</span>
+          <span> x = 1;</span>
+        </code>
+      </CodeBlockWithCopy>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    });
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
+  });
+
+  it('does not render a copy button for an empty code block', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>{''}</code>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-block-with-copy')).not.toBeInTheDocument();
+  });
+
+  it('does not render a copy button for a whitespace-only code block', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>{'   \n  '}</code>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/common/CopyButton.test.tsx
+++ b/tests/unit/components/common/CopyButton.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * CopyButton Component Tests (Issue #981)
+ *
+ * Covers the shared copy button extracted from AssistantMessageList:
+ * - Default / custom label rendering
+ * - Custom className passthrough (used for absolute positioning over code)
+ * - Clipboard copy on click
+ * - Copy -> Copied -> Copy feedback transition (1.5s reset)
+ * - Timer cleanup safety on unmount
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CopyButton } from '@/components/common/CopyButton';
+
+// Hoisted mock for clipboard-utils (vi.mock factory is hoisted above imports)
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
+
+// Must match COPY_FEEDBACK_RESET_SHORT_MS in src/config/ui-feedback-config.ts
+const COPY_FEEDBACK_RESET_SHORT_MS = 1500;
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders with the default "Copy" label', () => {
+    render(<CopyButton text="hello" />);
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('renders a custom label', () => {
+    render(<CopyButton text="hello" label="Copy code" />);
+    expect(screen.getByRole('button', { name: 'Copy code' })).toBeInTheDocument();
+  });
+
+  it('appends a custom className to the button', () => {
+    render(<CopyButton text="hello" className="absolute right-2 top-2" />);
+    const button = screen.getByRole('button', { name: 'Copy' });
+    expect(button).toHaveClass('absolute', 'right-2', 'top-2');
+  });
+
+  it('copies the provided text to the clipboard on click', async () => {
+    render(<CopyButton text="const x = 1;" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
+  });
+
+  it('shows "Copied" feedback after a successful copy', async () => {
+    render(<CopyButton text="hello" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+  });
+
+  describe('feedback reset timer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('reverts to "Copy" after the feedback duration', async () => {
+      render(<CopyButton text="hello" />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+      expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(COPY_FEEDBACK_RESET_SHORT_MS);
+      });
+      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Copied' })).not.toBeInTheDocument();
+    });
+
+    it('does not throw when unmounted during feedback (timer cleanup)', async () => {
+      const { unmount } = render(<CopyButton text="hello" />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      expect(() => unmount()).not.toThrow();
+      // The cleared timer must not fire a state update after unmount.
+      expect(() => {
+        vi.advanceTimersByTime(COPY_FEEDBACK_RESET_SHORT_MS);
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Closes #981

markdown ファイルプレビューのコードブロックを **PC版・スマホ版の両方でコピー可能** にした。各コードブロックの右上にコピーボタンを配置し、ワンクリック/タップでブロック内のプレーンテキストをクリップボードへコピーできる。

## 変更内容
- `src/components/common/CopyButton.tsx`（新規）: `AssistantMessageList` 内に内包されていたコピーボタンを共通コンポーネントへ抽出（既存挙動は不変、参照を差し替え）。
- `src/components/common/CodeBlockWithCopy.tsx`（新規）: 非mermaid のコードブロックを `relative group` でラップし、右上にコピーボタンを重ねるラッパー。コピー処理は既存 `clipboard-utils.ts` の `copyToClipboard()` を流用。
- `src/components/worktree/MermaidCodeBlock.tsx`: 非mermaid ブロックを `CodeBlockWithCopy` で描画（`MarkdownPreview.tsx` の code レンダラー経由でファイルプレビューに反映）。mermaid ダイアグラム・inline code は不変。
- `src/app/worktrees/[id]/files/[...path]/page.tsx`: ファイル全画面プレビューの code/pre レンダラーにコピーボタンを追加。
- スマホ（タッチ端末）はホバー不可のためボタンを操作可能に配慮。PCはホバー表示。

## 変更ファイル
- `src/components/common/CopyButton.tsx`（新規）
- `src/components/common/CodeBlockWithCopy.tsx`（新規）
- `src/components/worktree/MermaidCodeBlock.tsx`
- `src/components/home/AssistantMessageList.tsx`
- `src/app/worktrees/[id]/files/[...path]/page.tsx`
- テスト3本: `tests/unit/components/common/CopyButton.test.tsx`, `tests/unit/components/common/CodeBlockWithCopy.test.tsx`, `tests/unit/components/MermaidCodeBlock.test.tsx`

## 品質ゲート（全パス）
- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm run test:unit（450 files / 8067 tests pass）
- ✅ npm run build
