### PR TITLE
fix(markdown): プレビューでインラインコードにコピーボタンが表示される（#981リグレッション）

### DIFF
--- a/src/app/worktrees/[id]/files/[...path]/page.tsx
+++ b/src/app/worktrees/[id]/files/[...path]/page.tsx
@@ -153,9 +153,14 @@ export default function FileViewerPage() {
                     remarkPlugins={[remarkGfm]}
                     rehypePlugins={[rehypeHighlight]}
                     components={{
-                      // Custom components for better rendering
-                      code: ({ inline, className, children, ...props }: { inline?: boolean; className?: string; children?: React.ReactNode }) => {
-                        if (inline) {
+                      // Custom components for better rendering.
+                      // Issue #983: react-markdown v10 dropped the `inline`
+                      // prop. Inline code carries no `language-*` class; fenced
+                      // block code does (and gets a copy button via the `pre`
+                      // renderer below). Detect inline via the class instead.
+                      code: ({ className, children, ...props }: { className?: string; children?: React.ReactNode }) => {
+                        const isInline = !className || !className.includes('language-');
+                        if (isInline) {
                           return (
                             <code className="bg-gray-100 text-gray-800 px-1.5 py-0.5 rounded text-sm font-mono" {...props}>
                               {children}

--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -29,6 +29,7 @@ import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import { X, AlertTriangle, FileText, Eye } from 'lucide-react';
 import { MermaidCodeBlock } from '@/components/worktree/MermaidCodeBlock';
+import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 import { classifyLink, resolveRelativePath, sanitizeHref, REHYPE_SANITIZE_SCHEMA } from '@/lib/link-utils';
 import { encodePathForUrl } from '@/lib/url-path-encoder';
 import type { Components } from 'react-markdown';
@@ -71,6 +72,20 @@ export interface LargeFileWarningProps {
 // ============================================================================
 // MarkdownPreview Component
 // ============================================================================
+
+/**
+ * Detects whether a `<pre>`'s child is a mermaid fenced block. react-markdown
+ * passes the (unrendered) `<code>` element as the pre's only child; mermaid
+ * blocks carry a `language-mermaid` class. Such blocks render a diagram rather
+ * than copyable source, so the `pre` renderer must not wrap them with a copy
+ * button. (Issue #983)
+ */
+function isMermaidPreChild(children: React.ReactNode): boolean {
+  const child = React.Children.toArray(children)[0];
+  if (!React.isValidElement(child)) return false;
+  const className = (child.props as { className?: string }).className;
+  return typeof className === 'string' && className.split(' ').includes('language-mermaid');
+}
 
 /**
  * Fetches an image from the worktree file API and displays it as a data URI.
@@ -158,6 +173,22 @@ export const MarkdownPreview = memo(function MarkdownPreview({
   const markdownComponents: Partial<Components> = useMemo(
     () => ({
       code: MermaidCodeBlock, // [Issue #100] mermaid diagram support
+      // [Issue #983] Attach the copy button at the block level. The `pre`
+      // renderer fires only for fenced/indented code (never inline code), so
+      // inline code is never decorated or forced onto its own line. The wrapper
+      // sits outside the scrollable <pre> so the button stays pinned. Mermaid
+      // blocks render a diagram, not copyable source, so they keep a plain
+      // <pre> (no button) exactly as the default renderer produced.
+      pre: ({ children }) => {
+        if (isMermaidPreChild(children)) {
+          return <pre>{children}</pre>;
+        }
+        return (
+          <CodeBlockWithCopy>
+            <pre className="overflow-x-auto">{children}</pre>
+          </CodeBlockWithCopy>
+        );
+      },
       // Resolve relative image paths via worktree file API (returns Base64 data URI in JSON)
       img: ({ src, alt, width, height, ...props }) => {
         const w = (width ?? props.node?.properties?.width) as string | undefined;

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -12,7 +12,6 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { Loader2 } from 'lucide-react';
-import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 
 /**
  * Dynamic import of MermaidDiagram with SSR disabled
@@ -49,8 +48,6 @@ export interface MermaidCodeBlockProps {
   children?: React.ReactNode | string | string[];
   /** ReactMarkdown passes AST node */
   node?: unknown;
-  /** Whether this is an inline code block */
-  inline?: boolean;
 }
 
 /**
@@ -114,31 +111,17 @@ function isMermaidLanguage(className?: string): boolean {
 export function MermaidCodeBlock({
   className,
   children,
-  inline,
 }: MermaidCodeBlockProps): JSX.Element {
-  // Inline code blocks are always rendered as regular code
-  if (inline) {
-    return (
-      <code className={className}>
-        {children}
-      </code>
-    );
-  }
-
-  // Check if this is a mermaid code block
+  // Fenced mermaid blocks render as a diagram.
   if (isMermaidLanguage(className)) {
     const code = extractCodeString(children);
     return <MermaidDiagram code={code} />;
   }
 
-  // Non-mermaid code blocks are rendered as regular code elements, wrapped with
-  // a copy button (Issue #981). The wrapper is a <span> so it stays valid
-  // phrasing content inside the parent <pre>.
-  return (
-    <CodeBlockWithCopy as="span">
-      <code className={className}>
-        {children}
-      </code>
-    </CodeBlockWithCopy>
-  );
+  // Everything else — inline code and non-mermaid block code — renders as a
+  // plain <code>. react-markdown v10 no longer passes an `inline` prop, so the
+  // copy button is attached by MarkdownPreview's `pre` renderer (block code
+  // only); inline code has no <pre> ancestor and is therefore never decorated,
+  // fixing the inline-code line-break regression. (Issue #983)
+  return <code className={className}>{children}</code>;
 }

--- a/tests/unit/components/MarkdownPreview.codeCopy.test.tsx
+++ b/tests/unit/components/MarkdownPreview.codeCopy.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for Issue #983 — markdown preview copy button placement.
+ *
+ * react-markdown v10 dropped the `code` component's `inline` prop, which made
+ * every inline `code` span flow through the copy-button wrapper — adding a
+ * button and forcing the inline code onto its own line. The copy button is now
+ * attached by the `pre` renderer (block code only). These tests exercise the
+ * real ReactMarkdown render path (MermaidCodeBlock + CodeBlockWithCopy are NOT
+ * mocked) to lock in: inline code = no button / no line break, fenced block =
+ * button, mermaid diagram = unchanged (no button).
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { MarkdownPreview } from '@/components/worktree/MarkdownPreview';
+
+// Hoisted clipboard mock for the copy button.
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
+
+// Render mermaid diagrams synchronously without the real mermaid runtime.
+vi.mock('@/components/worktree/MermaidDiagram', () => ({
+  MermaidDiagram: ({ code }: { code: string }) => (
+    <div data-testid="mermaid-diagram">{code}</div>
+  ),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () => {
+    const DynamicMermaid = ({ code }: { code: string }) => (
+      <div data-testid="mermaid-diagram">{code}</div>
+    );
+    return DynamicMermaid;
+  },
+}));
+
+describe('MarkdownPreview copy button placement (Issue #983)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  it('does not attach a copy button to inline code', () => {
+    render(<MarkdownPreview content={'Here is `inline code` in a sentence.'} />);
+
+    const codeEl = screen.getByText('inline code');
+    expect(codeEl.tagName).toBe('CODE');
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-block-with-copy')).not.toBeInTheDocument();
+  });
+
+  it('does not wrap inline code in the block-level copy wrapper (no line break)', () => {
+    render(<MarkdownPreview content={'Text with `code` here.'} />);
+
+    const codeEl = screen.getByText('code');
+    // The inline <code> must stay inside its paragraph, not the copy-button
+    // block wrapper that forced inline code onto its own line.
+    expect(codeEl.closest('[data-testid="code-block-with-copy"]')).toBeNull();
+  });
+
+  it('attaches a working copy button to a fenced code block with a language', async () => {
+    render(<MarkdownPreview content={'```js\nconst x = 1;\n```'} />);
+
+    const button = screen.getByRole('button', { name: 'Copy' });
+    expect(button).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining('const x = 1;'),
+    );
+  });
+
+  it('attaches a copy button to a fenced code block without a language', () => {
+    render(<MarkdownPreview content={'```\nplain block\n```'} />);
+
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('leaves mermaid diagrams unchanged (no copy button)', () => {
+    render(<MarkdownPreview content={'```mermaid\ngraph TD\nA-->B\n```'} />);
+
+    expect(screen.getByTestId('mermaid-diagram')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-block-with-copy')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/MermaidCodeBlock.test.tsx
+++ b/tests/unit/components/MermaidCodeBlock.test.tsx
@@ -1,26 +1,18 @@
 /**
  * MermaidCodeBlock Component Tests
  *
- * Tests for the code block wrapper component including:
- * - Mermaid language detection (className='language-mermaid')
- * - Non-mermaid code block passthrough
- * - Inline code block passthrough
+ * MermaidCodeBlock renders a mermaid diagram for `language-mermaid` fenced
+ * blocks and a plain <code> element for everything else (inline code and
+ * non-mermaid block code). Since Issue #983 the copy button for block code is
+ * attached by MarkdownPreview's `pre` renderer — not here — so this component
+ * never renders a copy button.
  *
  * @vitest-environment jsdom
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MermaidCodeBlock } from '@/components/worktree/MermaidCodeBlock';
-
-// Hoisted clipboard mock for the copy button (Issue #981)
-const { mockCopyToClipboard } = vi.hoisted(() => ({
-  mockCopyToClipboard: vi.fn(),
-}));
-
-vi.mock('@/lib/clipboard-utils', () => ({
-  copyToClipboard: mockCopyToClipboard,
-}));
 
 // Mock MermaidDiagram component
 vi.mock('@/components/worktree/MermaidDiagram', () => ({
@@ -31,11 +23,7 @@ vi.mock('@/components/worktree/MermaidDiagram', () => ({
 
 // Mock next/dynamic to render the component directly
 vi.mock('next/dynamic', () => ({
-  default: (
-    loader: () => Promise<{ MermaidDiagram: React.ComponentType<{ code: string }> }>,
-    _options: unknown
-  ) => {
-    // Return a component that renders the loading state briefly then the actual component
+  default: () => {
     const DynamicComponent = (props: { code: string }) => {
       return <div data-testid="mermaid-diagram-mock">{props.code}</div>;
     };
@@ -99,7 +87,7 @@ describe('MermaidCodeBlock', () => {
       expect(codeElement).toHaveClass('language-javascript');
     });
 
-    it('should render regular code element when no className', () => {
+    it('should render regular code element when no className (inline code)', () => {
       const plainCode = 'plain text';
 
       render(
@@ -124,36 +112,6 @@ describe('MermaidCodeBlock', () => {
       const codeElement = screen.getByText(pythonCode);
       expect(codeElement.tagName).toBe('CODE');
       expect(codeElement).toHaveClass('language-python');
-    });
-  });
-
-  describe('Inline Code Block Passthrough', () => {
-    it('should render inline code as regular code element', () => {
-      const inlineCode = 'inline code';
-
-      render(
-        <MermaidCodeBlock inline={true}>
-          {inlineCode}
-        </MermaidCodeBlock>
-      );
-
-      const codeElement = screen.getByText(inlineCode);
-      expect(codeElement.tagName).toBe('CODE');
-    });
-
-    it('should not render MermaidDiagram for inline code even with mermaid className', () => {
-      const inlineCode = 'graph TD';
-
-      render(
-        <MermaidCodeBlock inline={true} className="language-mermaid">
-          {inlineCode}
-        </MermaidCodeBlock>
-      );
-
-      // Should render as regular code, not MermaidDiagram
-      const codeElement = screen.getByText(inlineCode);
-      expect(codeElement.tagName).toBe('CODE');
-      expect(screen.queryByTestId('mermaid-diagram-mock')).not.toBeInTheDocument();
     });
   });
 
@@ -204,37 +162,20 @@ describe('MermaidCodeBlock', () => {
     });
   });
 
-  describe('Copy button (Issue #981)', () => {
-    beforeEach(() => {
-      mockCopyToClipboard.mockResolvedValue(undefined);
-    });
-
-    it('renders a copy button for non-mermaid block code', () => {
+  describe('No copy button here (Issue #983)', () => {
+    it('does not render a copy button for non-mermaid block code', () => {
       render(
         <MermaidCodeBlock className="language-javascript">
           const x = 1;
         </MermaidCodeBlock>
       );
 
-      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
-      // The underlying code element is preserved
+      // The copy button is attached by MarkdownPreview's `pre` renderer, not
+      // here, so this component renders only the plain <code> element.
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
       const codeElement = screen.getByText('const x = 1;');
       expect(codeElement.tagName).toBe('CODE');
       expect(codeElement).toHaveClass('language-javascript');
-    });
-
-    it('copies the code text when the copy button is clicked', async () => {
-      render(
-        <MermaidCodeBlock className="language-javascript">
-          const x = 1;
-        </MermaidCodeBlock>
-      );
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
-      });
-
-      expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
     });
 
     it('does not render a copy button for mermaid diagrams', () => {
@@ -245,16 +186,6 @@ describe('MermaidCodeBlock', () => {
       );
 
       expect(screen.getByTestId('mermaid-diagram-mock')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
-    });
-
-    it('does not render a copy button for inline code', () => {
-      render(
-        <MermaidCodeBlock inline={true} className="language-javascript">
-          inline code
-        </MermaidCodeBlock>
-      );
-
       expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## 概要

markdown プレビューでインラインコードにコピーボタンが表示される／改行されるリグレッション（#981）を修正します。

Closes #983

## 根本原因

react-markdown v10 は `code` コンポーネントに `inline` prop を渡さない（v9 で廃止）。`MermaidCodeBlock` がインライン判定に `inline` を使っていたため常に `undefined` となり、全インラインコードが `CodeBlockWithCopy` に流れてコピーボタンが付与され、`as="span"` の `block` クラスでブロック化（改行）していた。

## 修正内容

`inline` prop に依存せず、コピーボタンを **`pre` レンダラー**に付与（= ファイルビューアページと同じ正しいパターン）。`pre` はブロックコードにのみ出力されるため、インライン誤検知が原理的に起きない。

- `src/components/worktree/MarkdownPreview.tsx`: `pre` レンダラーを追加し、ブロックコードを `CodeBlockWithCopy` でラップ。mermaid 由来の `pre`（`isMermaidPreChild`）はボタンなしの plain `<pre>` を維持。
- `src/components/worktree/MermaidCodeBlock.tsx`: `inline` 依存と `CodeBlockWithCopy` ラップを撤去。mermaid は `<MermaidDiagram>`、それ以外（インライン/非mermaidブロック）はプレーン `<code>` を返すのみ。
- `src/app/worktrees/[id]/files/[...path]/page.tsx`: 壊れた `inline` 判定を整理。
- テスト2本（`MarkdownPreview.codeCopy.test.tsx` 新規 / `MermaidCodeBlock.test.tsx` 更新）。

## 受け入れ条件

- [x] プレビューでインラインコードにコピーボタンが表示されない／改行されない
- [x] フェンスドコードブロックにはコピーボタンが表示される（言語指定有無を問わず）
- [x] mermaid ダイアグラム表示は不変
- [x] 「インライン=ボタンなし／ブロック=ボタンあり」回帰テスト追加
- [x] 4ゲート（lint / tsc / test:unit / build）全パス（451 files / 8068 tests）
