### PR TITLE
chore: v0.7.4以降のUI改善・不具合修正を main へ反映

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -36,7 +36,17 @@
     "moveConfirm": "Move here",
     "moveSuccess": "Moved successfully",
     "timeAgo": "{time} ago",
-    "rootDirectory": "Root"
+    "rootDirectory": "Root",
+    "metadata": {
+      "size": "Size",
+      "created": "Created",
+      "modified": "Modified",
+      "settingsLabel": "Metadata display settings",
+      "settingsTitle": "Show inline",
+      "showSize": "File size",
+      "showCreated": "Created date",
+      "showModified": "Modified date"
+    }
   },
   "update": {
     "available": "A new version is available",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -36,7 +36,17 @@
     "moveConfirm": "ここに移動",
     "moveSuccess": "移動しました",
     "timeAgo": "{time}前",
-    "rootDirectory": "ルート"
+    "rootDirectory": "ルート",
+    "metadata": {
+      "size": "サイズ",
+      "created": "作成",
+      "modified": "更新",
+      "settingsLabel": "メタデータ表示設定",
+      "settingsTitle": "インライン表示",
+      "showSize": "ファイルサイズ",
+      "showCreated": "作成日時",
+      "showModified": "更新日時"
+    }
   },
   "update": {
     "available": "新しいバージョンが利用可能です",

--- a/src/app/worktrees/[id]/files/[...path]/page.tsx
+++ b/src/app/worktrees/[id]/files/[...path]/page.tsx
@@ -153,9 +153,14 @@ export default function FileViewerPage() {
                     remarkPlugins={[remarkGfm]}
                     rehypePlugins={[rehypeHighlight]}
                     components={{
-                      // Custom components for better rendering
-                      code: ({ inline, className, children, ...props }: { inline?: boolean; className?: string; children?: React.ReactNode }) => {
-                        if (inline) {
+                      // Custom components for better rendering.
+                      // Issue #983: react-markdown v10 dropped the `inline`
+                      // prop. Inline code carries no `language-*` class; fenced
+                      // block code does (and gets a copy button via the `pre`
+                      // renderer below). Detect inline via the class instead.
+                      code: ({ className, children, ...props }: { className?: string; children?: React.ReactNode }) => {
+                        const isInline = !className || !className.includes('language-');
+                        if (isInline) {
                           return (
                             <code className="bg-gray-100 text-gray-800 px-1.5 py-0.5 rounded text-sm font-mono" {...props}>
                               {children}

--- a/src/app/worktrees/[id]/files/[...path]/page.tsx
+++ b/src/app/worktrees/[id]/files/[...path]/page.tsx
@@ -15,6 +15,7 @@ import rehypeHighlight from 'rehype-highlight';
 import { FileContent } from '@/types/models';
 import { ImageViewer } from '@/components/worktree/ImageViewer';
 import { VideoViewer } from '@/components/worktree/VideoViewer';
+import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 
 export default function FileViewerPage() {
   const router = useRouter();
@@ -167,10 +168,15 @@ export default function FileViewerPage() {
                           </code>
                         );
                       },
+                      // Issue #981: wrap code blocks with a copy button. The
+                      // wrapper sits outside the scrollable <pre> so the button
+                      // stays pinned to the top-right while code scrolls.
                       pre: ({ children }: { children?: React.ReactNode }) => (
-                        <pre className="overflow-x-auto">
-                          {children}
-                        </pre>
+                        <CodeBlockWithCopy>
+                          <pre className="overflow-x-auto">
+                            {children}
+                          </pre>
+                        </CodeBlockWithCopy>
                       ),
                       table: ({ children }: { children?: React.ReactNode }) => (
                         <div className="overflow-x-auto">

--- a/src/components/common/CodeBlockWithCopy.tsx
+++ b/src/components/common/CodeBlockWithCopy.tsx
@@ -1,0 +1,98 @@
+/**
+ * CodeBlockWithCopy Component
+ *
+ * Issue #981: Wraps a rendered markdown code block (a `<code>` or `<pre>`
+ * element) in a `relative group` container and overlays a {@link CopyButton}
+ * in the top-right corner.
+ *
+ * Used by the markdown *file preview* render paths only:
+ * - `MermaidCodeBlock` (the `code` renderer used by MarkdownPreview) wraps the
+ *   non-mermaid `<code>` element, passing `as="span"` so the wrapper is valid
+ *   phrasing content inside the parent `<pre>`.
+ * - The file viewer page wraps the `<pre>` element from its `pre` renderer
+ *   (default `as="div"`, sitting outside the scrollable `<pre>` so the button
+ *   stays pinned while code scrolls horizontally).
+ *
+ * The button is hidden by default on pointer/desktop widths and revealed on
+ * hover/focus; on small (touch) widths it is always visible since hover is
+ * unavailable. The copy target is the plain text content of the code block
+ * (highlight.js decoration markup stripped), extracted via
+ * {@link extractCodeText}.
+ *
+ * @module components/common/CodeBlockWithCopy
+ */
+
+'use client';
+
+import React from 'react';
+import { CopyButton } from './CopyButton';
+
+/**
+ * Recursively extract the plain text content from a React node tree.
+ *
+ * rehype-highlight rewrites code children into nested `<span>` elements, so a
+ * naive `String(children)` yields `[object Object]`. This walks the tree and
+ * concatenates string/number leaves, mirroring DOM `textContent`.
+ */
+export function extractCodeText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractCodeText).join('');
+  }
+  if (React.isValidElement(node)) {
+    return extractCodeText((node.props as { children?: React.ReactNode }).children);
+  }
+  return '';
+}
+
+export interface CodeBlockWithCopyProps {
+  /** Rendered code block content (a `<code>` or `<pre>` element) */
+  children: React.ReactNode;
+  /**
+   * Wrapper element tag. Use `'span'` when rendered inside a `<pre>` (phrasing
+   * context); `'div'` otherwise. Defaults to `'div'`.
+   */
+  as?: 'div' | 'span';
+  /** Extra classes for the wrapper */
+  className?: string;
+}
+
+/**
+ * Wraps a code block and overlays a copy button. Renders the children
+ * unchanged (no button) when the block has no copyable text.
+ */
+export function CodeBlockWithCopy({
+  children,
+  as = 'div',
+  className = '',
+}: CodeBlockWithCopyProps): JSX.Element {
+  const Wrapper = as;
+  const text = extractCodeText(children);
+
+  // Nothing meaningful to copy: render the block as-is without a button.
+  if (!text || text.trim().length === 0) {
+    return <Wrapper className={className || undefined}>{children}</Wrapper>;
+  }
+
+  const wrapperClass = `relative group ${as === 'span' ? 'block ' : ''}${className}`.trim();
+
+  return (
+    <Wrapper className={wrapperClass} data-testid="code-block-with-copy">
+      {children}
+      <CopyButton
+        text={text}
+        className="absolute right-2 top-2 z-10 opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 focus:opacity-100"
+      />
+    </Wrapper>
+  );
+}
+
+export default CodeBlockWithCopy;

--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,0 +1,88 @@
+/**
+ * CopyButton Component
+ *
+ * Issue #981: Extracted from AssistantMessageList for reuse across the app
+ * (assistant chat message bubbles + markdown file preview code blocks).
+ *
+ * Behavior is preserved verbatim from the original AssistantMessageList
+ * implementation: copies `text` via `copyToClipboard`, shows a Check icon for
+ * `COPY_FEEDBACK_RESET_SHORT_MS` (1.5s), then reverts to the Copy icon. The
+ * timer is cleared on unmount and de-duplicated on rapid clicks.
+ *
+ * @module components/common/CopyButton
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { copyToClipboard } from '@/lib/clipboard-utils';
+import { COPY_FEEDBACK_RESET_SHORT_MS } from '@/config/ui-feedback-config';
+
+function IconCopy() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+export interface CopyButtonProps {
+  /** Text copied to the clipboard when the button is pressed */
+  text: string;
+  /** Extra classes appended to the button (e.g. absolute positioning) */
+  className?: string;
+  /** Accessible label / visible caption shown next to the icon */
+  label?: string;
+}
+
+/**
+ * Compact copy-to-clipboard button with transient "Copied" feedback.
+ */
+export function CopyButton({ text, className = '', label = 'Copy' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    try {
+      await copyToClipboard(text);
+      setCopied(true);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_RESET_SHORT_MS);
+    } catch {
+      // ignore - copyToClipboard handles fallback
+    }
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/70 px-2 py-0.5 text-[11px] font-medium text-slate-300 transition-colors hover:bg-slate-800 ${className}`}
+      aria-label={copied ? 'Copied' : label}
+      title={copied ? 'Copied!' : label}
+    >
+      {copied ? <IconCheck /> : <IconCopy />}
+      <span>{copied ? 'Copied' : label}</span>
+    </button>
+  );
+}
+
+export default CopyButton;

--- a/src/components/common/TruncationTooltip.tsx
+++ b/src/components/common/TruncationTooltip.tsx
@@ -1,16 +1,23 @@
 /**
- * TruncationTooltip Component (Issue #859)
+ * TruncationTooltip Component (Issue #859, #975)
  *
  * A hover-delayed tooltip for text that is visually truncated (CSS
  * `text-overflow: ellipsis`). It replaces the native `title` attribute on
  * file names in the file tree, whose show-delay is browser-controlled and
  * sluggish (~0.5–1s in Chrome) and cannot be tuned from JS/CSS.
  *
+ * [Issue #975] An optional `metadata` prop lets a caller surface extra
+ * formatted info (e.g. a file's size / created / modified lines) inside the
+ * SAME bubble as the name, so a single styled tooltip replaces the previous
+ * two independent ones (native `title` metadata + this name tooltip).
+ *
  * Design notes:
  *   - The trigger is the truncating element itself (the caller passes the
  *     same `truncate`/`overflow-hidden` className it used before), so we can
  *     measure `scrollWidth > clientWidth` to decide whether the text is
- *     actually clipped. Short names that fit never show a tooltip.
+ *     actually clipped. Short names that fit never show a tooltip — unless
+ *     `metadata` is supplied, in which case the bubble always appears on hover
+ *     so the metadata is reachable even for short, non-clipped names.
  *   - The tooltip is rendered through a React portal to `document.body` with
  *     `position: fixed`, mirroring `BranchListItem`'s approach, so it is never
  *     clipped by the file tree's `overflow-y: auto` scroll container.
@@ -55,6 +62,14 @@ export interface TruncationTooltipProps {
    * `content` when omitted.
    */
   children?: React.ReactNode;
+  /**
+   * [Issue #975] Optional pre-formatted metadata (newline-separated lines)
+   * rendered below the name inside the same bubble. When present, the tooltip
+   * shows on hover even if the name is not truncated, so callers can attach
+   * always-available info (e.g. file size / created / modified). Omit it for a
+   * name-only tooltip (the default truncation behavior is unchanged).
+   */
+  metadata?: string;
 }
 
 /**
@@ -73,6 +88,7 @@ export function TruncationTooltip({
   delay = TRUNCATION_TOOLTIP_DELAY_MS,
   className,
   children,
+  metadata,
 }: TruncationTooltipProps): React.ReactElement {
   const triggerRef = useRef<HTMLSpanElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -91,8 +107,11 @@ export function TruncationTooltip({
   const handleMouseEnter = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
-    // Only show a tooltip when the name is actually clipped.
-    if (el.scrollWidth <= el.clientWidth) return;
+    // Show when the name is actually clipped OR when there is metadata to
+    // surface (file rows attach metadata so their info is reachable on hover
+    // even when the name itself fits). [Issue #975]
+    const isTruncated = el.scrollWidth > el.clientWidth;
+    if (!isTruncated && !metadata) return;
 
     clearTimer();
     timerRef.current = setTimeout(() => {
@@ -109,7 +128,7 @@ export function TruncationTooltip({
       setVisible(true);
       timerRef.current = null;
     }, delay);
-  }, [clearTimer, delay]);
+  }, [clearTimer, delay, metadata]);
 
   const handleMouseLeave = useCallback(() => {
     clearTimer();
@@ -133,10 +152,15 @@ export function TruncationTooltip({
           <span
             role="tooltip"
             aria-hidden="true"
-            className="fixed z-[9999] max-w-md px-2 py-1 text-xs font-medium rounded bg-gray-900 text-gray-100 shadow-lg pointer-events-none break-all"
+            className="fixed z-[9999] max-w-md px-2 py-1 text-xs font-medium rounded bg-gray-900 text-gray-100 shadow-lg pointer-events-none"
             style={{ top: coords.top, left: coords.left }}
           >
-            {content}
+            <span className="block break-all">{content}</span>
+            {metadata && (
+              <span className="mt-0.5 block whitespace-pre-line font-normal text-gray-300">
+                {metadata}
+              </span>
+            )}
           </span>,
           document.body
         )}

--- a/src/components/home/AssistantMessageList.tsx
+++ b/src/components/home/AssistantMessageList.tsx
@@ -7,8 +7,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import type { AssistantMessage } from '@/lib/db/assistant-conversation-db';
-import { copyToClipboard } from '@/lib/clipboard-utils';
-import { COPY_FEEDBACK_RESET_SHORT_MS } from '@/config/ui-feedback-config';
+import { CopyButton } from '@/components/common/CopyButton';
 
 interface AssistantMessageListProps {
   messages: AssistantMessage[];
@@ -23,72 +22,11 @@ function formatTimestamp(timestamp: Date): string {
   return timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-function IconCopy() {
-  return (
-    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-    </svg>
-  );
-}
-
-function IconCheck() {
-  return (
-    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-    </svg>
-  );
-}
-
 function IconPencil() {
   return (
     <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
     </svg>
-  );
-}
-
-interface CopyButtonProps {
-  text: string;
-  className?: string;
-  label?: string;
-}
-
-function CopyButton({ text, className = '', label = 'Copy' }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, []);
-
-  const handleClick = useCallback(async () => {
-    try {
-      await copyToClipboard(text);
-      setCopied(true);
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-      timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_RESET_SHORT_MS);
-    } catch {
-      // ignore - copyToClipboard handles fallback
-    }
-  }, [text]);
-
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className={`inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/70 px-2 py-0.5 text-[11px] font-medium text-slate-300 transition-colors hover:bg-slate-800 ${className}`}
-      aria-label={copied ? 'Copied' : label}
-      title={copied ? 'Copied!' : label}
-    >
-      {copied ? <IconCheck /> : <IconCopy />}
-      <span>{copied ? 'Copied' : label}</span>
-    </button>
   );
 }
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -435,9 +435,14 @@ export const Sidebar = memo(function Sidebar() {
         data-testid="sidebar-header"
         className="flex-shrink-0 px-4 py-4 border-b border-gray-700"
       >
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-white">Branches</h2>
-          <div className="flex items-center gap-1">
+        {/* Issue #976: wrap the heading + actions when the sidebar is narrow so
+            the button group drops to a new line instead of overflowing
+            horizontally into the adjacent ActivityBar. flex-wrap on both the row
+            and the actions group keeps everything within the sidebar width
+            without an overflow clip (which would crop the Sort dropdown). */}
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
+          <h2 className="min-w-0 truncate text-lg font-semibold text-white">Branches</h2>
+          <div className="flex flex-wrap items-center gap-1">
             <ViewModeToggle viewMode={viewMode} onToggle={setViewMode} />
             <SortSelector />
             <SyncButton refreshWorktrees={refreshWorktrees} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -36,6 +36,7 @@ import { useSidebarContext } from '@/contexts/SidebarContext';
 import { BranchListItem } from '@/components/sidebar/BranchListItem';
 import { SortSelector } from '@/components/sidebar/SortSelector';
 import { Tooltip } from '@/components/common/Tooltip';
+import { TruncationTooltip } from '@/components/common/TruncationTooltip';
 import { LocaleSwitcher } from '@/components/common/LocaleSwitcher';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import { LogoutButton } from '@/components/common/LogoutButton';
@@ -478,7 +479,7 @@ export const Sidebar = memo(function Sidebar() {
         onScroll={saveBranchListScroll}
         onMouseEnter={handleListMouseEnter}
         onMouseLeave={handleListMouseLeave}
-        className="flex-1 overflow-y-auto"
+        className="flex-1 overflow-y-auto overflow-x-hidden"
       >
         {isEmpty ? (
           <div className="px-4 py-8 text-center text-gray-400">
@@ -575,7 +576,7 @@ function SortableGroupItem({
   };
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} className="w-full min-w-0">
       <GroupHeader
         repositoryName={group.repositoryName}
         branchCount={group.branches.length}
@@ -680,7 +681,7 @@ function GroupHeader({
         onClick={onClick}
         aria-expanded={isExpanded}
         className="
-          flex-1 flex items-center gap-2 px-2 py-2
+          flex-1 min-w-0 flex items-center gap-2 px-2 py-2
           text-xs font-semibold text-gray-300 uppercase tracking-wider
           focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500
           transition-colors
@@ -688,7 +689,9 @@ function GroupHeader({
       >
         <ChevronIcon isExpanded={isExpanded} />
         <GroupIcon color={generateRepositoryColor(repositoryName)} />
-        <span className="flex-1 text-left truncate">{repositoryName}</span>
+        <TruncationTooltip content={repositoryName} className="flex-1 min-w-0 text-left truncate">
+          {repositoryName}
+        </TruncationTooltip>
         <span className="text-gray-500 font-normal pr-2">{branchCount}</span>
       </button>
     </div>

--- a/src/components/worktree/FileMetadataToggle.tsx
+++ b/src/components/worktree/FileMetadataToggle.tsx
@@ -1,0 +1,120 @@
+/**
+ * FileMetadataToggle Component (Issue #969)
+ *
+ * A small gear button in the file-tree toolbar that opens a popover with three
+ * checkboxes controlling which metadata columns (size / created / modified) are
+ * shown inline in each file row. State is owned by `useFileMetadataDisplay`
+ * (localStorage-persisted) and passed in by the parent so the same settings can
+ * also drive `TreeNode` rendering without prop drilling through it.
+ */
+
+'use client';
+
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Settings2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type {
+  FileMetadataDisplaySettings,
+} from '@/hooks/useFileMetadataDisplay';
+
+export interface FileMetadataToggleProps {
+  /** Current visibility settings. */
+  settings: FileMetadataDisplaySettings;
+  /** Toggle a single key. */
+  onToggle: (key: keyof FileMetadataDisplaySettings) => void;
+}
+
+interface Row {
+  key: keyof FileMetadataDisplaySettings;
+  labelKey: string;
+}
+
+const ROWS: Row[] = [
+  { key: 'showSize', labelKey: 'fileTree.metadata.showSize' },
+  { key: 'showCreated', labelKey: 'fileTree.metadata.showCreated' },
+  { key: 'showModified', labelKey: 'fileTree.metadata.showModified' },
+];
+
+export const FileMetadataToggle = memo(function FileMetadataToggle({
+  settings,
+  onToggle,
+}: FileMetadataToggleProps) {
+  const t = useTranslations('worktree');
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close the popover when clicking outside or pressing Escape.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onPointerDown = (e: MouseEvent): void => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const handleToggle = useCallback(
+    (key: keyof FileMetadataDisplaySettings) => {
+      onToggle(key);
+    },
+    [onToggle]
+  );
+
+  return (
+    <div className="relative" ref={containerRef} data-testid="file-metadata-toggle">
+      <button
+        type="button"
+        data-testid="file-metadata-toggle-button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t('fileTree.metadata.settingsLabel')}
+        title={t('fileTree.metadata.settingsLabel')}
+        className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+      >
+        <Settings2 className="w-4 h-4" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="file-metadata-toggle-menu"
+          className="absolute right-0 top-full z-20 mt-1 min-w-[12rem] rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1"
+        >
+          <div className="px-2 py-1 text-[11px] font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wide">
+            {t('fileTree.metadata.settingsTitle')}
+          </div>
+          {ROWS.map((row) => (
+            <label
+              key={row.key}
+              className="flex items-center gap-2 px-2 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/60 rounded cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                data-testid={`file-metadata-toggle-${row.key}`}
+                checked={settings[row.key]}
+                onChange={() => handleToggle(row.key)}
+                className="h-3.5 w-3.5 accent-cyan-500"
+              />
+              <span>{t(row.labelKey)}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default FileMetadataToggle;

--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -23,8 +23,10 @@ import type { TreeItem, TreeResponse, SearchMode, SearchResultItem } from '@/typ
 import { useContextMenu } from '@/hooks/useContextMenu';
 import { ContextMenu } from '@/components/worktree/ContextMenu';
 import { TreeNode } from '@/components/worktree/TreeNode';
+import { FileMetadataToggle } from '@/components/worktree/FileMetadataToggle';
 import { computeMatchedPaths } from '@/lib/utils';
 import { useFilePolling } from '@/hooks/useFilePolling';
+import { useFileMetadataDisplay } from '@/hooks/useFileMetadataDisplay';
 import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import { useLocale } from 'next-intl';
 import { FilePlus, FolderPlus, AlertCircle, RefreshCw } from 'lucide-react';
@@ -113,6 +115,10 @@ export const FileTreeView = memo(function FileTreeView({
 }: FileTreeViewProps) {
   // [Issue #162] Get locale for date formatting
   const locale = useLocale();
+  // [Issue #969] Inline metadata column visibility (size / created / modified),
+  // localStorage-persisted and synced across hook instances.
+  const { settings: metadataDisplay, toggle: toggleMetadata } =
+    useFileMetadataDisplay();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rootItems, setRootItems] = useState<TreeItem[]>([]);
@@ -596,8 +602,10 @@ export const FileTreeView = memo(function FileTreeView({
             <span>New Directory</span>
           </button>
         )}
-        {/* Right-aligned group: refetch indicator + manual refresh button. */}
+        {/* Right-aligned group: metadata toggle + refetch indicator + manual refresh button. */}
         <div className="ml-auto flex items-center gap-1">
+          {/* [Issue #969] Toggle which metadata columns show inline per file row. */}
+          <FileMetadataToggle settings={metadataDisplay} onToggle={toggleMetadata} />
           {/* [Issue #706] Compact refetch indicator. The tree DOM (and its
               scroll position) is preserved while a background refresh runs. */}
           {isRefetching && (
@@ -673,6 +681,7 @@ export const FileTreeView = memo(function FileTreeView({
           searchMode={searchMode}
           matchedPaths={matchedPaths}
           dateFnsLocaleStr={locale}
+          metadataDisplay={metadataDisplay}
         />
       ))}
 

--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -29,6 +29,7 @@ import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import { X, AlertTriangle, FileText, Eye } from 'lucide-react';
 import { MermaidCodeBlock } from '@/components/worktree/MermaidCodeBlock';
+import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 import { classifyLink, resolveRelativePath, sanitizeHref, REHYPE_SANITIZE_SCHEMA } from '@/lib/link-utils';
 import { encodePathForUrl } from '@/lib/url-path-encoder';
 import type { Components } from 'react-markdown';
@@ -71,6 +72,20 @@ export interface LargeFileWarningProps {
 // ============================================================================
 // MarkdownPreview Component
 // ============================================================================
+
+/**
+ * Detects whether a `<pre>`'s child is a mermaid fenced block. react-markdown
+ * passes the (unrendered) `<code>` element as the pre's only child; mermaid
+ * blocks carry a `language-mermaid` class. Such blocks render a diagram rather
+ * than copyable source, so the `pre` renderer must not wrap them with a copy
+ * button. (Issue #983)
+ */
+function isMermaidPreChild(children: React.ReactNode): boolean {
+  const child = React.Children.toArray(children)[0];
+  if (!React.isValidElement(child)) return false;
+  const className = (child.props as { className?: string }).className;
+  return typeof className === 'string' && className.split(' ').includes('language-mermaid');
+}
 
 /**
  * Fetches an image from the worktree file API and displays it as a data URI.
@@ -158,6 +173,22 @@ export const MarkdownPreview = memo(function MarkdownPreview({
   const markdownComponents: Partial<Components> = useMemo(
     () => ({
       code: MermaidCodeBlock, // [Issue #100] mermaid diagram support
+      // [Issue #983] Attach the copy button at the block level. The `pre`
+      // renderer fires only for fenced/indented code (never inline code), so
+      // inline code is never decorated or forced onto its own line. The wrapper
+      // sits outside the scrollable <pre> so the button stays pinned. Mermaid
+      // blocks render a diagram, not copyable source, so they keep a plain
+      // <pre> (no button) exactly as the default renderer produced.
+      pre: ({ children }) => {
+        if (isMermaidPreChild(children)) {
+          return <pre>{children}</pre>;
+        }
+        return (
+          <CodeBlockWithCopy>
+            <pre className="overflow-x-auto">{children}</pre>
+          </CodeBlockWithCopy>
+        );
+      },
       // Resolve relative image paths via worktree file API (returns Base64 data URI in JSON)
       img: ({ src, alt, width, height, ...props }) => {
         const w = (width ?? props.node?.properties?.width) as string | undefined;

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -12,7 +12,6 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { Loader2 } from 'lucide-react';
-import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 
 /**
  * Dynamic import of MermaidDiagram with SSR disabled
@@ -49,8 +48,6 @@ export interface MermaidCodeBlockProps {
   children?: React.ReactNode | string | string[];
   /** ReactMarkdown passes AST node */
   node?: unknown;
-  /** Whether this is an inline code block */
-  inline?: boolean;
 }
 
 /**
@@ -114,31 +111,17 @@ function isMermaidLanguage(className?: string): boolean {
 export function MermaidCodeBlock({
   className,
   children,
-  inline,
 }: MermaidCodeBlockProps): JSX.Element {
-  // Inline code blocks are always rendered as regular code
-  if (inline) {
-    return (
-      <code className={className}>
-        {children}
-      </code>
-    );
-  }
-
-  // Check if this is a mermaid code block
+  // Fenced mermaid blocks render as a diagram.
   if (isMermaidLanguage(className)) {
     const code = extractCodeString(children);
     return <MermaidDiagram code={code} />;
   }
 
-  // Non-mermaid code blocks are rendered as regular code elements, wrapped with
-  // a copy button (Issue #981). The wrapper is a <span> so it stays valid
-  // phrasing content inside the parent <pre>.
-  return (
-    <CodeBlockWithCopy as="span">
-      <code className={className}>
-        {children}
-      </code>
-    </CodeBlockWithCopy>
-  );
+  // Everything else — inline code and non-mermaid block code — renders as a
+  // plain <code>. react-markdown v10 no longer passes an `inline` prop, so the
+  // copy button is attached by MarkdownPreview's `pre` renderer (block code
+  // only); inline code has no <pre> ancestor and is therefore never decorated,
+  // fixing the inline-code line-break regression. (Issue #983)
+  return <code className={className}>{children}</code>;
 }

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -12,6 +12,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { Loader2 } from 'lucide-react';
+import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
 
 /**
  * Dynamic import of MermaidDiagram with SSR disabled
@@ -130,10 +131,14 @@ export function MermaidCodeBlock({
     return <MermaidDiagram code={code} />;
   }
 
-  // Non-mermaid code blocks are rendered as regular code elements
+  // Non-mermaid code blocks are rendered as regular code elements, wrapped with
+  // a copy button (Issue #981). The wrapper is a <span> so it stays valid
+  // phrasing content inside the parent <pre>.
   return (
-    <code className={className}>
-      {children}
-    </code>
+    <CodeBlockWithCopy as="span">
+      <code className={className}>
+        {children}
+      </code>
+    </CodeBlockWithCopy>
   );
 }

--- a/src/components/worktree/PaneResizer.tsx
+++ b/src/components/worktree/PaneResizer.tsx
@@ -40,25 +40,67 @@ export interface PaneResizerProps {
 /** Keyboard step size in pixels for arrow key navigation */
 const KEYBOARD_STEP = 10;
 
-/** Base classes shared by all resizer states */
+/**
+ * Base classes shared by all resizer states.
+ *
+ * VS Code-style thin divider (Issue #970): the line stays a constant 1px and
+ * uses the same subtle color as fixed panel borders (`gray-200`/`gray-700`),
+ * so it blends in until hovered. An accent color appears on hover/focus only —
+ * the line never thickens on hover. `relative` provides the positioning context
+ * for the transparent `::before` hit area added per-orientation below.
+ */
 const BASE_CLASSES = [
+  'relative',
   'flex-shrink-0',
-  'bg-gray-700',
+  'bg-gray-200',
+  'dark:bg-gray-700',
   'transition-colors',
   'duration-150',
   'hover:bg-cyan-500',
+  // Explicit dark hover variant: with `darkMode: 'class'`, the base
+  // `dark:bg-gray-700` outranks a plain `hover:` accent in dark mode, so the
+  // hover accent must be re-stated under `dark:` to win (Issue #970).
+  'dark:hover:bg-cyan-500',
   'focus:outline-none',
   'focus:ring-2',
   'focus:ring-cyan-500',
   'focus:ring-offset-2',
-  'focus:ring-offset-gray-900',
+  'focus:ring-offset-white',
+  'dark:focus:ring-offset-gray-900',
 ] as const;
 
-/** Classes for horizontal orientation */
-const HORIZONTAL_CLASSES = ['w-1', 'h-full', 'cursor-col-resize', 'hover:w-2'] as const;
+/**
+ * Classes for horizontal orientation.
+ *
+ * The visible line is 1px (`w-1`); a transparent `::before` extends the click
+ * target ±4px horizontally (`before:-inset-x-1`) so the thin divider stays easy
+ * to grab without looking thick (VS Code technique, Issue #970).
+ */
+const HORIZONTAL_CLASSES = [
+  'w-1',
+  'h-full',
+  'cursor-col-resize',
+  "before:content-['']",
+  'before:absolute',
+  'before:inset-y-0',
+  'before:-inset-x-1',
+] as const;
 
-/** Classes for vertical orientation */
-const VERTICAL_CLASSES = ['h-1', 'w-full', 'cursor-row-resize', 'hover:h-2'] as const;
+/**
+ * Classes for vertical orientation.
+ *
+ * The visible line is 1px (`h-1`); a transparent `::before` extends the click
+ * target ±4px vertically (`before:-inset-y-1`) for easy grabbing.
+ */
+const VERTICAL_CLASSES = [
+  'h-1',
+  'w-full',
+  'cursor-row-resize',
+  "before:content-['']",
+  'before:absolute',
+  'before:inset-x-0',
+  'before:-inset-y-1',
+] as const;
 
 // ============================================================================
 // Helper Functions
@@ -241,8 +283,11 @@ export const PaneResizer = memo(function PaneResizer({
   // Build class names with memoization for performance
   const className = useMemo(() => {
     const orientationClasses = isHorizontal ? HORIZONTAL_CLASSES : VERTICAL_CLASSES;
+    // While dragging, accent the line and let it thicken slightly as live
+    // feedback (only hover stays a constant 1px — Issue #970). `dark:bg-cyan-500`
+    // is needed so the accent outranks the base `dark:bg-gray-700` in dark mode.
     const draggingClasses = isDragging
-      ? ['bg-cyan-500', 'dragging', isHorizontal ? 'w-2' : 'h-2']
+      ? ['bg-cyan-500', 'dark:bg-cyan-500', 'dragging', isHorizontal ? 'w-2' : 'h-2']
       : [];
 
     return [...BASE_CLASSES, ...orientationClasses, ...draggingClasses].join(' ');

--- a/src/components/worktree/TerminalSplitContainer.tsx
+++ b/src/components/worktree/TerminalSplitContainer.tsx
@@ -285,6 +285,57 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
         </span>
 
         {/*
+          Issue #977: all action-bar buttons are left-aligned in a single
+          group, ordered +Split → -Split → Equal widths → History → Files.
+          The `ml-auto` that previously pushed +Split (and everything after)
+          to the right has been removed so the bar reads left-to-right.
+        */}
+        <button
+          type="button"
+          onClick={addSplit}
+          disabled={!canAdd}
+          aria-disabled={!canAdd}
+          aria-label="Add terminal split"
+          data-testid="add-terminal-split"
+          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          + Split
+        </button>
+        <button
+          type="button"
+          onClick={removeSplit}
+          disabled={!canRemove}
+          aria-disabled={!canRemove}
+          aria-label="Remove last terminal split"
+          data-testid="remove-terminal-split"
+          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          - Split
+        </button>
+
+        {/*
+          Issue #861: equalize terminal split widths (each → 1/n) and reset the
+          Message History width to default in one action. Disabled only when
+          there is nothing to equalize (single split AND History hidden).
+        */}
+        <button
+          type="button"
+          onClick={handleEqualizeWidths}
+          disabled={!canEqualize}
+          aria-disabled={!canEqualize}
+          aria-label={t('terminal.equalizeWidthsHint')}
+          title={t('terminal.equalizeWidthsHint')}
+          data-testid="equalize-split-widths"
+          className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <AlignHorizontalDistributeCenter
+            className="w-3.5 h-3.5 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span>{t('terminal.equalizeWidths')}</span>
+        </button>
+
+        {/*
           Issue #841 (Phase 2): History / Files visibility toggles. Always
           shown (split-count independent). Active = cyan accent, inactive =
           gray. `aria-pressed` reflects current visibility. The existing
@@ -333,51 +384,6 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
         >
           <Files className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
           <span>{t('terminal.filesLabel')}</span>
-        </button>
-
-        <button
-          type="button"
-          onClick={addSplit}
-          disabled={!canAdd}
-          aria-disabled={!canAdd}
-          aria-label="Add terminal split"
-          data-testid="add-terminal-split"
-          className="ml-auto text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          + Split
-        </button>
-        <button
-          type="button"
-          onClick={removeSplit}
-          disabled={!canRemove}
-          aria-disabled={!canRemove}
-          aria-label="Remove last terminal split"
-          data-testid="remove-terminal-split"
-          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          - Split
-        </button>
-
-        {/*
-          Issue #861: equalize terminal split widths (each → 1/n) and reset the
-          Message History width to default in one action. Disabled only when
-          there is nothing to equalize (single split AND History hidden).
-        */}
-        <button
-          type="button"
-          onClick={handleEqualizeWidths}
-          disabled={!canEqualize}
-          aria-disabled={!canEqualize}
-          aria-label={t('terminal.equalizeWidthsHint')}
-          title={t('terminal.equalizeWidthsHint')}
-          data-testid="equalize-split-widths"
-          className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <AlignHorizontalDistributeCenter
-            className="w-3.5 h-3.5 flex-shrink-0"
-            aria-hidden="true"
-          />
-          <span>{t('terminal.equalizeWidths')}</span>
         </button>
       </div>
 

--- a/src/components/worktree/TreeNode.tsx
+++ b/src/components/worktree/TreeNode.tsx
@@ -8,7 +8,7 @@
  * - Search query highlighting
  * - Right-click and long-press context menu support
  * - Keyboard navigation
- * - File metadata display (size, birthtime)
+ * - Toggleable inline file metadata (size / created / modified) + hover tooltip [Issue #969]
  *
  * [Issue #123] Touch long press context menu for iPad/iPhone
  */
@@ -16,12 +16,17 @@
 'use client';
 
 import React, { useState, useCallback, useMemo, memo } from 'react';
+import { useTranslations } from 'next-intl';
 import type { TreeItem, SearchMode } from '@/types/models';
 import { useLongPress } from '@/hooks/useLongPress';
 import { escapeRegExp } from '@/lib/utils';
-import { formatRelativeTime } from '@/lib/date-utils';
+import { formatRelativeTime, formatMessageTimestamp } from '@/lib/date-utils';
 import { getDateFnsLocale } from '@/lib/date-locale';
 import { TruncationTooltip } from '@/components/common/TruncationTooltip';
+import {
+  DEFAULT_FILE_METADATA_DISPLAY,
+  type FileMetadataDisplaySettings,
+} from '@/hooks/useFileMetadataDisplay';
 
 // ============================================================================
 // Types
@@ -74,6 +79,11 @@ export interface TreeNodeProps {
   matchedPaths?: Set<string>;
   /** [Issue #162] date-fns locale string for formatRelativeTime */
   dateFnsLocaleStr?: string;
+  /**
+   * [Issue #969] Which metadata columns (size / created / modified) to render
+   * inline. Defaults to size-only (timestamps available on hover) when omitted.
+   */
+  metadataDisplay?: FileMetadataDisplaySettings;
 }
 
 // ============================================================================
@@ -253,12 +263,44 @@ export const TreeNode = memo(function TreeNode({
   searchMode,
   matchedPaths,
   dateFnsLocaleStr,
+  metadataDisplay = DEFAULT_FILE_METADATA_DISPLAY,
 }: TreeNodeProps) {
+  const t = useTranslations('worktree');
   const [loading, setLoading] = useState(false);
   const fullPath = path ? `${path}/${item.name}` : item.name;
   const isExpanded = expanded.has(fullPath);
   const isDirectory = item.type === 'directory';
   const children = cache.get(fullPath);
+
+  // [Issue #969] date-fns locale resolved once for both inline relative times
+  // and the hover tooltip's absolute timestamps.
+  const dateFnsLocale = useMemo(
+    () => (dateFnsLocaleStr ? getDateFnsLocale(dateFnsLocaleStr) : undefined),
+    [dateFnsLocaleStr]
+  );
+
+  /**
+   * [Issue #969] Formatted, locale-aware metadata tooltip for file rows.
+   * Built into the row's `title` attribute (newline-separated) so the
+   * created/modified/size info is always available on hover, even when the
+   * inline columns are toggled off. Directories get no tooltip.
+   */
+  const metadataTitle = useMemo(() => {
+    if (isDirectory) return undefined;
+    const lines: string[] = [];
+    if (item.size !== undefined) {
+      lines.push(`${t('fileTree.metadata.size')}: ${formatFileSize(item.size)}`);
+    }
+    if (item.birthtime) {
+      const created = formatMessageTimestamp(new Date(item.birthtime), dateFnsLocale);
+      if (created) lines.push(`${t('fileTree.metadata.created')}: ${created}`);
+    }
+    if (item.mtime) {
+      const modified = formatMessageTimestamp(new Date(item.mtime), dateFnsLocale);
+      if (modified) lines.push(`${t('fileTree.metadata.modified')}: ${modified}`);
+    }
+    return lines.length > 0 ? lines.join('\n') : undefined;
+  }, [isDirectory, item.size, item.birthtime, item.mtime, dateFnsLocale, t]);
 
   const handleClick = useCallback(async () => {
     if (isDirectory) {
@@ -338,6 +380,7 @@ export const TreeNode = memo(function TreeNode({
         tabIndex={0}
         className="flex items-center gap-2 py-1.5 pr-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors"
         style={combinedStyle}
+        title={metadataTitle}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         onContextMenu={handleContextMenu}
@@ -380,20 +423,35 @@ export const TreeNode = memo(function TreeNode({
           )}
         </TruncationTooltip>
 
-        {/* File size or item count */}
-        <span className="text-xs text-gray-400 flex-shrink-0">
-          {isDirectory
-            ? item.itemCount !== undefined && `${item.itemCount} items`
-            : formatFileSize(item.size)}
-        </span>
-
-        {/* [Issue #162] File birthtime display */}
-        {!isDirectory && item.birthtime && (
+        {/* [Issue #969] File size or item count — toggleable inline column */}
+        {metadataDisplay.showSize && (
           <span
+            data-testid="tree-item-size"
             className="text-xs text-gray-400 flex-shrink-0"
-            title={item.birthtime}
           >
-            {formatRelativeTime(item.birthtime, dateFnsLocaleStr ? getDateFnsLocale(dateFnsLocaleStr) : undefined)}
+            {isDirectory
+              ? item.itemCount !== undefined && `${item.itemCount} items`
+              : formatFileSize(item.size)}
+          </span>
+        )}
+
+        {/* [Issue #162/#969] File creation time (birthtime) — toggleable inline column */}
+        {!isDirectory && metadataDisplay.showCreated && item.birthtime && (
+          <span
+            data-testid="tree-item-created"
+            className="text-xs text-gray-400 flex-shrink-0"
+          >
+            {formatRelativeTime(item.birthtime, dateFnsLocale)}
+          </span>
+        )}
+
+        {/* [Issue #969] File modification time (mtime) — toggleable inline column */}
+        {!isDirectory && metadataDisplay.showModified && item.mtime && (
+          <span
+            data-testid="tree-item-modified"
+            className="text-xs text-gray-400 flex-shrink-0"
+          >
+            {formatRelativeTime(item.mtime, dateFnsLocale)}
           </span>
         )}
       </div>
@@ -460,6 +518,7 @@ export const TreeNode = memo(function TreeNode({
                 searchMode={searchMode}
                 matchedPaths={matchedPaths}
                 dateFnsLocaleStr={dateFnsLocaleStr}
+                metadataDisplay={metadataDisplay}
               />
             ))}
         </div>

--- a/src/components/worktree/TreeNode.tsx
+++ b/src/components/worktree/TreeNode.tsx
@@ -280,12 +280,15 @@ export const TreeNode = memo(function TreeNode({
   );
 
   /**
-   * [Issue #969] Formatted, locale-aware metadata tooltip for file rows.
-   * Built into the row's `title` attribute (newline-separated) so the
-   * created/modified/size info is always available on hover, even when the
-   * inline columns are toggled off. Directories get no tooltip.
+   * [Issue #969, #975] Formatted, locale-aware metadata for file rows,
+   * newline-separated. Passed to `TruncationTooltip` so the size/created/
+   * modified info shows in the SAME bubble as the file name (one unified
+   * tooltip instead of the old native `title`). The full set is always
+   * surfaced on hover regardless of which inline columns are toggled, so the
+   * created/modified data stays reachable even in the default size-only view.
+   * Directories get no metadata (undefined → name-only tooltip when clipped).
    */
-  const metadataTitle = useMemo(() => {
+  const metadataTooltip = useMemo(() => {
     if (isDirectory) return undefined;
     const lines: string[] = [];
     if (item.size !== undefined) {
@@ -380,7 +383,6 @@ export const TreeNode = memo(function TreeNode({
         tabIndex={0}
         className="flex items-center gap-2 py-1.5 pr-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors"
         style={combinedStyle}
-        title={metadataTitle}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         onContextMenu={handleContextMenu}
@@ -410,10 +412,12 @@ export const TreeNode = memo(function TreeNode({
         )}
 
         {/* Name - with highlight for name search */}
-        {/* [Issue #859] JS tooltip (Portal) shows full name on hover when truncated,
-            replacing the native `title` whose show-delay is browser-controlled and slow */}
+        {/* [Issue #859/#975] One JS tooltip (Portal) shows the full name plus the
+            file's metadata (size/created/modified) on hover, replacing both the
+            slow native `title` and the previous separate metadata tooltip. */}
         <TruncationTooltip
           content={item.name}
+          metadata={metadataTooltip}
           className="flex-1 truncate text-sm text-gray-700 dark:text-gray-300"
         >
           {searchMode === 'name' && searchQuery ? (

--- a/src/hooks/useFileMetadataDisplay.ts
+++ b/src/hooks/useFileMetadataDisplay.ts
@@ -1,0 +1,192 @@
+/**
+ * useFileMetadataDisplay Hook (Issue #969)
+ *
+ * Manages which file-metadata columns (size / created / modified) are shown
+ * inline in the file tree, persisted to localStorage. Mirrors
+ * `useFilePanelState` (Issue #840): same-window writes are broadcast via a
+ * CustomEvent so multiple hook instances on the same page stay in sync (the
+ * native `storage` event only fires for *other* tabs).
+ *
+ * Persistence:
+ *   - `commandmate.worktree.fileMetadataDisplay`
+ *     (JSON: { showSize, showCreated, showModified })
+ *
+ * Default (Issue #969 recommendation — VS Code-style: size only inline,
+ * timestamps on hover):
+ *   - showSize: true, showCreated: false, showModified: false
+ *
+ * SSR / hydration:
+ *   - SSR returns the default. An effect on mount syncs from localStorage.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const FILE_METADATA_DISPLAY_STORAGE_KEY =
+  'commandmate.worktree.fileMetadataDisplay';
+
+/** Inline file-metadata column visibility settings. */
+export interface FileMetadataDisplaySettings {
+  /** Show the file size (or directory item count) inline. */
+  showSize: boolean;
+  /** Show the creation time (birthtime) inline. */
+  showCreated: boolean;
+  /** Show the last-modification time (mtime) inline. */
+  showModified: boolean;
+}
+
+export const DEFAULT_FILE_METADATA_DISPLAY: FileMetadataDisplaySettings = {
+  showSize: true,
+  showCreated: false,
+  showModified: false,
+};
+
+export interface UseFileMetadataDisplayReturn {
+  /** Current visibility settings. */
+  settings: FileMetadataDisplaySettings;
+  /** Toggle a single key (also persists). */
+  toggle: (key: keyof FileMetadataDisplaySettings) => void;
+  /** Replace all settings explicitly (also persists). */
+  setSettings: (next: FileMetadataDisplaySettings) => void;
+}
+
+function sanitize(value: unknown): FileMetadataDisplaySettings {
+  if (typeof value !== 'object' || value === null) {
+    return { ...DEFAULT_FILE_METADATA_DISPLAY };
+  }
+  const v = value as Partial<Record<keyof FileMetadataDisplaySettings, unknown>>;
+  return {
+    showSize:
+      typeof v.showSize === 'boolean'
+        ? v.showSize
+        : DEFAULT_FILE_METADATA_DISPLAY.showSize,
+    showCreated:
+      typeof v.showCreated === 'boolean'
+        ? v.showCreated
+        : DEFAULT_FILE_METADATA_DISPLAY.showCreated,
+    showModified:
+      typeof v.showModified === 'boolean'
+        ? v.showModified
+        : DEFAULT_FILE_METADATA_DISPLAY.showModified,
+  };
+}
+
+function readStored(): FileMetadataDisplaySettings {
+  if (typeof window === 'undefined') {
+    return { ...DEFAULT_FILE_METADATA_DISPLAY };
+  }
+  try {
+    const raw = window.localStorage.getItem(FILE_METADATA_DISPLAY_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_FILE_METADATA_DISPLAY };
+    return sanitize(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_FILE_METADATA_DISPLAY };
+  }
+}
+
+function writeStored(settings: FileMetadataDisplaySettings): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      FILE_METADATA_DISPLAY_STORAGE_KEY,
+      JSON.stringify(settings)
+    );
+  } catch {
+    /* unavailable */
+  }
+}
+
+/**
+ * Custom event used to broadcast hook state changes across multiple
+ * `useFileMetadataDisplay` instances on the same page (same rationale as
+ * `useFilePanelState` — Issue #730): same-window localStorage writes do not
+ * fire the native `storage` event.
+ */
+const FILE_METADATA_DISPLAY_EVENT = 'commandmate:fileMetadataDisplayChange';
+
+interface FileMetadataDisplayEventDetail {
+  settings: FileMetadataDisplaySettings;
+}
+
+function emitChange(detail: FileMetadataDisplayEventDetail): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent<FileMetadataDisplayEventDetail>(
+        FILE_METADATA_DISPLAY_EVENT,
+        { detail }
+      )
+    );
+  } catch {
+    /* CustomEvent may be unavailable in very old environments */
+  }
+}
+
+function settingsEqual(
+  a: FileMetadataDisplaySettings,
+  b: FileMetadataDisplaySettings
+): boolean {
+  return (
+    a.showSize === b.showSize &&
+    a.showCreated === b.showCreated &&
+    a.showModified === b.showModified
+  );
+}
+
+export function useFileMetadataDisplay(): UseFileMetadataDisplayReturn {
+  const [settings, setSettingsState] = useState<FileMetadataDisplaySettings>(
+    DEFAULT_FILE_METADATA_DISPLAY
+  );
+
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+
+  // Hydrate once on mount.
+  useEffect(() => {
+    setSettingsState(readStored());
+  }, []);
+
+  // Sync state across hook instances on the same page.
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const onChange = (event: Event): void => {
+      const ce = event as CustomEvent<FileMetadataDisplayEventDetail>;
+      if (!ce.detail) return;
+      if (!settingsEqual(ce.detail.settings, settingsRef.current)) {
+        setSettingsState(ce.detail.settings);
+      }
+    };
+    window.addEventListener(FILE_METADATA_DISPLAY_EVENT, onChange);
+    return () =>
+      window.removeEventListener(FILE_METADATA_DISPLAY_EVENT, onChange);
+  }, []);
+
+  const setSettings = useCallback(
+    (next: FileMetadataDisplaySettings): void => {
+      // Update the ref synchronously so multiple toggles within the same tick
+      // compose off the latest value (the ref is otherwise only refreshed on
+      // the next render).
+      settingsRef.current = next;
+      setSettingsState(next);
+      writeStored(next);
+      emitChange({ settings: next });
+    },
+    []
+  );
+
+  const toggle = useCallback(
+    (key: keyof FileMetadataDisplaySettings): void => {
+      const next: FileMetadataDisplaySettings = {
+        ...settingsRef.current,
+        [key]: !settingsRef.current[key],
+      };
+      setSettings(next);
+    },
+    [setSettings]
+  );
+
+  return { settings, toggle, setSettings };
+}
+
+export default useFileMetadataDisplay;

--- a/src/lib/file-tree.ts
+++ b/src/lib/file-tree.ts
@@ -192,11 +192,18 @@ export async function readDirectory(
         });
       } else if (entryStat.isFile()) {
         const ext = extname(name);
+        // [Issue #969] Expose both creation (birthtime) and last-modification
+        // (mtime) timestamps so the UI can show them inline and/or on hover.
+        // Platform note: `birthtime` is reliable on macOS/Windows but on some
+        // Linux filesystems it is not a true creation time (may equal ctime or
+        // be zeroed). `mtime` is portable. `ctime` is intentionally NOT exposed
+        // because its meaning is OS-dependent (inode change time on Linux).
         const item: TreeItem = {
           name,
           type: 'file',
           size: entryStat.size,
           birthtime: entryStat.birthtime.toISOString(),
+          mtime: entryStat.mtime.toISOString(),
         };
         if (ext && ext.length > 1) {
           item.extension = ext.slice(1); // Remove the leading dot

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -337,8 +337,13 @@ export interface TreeItem {
   extension?: string;
   /** Number of items in directory (directories only) */
   itemCount?: number;
-  /** File creation time (ISO 8601 string) - files only [CO-001] */
+  /**
+   * File creation time (ISO 8601 string) - files only [CO-001].
+   * Platform note: not a reliable creation time on some Linux filesystems.
+   */
   birthtime?: string;
+  /** File last-modification time (ISO 8601 string) - files only [Issue #969] */
+  mtime?: string;
 }
 
 /**

--- a/tests/unit/components/MarkdownPreview.codeCopy.test.tsx
+++ b/tests/unit/components/MarkdownPreview.codeCopy.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for Issue #983 — markdown preview copy button placement.
+ *
+ * react-markdown v10 dropped the `code` component's `inline` prop, which made
+ * every inline `code` span flow through the copy-button wrapper — adding a
+ * button and forcing the inline code onto its own line. The copy button is now
+ * attached by the `pre` renderer (block code only). These tests exercise the
+ * real ReactMarkdown render path (MermaidCodeBlock + CodeBlockWithCopy are NOT
+ * mocked) to lock in: inline code = no button / no line break, fenced block =
+ * button, mermaid diagram = unchanged (no button).
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { MarkdownPreview } from '@/components/worktree/MarkdownPreview';
+
+// Hoisted clipboard mock for the copy button.
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
+
+// Render mermaid diagrams synchronously without the real mermaid runtime.
+vi.mock('@/components/worktree/MermaidDiagram', () => ({
+  MermaidDiagram: ({ code }: { code: string }) => (
+    <div data-testid="mermaid-diagram">{code}</div>
+  ),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () => {
+    const DynamicMermaid = ({ code }: { code: string }) => (
+      <div data-testid="mermaid-diagram">{code}</div>
+    );
+    return DynamicMermaid;
+  },
+}));
+
+describe('MarkdownPreview copy button placement (Issue #983)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  it('does not attach a copy button to inline code', () => {
+    render(<MarkdownPreview content={'Here is `inline code` in a sentence.'} />);
+
+    const codeEl = screen.getByText('inline code');
+    expect(codeEl.tagName).toBe('CODE');
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-block-with-copy')).not.toBeInTheDocument();
+  });
+
+  it('does not wrap inline code in the block-level copy wrapper (no line break)', () => {
+    render(<MarkdownPreview content={'Text with `code` here.'} />);
+
+    const codeEl = screen.getByText('code');
+    // The inline <code> must stay inside its paragraph, not the copy-button
+    // block wrapper that forced inline code onto its own line.
+    expect(codeEl.closest('[data-testid="code-block-with-copy"]')).toBeNull();
+  });
+
+  it('attaches a working copy button to a fenced code block with a language', async () => {
+    render(<MarkdownPreview content={'```js\nconst x = 1;\n```'} />);
+
+    const button = screen.getByRole('button', { name: 'Copy' });
+    expect(button).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining('const x = 1;'),
+    );
+  });
+
+  it('attaches a copy button to a fenced code block without a language', () => {
+    render(<MarkdownPreview content={'```\nplain block\n```'} />);
+
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('leaves mermaid diagrams unchanged (no copy button)', () => {
+    render(<MarkdownPreview content={'```mermaid\ngraph TD\nA-->B\n```'} />);
+
+    expect(screen.getByTestId('mermaid-diagram')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-block-with-copy')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/MermaidCodeBlock.test.tsx
+++ b/tests/unit/components/MermaidCodeBlock.test.tsx
@@ -10,8 +10,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MermaidCodeBlock } from '@/components/worktree/MermaidCodeBlock';
+
+// Hoisted clipboard mock for the copy button (Issue #981)
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
 
 // Mock MermaidDiagram component
 vi.mock('@/components/worktree/MermaidDiagram', () => ({
@@ -192,6 +201,61 @@ describe('MermaidCodeBlock', () => {
 
       // Should still render (empty diagram will show error)
       expect(screen.getByTestId('mermaid-diagram-mock')).toBeInTheDocument();
+    });
+  });
+
+  describe('Copy button (Issue #981)', () => {
+    beforeEach(() => {
+      mockCopyToClipboard.mockResolvedValue(undefined);
+    });
+
+    it('renders a copy button for non-mermaid block code', () => {
+      render(
+        <MermaidCodeBlock className="language-javascript">
+          const x = 1;
+        </MermaidCodeBlock>
+      );
+
+      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+      // The underlying code element is preserved
+      const codeElement = screen.getByText('const x = 1;');
+      expect(codeElement.tagName).toBe('CODE');
+      expect(codeElement).toHaveClass('language-javascript');
+    });
+
+    it('copies the code text when the copy button is clicked', async () => {
+      render(
+        <MermaidCodeBlock className="language-javascript">
+          const x = 1;
+        </MermaidCodeBlock>
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+      });
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
+    });
+
+    it('does not render a copy button for mermaid diagrams', () => {
+      render(
+        <MermaidCodeBlock className="language-mermaid">
+          graph TD
+        </MermaidCodeBlock>
+      );
+
+      expect(screen.getByTestId('mermaid-diagram-mock')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    });
+
+    it('does not render a copy button for inline code', () => {
+      render(
+        <MermaidCodeBlock inline={true} className="language-javascript">
+          inline code
+        </MermaidCodeBlock>
+      );
+
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/components/MermaidCodeBlock.test.tsx
+++ b/tests/unit/components/MermaidCodeBlock.test.tsx
@@ -1,26 +1,18 @@
 /**
  * MermaidCodeBlock Component Tests
  *
- * Tests for the code block wrapper component including:
- * - Mermaid language detection (className='language-mermaid')
- * - Non-mermaid code block passthrough
- * - Inline code block passthrough
+ * MermaidCodeBlock renders a mermaid diagram for `language-mermaid` fenced
+ * blocks and a plain <code> element for everything else (inline code and
+ * non-mermaid block code). Since Issue #983 the copy button for block code is
+ * attached by MarkdownPreview's `pre` renderer — not here — so this component
+ * never renders a copy button.
  *
  * @vitest-environment jsdom
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MermaidCodeBlock } from '@/components/worktree/MermaidCodeBlock';
-
-// Hoisted clipboard mock for the copy button (Issue #981)
-const { mockCopyToClipboard } = vi.hoisted(() => ({
-  mockCopyToClipboard: vi.fn(),
-}));
-
-vi.mock('@/lib/clipboard-utils', () => ({
-  copyToClipboard: mockCopyToClipboard,
-}));
 
 // Mock MermaidDiagram component
 vi.mock('@/components/worktree/MermaidDiagram', () => ({
@@ -31,11 +23,7 @@ vi.mock('@/components/worktree/MermaidDiagram', () => ({
 
 // Mock next/dynamic to render the component directly
 vi.mock('next/dynamic', () => ({
-  default: (
-    loader: () => Promise<{ MermaidDiagram: React.ComponentType<{ code: string }> }>,
-    _options: unknown
-  ) => {
-    // Return a component that renders the loading state briefly then the actual component
+  default: () => {
     const DynamicComponent = (props: { code: string }) => {
       return <div data-testid="mermaid-diagram-mock">{props.code}</div>;
     };
@@ -99,7 +87,7 @@ describe('MermaidCodeBlock', () => {
       expect(codeElement).toHaveClass('language-javascript');
     });
 
-    it('should render regular code element when no className', () => {
+    it('should render regular code element when no className (inline code)', () => {
       const plainCode = 'plain text';
 
       render(
@@ -124,36 +112,6 @@ describe('MermaidCodeBlock', () => {
       const codeElement = screen.getByText(pythonCode);
       expect(codeElement.tagName).toBe('CODE');
       expect(codeElement).toHaveClass('language-python');
-    });
-  });
-
-  describe('Inline Code Block Passthrough', () => {
-    it('should render inline code as regular code element', () => {
-      const inlineCode = 'inline code';
-
-      render(
-        <MermaidCodeBlock inline={true}>
-          {inlineCode}
-        </MermaidCodeBlock>
-      );
-
-      const codeElement = screen.getByText(inlineCode);
-      expect(codeElement.tagName).toBe('CODE');
-    });
-
-    it('should not render MermaidDiagram for inline code even with mermaid className', () => {
-      const inlineCode = 'graph TD';
-
-      render(
-        <MermaidCodeBlock inline={true} className="language-mermaid">
-          {inlineCode}
-        </MermaidCodeBlock>
-      );
-
-      // Should render as regular code, not MermaidDiagram
-      const codeElement = screen.getByText(inlineCode);
-      expect(codeElement.tagName).toBe('CODE');
-      expect(screen.queryByTestId('mermaid-diagram-mock')).not.toBeInTheDocument();
     });
   });
 
@@ -204,37 +162,20 @@ describe('MermaidCodeBlock', () => {
     });
   });
 
-  describe('Copy button (Issue #981)', () => {
-    beforeEach(() => {
-      mockCopyToClipboard.mockResolvedValue(undefined);
-    });
-
-    it('renders a copy button for non-mermaid block code', () => {
+  describe('No copy button here (Issue #983)', () => {
+    it('does not render a copy button for non-mermaid block code', () => {
       render(
         <MermaidCodeBlock className="language-javascript">
           const x = 1;
         </MermaidCodeBlock>
       );
 
-      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
-      // The underlying code element is preserved
+      // The copy button is attached by MarkdownPreview's `pre` renderer, not
+      // here, so this component renders only the plain <code> element.
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
       const codeElement = screen.getByText('const x = 1;');
       expect(codeElement.tagName).toBe('CODE');
       expect(codeElement).toHaveClass('language-javascript');
-    });
-
-    it('copies the code text when the copy button is clicked', async () => {
-      render(
-        <MermaidCodeBlock className="language-javascript">
-          const x = 1;
-        </MermaidCodeBlock>
-      );
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
-      });
-
-      expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
     });
 
     it('does not render a copy button for mermaid diagrams', () => {
@@ -245,16 +186,6 @@ describe('MermaidCodeBlock', () => {
       );
 
       expect(screen.getByTestId('mermaid-diagram-mock')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
-    });
-
-    it('does not render a copy button for inline code', () => {
-      render(
-        <MermaidCodeBlock inline={true} className="language-javascript">
-          inline code
-        </MermaidCodeBlock>
-      );
-
       expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
     });
   });

--- a/tests/unit/components/PaneResizer.test.tsx
+++ b/tests/unit/components/PaneResizer.test.tsx
@@ -224,6 +224,75 @@ describe('PaneResizer', () => {
     });
   });
 
+  describe('VS Code-style thin divider (Issue #970)', () => {
+    it('should use subtle panel-border color matching fixed borders (light/dark)', () => {
+      render(<PaneResizer onResize={mockOnResize} />);
+      const separator = screen.getByRole('separator');
+      // Same color family as fixed panel borders (gray-200 / dark gray-700),
+      // not the heavy bg-gray-700 used before.
+      expect(separator.className).toContain('bg-gray-200');
+      expect(separator.className).toContain('dark:bg-gray-700');
+      expect(separator.className).not.toMatch(/(^|\s)bg-gray-700(\s|$)/);
+    });
+
+    it('should keep a constant 1px line at rest (no hover thickening)', () => {
+      const { rerender } = render(
+        <PaneResizer onResize={mockOnResize} orientation="horizontal" />
+      );
+      let separator = screen.getByRole('separator');
+      expect(separator.className).toContain('w-1');
+      // Hover must NOT thicken the line.
+      expect(separator.className).not.toMatch(/hover:w-2/);
+
+      rerender(<PaneResizer onResize={mockOnResize} orientation="vertical" />);
+      separator = screen.getByRole('separator');
+      expect(separator.className).toContain('h-1');
+      expect(separator.className).not.toMatch(/hover:h-2/);
+    });
+
+    it('should show an accent color on hover in both themes', () => {
+      render(<PaneResizer onResize={mockOnResize} />);
+      const separator = screen.getByRole('separator');
+      expect(separator.className).toContain('hover:bg-cyan-500');
+      // dark:class strategy requires an explicit dark hover variant to beat the
+      // base dark:bg-gray-700.
+      expect(separator.className).toContain('dark:hover:bg-cyan-500');
+    });
+
+    it('should provide a transparent ±4px hit area for horizontal resizer', () => {
+      render(<PaneResizer onResize={mockOnResize} orientation="horizontal" />);
+      const separator = screen.getByRole('separator');
+      expect(separator.className).toContain('relative');
+      expect(separator.className).toContain('before:absolute');
+      expect(separator.className).toContain('before:-inset-x-1');
+    });
+
+    it('should provide a transparent ±4px hit area for vertical resizer', () => {
+      render(<PaneResizer onResize={mockOnResize} orientation="vertical" />);
+      const separator = screen.getByRole('separator');
+      expect(separator.className).toContain('relative');
+      expect(separator.className).toContain('before:absolute');
+      expect(separator.className).toContain('before:-inset-y-1');
+    });
+
+    it('should still thicken and accent only while actively dragging', () => {
+      render(<PaneResizer onResize={mockOnResize} orientation="horizontal" />);
+      const separator = screen.getByRole('separator');
+
+      // At rest: no thickening class applied.
+      expect(separator.className).not.toMatch(/(^|\s)w-2(\s|$)/);
+
+      fireEvent.mouseDown(separator, { clientX: 100, clientY: 50 });
+      // Dragging: accent + thicken as live feedback.
+      expect(separator.className).toContain('bg-cyan-500');
+      expect(separator.className).toContain('dark:bg-cyan-500');
+      expect(separator.className).toMatch(/(^|\s)w-2(\s|$)/);
+
+      fireEvent.mouseUp(document);
+      expect(separator.className).not.toMatch(/(^|\s)w-2(\s|$)/);
+    });
+  });
+
   describe('Touch support', () => {
     it('should handle touchstart event', () => {
       render(<PaneResizer onResize={mockOnResize} orientation="horizontal" />);

--- a/tests/unit/components/common/CodeBlockWithCopy.test.tsx
+++ b/tests/unit/components/common/CodeBlockWithCopy.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * CodeBlockWithCopy Component Tests (Issue #981)
+ *
+ * Covers:
+ * - extractCodeText: plain text extraction from React node trees (the shape
+ *   rehype-highlight produces) and primitive/edge inputs
+ * - Wrapper rendering: relative group container, span vs div tag
+ * - Copy button presence + copying the extracted plain text
+ * - No button rendered for empty / whitespace-only code blocks
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CodeBlockWithCopy, extractCodeText } from '@/components/common/CodeBlockWithCopy';
+
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
+
+describe('extractCodeText', () => {
+  it('returns a plain string unchanged', () => {
+    expect(extractCodeText('const x = 1;')).toBe('const x = 1;');
+  });
+
+  it('stringifies numbers', () => {
+    expect(extractCodeText(42)).toBe('42');
+  });
+
+  it('joins arrays of strings', () => {
+    expect(extractCodeText(['graph TD', '\n', 'A-->B'])).toBe('graph TD\nA-->B');
+  });
+
+  it('returns empty string for null / undefined / boolean', () => {
+    expect(extractCodeText(null)).toBe('');
+    expect(extractCodeText(undefined)).toBe('');
+    expect(extractCodeText(true)).toBe('');
+    expect(extractCodeText(false)).toBe('');
+  });
+
+  it('walks a nested React element tree (highlight.js shape) and concatenates text', () => {
+    const tree = (
+      <code className="hljs language-js">
+        <span className="hljs-keyword">const</span>
+        <span> x = </span>
+        <span className="hljs-number">1</span>
+        <span>;</span>
+      </code>
+    );
+    expect(extractCodeText(tree)).toBe('const x = 1;');
+  });
+});
+
+describe('CodeBlockWithCopy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders its children', () => {
+    render(
+      <CodeBlockWithCopy>
+        <pre>
+          <code>echo hi</code>
+        </pre>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.getByText('echo hi')).toBeInTheDocument();
+  });
+
+  it('renders a copy button for non-empty code blocks', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('wraps content in a relative group container', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    const wrapper = screen.getByTestId('code-block-with-copy');
+    expect(wrapper).toHaveClass('relative', 'group');
+  });
+
+  it('renders a div wrapper by default', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    const wrapper = screen.getByTestId('code-block-with-copy');
+    expect(wrapper.tagName).toBe('DIV');
+  });
+
+  it('renders a span wrapper (block) when as="span"', () => {
+    render(
+      <CodeBlockWithCopy as="span">
+        <code>echo hi</code>
+      </CodeBlockWithCopy>,
+    );
+    const wrapper = screen.getByTestId('code-block-with-copy');
+    expect(wrapper.tagName).toBe('SPAN');
+    expect(wrapper).toHaveClass('block');
+  });
+
+  it('copies the extracted plain text (not highlight markup) when clicked', async () => {
+    render(
+      <CodeBlockWithCopy>
+        <code className="hljs">
+          <span className="hljs-keyword">const</span>
+          <span> x = 1;</span>
+        </code>
+      </CodeBlockWithCopy>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    });
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
+  });
+
+  it('does not render a copy button for an empty code block', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>{''}</code>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-block-with-copy')).not.toBeInTheDocument();
+  });
+
+  it('does not render a copy button for a whitespace-only code block', () => {
+    render(
+      <CodeBlockWithCopy>
+        <code>{'   \n  '}</code>
+      </CodeBlockWithCopy>,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/common/CopyButton.test.tsx
+++ b/tests/unit/components/common/CopyButton.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * CopyButton Component Tests (Issue #981)
+ *
+ * Covers the shared copy button extracted from AssistantMessageList:
+ * - Default / custom label rendering
+ * - Custom className passthrough (used for absolute positioning over code)
+ * - Clipboard copy on click
+ * - Copy -> Copied -> Copy feedback transition (1.5s reset)
+ * - Timer cleanup safety on unmount
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CopyButton } from '@/components/common/CopyButton';
+
+// Hoisted mock for clipboard-utils (vi.mock factory is hoisted above imports)
+const { mockCopyToClipboard } = vi.hoisted(() => ({
+  mockCopyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
+}));
+
+// Must match COPY_FEEDBACK_RESET_SHORT_MS in src/config/ui-feedback-config.ts
+const COPY_FEEDBACK_RESET_SHORT_MS = 1500;
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders with the default "Copy" label', () => {
+    render(<CopyButton text="hello" />);
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+  });
+
+  it('renders a custom label', () => {
+    render(<CopyButton text="hello" label="Copy code" />);
+    expect(screen.getByRole('button', { name: 'Copy code' })).toBeInTheDocument();
+  });
+
+  it('appends a custom className to the button', () => {
+    render(<CopyButton text="hello" className="absolute right-2 top-2" />);
+    const button = screen.getByRole('button', { name: 'Copy' });
+    expect(button).toHaveClass('absolute', 'right-2', 'top-2');
+  });
+
+  it('copies the provided text to the clipboard on click', async () => {
+    render(<CopyButton text="const x = 1;" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('const x = 1;');
+  });
+
+  it('shows "Copied" feedback after a successful copy', async () => {
+    render(<CopyButton text="hello" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+  });
+
+  describe('feedback reset timer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('reverts to "Copy" after the feedback duration', async () => {
+      render(<CopyButton text="hello" />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+      expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(COPY_FEEDBACK_RESET_SHORT_MS);
+      });
+      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Copied' })).not.toBeInTheDocument();
+    });
+
+    it('does not throw when unmounted during feedback (timer cleanup)', async () => {
+      const { unmount } = render(<CopyButton text="hello" />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      expect(() => unmount()).not.toThrow();
+      // The cleared timer must not fire a state update after unmount.
+      expect(() => {
+        vi.advanceTimersByTime(COPY_FEEDBACK_RESET_SHORT_MS);
+      }).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/components/common/TruncationTooltip.test.tsx
+++ b/tests/unit/components/common/TruncationTooltip.test.tsx
@@ -213,6 +213,74 @@ describe('TruncationTooltip (Issue #859)', () => {
     expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument();
   });
 
+  // [Issue #975] Metadata is folded into the same bubble as the name so a
+  // single styled tooltip replaces the old native `title` + name tooltip pair.
+  it('shows the tooltip with name + metadata even when the text is NOT truncated', () => {
+    render(
+      <TruncationTooltip
+        content="app.ts"
+        metadata={'Size: 2.0 KB\nModified: yesterday'}
+        className="truncate"
+      >
+        app.ts
+      </TruncationTooltip>
+    );
+    const trigger = screen.getByText('app.ts');
+    setTruncation(trigger, false);
+
+    fireEvent.mouseEnter(trigger);
+    act(() => {
+      vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS);
+    });
+
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+    expect(tooltip).toBeInTheDocument();
+    // One bubble carries both the name and the formatted metadata lines.
+    expect(tooltip).toHaveTextContent('app.ts');
+    expect(tooltip).toHaveTextContent('Size: 2.0 KB');
+    expect(tooltip).toHaveTextContent('Modified: yesterday');
+  });
+
+  it('still shows name + metadata together when the name IS truncated', () => {
+    render(
+      <TruncationTooltip
+        content="a-very-long-file-name.tsx"
+        metadata={'Size: 3.5 MB'}
+        className="truncate"
+      >
+        a-very-long-file-name.tsx
+      </TruncationTooltip>
+    );
+    const trigger = screen.getByText('a-very-long-file-name.tsx');
+    setTruncation(trigger, true);
+
+    fireEvent.mouseEnter(trigger);
+    act(() => {
+      vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS);
+    });
+
+    const tooltip = screen.getByRole('tooltip', { hidden: true });
+    expect(tooltip).toHaveTextContent('a-very-long-file-name.tsx');
+    expect(tooltip).toHaveTextContent('Size: 3.5 MB');
+  });
+
+  it('does NOT show a tooltip when there is no metadata and the text is not truncated', () => {
+    render(
+      <TruncationTooltip content="short.ts" className="truncate">
+        short.ts
+      </TruncationTooltip>
+    );
+    const trigger = screen.getByText('short.ts');
+    setTruncation(trigger, false);
+
+    fireEvent.mouseEnter(trigger);
+    act(() => {
+      vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS + 50);
+    });
+
+    expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+  });
+
   it('clears the scheduled timer on unmount (no tooltip flash after unmount)', () => {
     const { unmount } = render(
       <TruncationTooltip content="a-very-long-file-name.tsx" className="truncate">

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -898,6 +898,50 @@ describe('Sidebar', () => {
     });
   });
 
+  // Issue #976: when the sidebar is narrowed, the header's heading + action
+  // buttons must wrap onto multiple lines instead of overflowing horizontally
+  // and overlapping the adjacent ActivityBar.
+  describe('Responsive header wrapping (Issue #976)', () => {
+    it('lets the header row wrap so the action buttons drop to a new line when narrow', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const header = await screen.findByTestId('sidebar-header');
+      const row = header.firstElementChild as HTMLElement;
+      expect(row.className).toMatch(/flex-wrap/);
+    });
+
+    it('lets the action button group itself wrap so icons stay within the sidebar width', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      // The Repositories link lives inside the action button group; walk up to
+      // that group container and assert it can wrap internally as a last resort.
+      const link = await screen.findByRole('link', { name: 'Repositories' });
+      const actions = link.closest('div.flex.flex-wrap') as HTMLElement;
+      expect(actions).not.toBeNull();
+      expect(actions.className).toMatch(/flex-wrap/);
+    });
+
+    it('keeps the Branches heading shrinkable (min-w-0) and truncatable so it never pushes the buttons out', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const heading = await screen.findByText('Branches');
+      expect(heading).toHaveClass('min-w-0');
+      expect(heading).toHaveClass('truncate');
+    });
+  });
+
   describe('Flat view', () => {
     it('should show flat list when view mode is flat', async () => {
       // Set localStorage to flat mode before rendering

--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -837,6 +837,67 @@ describe('Sidebar', () => {
     });
   });
 
+  describe('Horizontal scrollbar suppression (Issue #971)', () => {
+    const longNameWorktrees: Worktree[] = [
+      {
+        id: 'long-repo-feature',
+        name: 'feature/some-work',
+        path: '/path/to/long',
+        repositoryPath: '/path/to/very-long-repo',
+        repositoryName: 'a-very-long-repository-name-that-overflows-the-sidebar-width',
+      },
+    ];
+
+    beforeEach(() => {
+      (worktreeApi.getAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        worktrees: longNameWorktrees,
+        repositories: [],
+      });
+    });
+
+    it('disables horizontal scrolling on the branch list container', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      await waitFor(() => {
+        const branchList = screen.getByTestId('branch-list');
+        expect(branchList.className).toMatch(/overflow-x-hidden/);
+      });
+    });
+
+    it('makes the group header a min-w-0 flex container so truncate can apply', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const groupHeader = await screen.findByTestId('group-header');
+      expect(groupHeader.className).toMatch(/min-w-0/);
+    });
+
+    it('truncates the repository name without a native title attribute', async () => {
+      render(
+        <Wrapper>
+          <Sidebar />
+        </Wrapper>
+      );
+
+      const repoName = await screen.findByText(
+        'a-very-long-repository-name-that-overflows-the-sidebar-width'
+      );
+      // Truncation is enabled so the long name is clipped rather than overflowing.
+      expect(repoName).toHaveClass('truncate');
+      expect(repoName).toHaveClass('min-w-0');
+      // TruncationTooltip controls the hover delay in JS; it must not fall back
+      // to a native title attribute (Issue #971 / #859).
+      expect(repoName).not.toHaveAttribute('title');
+    });
+  });
+
   describe('Flat view', () => {
     it('should show flat list when view mode is flat', async () => {
       // Set localStorage to flat mode before rendering

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -1371,10 +1371,10 @@ describe('FileTreeView', () => {
       expect(fetchCount).toBeLessThan(10);
     });
 
-    it('hides the created column inline by default and exposes metadata via the row title [Issue #969]', async () => {
+    it('hides the created column inline by default and exposes metadata via the hover tooltip [Issue #969, #975]', async () => {
       // [Issue #162 -> #969] birthtime is no longer rendered inline by default
-      // (default = size only). The created/modified/size data is instead
-      // available via the row's formatted `title` tooltip.
+      // (default = size only). [Issue #975] The created/modified/size data is
+      // instead surfaced through the unified hover tooltip (no native `title`).
       window.localStorage.clear();
       const birthtimeData: TreeResponse = {
         path: '',
@@ -1411,13 +1411,15 @@ describe('FileTreeView', () => {
 
       // The raw ISO string is no longer used as a title (it is now formatted).
       expect(screen.queryByTitle('2026-02-10T10:00:00Z')).not.toBeInTheDocument();
-
-      // The row carries a formatted, multi-line metadata title for hover.
+      // No native `title` remains on the row — metadata moved to the tooltip.
       const row = screen.getByTestId('tree-item-test-file.ts');
-      const title = row.getAttribute('title');
-      expect(title).toBeTruthy();
-      expect(title).toContain('512 B');
-      expect(title!.split('\n').length).toBe(3);
+      expect(row.getAttribute('title')).toBeNull();
+
+      // Hovering the file name surfaces the formatted metadata in one bubble.
+      fireEvent.mouseEnter(screen.getByText('test-file.ts'));
+      const tooltip = await screen.findByRole('tooltip', { hidden: true });
+      expect(tooltip).toHaveTextContent('test-file.ts');
+      expect(tooltip).toHaveTextContent('512 B');
     });
 
     it('toggles inline metadata columns via the toolbar gear [Issue #969]', async () => {

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -1371,8 +1371,11 @@ describe('FileTreeView', () => {
       expect(fetchCount).toBeLessThan(10);
     });
 
-    it('should display birthtime without hidden class (visible on all screen sizes)', async () => {
-      // [Issue #162] birthtime should be visible on all screen sizes (no hidden sm:inline)
+    it('hides the created column inline by default and exposes metadata via the row title [Issue #969]', async () => {
+      // [Issue #162 -> #969] birthtime is no longer rendered inline by default
+      // (default = size only). The created/modified/size data is instead
+      // available via the row's formatted `title` tooltip.
+      window.localStorage.clear();
       const birthtimeData: TreeResponse = {
         path: '',
         name: '',
@@ -1383,6 +1386,7 @@ describe('FileTreeView', () => {
             size: 512,
             extension: 'ts',
             birthtime: '2026-02-10T10:00:00Z',
+            mtime: '2026-02-11T12:00:00Z',
           },
         ],
         parentPath: null,
@@ -1399,14 +1403,59 @@ describe('FileTreeView', () => {
         expect(screen.getByText('test-file.ts')).toBeInTheDocument();
       });
 
-      // Find the birthtime span by its title attribute
-      const birthtimeSpan = screen.getByTitle('2026-02-10T10:00:00Z');
-      expect(birthtimeSpan).toBeInTheDocument();
+      // Default: created/modified columns are NOT rendered inline.
+      expect(screen.queryByTestId('tree-item-created')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('tree-item-modified')).not.toBeInTheDocument();
+      // Size column IS shown inline by default.
+      expect(screen.getByTestId('tree-item-size')).toBeInTheDocument();
 
-      // Bug fix: birthtime should NOT have 'hidden' class (was 'hidden sm:inline')
-      expect(birthtimeSpan).not.toHaveClass('hidden');
-      // It should also NOT have 'sm:inline' class
-      expect(birthtimeSpan.className).not.toContain('sm:inline');
+      // The raw ISO string is no longer used as a title (it is now formatted).
+      expect(screen.queryByTitle('2026-02-10T10:00:00Z')).not.toBeInTheDocument();
+
+      // The row carries a formatted, multi-line metadata title for hover.
+      const row = screen.getByTestId('tree-item-test-file.ts');
+      const title = row.getAttribute('title');
+      expect(title).toBeTruthy();
+      expect(title).toContain('512 B');
+      expect(title!.split('\n').length).toBe(3);
+    });
+
+    it('toggles inline metadata columns via the toolbar gear [Issue #969]', async () => {
+      window.localStorage.clear();
+      const data: TreeResponse = {
+        path: '',
+        name: '',
+        items: [
+          {
+            name: 'toggle-me.ts',
+            type: 'file',
+            size: 512,
+            extension: 'ts',
+            birthtime: '2026-02-10T10:00:00Z',
+            mtime: '2026-02-11T12:00:00Z',
+          },
+        ],
+        parentPath: null,
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(data),
+      });
+
+      render(<FileTreeView worktreeId="test-worktree" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('toggle-me.ts')).toBeInTheDocument();
+      });
+
+      // Open the gear popover and enable the "created" column.
+      fireEvent.click(screen.getByTestId('file-metadata-toggle-button'));
+      fireEvent.click(screen.getByTestId('file-metadata-toggle-showCreated'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('tree-item-created')).toBeInTheDocument();
+      });
     });
 
     it('should cancel previous reload when refreshTrigger changes rapidly', async () => {

--- a/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
@@ -479,3 +479,37 @@ describe('TerminalSplitContainer drop validation (Issue #786 / #869)', () => {
     expect(screen.getByTestId('pane-cli-0')).toHaveTextContent('gemini');
   });
 });
+
+// ===========================================================================
+// Issue #977: the action-bar buttons are all left-aligned in a single group,
+// ordered +Split → -Split → Equal widths → History → Files. The `ml-auto` that
+// previously split the bar into left/right groups has been removed.
+// ===========================================================================
+describe('TerminalSplitContainer action-bar layout (Issue #977)', () => {
+  it('renders the action buttons in DOM order +Split → -Split → Equal widths → History → Files', () => {
+    setup();
+    const order = [
+      'add-terminal-split',
+      'remove-terminal-split',
+      'equalize-split-widths',
+      'toggle-history-pane',
+      'toggle-file-panel',
+    ];
+    // Each button must precede the next in document order (left-to-right bar).
+    for (let i = 0; i < order.length - 1; i++) {
+      const current = screen.getByTestId(order[i]);
+      const next = screen.getByTestId(order[i + 1]);
+      expect(
+        current.compareDocumentPosition(next) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+  });
+
+  it('does not push +Split to the right with ml-auto (left-aligned bar)', () => {
+    setup();
+    expect(screen.getByTestId('add-terminal-split').className).not.toContain(
+      'ml-auto',
+    );
+  });
+});

--- a/tests/unit/components/worktree/TreeNode.test.tsx
+++ b/tests/unit/components/worktree/TreeNode.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for TreeNode metadata display (Issue #969)
+ *
+ * Covers the toggleable inline columns (size / created / modified) and the
+ * formatted hover tooltip built into the row's `title` attribute.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TreeNode } from '@/components/worktree/TreeNode';
+import type { TreeItem } from '@/types/models';
+import type { FileMetadataDisplaySettings } from '@/hooks/useFileMetadataDisplay';
+
+const FILE: TreeItem = {
+  name: 'app.ts',
+  type: 'file',
+  size: 2048,
+  extension: 'ts',
+  birthtime: '2026-06-01T10:00:00.000Z',
+  mtime: '2026-06-20T15:30:00.000Z',
+};
+
+function renderNode(
+  item: TreeItem,
+  metadataDisplay?: FileMetadataDisplaySettings
+) {
+  return render(
+    <TreeNode
+      item={item}
+      path=""
+      depth={0}
+      worktreeId="wt-1"
+      expanded={new Set<string>()}
+      cache={new Map()}
+      onToggle={() => {}}
+      onLoadChildren={async () => {}}
+      dateFnsLocaleStr="en"
+      metadataDisplay={metadataDisplay}
+    />
+  );
+}
+
+describe('TreeNode metadata display [Issue #969]', () => {
+  it('shows size inline by default and hides created/modified', () => {
+    renderNode(FILE);
+    expect(screen.getByTestId('tree-item-size')).toBeInTheDocument();
+    expect(screen.queryByTestId('tree-item-created')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tree-item-modified')).not.toBeInTheDocument();
+  });
+
+  it('hides size inline when showSize is false', () => {
+    renderNode(FILE, { showSize: false, showCreated: false, showModified: false });
+    expect(screen.queryByTestId('tree-item-size')).not.toBeInTheDocument();
+  });
+
+  it('shows created inline when showCreated is true', () => {
+    renderNode(FILE, { showSize: true, showCreated: true, showModified: false });
+    expect(screen.getByTestId('tree-item-created')).toBeInTheDocument();
+    expect(screen.queryByTestId('tree-item-modified')).not.toBeInTheDocument();
+  });
+
+  it('shows modified inline when showModified is true', () => {
+    renderNode(FILE, { showSize: true, showCreated: false, showModified: true });
+    expect(screen.getByTestId('tree-item-modified')).toBeInTheDocument();
+  });
+
+  it('builds a formatted, multi-line title tooltip on file rows', () => {
+    renderNode(FILE);
+    const row = screen.getByTestId('tree-item-app.ts');
+    const title = row.getAttribute('title');
+    expect(title).toBeTruthy();
+    // Size line (formatFileSize(2048) === '2.0 KB')
+    expect(title).toContain('2.0 KB');
+    // Localized labels resolve via the mocked useTranslations (key passthrough)
+    expect(title).toContain('worktree.fileTree.metadata.size');
+    expect(title).toContain('worktree.fileTree.metadata.created');
+    expect(title).toContain('worktree.fileTree.metadata.modified');
+    // Multi-line (newline-separated)
+    expect(title!.split('\n').length).toBe(3);
+  });
+
+  it('does not set a metadata title on directory rows', () => {
+    const dir: TreeItem = { name: 'src', type: 'directory', itemCount: 3 };
+    renderNode(dir);
+    const row = screen.getByTestId('tree-item-src');
+    expect(row.getAttribute('title')).toBeNull();
+  });
+
+  it('shows item count for directories when size column is on', () => {
+    const dir: TreeItem = { name: 'src', type: 'directory', itemCount: 3 };
+    renderNode(dir);
+    expect(screen.getByTestId('tree-item-size')).toHaveTextContent('3 items');
+  });
+});

--- a/tests/unit/components/worktree/TreeNode.test.tsx
+++ b/tests/unit/components/worktree/TreeNode.test.tsx
@@ -1,14 +1,16 @@
 /**
- * Tests for TreeNode metadata display (Issue #969)
+ * Tests for TreeNode metadata display (Issue #969, #975)
  *
  * Covers the toggleable inline columns (size / created / modified) and the
- * formatted hover tooltip built into the row's `title` attribute.
+ * unified hover tooltip (file name + metadata) rendered by TruncationTooltip
+ * — replacing the previous native `title` metadata tooltip (Issue #975).
  * @vitest-environment jsdom
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { TreeNode } from '@/components/worktree/TreeNode';
+import { TRUNCATION_TOOLTIP_DELAY_MS } from '@/components/common/TruncationTooltip';
 import type { TreeItem } from '@/types/models';
 import type { FileMetadataDisplaySettings } from '@/hooks/useFileMetadataDisplay';
 
@@ -65,26 +67,58 @@ describe('TreeNode metadata display [Issue #969]', () => {
     expect(screen.getByTestId('tree-item-modified')).toBeInTheDocument();
   });
 
-  it('builds a formatted, multi-line title tooltip on file rows', () => {
-    renderNode(FILE);
-    const row = screen.getByTestId('tree-item-app.ts');
-    const title = row.getAttribute('title');
-    expect(title).toBeTruthy();
-    // Size line (formatFileSize(2048) === '2.0 KB')
-    expect(title).toContain('2.0 KB');
-    // Localized labels resolve via the mocked useTranslations (key passthrough)
-    expect(title).toContain('worktree.fileTree.metadata.size');
-    expect(title).toContain('worktree.fileTree.metadata.created');
-    expect(title).toContain('worktree.fileTree.metadata.modified');
-    // Multi-line (newline-separated)
-    expect(title!.split('\n').length).toBe(3);
-  });
+  describe('unified hover tooltip [Issue #975]', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
 
-  it('does not set a metadata title on directory rows', () => {
-    const dir: TreeItem = { name: 'src', type: 'directory', itemCount: 3 };
-    renderNode(dir);
-    const row = screen.getByTestId('tree-item-src');
-    expect(row.getAttribute('title')).toBeNull();
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('no longer sets a native title attribute on file rows', () => {
+      renderNode(FILE);
+      const row = screen.getByTestId('tree-item-app.ts');
+      // Metadata moved out of the native `title` into the custom tooltip.
+      expect(row.getAttribute('title')).toBeNull();
+    });
+
+    it('shows name + formatted metadata in a single bubble on hover', () => {
+      renderNode(FILE);
+      // The name trigger carries metadata, so the bubble appears on hover
+      // even though jsdom reports the name as non-truncated.
+      const trigger = screen.getByText('app.ts');
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS);
+      });
+
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      // File name is part of the same bubble.
+      expect(tooltip).toHaveTextContent('app.ts');
+      // Size line (formatFileSize(2048) === '2.0 KB')
+      expect(tooltip).toHaveTextContent('2.0 KB');
+      // Localized labels resolve via the mocked useTranslations (key passthrough)
+      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.size');
+      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.created');
+      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.modified');
+    });
+
+    it('does not show a metadata tooltip on directory rows', () => {
+      const dir: TreeItem = { name: 'src', type: 'directory', itemCount: 3 };
+      renderNode(dir);
+      const row = screen.getByTestId('tree-item-src');
+      expect(row.getAttribute('title')).toBeNull();
+
+      // Directories pass no metadata; with a non-truncated name (jsdom) the
+      // bubble never appears.
+      const trigger = screen.getByText('src');
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        vi.advanceTimersByTime(TRUNCATION_TOOLTIP_DELAY_MS + 50);
+      });
+      expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+    });
   });
 
   it('shows item count for directories when size column is on', () => {

--- a/tests/unit/hooks/useFileMetadataDisplay.test.ts
+++ b/tests/unit/hooks/useFileMetadataDisplay.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for useFileMetadataDisplay (Issue #969)
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useFileMetadataDisplay,
+  FILE_METADATA_DISPLAY_STORAGE_KEY,
+  DEFAULT_FILE_METADATA_DISPLAY,
+} from '@/hooks/useFileMetadataDisplay';
+
+describe('useFileMetadataDisplay', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to size-only (created/modified hidden inline)', () => {
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    expect(result.current.settings).toEqual(DEFAULT_FILE_METADATA_DISPLAY);
+    expect(result.current.settings).toEqual({
+      showSize: true,
+      showCreated: false,
+      showModified: false,
+    });
+  });
+
+  it('toggle() flips a single key and persists', () => {
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    act(() => {
+      result.current.toggle('showCreated');
+    });
+    expect(result.current.settings.showCreated).toBe(true);
+    expect(result.current.settings.showSize).toBe(true);
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(FILE_METADATA_DISPLAY_STORAGE_KEY)!
+    );
+    expect(stored.showCreated).toBe(true);
+
+    act(() => {
+      result.current.toggle('showCreated');
+    });
+    expect(result.current.settings.showCreated).toBe(false);
+  });
+
+  it('toggle() can hide size and show modified independently', () => {
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    act(() => {
+      result.current.toggle('showSize');
+      result.current.toggle('showModified');
+    });
+    expect(result.current.settings).toEqual({
+      showSize: false,
+      showCreated: false,
+      showModified: true,
+    });
+  });
+
+  it('setSettings() replaces all settings and persists', () => {
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    act(() => {
+      result.current.setSettings({
+        showSize: false,
+        showCreated: true,
+        showModified: true,
+      });
+    });
+    expect(result.current.settings).toEqual({
+      showSize: false,
+      showCreated: true,
+      showModified: true,
+    });
+    const stored = JSON.parse(
+      window.localStorage.getItem(FILE_METADATA_DISPLAY_STORAGE_KEY)!
+    );
+    expect(stored).toEqual({
+      showSize: false,
+      showCreated: true,
+      showModified: true,
+    });
+  });
+
+  it('restores stored settings on mount', () => {
+    window.localStorage.setItem(
+      FILE_METADATA_DISPLAY_STORAGE_KEY,
+      JSON.stringify({ showSize: false, showCreated: true, showModified: false })
+    );
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    expect(result.current.settings).toEqual({
+      showSize: false,
+      showCreated: true,
+      showModified: false,
+    });
+  });
+
+  it('falls back to defaults when stored value is invalid JSON', () => {
+    window.localStorage.setItem(FILE_METADATA_DISPLAY_STORAGE_KEY, 'not-json');
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    expect(result.current.settings).toEqual(DEFAULT_FILE_METADATA_DISPLAY);
+  });
+
+  it('fills missing keys with defaults (partial stored object)', () => {
+    window.localStorage.setItem(
+      FILE_METADATA_DISPLAY_STORAGE_KEY,
+      JSON.stringify({ showCreated: true })
+    );
+    const { result } = renderHook(() => useFileMetadataDisplay());
+    expect(result.current.settings).toEqual({
+      showSize: true,
+      showCreated: true,
+      showModified: false,
+    });
+  });
+
+  it('syncs state across hook instances on the same page', () => {
+    const a = renderHook(() => useFileMetadataDisplay());
+    const b = renderHook(() => useFileMetadataDisplay());
+
+    act(() => {
+      a.result.current.toggle('showModified');
+    });
+
+    expect(a.result.current.settings.showModified).toBe(true);
+    expect(b.result.current.settings.showModified).toBe(true);
+  });
+});

--- a/tests/unit/lib/file-tree-timestamps.test.ts
+++ b/tests/unit/lib/file-tree-timestamps.test.ts
@@ -66,6 +66,41 @@ describe('readDirectory birthtime', () => {
     });
   });
 
+  describe('file mtime [Issue #969]', () => {
+    it('should include mtime for files', async () => {
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      const result = await readDirectory(testDir, '');
+
+      const file = result.items.find(item => item.name === 'test.txt');
+      expect(file).toBeDefined();
+      expect(file?.mtime).toBeDefined();
+      expect(typeof file?.mtime).toBe('string');
+    });
+
+    it('should return mtime as valid ISO 8601 string', async () => {
+      writeFileSync(join(testDir, 'test.txt'), 'content');
+
+      const result = await readDirectory(testDir, '');
+
+      const file = result.items.find(item => item.name === 'test.txt');
+      const date = new Date(file!.mtime!);
+      expect(date.getTime()).not.toBeNaN();
+    });
+
+    it('should return a recent mtime for a newly written file', async () => {
+      const beforeWrite = new Date();
+      writeFileSync(join(testDir, 'recent.txt'), 'content');
+
+      const result = await readDirectory(testDir, '');
+
+      const file = result.items.find(item => item.name === 'recent.txt');
+      const mtime = new Date(file!.mtime!);
+      expect(mtime.getTime()).toBeGreaterThanOrEqual(beforeWrite.getTime() - 1000);
+      expect(mtime.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+  });
+
   describe('directory items', () => {
     it('should NOT include birthtime for directories', async () => {
       mkdirSync(join(testDir, 'subdir'));
@@ -75,6 +110,16 @@ describe('readDirectory birthtime', () => {
       const dir = result.items.find(item => item.name === 'subdir');
       expect(dir).toBeDefined();
       expect(dir?.birthtime).toBeUndefined();
+    });
+
+    it('should NOT include mtime for directories [Issue #969]', async () => {
+      mkdirSync(join(testDir, 'subdir'));
+
+      const result = await readDirectory(testDir, '');
+
+      const dir = result.items.find(item => item.name === 'subdir');
+      expect(dir).toBeDefined();
+      expect(dir?.mtime).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## 概要

develop に蓄積された v0.7.4 リリース以降のUI改善・不具合修正を main へ反映します。

## 含まれる変更（9コミット）

### 機能追加（feat）
- **#969** ファイルツリーのメタデータ列をトグル表示可能に＋ホバーツールチップ（PR #972）
- **#970** PaneResizer の分割線を VS Code 風の細線に（PR #973）
- **#975** ファイルツリーのツールチップを1つ（メタデータ＋名前）に統合（PR #978）
- **#977** PC版ターミナルヘッダーボタンを左寄せ（+Split/-Split/Equal widths/History/Files 順）（PR #980）
- **#981** markdownプレビューのコードブロックを PC/スマホでコピー可能に（PR #982）

### 不具合修正（fix）
- **#971** サイドバーの水平スクロールバーを truncate＋ホバーツールチップで除去（PR #974）
- **#976** 狭幅時にヘッダーボタンを折り返して ActivityBar との重なりを回避（PR #979）
- **#983** markdownプレビューでインラインコードにコピーボタンが表示される #981 リグレッションを修正（PR #984）

### その他
- v0.7.4 リリースの develop へのマージ反映（chore）

## 品質確認

全変更は develop 上で各PR時にCI（Build / Lint / Type Check / Unit Tests / Security Audit / CLAUDE.md size check）を通過済み。直近の develop 統合4ゲートも全Pass（451 files / 8068 tests）。

## 備考

- `package.json` のバージョンは v0.7.4 のまま（バージョンbumpは未実施）。リリースとして扱う場合は別途バージョン更新が必要。
