### PR TITLE
fix: Antigravity選択リストTUIを検出しNavigationButtonsを表示する (#995)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -516,6 +516,26 @@ export const ANTIGRAVITY_THINKING_PATTERN = /[\u2800-\u28FF]|Generating|esc to c
 export const ANTIGRAVITY_SEPARATOR_PATTERN = /^─{3,}$/m;
 
 /**
+ * Antigravity (agy) selection list pattern (Issue #995)
+ * Detects agy's interactive arrow-key selection TUIs (e.g. the "Switch Model"
+ * model picker, permission-approval menus). Their footer status bar renders
+ * "esc to cancel", which ANTIGRAVITY_THINKING_PATTERN also matches, so this
+ * pattern must be checked BEFORE thinking detection in status-detector.ts to
+ * keep the selection screen from being misreported as "generating".
+ *
+ * Matches (either is sufficient):
+ *   - The "Switch Model" header of the model picker.
+ *   - The keyboard navigation hint line combining ↑/↓ Navigate + enter Select,
+ *     e.g. "Keyboard: ↑/↓ Navigate  enter Select  esc Go Back". This hint is
+ *     common to agy selection TUIs, so it also covers non-model selection lists.
+ *
+ * No /g flag (S4-5: would make test() stateful).
+ * Single unnested `.*` (SEC4-001: ReDoS safe); `.` never crosses newlines, so the
+ * Navigate/Select alternative requires both hints on the same (keyboard hint) line.
+ */
+export const ANTIGRAVITY_SELECTION_LIST_PATTERN = /Switch Model|↑\/↓\s+Navigate.*enter\s+Select/m;
+
+/**
  * Antigravity (agy) skip patterns for response cleaning (Issue #988)
  * Filters turn/input-box separators, the bare ">" input prompt, the idle status
  * bar ("? for shortcuts ... <model>"), the thinking footer/spinner, banner block

--- a/src/lib/detection/status-detector.ts
+++ b/src/lib/detection/status-detector.ts
@@ -24,7 +24,7 @@
  * coupling via a minimal DTO/projection type.
  */
 
-import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN } from './cli-patterns';
+import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN, ANTIGRAVITY_SELECTION_LIST_PATTERN } from './cli-patterns';
 import { detectPrompt } from './prompt-detector';
 import type { PromptDetectionResult } from './prompt-detector';
 import type { CLIToolType } from '@/lib/cli-tools/types';
@@ -104,6 +104,7 @@ export const STATUS_REASON = {
   CLAUDE_SELECTION_LIST: 'claude_selection_list',
   COPILOT_SELECTION_LIST: 'copilot_selection_list',
   CODEX_SELECTION_LIST: 'codex_selection_list',
+  ANTIGRAVITY_SELECTION_LIST: 'antigravity_selection_list',
   OPENCODE_RESPONSE_COMPLETE: 'opencode_response_complete',
   INPUT_PROMPT: 'input_prompt',
   NO_RECENT_OUTPUT: 'no_recent_output',
@@ -122,6 +123,7 @@ export const SELECTION_LIST_REASONS = new Set<string>([
   STATUS_REASON.CLAUDE_SELECTION_LIST,
   STATUS_REASON.COPILOT_SELECTION_LIST,
   STATUS_REASON.CODEX_SELECTION_LIST,
+  STATUS_REASON.ANTIGRAVITY_SELECTION_LIST,
 ]);
 
 /**
@@ -260,6 +262,25 @@ export function detectSessionStatus(
         };
       }
     }
+  }
+
+  // 0.9. Antigravity: selection list detection BEFORE thinking detection (Issue #995)
+  // agy's "Switch Model" (and other) selection TUIs render an "esc to cancel"
+  // footer that ANTIGRAVITY_THINKING_PATTERN also matches, so the generic thinking
+  // check at priority 2 (and the antigravity footer branch at 2.8) would otherwise
+  // misreport the selection screen as "generating" and NavigationButtons would never
+  // be shown. Detecting the selection list here — ahead of thinking — is the fix.
+  // Mirrors the Copilot (priority 0) / Codex (priority 0.8) early-detection pattern.
+  if (cliToolId === 'antigravity' && ANTIGRAVITY_SELECTION_LIST_PATTERN.test(lastLines)) {
+    const agyPromptOptions = buildDetectPromptOptions(cliToolId);
+    const agyPromptDetection = detectPrompt(stripBoxDrawing(cleanOutput), agyPromptOptions);
+    return {
+      status: 'waiting',
+      confidence: 'high',
+      reason: STATUS_REASON.ANTIGRAVITY_SELECTION_LIST,
+      hasActivePrompt: false,
+      promptDetection: agyPromptDetection,
+    };
   }
 
   // 1. Interactive prompt detection (highest priority)

--- a/tests/unit/cli-patterns-selection.test.ts
+++ b/tests/unit/cli-patterns-selection.test.ts
@@ -14,6 +14,7 @@ import {
   OPENCODE_RESPONSE_COMPLETE,
   COPILOT_SELECTION_LIST_PATTERN,
   CLAUDE_SELECTION_LIST_FOOTER,
+  ANTIGRAVITY_SELECTION_LIST_PATTERN,
 } from '@/lib/detection/cli-patterns';
 
 describe('OPENCODE_SELECTION_LIST_PATTERN', () => {
@@ -144,5 +145,49 @@ describe('CLAUDE_SELECTION_LIST_FOOTER', () => {
     expect(CLAUDE_SELECTION_LIST_FOOTER.test('> ')).toBe(false);
     expect(CLAUDE_SELECTION_LIST_FOOTER.test('esc to interrupt')).toBe(false);
     expect(CLAUDE_SELECTION_LIST_FOOTER.test('Press enter to continue')).toBe(false);
+  });
+});
+
+describe('ANTIGRAVITY_SELECTION_LIST_PATTERN (Issue #995)', () => {
+  it('should be a RegExp', () => {
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN).toBeInstanceOf(RegExp);
+  });
+
+  it('should match the "Switch Model" header', () => {
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('Switch Model')).toBe(true);
+  });
+
+  it('should match the "↑/↓ Navigate ... enter Select" keyboard hint line', () => {
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('Keyboard: ↑/↓ Navigate  enter Select  esc Go Back')).toBe(true);
+  });
+
+  it('should match the actual Switch Model TUI (multiline)', () => {
+    const multiline = [
+      'Switch Model',
+      '',
+      '> Gemini 3.5 Flash (Medium)    (current)',
+      '  Gemini 3.5 Flash (High)',
+      '  Claude Sonnet 4.6 (Thinking)',
+      '',
+      'Keyboard: ↑/↓ Navigate  enter Select  esc Go Back',
+      '',
+      'esc to cancel                                        Gemini 3.5 Flash (Medium)',
+    ].join('\n');
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test(multiline)).toBe(true);
+  });
+
+  it('should not match the idle status bar / thinking footer', () => {
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('? for shortcuts                          gemini-2.5')).toBe(false);
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('⠉ esc to cancel')).toBe(false);
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('  Generating a response for you')).toBe(false);
+  });
+
+  it('should not match regular conversational output', () => {
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('Here is your code:')).toBe(false);
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('Please navigate to the settings page and select a model.')).toBe(false);
+  });
+
+  it('should not use the global flag (no /g)', () => {
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.global).toBe(false);
   });
 });

--- a/tests/unit/status-detector-selection.test.ts
+++ b/tests/unit/status-detector-selection.test.ts
@@ -156,15 +156,16 @@ describe('SELECTION_LIST_REASONS Set', () => {
     expect(SELECTION_LIST_REASONS).toBeInstanceOf(Set);
   });
 
-  it('should contain all four selection list reasons', () => {
+  it('should contain all five selection list reasons', () => {
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.OPENCODE_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.CLAUDE_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.COPILOT_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.CODEX_SELECTION_LIST)).toBe(true);
+    expect(SELECTION_LIST_REASONS.has(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST)).toBe(true);
   });
 
-  it('should have exactly 4 entries', () => {
-    expect(SELECTION_LIST_REASONS.size).toBe(4);
+  it('should have exactly 5 entries', () => {
+    expect(SELECTION_LIST_REASONS.size).toBe(5);
   });
 
   it('should not contain unrelated reasons', () => {
@@ -455,5 +456,97 @@ describe('detectSessionStatus - Codex /model Step 1 model selection (Issue #622)
     const result = detectSessionStatus(output, 'codex');
 
     expect(result.reason).not.toBe(STATUS_REASON.CODEX_SELECTION_LIST);
+  });
+});
+
+describe('STATUS_REASON - ANTIGRAVITY_SELECTION_LIST (Issue #995)', () => {
+  it('should export ANTIGRAVITY_SELECTION_LIST constant', () => {
+    expect(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST).toBe('antigravity_selection_list');
+  });
+});
+
+// Actual agy "Switch Model" TUI from Issue #995. The footer status bar renders
+// "esc to cancel", which ANTIGRAVITY_THINKING_PATTERN also matches — so this is
+// the exact collision the fix must resolve (selection list must win over thinking).
+const AGY_SWITCH_MODEL_OUTPUT = [
+  'Switch Model',
+  '',
+  '> Gemini 3.5 Flash (Medium)    (current)',
+  '  Gemini 3.5 Flash (High)',
+  '  Gemini 3.1 Pro (Low)',
+  '  Claude Sonnet 4.6 (Thinking)',
+  '  Claude Opus 4.6 (Thinking)',
+  '  GPT-OSS 120B (Medium)',
+  '',
+  'Keyboard: ↑/↓ Navigate  enter Select  esc Go Back',
+  '',
+  'esc to cancel                                        Gemini 3.5 Flash (Medium)',
+].join('\n');
+
+describe('detectSessionStatus - Antigravity selection_list detection (Issue #995)', () => {
+  it('should detect the Switch Model TUI and return waiting status', () => {
+    const result = detectSessionStatus(AGY_SWITCH_MODEL_OUTPUT, 'antigravity');
+    expect(result.status).toBe('waiting');
+    expect(result.confidence).toBe('high');
+    expect(result.reason).toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
+    expect(result.hasActivePrompt).toBe(false);
+  });
+
+  it('should prioritize selection list over the "esc to cancel" thinking footer', () => {
+    // Regression guard for the root cause: the "esc to cancel" footer matches
+    // ANTIGRAVITY_THINKING_PATTERN, so without priority-0.9 ordering the screen
+    // would be misreported as running/thinking_indicator.
+    const result = detectSessionStatus(AGY_SWITCH_MODEL_OUTPUT, 'antigravity');
+    expect(result.reason).not.toBe(STATUS_REASON.THINKING_INDICATOR);
+    expect(result.status).not.toBe('running');
+  });
+
+  it('should mark the reason as a selection-list reason (NavigationButtons shown)', () => {
+    const result = detectSessionStatus(AGY_SWITCH_MODEL_OUTPUT, 'antigravity');
+    expect(SELECTION_LIST_REASONS.has(result.reason)).toBe(true);
+  });
+
+  it('should still detect running from the "esc to cancel" footer during generation', () => {
+    // No selection-list markers → the thinking footer must still win (running).
+    const output = [
+      '  Generating a response for you',
+      '────────────────────────────',
+      '> ',
+      '⠉ esc to cancel',
+    ].join('\n');
+
+    const result = detectSessionStatus(output, 'antigravity');
+    expect(result.status).toBe('running');
+    expect(result.reason).toBe(STATUS_REASON.THINKING_INDICATOR);
+  });
+
+  it('should still detect ready from the bare ">" prompt when idle', () => {
+    const output = [
+      '  Here is the answer.',
+      '────────────────────────────',
+      '> ',
+      '? for shortcuts                          gemini-2.5',
+    ].join('\n');
+
+    const result = detectSessionStatus(output, 'antigravity');
+    expect(result.status).toBe('ready');
+    expect(result.reason).toBe(STATUS_REASON.INPUT_PROMPT);
+  });
+
+  it('should NOT trigger antigravity_selection_list for non-antigravity tools', () => {
+    const result = detectSessionStatus(AGY_SWITCH_MODEL_OUTPUT, 'claude');
+    expect(result.reason).not.toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
+  });
+
+  it('should NOT detect selection list for a normal antigravity response', () => {
+    const output = [
+      '  Here is your refactored function.',
+      '────────────────────────────',
+      '> ',
+      '? for shortcuts                          gemini-2.5',
+    ].join('\n');
+
+    const result = detectSessionStatus(output, 'antigravity');
+    expect(result.reason).not.toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
   });
 });


### PR DESCRIPTION
## 概要

Issue #995 の修正。worktree ターミナルで Antigravity（`agy`）の "Switch Model" 等の選択リストTUIを開いても `↑↓`/Enter の `NavigationButtons` が表示されず、モデル選択が操作不能だった問題を修正する。

Closes #995

## 根本原因

Antigravity は Phase A（#988）で prompt/thinking 検出のみ実装され、**選択リスト検出が未実装**だった。加えて `agy` の選択TUIフッター "esc to cancel" が `ANTIGRAVITY_THINKING_PATTERN` にマッチするため、選択画面が「生成中(thinking)」と誤検出され、`isSelectionListActive=false` → `NavigationButtons` が描画されず操作不能になっていた。

## 変更内容（単一コミット）

1. **`src/lib/detection/cli-patterns.ts`**: `ANTIGRAVITY_SELECTION_LIST_PATTERN` を追加。
   - `/Switch Model|↑\/↓\s+Navigate.*enter\s+Select/m` — "Switch Model" ヘッダ、または `↑/↓ Navigate … enter Select` のキーボードヒント行にマッチ（モデル選択以外の選択リストもカバー）。
   - `/g` フラグ無し（test() の stateful 化防止）、単一の非ネスト `.*`（ReDoS 安全）。
2. **`src/lib/detection/status-detector.ts`**:
   - `STATUS_REASON.ANTIGRAVITY_SELECTION_LIST` を追加し `SELECTION_LIST_REASONS`（4→5件）に含める。
   - antigravity 分岐に **priority 0.9 の早期検出ブロック**を追加。thinking 検出（priority 2 / antigravity フッター 2.8）より**前**に選択リストを判定し `status:'waiting'` を返す。これが順序修正の肝（Copilot priority 0 / Codex priority 0.8 と同型）。
3. **テスト追加**:
   - `tests/unit/cli-patterns-selection.test.ts` — 実際の "Switch Model" TUI を含むパターン網羅。
   - `tests/unit/status-detector-selection.test.ts` — 検出・thinking衝突の順序ガード・running/idle 回帰保全・非antigravity ネガティブテスト・`SELECTION_LIST_REASONS` 件数 4→5 更新。

## 影響

- `NavigationButtons` / `/api/worktrees/[id]/special-keys` / `session-key-sender` はツール非依存のため、検出が通ることで既存経路で `↑↓`/Enter が `agy` セッションへ届くようになる。
- 他ツール（claude/codex/copilot/opencode）の検出ロジックには影響なし（新ブロックは `cliToolId === 'antigravity'` でガード）。

## 品質ゲート（オーケストレーターが worktree で独立検証）

| チェック | 結果 |
|---------|------|
| `npm run lint` | ✅ No ESLint warnings or errors |
| `npx tsc --noEmit` | ✅ clean |
| `npm run test:unit` | ✅ 456 files / 8182 tests passed |
| `npm run build` | ✅ success |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
