### PR TITLE
fix: detect Antigravity permission-approval menu so selection window shows (#997)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -516,24 +516,29 @@ export const ANTIGRAVITY_THINKING_PATTERN = /[\u2800-\u28FF]|Generating|esc to c
 export const ANTIGRAVITY_SEPARATOR_PATTERN = /^─{3,}$/m;
 
 /**
- * Antigravity (agy) selection list pattern (Issue #995)
+ * Antigravity (agy) selection list pattern (Issue #995, broadened in #997)
  * Detects agy's interactive arrow-key selection TUIs (e.g. the "Switch Model"
- * model picker, permission-approval menus). Their footer status bar renders
- * "esc to cancel", which ANTIGRAVITY_THINKING_PATTERN also matches, so this
- * pattern must be checked BEFORE thinking detection in status-detector.ts to
- * keep the selection screen from being misreported as "generating".
+ * model picker, the "Do you want to proceed?" permission-approval menu). Their
+ * footer status bar renders "esc to cancel", which ANTIGRAVITY_THINKING_PATTERN
+ * also matches, so this pattern must be checked BEFORE thinking detection in
+ * status-detector.ts to keep the selection screen from being misreported as
+ * "generating".
  *
  * Matches (either is sufficient):
  *   - The "Switch Model" header of the model picker.
- *   - The keyboard navigation hint line combining ↑/↓ Navigate + enter Select,
- *     e.g. "Keyboard: ↑/↓ Navigate  enter Select  esc Go Back". This hint is
- *     common to agy selection TUIs, so it also covers non-model selection lists.
+ *   - The "↑/↓ Navigate" arrow-key navigation hint, common to every agy
+ *     selection TUI footer. Issue #995 originally required an "enter Select"
+ *     hint too, but the permission-approval menu footer is
+ *     "↑/↓ Navigate · tab Amend · ctrl+g … · ctrl+r Review" (no "enter Select"),
+ *     so #997 relaxes this to the "↑/↓ Navigate" footer alone. This covers the
+ *     Switch Model picker, permission-approval menus, and future agy selection
+ *     TUIs in one shot, while staying agy-specific (the cliToolId === 'antigravity'
+ *     guard in status-detector.ts keeps other tools unaffected).
  *
  * No /g flag (S4-5: would make test() stateful).
- * Single unnested `.*` (SEC4-001: ReDoS safe); `.` never crosses newlines, so the
- * Navigate/Select alternative requires both hints on the same (keyboard hint) line.
+ * No `.*` at all (SEC4-001: ReDoS safe — strictly safer than the #995 form).
  */
-export const ANTIGRAVITY_SELECTION_LIST_PATTERN = /Switch Model|↑\/↓\s+Navigate.*enter\s+Select/m;
+export const ANTIGRAVITY_SELECTION_LIST_PATTERN = /Switch Model|↑\/↓\s*Navigate/m;
 
 /**
  * Antigravity (agy) skip patterns for response cleaning (Issue #988)

--- a/tests/unit/cli-patterns-selection.test.ts
+++ b/tests/unit/cli-patterns-selection.test.ts
@@ -161,6 +161,29 @@ describe('ANTIGRAVITY_SELECTION_LIST_PATTERN (Issue #995)', () => {
     expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test('Keyboard: ↑/↓ Navigate  enter Select  esc Go Back')).toBe(true);
   });
 
+  // Issue #997: the permission-approval menu footer has "↑/↓ Navigate" but NO
+  // "enter Select" hint, so the #995 pattern (which required both) missed it.
+  it('should match the permission-menu footer that lacks an "enter Select" hint (Issue #997)', () => {
+    expect(
+      ANTIGRAVITY_SELECTION_LIST_PATTERN.test('  ↑/↓ Navigate · tab Amend · ctrl+g edit/expand command · ctrl+r Review'),
+    ).toBe(true);
+  });
+
+  it('should match the actual "Do you want to proceed?" permission menu (multiline, Issue #997)', () => {
+    const multiline = [
+      '  Requesting permission for:',
+      '     git status',
+      'Do you want to proceed?',
+      '> 1. Yes',
+      "  2. Yes, and always allow in this conversation for commands that start with 'git status'",
+      "  3. Yes, and always allow for commands that start with 'git status' (Persist to settings.json)",
+      '  4. No',
+      '  ↑/↓ Navigate · tab Amend · ctrl+g edit/expand command · ctrl+r Review',
+      'esc to cancel                                                          Gemini 3.5 Flash (Medium)',
+    ].join('\n');
+    expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.test(multiline)).toBe(true);
+  });
+
   it('should match the actual Switch Model TUI (multiline)', () => {
     const multiline = [
       'Switch Model',

--- a/tests/unit/status-detector-selection.test.ts
+++ b/tests/unit/status-detector-selection.test.ts
@@ -550,3 +550,49 @@ describe('detectSessionStatus - Antigravity selection_list detection (Issue #995
     expect(result.reason).not.toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
   });
 });
+
+// Actual agy "Do you want to proceed?" permission-approval menu from Issue #997.
+// Its footer is "↑/↓ Navigate · tab Amend · ctrl+g … · ctrl+r Review" — note there
+// is NO "enter Select" hint, so the #995 pattern missed it and the "esc to cancel"
+// footer misreported the screen as running/thinking. #997 broadens the pattern to
+// the "↑/↓ Navigate" footer alone.
+const AGY_PERMISSION_MENU_OUTPUT = [
+  '  Requesting permission for:',
+  '     git status',
+  'Do you want to proceed?',
+  '> 1. Yes',
+  "  2. Yes, and always allow in this conversation for commands that start with 'git status'",
+  "  3. Yes, and always allow for commands that start with 'git status' (Persist to settings.json)",
+  '  4. No',
+  '  ↑/↓ Navigate · tab Amend · ctrl+g edit/expand command · ctrl+r Review',
+  'esc to cancel                                                          Gemini 3.5 Flash (Medium)',
+].join('\n');
+
+describe('detectSessionStatus - Antigravity permission-approval menu detection (Issue #997)', () => {
+  it('should detect the "Do you want to proceed?" menu and return waiting status', () => {
+    const result = detectSessionStatus(AGY_PERMISSION_MENU_OUTPUT, 'antigravity');
+    expect(result.status).toBe('waiting');
+    expect(result.confidence).toBe('high');
+    expect(result.reason).toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
+    expect(result.hasActivePrompt).toBe(false);
+  });
+
+  it('should prioritize the selection list over the "esc to cancel" thinking footer', () => {
+    // Root-cause regression guard: the "esc to cancel" footer matches
+    // ANTIGRAVITY_THINKING_PATTERN, so without priority-0.9 ordering the
+    // permission menu would be misreported as running/thinking_indicator.
+    const result = detectSessionStatus(AGY_PERMISSION_MENU_OUTPUT, 'antigravity');
+    expect(result.reason).not.toBe(STATUS_REASON.THINKING_INDICATOR);
+    expect(result.status).not.toBe('running');
+  });
+
+  it('should mark the reason as a selection-list reason (NavigationButtons shown)', () => {
+    const result = detectSessionStatus(AGY_PERMISSION_MENU_OUTPUT, 'antigravity');
+    expect(SELECTION_LIST_REASONS.has(result.reason)).toBe(true);
+  });
+
+  it('should NOT trigger antigravity_selection_list for non-antigravity tools', () => {
+    const result = detectSessionStatus(AGY_PERMISSION_MENU_OUTPUT, 'claude');
+    expect(result.reason).not.toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #997 の修正。Antigravity（`agy`）の**権限承認メニュー**（`Do you want to proceed?` の4択）で選択ウインドウ（`NavigationButtons` ↑↓/Enter）も `PromptPanel` も表示されず操作不能だった問題を修正する。#995（Switch Model 選択TUI 検出）の直接フォローアップ。

Closes #997

## 根本原因（ライブ pane で実測確認済み）

権限承認メニューは以下の理由でどの検出経路にも拾われず、footer の `esc to cancel` により **running（生成中）誤判定**になっていた。

1. **#995 のパターンが Switch Model 専用で狭い**: `ANTIGRAVITY_SELECTION_LIST_PATTERN = /Switch Model|↑\/↓\s+Navigate.*enter\s+Select/m` は権限メニュー footer（`↑/↓ Navigate · tab Amend · …`、"enter Select" 無し）にマッチせず、priority 0.9 で拾えない。
2. **multiple-choice 検出が agy のインジケータを認識できない**: agy のハイライト行は ASCII `>`（0x3E）で、`DEFAULT_OPTION_PATTERN` の `❯/●/›` に含まれない → Pass1 で `noPromptResult`。
3. **`esc to cancel` が thinking と衝突**: 選択リストとして拾えないと priority 2 の thinking にマッチ。

## 変更内容（単一コミット）

**Option A（選択リスト検出の拡張）を採用。**

```diff
- export const ANTIGRAVITY_SELECTION_LIST_PATTERN = /Switch Model|↑\/↓\s+Navigate.*enter\s+Select/m;
+ export const ANTIGRAVITY_SELECTION_LIST_PATTERN = /Switch Model|↑\/↓\s*Navigate/m;
```

- `↑/↓ Navigate` フッター単体を選択リストの確定シグナルとして扱い、Switch Model・権限承認メニュー・今後の全 agy 選択TUI を一括カバー。
- priority 0.9（`status-detector.ts`、`cliToolId === 'antigravity'` ガード済み）で `status:'waiting'` / `reason: ANTIGRAVITY_SELECTION_LIST` を返し `NavigationButtons`（↑↓/Enter/Esc）を表示。thinking 衝突も priority 0.9 が先に確定するため解消。
- `.*` を完全排除したため **#995 の形より ReDoS 的に厳密に安全**（`/g` フラグ無しも継続）。
- テスト追加: `tests/unit/cli-patterns-selection.test.ts`（+23）／`tests/unit/status-detector-selection.test.ts`（+46）で権限承認メニュー検出・順序ガード・Switch Model 回帰・非 agy ネガティブを網羅。

## 影響

- 他ツール（claude/codex/copilot/opencode）の検出ロジックには影響なし（`cliToolId === 'antigravity'` ガード）。
- `NavigationButtons` / `special-keys` API はツール非依存のため、検出が通ることで既存経路で ↑↓/Enter が agy セッションへ届く。

## 品質ゲート（オーケストレーターが worktree で独立検証）

| チェック | 結果 |
|---------|------|
| `npm run lint` | ✅ No ESLint warnings or errors |
| `npx tsc --noEmit` | ✅ clean |
| `npm run test:unit` | ✅ 456 files / 8188 tests passed |
| `npm run build` | ✅ success |

## 検証（新パターンの挙動）

| 入力 | `ANTIGRAVITY_SELECTION_LIST_PATTERN.test()` |
|------|:---:|
| 権限承認メニュー（実 pane） | ✅ true（修正後に検出） |
| Switch Model TUI | ✅ true（回帰維持） |
| 通常生成（nav footer なし） | ❌ false（誤検出なし） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
