### PR TITLE
fix(auto-yes): respond to Antigravity permission-approval menus (#999)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -823,7 +823,15 @@ export function buildDetectPromptOptions(
   if (cliToolId === 'copilot') {
     return { requireDefaultIndicator: false };
   }
-  // [Issue #988] Antigravity (agy) uses the standard ">" indicator, so the
-  // default (requireDefaultIndicator = true) is correct — no special case needed.
+  // [Issue #999] Antigravity (agy) permission-approval menus highlight the
+  // default with an ASCII ">" (0x3E), not the "❯/●/›" indicators that
+  // DEFAULT_OPTION_PATTERN recognizes, and their footer is "↑/↓ Navigate"
+  // (no "press enter to confirm"). Under the default requireDefaultIndicator=true
+  // the Pass 1 gate rejects these menus, so Auto-Yes never responds. Treat agy
+  // like claude/opencode/copilot so Pass 2 collects its "1. Yes / … / N. No"
+  // options and reports isPrompt=true.
+  if (cliToolId === 'antigravity') {
+    return { requireDefaultIndicator: false };
+  }
   return undefined; // Default behavior (requireDefaultIndicator = true)
 }

--- a/src/lib/prompt-answer-sender.ts
+++ b/src/lib/prompt-answer-sender.ts
@@ -67,7 +67,8 @@ export interface SendPromptAnswerParams {
 
 /**
  * Send an answer to a tmux session, using cursor-key navigation for
- * Claude Code multiple-choice prompts and text input for everything else.
+ * Claude Code / Antigravity multiple-choice prompts and text input for
+ * everything else.
  *
  * This function unifies the logic previously duplicated in:
  * - src/app/api/worktrees/[id]/prompt-response/route.ts (L114-187)
@@ -76,12 +77,16 @@ export interface SendPromptAnswerParams {
 export async function sendPromptAnswer(params: SendPromptAnswerParams): Promise<void> {
   const { sessionName, answer, cliToolId, promptData, fallbackPromptType, fallbackDefaultOptionNumber } = params;
 
-  // Determine if this is a Claude Code multiple-choice prompt requiring cursor navigation
-  const isClaudeMultiChoice = cliToolId === 'claude'
+  // Determine if this is an arrow-key-navigated multiple-choice prompt.
+  // Claude Code and Antigravity (agy) both render selection menus that only
+  // respond to cursor navigation + Enter, not to typed option numbers
+  // ([Issue #999] agy's "Do you want to proceed?" permission menu). Everything
+  // else (codex/gemini/copilot/opencode) accepts "N" + Enter as text.
+  const isCursorNavMultiChoice = (cliToolId === 'claude' || cliToolId === 'antigravity')
     && (promptData?.type === 'multiple_choice' || fallbackPromptType === 'multiple_choice')
     && /^\d+$/.test(answer);
 
-  if (isClaudeMultiChoice) {
+  if (isCursorNavMultiChoice) {
     const targetNum = parseInt(answer, 10);
 
     let defaultNum: number;

--- a/tests/unit/lib/cli-patterns.test.ts
+++ b/tests/unit/lib/cli-patterns.test.ts
@@ -594,6 +594,16 @@ More text`;
       expect(options?.requireDefaultIndicator).toBe(false);
     });
 
+    // Issue #999: agy permission menus highlight the default with ASCII ">"
+    // (not ❯/●/›) and lack a "press enter to confirm" footer, so the default
+    // requireDefaultIndicator=true gate rejected them and Auto-Yes never
+    // responded. antigravity must be treated like claude/opencode/copilot.
+    it('should return requireDefaultIndicator: false for antigravity (Issue #999)', () => {
+      const options = buildDetectPromptOptions('antigravity');
+      expect(options).toBeDefined();
+      expect(options?.requireDefaultIndicator).toBe(false);
+    });
+
     it('should return undefined for codex (default behavior)', () => {
       const options = buildDetectPromptOptions('codex');
       expect(options).toBeUndefined();

--- a/tests/unit/lib/prompt-answer-sender.test.ts
+++ b/tests/unit/lib/prompt-answer-sender.test.ts
@@ -378,6 +378,80 @@ describe('sendPromptAnswer', () => {
   });
 
   // =========================================================================
+  // Issue #999: Antigravity (agy) permission menus are arrow-key-navigated,
+  // like Claude Code. detectPrompt yields options with NO isDefault flag
+  // (ASCII ">" is not an ❯/●/› indicator), so defaultNum falls back to 1.
+  // Auto-answering "Yes" (option 1) => offset 0 => a bare Enter. A typed
+  // option number would be ignored by agy's arrow-nav TUI, so sendKeys must
+  // not be used.
+  // =========================================================================
+  describe('Issue #999: Antigravity multiple_choice uses cursor navigation', () => {
+    // Options exactly as detectPrompt produces them for the real agy menu:
+    // no option carries isDefault (the ">" highlight is not a default indicator).
+    const agyMenuOptions = [
+      { number: 1, label: 'Yes' },
+      { number: 2, label: "Yes, and always allow in this conversation for commands that start with 'git status'" },
+      { number: 3, label: "Yes, and always allow for commands that start with 'git status' (Persist to settings.json)" },
+      { number: 4, label: 'No' },
+    ];
+
+    it('sends a bare Enter (cursor nav, offset 0) when auto-answering "Yes" (option 1)', async () => {
+      const promptData: PromptData = {
+        type: 'multiple_choice',
+        question: 'Do you want to proceed?',
+        options: agyMenuOptions,
+        status: 'pending',
+      };
+
+      await sendPromptAnswer({
+        sessionName: 'agy-test',
+        answer: '1',
+        cliToolId: 'antigravity',
+        promptData,
+      });
+
+      // defaultNum falls back to 1 (no isDefault), targetNum 1 => offset 0 => Enter.
+      expect(sendSpecialKeys).toHaveBeenCalledWith('agy-test', ['Enter']);
+      // A typed "1" would be ignored by agy's arrow-nav TUI, so no text send.
+      expect(sendKeys).not.toHaveBeenCalled();
+    });
+
+    it('navigates Down to reach a non-default option ("No" = option 4)', async () => {
+      const promptData: PromptData = {
+        type: 'multiple_choice',
+        question: 'Do you want to proceed?',
+        options: agyMenuOptions,
+        status: 'pending',
+      };
+
+      await sendPromptAnswer({
+        sessionName: 'agy-test',
+        answer: '4',
+        cliToolId: 'antigravity',
+        promptData,
+      });
+
+      // offset = 4 - 1 = 3 => three Downs then Enter.
+      expect(sendSpecialKeys).toHaveBeenCalledWith('agy-test', ['Down', 'Down', 'Down', 'Enter']);
+      expect(sendKeys).not.toHaveBeenCalled();
+    });
+
+    it('uses cursor nav via fallbackPromptType when promptData is undefined', async () => {
+      await sendPromptAnswer({
+        sessionName: 'agy-test',
+        answer: '1',
+        cliToolId: 'antigravity',
+        promptData: undefined,
+        fallbackPromptType: 'multiple_choice',
+      });
+
+      // fallbackDefaultOptionNumber defaults to 1 => offset 0 => Enter.
+      expect(sendSpecialKeys).toHaveBeenCalledWith('agy-test', ['Enter']);
+      expect(sendKeys).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
   // 8. Offset > 0 -> Down + Enter
   // =========================================================================
   describe('Offset > 0 (navigate Down)', () => {

--- a/tests/unit/prompt-detector.test.ts
+++ b/tests/unit/prompt-detector.test.ts
@@ -1551,6 +1551,68 @@ Are you sure you want to continue? (yes/no)
 
       expect(result).toBeUndefined();
     });
+
+    it('should return requireDefaultIndicator: false for antigravity (Issue #999)', async () => {
+      const { buildDetectPromptOptions } = await import('@/lib/detection/cli-patterns');
+      const result = buildDetectPromptOptions('antigravity');
+
+      expect(result).toEqual({ requireDefaultIndicator: false });
+    });
+  });
+
+  // ==========================================================================
+  // Issue #999: Auto-Yes must detect + auto-answer the Antigravity (agy)
+  // permission-approval menu. This mirrors the real auto-yes-poller path:
+  //   detectPrompt(pane, buildDetectPromptOptions('antigravity')) -> resolveAutoAnswer
+  // The agy menu highlights the default with ASCII ">" (not ❯/●/›) and its
+  // footer is "↑/↓ Navigate" (no "press enter to confirm"), which the default
+  // requireDefaultIndicator=true gate rejected -> response-sent count was 0.
+  // ==========================================================================
+  describe('Issue #999: Antigravity permission-approval menu auto-answer', () => {
+    // Actual agy "Do you want to proceed?" pane text (from Issue #997 fixture).
+    const AGY_PERMISSION_MENU = [
+      '  Requesting permission for:',
+      '     git status',
+      'Do you want to proceed?',
+      '> 1. Yes',
+      "  2. Yes, and always allow in this conversation for commands that start with 'git status'",
+      "  3. Yes, and always allow for commands that start with 'git status' (Persist to settings.json)",
+      '  4. No',
+      '  ↑/↓ Navigate · tab Amend · ctrl+g edit/expand command · ctrl+r Review',
+      'esc to cancel                                                          Gemini 3.5 Flash (Medium)',
+    ].join('\n');
+
+    it('detects the agy menu as a multiple_choice prompt with option 1 = Yes', async () => {
+      const { buildDetectPromptOptions } = await import('@/lib/detection/cli-patterns');
+      const result = detectPrompt(AGY_PERMISSION_MENU, buildDetectPromptOptions('antigravity'));
+
+      expect(result.isPrompt).toBe(true);
+      expect(result.promptData).toBeDefined();
+      expect(isMultipleChoicePrompt(result.promptData!)).toBe(true);
+      const mc = result.promptData!;
+      if (!isMultipleChoicePrompt(mc)) throw new Error('expected multiple_choice');
+      expect(mc.options[0].number).toBe(1);
+      expect(mc.options[0].label).toBe('Yes');
+    });
+
+    it('is NOT detected under the default gate (proves the fix is required)', () => {
+      // requireDefaultIndicator defaults to true: agy's ">" is not an ❯/●/›
+      // indicator and there is no "press enter to confirm" footer, so Pass 1
+      // rejects the menu -> Auto-Yes never responds (the reported bug).
+      const result = detectPrompt(AGY_PERMISSION_MENU);
+      expect(result.isPrompt).toBe(false);
+    });
+
+    it('resolveAutoAnswer picks "1" (Yes) since no option carries the default flag', async () => {
+      const { buildDetectPromptOptions } = await import('@/lib/detection/cli-patterns');
+      const { resolveAutoAnswer } = await import('@/lib/polling/auto-yes-resolver');
+      const result = detectPrompt(AGY_PERMISSION_MENU, buildDetectPromptOptions('antigravity'));
+
+      expect(result.promptData).toBeDefined();
+      // ASCII ">" is not a DEFAULT_OPTION_PATTERN indicator, so isDefault is unset
+      // on every option and resolveAutoAnswer falls back to the first option (Yes).
+      expect(resolveAutoAnswer(result.promptData!)).toBe('1');
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## 概要

Issue #999 の修正。Antigravity（`agy`）ターミナルで **Auto-Yes が権限承認メニュー（`Do you want to proceed?`）に自動応答しない**問題を修正する。#997（選択ウインドウの UI 表示）の補完で、UI とは別経路の **Auto-Yes（自動応答）経路** を agy 対応にする。

Closes #999

## 根本原因（コードレベルで確定）

Auto-Yes は UI の選択ウインドウ（#997 で直した `status-detector.ts` 経路）とは**別の検出経路**（`auto-yes-poller.ts` → 独自 `detectPrompt()`）を使う。ライブログで `poller:started(antigravity)=4回` に対し `poller:response-sent(antigravity)=0回` を確認済み（＝検出できず無応答）。

1. **検出ギャップ**: `buildDetectPromptOptions('antigravity')` が `undefined`（=`requireDefaultIndicator: true`）を返し、agy のハイライト（ASCII `>` 0x3E、`❯/●/›` ではない）＋フッター `↑/↓ Navigate`（`press enter to confirm` 無し）が Pass1 ゲートで reject → `isPrompt=false`。
2. **送出ギャップ**: `sendPromptAnswer` のカーソルナビ（矢印+Enter）が `cliToolId === 'claude'` 限定で、agy には番号テキストを送ってしまう（矢印ナビ型 agy TUI は受け付けない）。

## 変更内容（単一コミット）

**採用: Option A（検出＋送出の2点修正）**

```diff
// src/lib/detection/cli-patterns.ts  buildDetectPromptOptions
+  if (cliToolId === 'antigravity') {
+    return { requireDefaultIndicator: false };
+  }
```
```diff
// src/lib/prompt-answer-sender.ts
-  const isClaudeMultiChoice = cliToolId === 'claude'
+  const isCursorNavMultiChoice = (cliToolId === 'claude' || cliToolId === 'antigravity')
     && (promptData?.type === 'multiple_choice' || fallbackPromptType === 'multiple_choice')
     && /^\d+$/.test(answer);
```

- ①検出: agy を claude/opencode/copilot と同列にし、Pass2 が `1. Yes / … / N. No` を収集 → `isPrompt=true`。`isDefault` 無しのため `resolveAutoAnswer` は先頭=option 1（Yes）を選択。
- ②送出: agy をカーソルナビ分岐に含める。権限メニューは "Yes" が既定ハイライト（offset 0）→ **Enter** で確定。
- 旧 #988 の誤コメント（「agy は標準 `>` を使うので既定で正しい」）も訂正。
- 他ツール（claude/codex/copilot/opencode/gemini）の挙動は不変。

## テスト

- `tests/unit/lib/cli-patterns.test.ts`（+10）: `buildDetectPromptOptions('antigravity')` が `requireDefaultIndicator: false` を返す
- `tests/unit/lib/prompt-answer-sender.test.ts`（+74）: agy multiple-choice がカーソルナビ（Enter/矢印+Enter）で送出される
- `tests/unit/prompt-detector.test.ts`（+62）: agy 権限メニューの実 pane で `detectPrompt` が `isPrompt=true`・option 1=Yes

## 品質ゲート（オーケストレーターが worktree で独立検証）

| チェック | 結果 |
|---------|------|
| `npm run lint` | ✅ No ESLint warnings or errors |
| `npx tsc --noEmit` | ✅ clean |
| `npm run test:unit` | ✅ 456 files / 8196 tests passed |
| `npm run build` | ✅ success |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
