### PR TITLE
fix(cli): ls --branch を実ブランチ名で絞り込む (#1003)

### DIFF
--- a/src/cli/commands/ls.ts
+++ b/src/cli/commands/ls.ts
@@ -79,10 +79,12 @@ export function createLsCommand(): Command {
 
         let worktrees = data.worktrees;
 
-        // [DR2-08] Filter by name (not branch) prefix
+        // [DR2-08] Filter by real branch prefix (Issue #1003), falling back to
+        // `name` when the branch is not yet synced (NULL) so legacy behavior and
+        // pre-#1003 rows keep working.
         if (options.branch) {
           worktrees = worktrees.filter(wt =>
-            wt.name.startsWith(options.branch!)
+            (wt.branch ?? wt.name).startsWith(options.branch!)
           );
         }
 

--- a/src/cli/types/api-responses.ts
+++ b/src/cli/types/api-responses.ts
@@ -13,10 +13,20 @@ export interface WorktreeListResponse {
 }
 
 // Mirrors: src/types/models.ts Worktree (subset)
-// [DR2-08] Field name is "name" (not "branch") matching server-side Worktree type
+// [DR2-08] `name` is the display name / id-derived slug; `branch` (Issue #1003)
+// is the real git branch. They usually coincide for sync-generated worktrees
+// but can diverge, so `ls --branch` filters on `branch` (falling back to `name`).
 export interface WorktreeItem {
   id: string;
   name: string;
+  /**
+   * Mirrors: src/types/models.ts Worktree.branch (Issue #1003).
+   * Git branch captured at sync time — a distinct concept from
+   * gitStatus.currentBranch (live) and initialBranch (session start); it lags a
+   * checkout until the next sync. Undefined for rows synced before Issue #1003
+   * or written by non-sync paths; consumers fall back to {@link name}.
+   */
+  branch?: string;
   cliToolId?: string;
   isSessionRunning?: boolean;
   isWaitingForResponse?: boolean;

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -18,6 +18,7 @@ import { v32_migrations } from './v32-add-messages-role-composite-index';
 import { v33_migrations } from './v33-agent-instances';
 import { v34_migrations } from './v34-repository-todos';
 import { v35_migrations } from './v35-timer-instance-id';
+import { v36_migrations } from './v36-worktree-branch';
 
 /**
  * Complete ordered list of all migrations.
@@ -41,4 +42,5 @@ export const migrations: Migration[] = [
   ...v33_migrations,
   ...v34_migrations,
   ...v35_migrations,
+  ...v36_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 35;
+export const CURRENT_SCHEMA_VERSION = 36;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v36-worktree-branch.ts
+++ b/src/lib/db/migrations/v36-worktree-branch.ts
@@ -1,0 +1,41 @@
+/** Migration v36: Add branch column to worktrees (Issue #1003).
+ *
+ * `ls --branch` historically filtered on the worktree `name` field, which for
+ * sync-generated worktrees is the git branch but for others can diverge (the id
+ * slug / display name). To let `ls --branch` filter on the real branch, we
+ * persist the branch captured at sync time (scanWorktrees) in a dedicated
+ * column.
+ *
+ * This is a third, distinct branch concept from the two that already exist:
+ *   - worktrees.initial_branch (Issue #111): branch recorded at session start.
+ *   - gitStatus.currentBranch: the live branch resolved on read.
+ *   - worktrees.branch (this migration): sync-time snapshot from `git worktree list`.
+ *
+ * No backfill: there is no in-DB source for the real branch, so the column is
+ * NULL-initialized and populated on the next sync (scanWorktrees -> upsert).
+ * Consumers fall back to `name` while the column is NULL, preserving legacy
+ * behavior. The column is nullable so existing rows and non-sync writers (which
+ * omit branch) are unaffected.
+ */
+
+import type { Migration } from './runner';
+
+export const v36_migrations: Migration[] = [
+  {
+    version: 36,
+    name: 'add-branch-to-worktrees',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE worktrees ADD COLUMN branch TEXT;
+      `);
+
+      // No backfill: no in-DB source for the real branch. Populated on next sync.
+      console.log('Added branch column to worktrees table');
+    },
+    down: () => {
+      // SQLite cannot drop a column without a table rebuild; no-op rollback
+      // (mirrors the v35 timer instance_id migration).
+      console.log('No rollback for branch column (SQLite limitation)');
+    },
+  },
+];

--- a/src/lib/db/worktree-db.ts
+++ b/src/lib/db/worktree-db.ts
@@ -91,7 +91,7 @@ export function getWorktrees(
       w.id, w.name, w.path, w.repository_path, w.repository_name, w.description,
       w.last_user_message, w.last_user_message_at, w.last_message_summary,
       w.updated_at, w.favorite, w.status, w.link, w.cli_tool_id, w.last_viewed_at,
-      w.selected_agents, w.vibe_local_model, w.vibe_local_context_window,
+      w.selected_agents, w.vibe_local_model, w.vibe_local_context_window, w.branch,
       r.display_name as repository_display_name,
       (SELECT MAX(timestamp) FROM chat_messages
        WHERE worktree_id = w.id AND role = 'assistant' ${ACTIVE_FILTER}) as last_assistant_message_at
@@ -128,6 +128,7 @@ export function getWorktrees(
     selected_agents: string | null;
     vibe_local_model: string | null;
     vibe_local_context_window: number | null;
+    branch: string | null;
     repository_display_name: string | null;
     last_assistant_message_at: number | null;
   }>;
@@ -143,6 +144,7 @@ export function getWorktrees(
       id: row.id,
       name: row.name,
       path: row.path,
+      branch: row.branch ?? undefined,
       repositoryPath: row.repository_path || '',
       repositoryName: row.repository_name || '',
       repositoryDisplayName: row.repository_display_name || undefined,
@@ -233,7 +235,7 @@ export function getWorktreeById(
       w.id, w.name, w.path, w.repository_path, w.repository_name, w.description,
       w.last_user_message, w.last_user_message_at, w.last_message_summary,
       w.updated_at, w.favorite, w.status, w.link, w.cli_tool_id, w.last_viewed_at,
-      w.selected_agents, w.vibe_local_model, w.vibe_local_context_window,
+      w.selected_agents, w.vibe_local_model, w.vibe_local_context_window, w.branch,
       r.display_name as repository_display_name,
       (SELECT MAX(timestamp) FROM chat_messages
        WHERE worktree_id = w.id AND role = 'assistant' ${ACTIVE_FILTER}) as last_assistant_message_at
@@ -261,6 +263,7 @@ export function getWorktreeById(
     selected_agents: string | null;
     vibe_local_model: string | null;
     vibe_local_context_window: number | null;
+    branch: string | null;
     repository_display_name: string | null;
     last_assistant_message_at: number | null;
   } | undefined;
@@ -273,6 +276,7 @@ export function getWorktreeById(
     id: row.id,
     name: row.name,
     path: row.path,
+    branch: row.branch ?? undefined,
     repositoryPath: row.repository_path || '',
     repositoryName: row.repository_name || '',
     repositoryDisplayName: row.repository_display_name || undefined,
@@ -307,9 +311,9 @@ export function upsertWorktree(
   const stmt = db.prepare(`
     INSERT INTO worktrees (
       id, name, path, repository_path, repository_name, description,
-      last_user_message, last_user_message_at, last_message_summary, updated_at, cli_tool_id
+      last_user_message, last_user_message_at, last_message_summary, updated_at, cli_tool_id, branch
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       path = excluded.path,
@@ -320,7 +324,9 @@ export function upsertWorktree(
       last_user_message_at = COALESCE(excluded.last_user_message_at, worktrees.last_user_message_at),
       last_message_summary = COALESCE(excluded.last_message_summary, worktrees.last_message_summary),
       updated_at = COALESCE(excluded.updated_at, worktrees.updated_at),
-      cli_tool_id = COALESCE(excluded.cli_tool_id, worktrees.cli_tool_id)
+      cli_tool_id = COALESCE(excluded.cli_tool_id, worktrees.cli_tool_id),
+      -- Issue #1003: keep the last known branch when a non-sync writer omits it.
+      branch = COALESCE(excluded.branch, worktrees.branch)
   `);
 
   stmt.run(
@@ -334,7 +340,8 @@ export function upsertWorktree(
     worktree.lastUserMessageAt?.getTime() || null,
     worktree.lastMessageSummary || null,
     worktree.updatedAt?.getTime() || null,
-    worktree.cliToolId || 'claude'
+    worktree.cliToolId || 'claude',
+    worktree.branch || null
   );
 }
 

--- a/src/lib/git/worktrees.ts
+++ b/src/lib/git/worktrees.ts
@@ -185,6 +185,9 @@ export async function scanWorktrees(rootDir: string): Promise<Worktree[]> {
       .map((wt) => ({
         id: generateWorktreeId(wt.branch, repositoryName),
         name: wt.branch,
+        // Issue #1003: persist the real branch (sync-time snapshot) so
+        // `ls --branch` can filter on it rather than the derived name/id slug.
+        branch: wt.branch,
         path: path.resolve(wt.path),
         repositoryPath,
         repositoryName,

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -62,6 +62,21 @@ export interface Worktree {
   repositoryPath: string;
   /** Repository display name (e.g., "MyProject") */
   repositoryName: string;
+  /**
+   * Git branch captured at sync time (scanWorktrees), Issue #1003.
+   *
+   * This is a THIRD, distinct branch concept — do not conflate it with the
+   * existing two:
+   *   - {@link GitStatus.initialBranch}: branch recorded at session start.
+   *   - {@link GitStatus.currentBranch}: the live branch resolved on read.
+   *   - branch (this field): a `git worktree list` snapshot from the last sync.
+   *
+   * Freshness/meaning therefore differ: it lags behind a checkout until the
+   * next sync. Optional and may be undefined for rows synced before Issue #1003
+   * (NULL in DB) or written by non-sync paths; consumers should fall back to
+   * {@link name}.
+   */
+  branch?: string;
   /** Repository user-defined alias (Issue #642) */
   repositoryDisplayName?: string;
   /** User description for this worktree */

--- a/tests/integration/api-worktrees.test.ts
+++ b/tests/integration/api-worktrees.test.ts
@@ -151,6 +151,27 @@ describe('GET /api/worktrees', () => {
     expect(item.agentInstances.every((i: { id: string; cliTool: string }) => i.id === i.cliTool)).toBe(true);
   });
 
+  it('should include branch for each worktree (Issue #1003)', async () => {
+    upsertWorktree(db, {
+      id: 'feature-branch',
+      name: 'feature/branch',
+      path: '/path/to/feature-branch',
+      repositoryPath: '/path/to/repo',
+      repositoryName: 'TestRepo',
+      branch: 'feature/branch',
+    });
+
+    const request = new Request('http://localhost:3000/api/worktrees');
+    const response = await getWorktrees(request as unknown as import('next/server').NextRequest);
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    const item = data.worktrees.find((w: { id: string }) => w.id === 'feature-branch');
+    expect(item).toBeDefined();
+    expect(item.branch).toBe('feature/branch');
+  });
+
   it('should return 500 on database error', async () => {
     // Close database to simulate error
     db.close();
@@ -203,6 +224,26 @@ describe('GET /api/worktrees/:id', () => {
     expect(data.id).toBe('feature-foo');
     expect(data.name).toBe('feature/foo');
     expect(data.path).toBe('/path/to/feature-foo');
+  });
+
+  it('should include branch in response (Issue #1003)', async () => {
+    upsertWorktree(db, {
+      id: 'feature-foo',
+      name: 'feature/foo',
+      path: '/path/to/feature-foo',
+      repositoryPath: '/path/to/repo',
+      repositoryName: 'TestRepo',
+      branch: 'feature/foo',
+    });
+
+    const request = new Request('http://localhost:3000/api/worktrees/feature-foo');
+    const params = { params: { id: 'feature-foo' } };
+    const response = await getWorktreeById(request as unknown as import('next/server').NextRequest, params);
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.branch).toBe('feature/foo');
   });
 
   it('should return 404 when worktree not found', async () => {

--- a/tests/unit/cli/commands/ls.test.ts
+++ b/tests/unit/cli/commands/ls.test.ts
@@ -105,3 +105,39 @@ describe('ls command action', () => {
     expect(output).toBe('No worktrees found.');
   });
 });
+
+describe('ls --branch filter uses real branch, not name (Issue #1003)', () => {
+  // Fixture where the derived `name` differs from the real git `branch`.
+  // The `id`/`name` here mimic sync-generated slugs (repo-prefixed, sanitized),
+  // so filtering by name would NOT match a `feature/` prefix.
+  const mockWorktreesWithBranch = {
+    worktrees: [
+      { id: 'wt1', name: 'myrepo-main', branch: 'main' },
+      { id: 'wt2', name: 'myrepo-feature-x', branch: 'feature/x' },
+      // No branch field: filter must fall back to `name` (legacy behavior).
+      { id: 'wt3', name: 'myrepo-fix-bug' },
+    ],
+    repositories: [],
+  };
+
+  it('filters by the real branch name, not the derived name field', async () => {
+    mockFetchResponse(mockWorktreesWithBranch);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--branch', 'feature/']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    // wt2's branch is "feature/x" (matches); its name "myrepo-feature-x" would NOT
+    // match "feature/" under the old name-based filter.
+    expect(output).toBe('wt2');
+  });
+
+  it('falls back to name when branch is absent', async () => {
+    mockFetchResponse(mockWorktreesWithBranch);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--branch', 'myrepo-fix']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    // wt3 has no branch, so the filter falls back to name "myrepo-fix-bug".
+    expect(output).toBe('wt3');
+  });
+});

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -195,6 +195,56 @@ describe('Database Operations', () => {
         expect(result).toBeNull();
       });
     });
+
+    describe('branch persistence (Issue #1003)', () => {
+      it('round-trips branch through upsert -> getWorktrees / getWorktreeById', () => {
+        upsertWorktree(testDb, {
+          id: 'repo-feature-foo',
+          name: 'feature/foo',
+          path: '/path/to/feature-foo',
+          repositoryPath: '/path/to/repo',
+          repositoryName: 'repo',
+          branch: 'feature/foo',
+        });
+
+        expect(getWorktrees(testDb)[0].branch).toBe('feature/foo');
+        expect(getWorktreeById(testDb, 'repo-feature-foo')?.branch).toBe('feature/foo');
+      });
+
+      it('returns undefined branch when not provided (NULL in DB)', () => {
+        upsertWorktree(testDb, {
+          id: 'main',
+          name: 'main',
+          path: '/path/to/main',
+          repositoryPath: '/path/to/repo',
+          repositoryName: 'repo',
+        });
+
+        expect(getWorktrees(testDb)[0].branch).toBeUndefined();
+        expect(getWorktreeById(testDb, 'main')?.branch).toBeUndefined();
+      });
+
+      it('preserves a stored branch when a later upsert omits it (COALESCE)', () => {
+        upsertWorktree(testDb, {
+          id: 'main',
+          name: 'main',
+          path: '/path/to/main',
+          repositoryPath: '/path/to/repo',
+          repositoryName: 'repo',
+          branch: 'main',
+        });
+        // A non-sync writer re-upserts without branch; the stored value must survive.
+        upsertWorktree(testDb, {
+          id: 'main',
+          name: 'main-renamed',
+          path: '/path/to/main',
+          repositoryPath: '/path/to/repo',
+          repositoryName: 'repo',
+        });
+
+        expect(getWorktreeById(testDb, 'main')?.branch).toBe('main');
+      });
+    });
   });
 
   describe('ChatMessage Operations', () => {

--- a/tests/unit/db/migration-v36-worktree-branch.test.ts
+++ b/tests/unit/db/migration-v36-worktree-branch.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for migration v36 (worktrees.branch column, Issue #1003).
+ *
+ * Three angles:
+ *  1. Fresh DB end state — running the full migration chain yields a nullable
+ *     `branch` column on the worktrees table.
+ *  2. Legacy apply (no data loss) — running v36.up() over a pre-v36 worktrees
+ *     table adds the column while leaving existing rows intact. There is NO
+ *     backfill (no in-DB source for the real branch), so the column is
+ *     NULL-initialized and populated on the next sync.
+ *  3. Idempotency — re-running the migration chain via the runner is a no-op
+ *     (version already recorded) and the branch column survives.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { v36_migrations } from '@/lib/db/migrations/v36-worktree-branch';
+
+interface ColumnInfo { name: string; notnull: number; dflt_value: unknown }
+
+function columns(db: Database.Database, table: string): ColumnInfo[] {
+  return db.pragma(`table_info(${table})`) as ColumnInfo[];
+}
+
+describe('migration v36: fresh DB end state', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('adds a nullable branch column to worktrees', () => {
+    const branch = columns(db, 'worktrees').find(c => c.name === 'branch');
+    expect(branch).toBeDefined();
+    // Nullable so existing/legacy rows and non-sync writers are unaffected.
+    expect(branch!.notnull).toBe(0);
+  });
+});
+
+describe('migration v36: legacy apply (up() in isolation)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    // Minimal pre-v36 worktrees schema (no branch column).
+    db.exec(`
+      CREATE TABLE worktrees (
+        id TEXT PRIMARY KEY,
+        name TEXT,
+        path TEXT,
+        updated_at INTEGER
+      );
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('adds branch column and preserves existing rows with branch NULL (no backfill, no data loss)', () => {
+    db.prepare(`INSERT INTO worktrees (id, name, path, updated_at) VALUES (?,?,?,?)`)
+      .run('wt-a', 'feature/foo', '/tmp/a', 1700000000000);
+
+    v36_migrations[0].up(db);
+
+    const cols = columns(db, 'worktrees').map(c => c.name);
+    expect(cols).toContain('branch');
+
+    const row = db.prepare(`SELECT id, name, branch FROM worktrees WHERE id = ?`).get('wt-a') as {
+      id: string;
+      name: string;
+      branch: string | null;
+    };
+    // Existing data intact; branch NULL-initialized (populated on next sync).
+    expect(row).toEqual({ id: 'wt-a', name: 'feature/foo', branch: null });
+  });
+});
+
+describe('migration v36: idempotency via runner', () => {
+  it('re-running runMigrations is a no-op and keeps the branch column', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    // Second run: v36 is already recorded, so nothing pending; must not throw.
+    expect(() => runMigrations(db)).not.toThrow();
+
+    const cols = columns(db, 'worktrees').map(c => c.name);
+    expect(cols).toContain('branch');
+    db.close();
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 35 after Migration #35 (timer instance_id)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(35);
+    it('should be 36 after Migration #36 (worktree branch)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(36);
     });
   });
 


### PR DESCRIPTION
## 概要

`commandmate ls --branch <prefix>` が worktree の `name`（表示名/id派生スラッグ）で前方一致していた問題を修正し、**実ブランチ名（sync 時スナップショット）で絞り込む**ようにする。関連 Issue: #1003。

## 背景

- 従来 `ls --branch` は `wt.name.startsWith(prefix)` でフィルタ（オプション名 `--branch` と実挙動が不一致）。
- API `/api/worktrees` は `branch` を返さず、CLI 型 `WorktreeItem` にも `branch` が無かった。
- git パース時に `ParsedWorktree.branch` は取得済みだったが DB に保持されず破棄されていた。

## 変更内容（方針A: DBカラム追加）

- **DB**: `worktrees` テーブルに `branch TEXT`（nullable）カラムを追加するマイグレーション `v36-worktree-branch`。backfill なし・`down` は no-op（SQLite 制約、v35 に倣う）。
- **sync**: `scanWorktrees` が sync 時に実ブランチ（`git worktree list` 由来）を `branch` として保存。upsert は `COALESCE(excluded.branch, worktrees.branch)` で非-sync writer 時に既存値を保持。
- **API**: `worktree-db.ts` の list/detail SELECT・型・マッピングに `branch` を追加 → `GET /api/worktrees`・`/api/worktrees/[id]` が `branch` を返す。
- **CLI**: `WorktreeItem.branch?: string` を追加。`ls --branch` フィルタを `(wt.branch ?? wt.name).startsWith(prefix)` に変更（**branch 未同期(NULL)時は name にフォールバック**し、pre-#1003 行・レガシー挙動・`/orchestrate` の `ls --branch feature/` を非破壊で維持）。
- **型**: `src/types/models.ts` の `Worktree` に `branch` を追加（`initial_branch`・live `currentBranch` とは別概念のsync時スナップショット）。

## 後方互換

- `branch` が NULL の行は `name` にフォールバックするため、既存 CLI 利用・orchestrate スキルは破綻しない。
- nullable カラムのため既存行・非-sync writer は無影響。

## テスト

- 追加: migration v36 単体テスト、`ls --branch` branch/フォールバック テスト、`worktree-db` の branch SELECT/upsert テスト、`api-worktrees` 統合テスト。
- 4ゲート（worktree 独立検証）:
  - `npm run lint` ✅ No ESLint warnings or errors
  - `npx tsc --noEmit` ✅
  - `npm run test:unit` ✅ 459 files / 8246 tests passed
  - `npm run build` ✅

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
