### PR TITLE
feat(cli): ls --id <prefix> で worktree ID 前方一致フィルタを追加 (#1005)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,7 @@ commandmate ls                             # worktree一覧表示
 commandmate ls --json                      # JSON形式で出力
 commandmate ls --quiet                     # IDのみ出力（1行1ID）
 commandmate ls --branch feature/           # ブランチ名プレフィックスでフィルタ
+commandmate ls --id <prefix>               # worktree IDのプレフィックスでフィルタ
 
 # メッセージ送信
 commandmate send <worktree-id> "メッセージ"                    # エージェントにメッセージ送信

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Operate agent sessions from the CLI. See the [CLI Operations Guide](./docs/en/us
 | `commandmate ls --json` | JSON output (for agent consumption) |
 | `commandmate ls --quiet` | IDs only, one per line (for piping) |
 | `commandmate ls --branch feature/` | Filter by branch name prefix |
+| `commandmate ls --id <prefix>` | Filter by worktree ID prefix |
 | `commandmate send <id> "message"` | Send a message to an agent |
 | `commandmate send <id> "msg" --auto-yes` | Send with auto-yes enabled |
 | `commandmate send <id> "msg" --agent codex` | Send to a specific agent |

--- a/docs/en/user-guide/cli-operations-guide.md
+++ b/docs/en/user-guide/cli-operations-guide.md
@@ -60,7 +60,10 @@ commandmate ls                          # Table format
 commandmate ls --json                   # JSON (for agents)
 commandmate ls --quiet                  # IDs only (one per line)
 commandmate ls --branch feature/        # Filter by branch prefix
+commandmate ls --id anvil-             # Filter by worktree id prefix
 ```
+
+> **About `--id`**: Worktree IDs are `<repo>-<branch>` slugs (e.g. `anvil-develop`), and `--id` front-matches on that ID. `--branch` and `--id` are applied independently; specifying both applies both (AND). When the same branch name (e.g. `develop`) exists across multiple repositories, an ID prefix such as `--id anvil-` narrows the result to a single repository's worktree. The front-match is case-sensitive and does not guarantee uniqueness (`--id anvil-develop` may also match `anvil-develop-2`). To pin down exactly one worktree, pipe `--quiet` output through `grep -x` or pass a prefix that is already unique.
 
 ### Output Example
 
@@ -107,6 +110,8 @@ commandmate send <worktree-id> "<message>" --auto-yes --duration 3h
 
 ```bash
 WT=$(commandmate ls --branch feature/101 --quiet)
+# Or disambiguate the same branch across repositories by worktree id prefix:
+WT=$(commandmate ls --id anvil- --quiet)
 commandmate send "$WT" "Implement this"
 ```
 

--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -77,7 +77,10 @@ commandmate ls                          # テーブル形式
 commandmate ls --json                   # JSON形式（エージェント向け）
 commandmate ls --quiet                  # IDのみ（1行1ID、パイプ用）
 commandmate ls --branch feature/        # ブランチ名プレフィックスでフィルタ
+commandmate ls --id anvil-              # worktree IDプレフィックスでフィルタ
 ```
+
+> **`--id` について**: worktree ID は `<リポジトリ名>-<ブランチ名>` 形式のスラッグ（例 `anvil-develop`）です。`--id` はこの ID の前方一致でフィルタします。`--branch` と `--id` は独立して適用され、同時指定すると両方が適用されます（AND）。同一ブランチ名（例 `develop`）が複数リポジトリに存在する場合、`--id anvil-` のように ID プレフィックスで特定リポジトリの worktree に絞り込めます。前方一致は case-sensitive で、一意性は保証しません（`--id anvil-develop` は `anvil-develop-2` にもマッチし得ます）。厳密に1件へ絞るには `--quiet` の出力を `grep -x` する等してください。
 
 ### 出力例
 
@@ -139,6 +142,10 @@ commandmate ls --quiet
 # ブランチ名でフィルタしてID取得
 commandmate ls --branch feature/101 --quiet
 # → mycodebranchdesk-feature-101
+
+# worktree IDプレフィックスでフィルタ（同一ブランチ×複数リポジトリの絞り込み）
+commandmate ls --id anvil- --quiet
+# → anvil-develop
 
 # 変数に格納
 WT=$(commandmate ls --branch feature/101 --quiet)

--- a/src/cli/commands/ls.ts
+++ b/src/cli/commands/ls.ts
@@ -71,6 +71,7 @@ export function createLsCommand(): Command {
     .option('--json', 'JSON output')
     .option('--quiet', 'IDs only (one per line)')
     .option('--branch <prefix>', 'Filter by branch name prefix')
+    .option('--id <prefix>', 'Filter by worktree id prefix')
     .option('--token <token>', TOKEN_WARNING)
     .action(async (options: LsOptions) => {
       try {
@@ -86,6 +87,14 @@ export function createLsCommand(): Command {
           worktrees = worktrees.filter(wt =>
             (wt.branch ?? wt.name).startsWith(options.branch!)
           );
+        }
+
+        // Issue #1005: Filter by worktree id prefix. Independent of `--branch`
+        // (AND-combined when both are given). Front-match / case-sensitive;
+        // the prefix does not guarantee uniqueness because ids are
+        // `<repo>-<branch>` slugs and startsWith can match sibling slugs.
+        if (options.id) {
+          worktrees = worktrees.filter(wt => wt.id.startsWith(options.id!));
         }
 
         const output = formatOutput(worktrees, options);

--- a/src/cli/docs/agent-operations.ts
+++ b/src/cli/docs/agent-operations.ts
@@ -27,6 +27,12 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
   commandmate ls --json                   # JSON output (for agent consumption)
   commandmate ls --quiet                  # IDs only, one per line (for piping)
   commandmate ls --branch <prefix>        # Filter by branch name prefix
+  commandmate ls --id <prefix>            # Filter by worktree id prefix
+
+  Worktree ids are <repo>-<branch> slugs (e.g. anvil-develop). --id / --branch
+  front-match is case-sensitive and does NOT guarantee uniqueness (e.g.
+  --id anvil-develop also matches anvil-develop-2). --branch and --id combine
+  as AND. Use --id to disambiguate the same branch across repositories.
 
   STATUS values:
     idle     - Session not started
@@ -47,6 +53,7 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
 
   Finding worktree IDs:
     WT=$(commandmate ls --branch feature/101 --quiet)
+    WT=$(commandmate ls --id anvil- --quiet)   # disambiguate by repo (id prefix)
     commandmate send "$WT" "Implement this"
 
 ### commandmate wait <worktree-id...>

--- a/src/cli/types/api-responses.ts
+++ b/src/cli/types/api-responses.ts
@@ -17,6 +17,11 @@ export interface WorktreeListResponse {
 // is the real git branch. They usually coincide for sync-generated worktrees
 // but can diverge, so `ls --branch` filters on `branch` (falling back to `name`).
 export interface WorktreeItem {
+  /**
+   * Primary worktree identifier: a `<repo>-<branch>` slug (e.g. `anvil-develop`),
+   * sanitized/lowercased. This is the prefix users pass to `ls --id` (Issue #1005)
+   * and the id accepted by send/capture/wait/respond/instances.
+   */
   id: string;
   name: string;
   /**

--- a/src/cli/types/index.ts
+++ b/src/cli/types/index.ts
@@ -179,6 +179,8 @@ export interface LsOptions {
   json?: boolean;
   quiet?: boolean;
   branch?: string;
+  /** Issue #1005: filter by worktree id prefix (front-match, AND-combined with branch) */
+  id?: string;
   token?: string;
 }
 

--- a/tests/unit/cli/commands/ls.test.ts
+++ b/tests/unit/cli/commands/ls.test.ts
@@ -141,3 +141,112 @@ describe('ls --branch filter uses real branch, not name (Issue #1003)', () => {
     expect(output).toBe('wt3');
   });
 });
+
+describe('ls --id filter (Issue #1005)', () => {
+  // Motivating scenario: the same branch name (`develop`) exists in multiple
+  // repositories, so `--branch develop` alone cannot disambiguate. Worktree IDs
+  // are `<repo>-<branch>` slugs, so `--id anvil-` narrows to one repository.
+  const mockWorktreesMultiRepo = {
+    worktrees: [
+      { id: 'anvil-develop', name: 'develop', branch: 'develop' },
+      { id: 'anvil-feature-x', name: 'feature/x', branch: 'feature/x' },
+      { id: 'mycodebranchdesk-develop', name: 'develop', branch: 'develop' },
+      { id: 'mycodebranchdesk-main', name: 'main', branch: 'main' },
+    ],
+    repositories: [],
+  };
+
+  it('filters by worktree id prefix', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--id', 'anvil-']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    // Both anvil-* worktrees match the id prefix.
+    expect(output).toBe('anvil-develop\nanvil-feature-x');
+  });
+
+  it('disambiguates same branch across repositories via id prefix', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    // `develop` exists in two repos; the repo-prefixed id slug disambiguates.
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--id', 'anvil-develop']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    expect(output).toBe('anvil-develop');
+  });
+
+  it('applies --branch and --id together as AND', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    // --branch develop matches anvil-develop + mycodebranchdesk-develop;
+    // --id anvil- narrows to just the anvil worktree (AND, not exclusive).
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--branch', 'develop', '--id', 'anvil-']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    expect(output).toBe('anvil-develop');
+  });
+
+  it('treats --id "" (empty string) as a no-op and returns all worktrees', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--id', '']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    // Falsy check (like --branch): empty prefix disables the filter.
+    expect(output).toBe('anvil-develop\nanvil-feature-x\nmycodebranchdesk-develop\nmycodebranchdesk-main');
+  });
+
+  it('is case-sensitive (startsWith)', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    // Uppercase prefix does not match the lowercase slug.
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--id', 'Anvil-']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    expect(output).toBe('');
+  });
+
+  it('produces empty --quiet output when 0 worktrees match', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--quiet', '--id', 'nonexistent-']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    expect(output).toBe('');
+  });
+
+  it('produces "[]" --json output when 0 worktrees match', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--json', '--id', 'nonexistent-']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    expect(output).toBe('[]');
+  });
+
+  it('produces "No worktrees found." table output when 0 worktrees match', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--id', 'nonexistent-']);
+    const output = mockConsoleLog.mock.calls[0][0];
+    expect(output).toBe('No worktrees found.');
+  });
+
+  it('is combinable with --json output', async () => {
+    mockFetchResponse(mockWorktreesMultiRepo);
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    await cmd.parseAsync(['node', 'ls', '--json', '--id', 'anvil-']);
+    const output = JSON.parse(mockConsoleLog.mock.calls[0][0]);
+    expect(output.map((wt: { id: string }) => wt.id)).toEqual(['anvil-develop', 'anvil-feature-x']);
+  });
+
+  it('registers the --id option in --help output', async () => {
+    const { createLsCommand } = await import('../../../../src/cli/commands/ls');
+    const cmd = createLsCommand();
+    const help = cmd.helpInformation();
+    expect(help).toContain('--id <prefix>');
+  });
+});


### PR DESCRIPTION
## 概要

`commandmate ls` に **`--id <prefix>`（worktree ID 前方一致フィルタ）** を追加する。`--branch`（#1003 で実ブランチ基準に修正）と対になる一次フィルタ。関連 Issue: #1005。

## 背景

worktree ID は `<リポジトリ名>-<ブランチ>` 形式のスラッグ（例 `anvil-develop`）で、`send`/`capture`/`wait`/`respond`/`instances` に渡す一次識別子。同一ブランチ名（例 `develop`）が複数リポジトリに存在する環境では、`--branch develop` は全リポジトリの develop worktree にマッチしてしまい、特定リポジトリの worktree を ID で絞る手段が無かった（従来は `ls --quiet | grep` で回避）。

## 変更内容

- **CLI**: `src/cli/commands/ls.ts` に `.option('--id <prefix>', ...)` を追加。`--branch` とは**独立したフィルタ**（同時指定で AND）。`worktrees.filter(wt => wt.id.startsWith(prefix))`（前方一致・case-sensitive）。
- **型**: `src/cli/types/index.ts` の `LsOptions` に `id?: string` を追加。`WorktreeItem.id` に用途の JSDoc を追記（挙動変更なし）。
- **docs**: `CLAUDE.md` / `README.md` / `docs/user-guide/cli-operations-guide.md`（日）/ `docs/en/user-guide/cli-operations-guide.md`（英）/ 埋め込み `src/cli/docs/agent-operations.ts` に `--id` を追記。
- API・DB 変更なし（`id` は既にレスポンスに存在）。

## 使い方

```bash
commandmate ls --id anvil-              # ID前方一致 → anvil-develop, anvil-main
commandmate ls --id anvil-develop      # → anvil-develop
commandmate ls --branch develop --id anvil-   # AND → anvil-develop
```

## テスト

- `tests/unit/cli/commands/ls.test.ts` に `--id` フィルタのテストを追加（+109行）: 前方一致 / 同一ブランチ×複数リポジトリの絞り込み / `--branch` との AND / 空文字 no-op / case-sensitive / 0件時の quiet・json・table 出力 / `--json` 併用 / `--help` 登録。
- 4ゲート（worktree 独立検証）:
  - `npm run lint` ✅ No ESLint warnings or errors
  - `npx tsc --noEmit` ✅
  - `npm run test:unit` ✅ 459 files / 8256 tests passed
  - `npm run build` ✅
- 実機スモーク（worktree CLI）: `ls --id anvil-` / `--id anvil-develop` / `--branch develop --id anvil-` / `--help` いずれも期待どおり。

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
