### PR TITLE
feat(ui): worktree詳細ページのインラインMarkdownプレビューにもサイドTOC（目次）を追加

### DIFF
--- a/src/app/worktrees/[id]/files/[...path]/page.tsx
+++ b/src/app/worktrees/[id]/files/[...path]/page.tsx
@@ -19,7 +19,7 @@ import { ImageViewer } from '@/components/worktree/ImageViewer';
 import { VideoViewer } from '@/components/worktree/VideoViewer';
 import { MarkdownToc } from '@/components/worktree/MarkdownToc';
 import { CodeBlockWithCopy } from '@/components/common/CodeBlockWithCopy';
-import { extractToc } from '@/lib/markdown-toc';
+import { extractToc, TOC_VISIBLE_STORAGE_KEY } from '@/lib/markdown-toc';
 
 /**
  * Sticky page-header height (px). Rendered headings get this much
@@ -27,9 +27,6 @@ import { extractToc } from '@/lib/markdown-toc';
  * jumped-to headings clear the header (Issue #1007).
  */
 const HEADER_OFFSET_PX = 57;
-
-/** localStorage key for TOC visibility (commandmate: namespace, Issue #1007). */
-const TOC_VISIBLE_STORAGE_KEY = 'commandmate:md-toc-visible';
 
 export default function FileViewerPage() {
   const router = useRouter();

--- a/src/components/worktree/MarkdownEditor.tsx
+++ b/src/components/worktree/MarkdownEditor.tsx
@@ -30,7 +30,8 @@ import React, {
   useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { AlertTriangle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, List } from 'lucide-react';
 import { debounce } from '@/lib/utils';
 import { copyToClipboard } from '@/lib/clipboard-utils';
 import { ToastContainer, useToast } from '@/components/common/Toast';
@@ -43,6 +44,8 @@ import {
   LargeFileWarning,
   type MobileTab,
 } from '@/components/worktree/MarkdownPreview';
+import { MarkdownToc } from '@/components/worktree/MarkdownToc';
+import { extractToc, TOC_VISIBLE_STORAGE_KEY } from '@/lib/markdown-toc';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useFullscreen } from '@/hooks/useFullscreen';
 import { useLocalStorageState } from '@/hooks/useLocalStorageState';
@@ -102,6 +105,123 @@ function getInitialViewMode(initialViewMode?: ViewMode): ViewMode {
 }
 
 /**
+ * Minimum preview-pane width (px) for the inline TOC sidebar to show
+ * (Issue #1009). Measured via `ResizeObserver` on the pane container itself
+ * (not the viewport) so the sidebar auto-hides in narrow split-view panes
+ * even on a wide screen.
+ */
+const TOC_SIDEBAR_MIN_WIDTH_PX = 640;
+
+export interface MarkdownPreviewPaneProps {
+  /** Debounced markdown content to render. */
+  previewContent: string;
+  /** Callback to open a file from a relative link. */
+  onOpenFile?: (path: string) => void;
+  /** Current file path for resolving relative links. */
+  filePath: string;
+  /** Worktree ID for resolving relative image paths. */
+  worktreeId: string;
+  /** Persisted TOC visibility (shared with the standalone file viewer). */
+  tocVisible: boolean;
+  /** Toggle callback for the TOC visibility. */
+  onToggleTocVisible: () => void;
+  /** i18n label for the TOC nav / toggle title. */
+  tocTitle: string;
+  /** i18n label for the toggle button when the TOC is hidden. */
+  tocShowLabel: string;
+  /** i18n label for the toggle button when the TOC is visible. */
+  tocHideLabel: string;
+}
+
+/**
+ * Markdown preview pane: renders the preview body plus an optional side TOC
+ * (Issue #1009). Reuses `extractToc`/`MarkdownToc` from the standalone file
+ * viewer (Issue #1007). The TOC sidebar and its toggle only appear when there
+ * are ≥2 headings AND the pane itself (not the viewport) is wide enough —
+ * measured with `ResizeObserver` so split-view panes narrower than the
+ * threshold never show a cramped sidebar.
+ */
+const MarkdownPreviewPane = memo(function MarkdownPreviewPane({
+  previewContent,
+  onOpenFile,
+  filePath,
+  worktreeId,
+  tocVisible,
+  onToggleTocVisible,
+  tocTitle,
+  tocShowLabel,
+  tocHideLabel,
+}: MarkdownPreviewPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const [widthAllowsToc, setWidthAllowsToc] = useState(false);
+
+  useEffect(() => {
+    setScrollEl(scrollRef.current);
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      setWidthAllowsToc(width >= TOC_SIDEBAR_MIN_WIDTH_PX);
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const tocEntries = useMemo(() => extractToc(previewContent), [previewContent]);
+  const hasToc = tocEntries.length >= 2;
+  // No-op toggle is never shown: narrow panes and 0-1 heading docs hide the
+  // control entirely rather than rendering a disabled/inert button.
+  const showToggle = hasToc && widthAllowsToc;
+  const showToc = showToggle && tocVisible;
+
+  return (
+    <div ref={containerRef} className="relative flex flex-1 overflow-hidden">
+      <div
+        ref={scrollRef}
+        data-testid="markdown-preview"
+        className="flex-1 min-w-0 p-4 overflow-y-auto prose prose-sm dark:prose-invert max-w-none prose-headings:scroll-mt-2"
+      >
+        <MarkdownPreview
+          content={previewContent}
+          onOpenFile={onOpenFile}
+          currentFilePath={filePath}
+          worktreeId={worktreeId}
+        />
+      </div>
+      {showToc && (
+        <aside
+          data-testid="markdown-preview-toc"
+          className="w-56 flex-shrink-0 overflow-y-auto border-l border-gray-200 dark:border-gray-700 py-4"
+        >
+          <div className="sticky top-0">
+            <MarkdownToc entries={tocEntries} title={tocTitle} headerOffset={0} root={scrollEl} />
+          </div>
+        </aside>
+      )}
+      {showToggle && (
+        <button
+          data-testid="markdown-preview-toc-toggle"
+          onClick={onToggleTocVisible}
+          aria-pressed={tocVisible}
+          aria-label={tocVisible ? tocHideLabel : tocShowLabel}
+          title={tocVisible ? tocHideLabel : tocShowLabel}
+          className="absolute top-2 right-2 z-10 flex items-center justify-center rounded-md border border-gray-200 dark:border-gray-700 bg-white/90 dark:bg-gray-800/90 p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 shadow-sm"
+        >
+          <List className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+});
+
+/**
  * MarkdownEditor Component
  *
  * @example
@@ -128,6 +248,8 @@ export const MarkdownEditor = memo(function MarkdownEditor({
   // Resolve file type: explicit prop > auto-detect from extension (Issue #646)
   const fileType = fileTypeProp ?? detectFileType(filePath);
   const isTextMode = fileType === 'text';
+
+  const tWorktree = useTranslations('worktree');
 
   // State
   const [content, setContent] = useState('');
@@ -206,6 +328,17 @@ export const MarkdownEditor = memo(function MarkdownEditor({
     defaultValue: false,
     validate: isValidBoolean,
   });
+
+  // Inline preview TOC visibility, shared with the standalone file viewer
+  // (Issue #1007 / #1009) so toggling one keeps the other in sync.
+  const { value: tocVisible, setValue: setTocVisible } = useLocalStorageState({
+    key: TOC_VISIBLE_STORAGE_KEY,
+    defaultValue: true,
+    validate: isValidBoolean,
+  });
+  const handleToggleTocVisible = useCallback(() => {
+    setTocVisible((visible) => !visible);
+  }, [setTocVisible]);
 
   // Swipe gesture for exiting maximized mode (mobile)
   const { ref: swipeRef } = useSwipeGesture({
@@ -789,12 +922,17 @@ export const MarkdownEditor = memo(function MarkdownEditor({
               data-testid="markdown-preview-container"
               className="flex flex-col overflow-hidden w-full"
             >
-              <div
-                data-testid="markdown-preview"
-                className="flex-1 p-4 overflow-y-auto prose prose-sm dark:prose-invert max-w-none"
-              >
-                <MarkdownPreview content={previewContent} onOpenFile={onOpenFile} currentFilePath={filePath} worktreeId={worktreeId} />
-              </div>
+              <MarkdownPreviewPane
+                previewContent={previewContent}
+                onOpenFile={onOpenFile}
+                filePath={filePath}
+                worktreeId={worktreeId}
+                tocVisible={tocVisible}
+                onToggleTocVisible={handleToggleTocVisible}
+                tocTitle={tWorktree('toc.title')}
+                tocShowLabel={tWorktree('toc.show')}
+                tocHideLabel={tWorktree('toc.hide')}
+              />
             </div>
           )
         ) : (
@@ -806,12 +944,17 @@ export const MarkdownEditor = memo(function MarkdownEditor({
             }`}
             style={viewMode === 'split' ? previewWidthStyle : { width: strategy.showPreview ? '100%' : '0%' }}
           >
-            <div
-              data-testid="markdown-preview"
-              className="flex-1 p-4 overflow-y-auto prose prose-sm dark:prose-invert max-w-none"
-            >
-              <MarkdownPreview content={previewContent} onOpenFile={onOpenFile} currentFilePath={filePath} worktreeId={worktreeId} />
-            </div>
+            <MarkdownPreviewPane
+              previewContent={previewContent}
+              onOpenFile={onOpenFile}
+              filePath={filePath}
+              worktreeId={worktreeId}
+              tocVisible={tocVisible}
+              onToggleTocVisible={handleToggleTocVisible}
+              tocTitle={tWorktree('toc.title')}
+              tocShowLabel={tWorktree('toc.show')}
+              tocHideLabel={tWorktree('toc.hide')}
+            />
           </div>
         )}
       </div>

--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -25,6 +25,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
+import rehypeSlug from 'rehype-slug';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import { X, AlertTriangle, FileText, Eye } from 'lucide-react';
@@ -231,8 +232,13 @@ export const MarkdownPreview = memo(function MarkdownPreview({
   // New array references cause ReactMarkdown to fully rebuild the DOM tree,
   // which detaches link elements and makes them unclickable.
   const remarkPlugins = useMemo(() => [remarkGfm], []);
+  // [Issue #1009] rehype-slug MUST run after rehype-sanitize: rehype-sanitize's
+  // clobberPrefix rewrites any pre-existing `id` to `user-content-<id>`, which
+  // would desync heading ids from the plain slugs `extractToc` (the inline TOC
+  // sidebar's data source) produces. Running slug after sanitize assigns plain
+  // ids that are never re-sanitized, so they match `extractToc` exactly.
   const rehypePlugins = useMemo(
-    () => [rehypeRaw, [rehypeSanitize, REHYPE_SANITIZE_SCHEMA], rehypeHighlight],
+    () => [rehypeRaw, [rehypeSanitize, REHYPE_SANITIZE_SCHEMA], rehypeSlug, rehypeHighlight],
     [],
   );
 

--- a/src/components/worktree/MarkdownToc.tsx
+++ b/src/components/worktree/MarkdownToc.tsx
@@ -9,6 +9,11 @@
  *   currently in view. The observer's top `rootMargin` is offset by the sticky
  *   header height so a heading hidden behind the header is not counted as
  *   "in view".
+ * - The observer's `root` defaults to the viewport, matching the standalone
+ *   file viewer page. The optional `root` prop lets an embedded, independently
+ *   scrolling pane (e.g. the worktree inline Markdown preview, Issue #1009)
+ *   pass its own scroll container instead (back-compat: omitting it keeps the
+ *   original viewport-root behaviour, Issue #1007).
  *
  * SSR / test safe: guards `typeof IntersectionObserver` before use.
  */
@@ -25,6 +30,12 @@ export interface MarkdownTocProps {
   title: string;
   /** Height (px) of the sticky page header, used for scroll-spy offset. */
   headerOffset?: number;
+  /**
+   * Scroll-spy `IntersectionObserver` root. Pass the scrolling pane element
+   * when the TOC lives inside its own scroll container (rather than the page
+   * viewport). Defaults to `null` (viewport root), matching prior behaviour.
+   */
+  root?: HTMLElement | null;
   /** Optional extra class names for the wrapper. */
   className?: string;
 }
@@ -46,6 +57,7 @@ export function MarkdownToc({
   entries,
   title,
   headerOffset = DEFAULT_HEADER_OFFSET,
+  root = null,
   className = '',
 }: MarkdownTocProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -67,6 +79,7 @@ export function MarkdownToc({
         }
       },
       {
+        root,
         // Shift the top edge down by the sticky header height so headings behind
         // the header do not register as "in view".
         rootMargin: `-${headerOffset}px 0px -70% 0px`,
@@ -87,7 +100,7 @@ export function MarkdownToc({
       observer.disconnect();
       observed.length = 0;
     };
-  }, [entries, headerOffset]);
+  }, [entries, headerOffset, root]);
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>, id: string) => {
     event.preventDefault();

--- a/src/lib/markdown-toc.ts
+++ b/src/lib/markdown-toc.ts
@@ -24,6 +24,12 @@
 
 import GithubSlugger from 'github-slugger';
 
+/**
+ * localStorage key for TOC visibility, shared across all Markdown TOC surfaces
+ * (standalone file viewer, Issue #1007; inline worktree preview, Issue #1009).
+ */
+export const TOC_VISIBLE_STORAGE_KEY = 'commandmate:md-toc-visible';
+
 /** A single table-of-contents entry. */
 export interface TocEntry {
   /** Heading level, 1–6 (number of leading `#`). */

--- a/tests/unit/components/MarkdownEditor.test.tsx
+++ b/tests/unit/components/MarkdownEditor.test.tsx
@@ -59,6 +59,29 @@ const mockRemoveEventListener = vi.fn();
 const originalAddEventListener = window.addEventListener;
 const originalRemoveEventListener = window.removeEventListener;
 
+// Mock ResizeObserver (jsdom has no native implementation), capturing the
+// callback so tests can simulate a pane resize (Issue #1009 TOC sidebar).
+type ROCallback = (entries: Array<{ contentRect: { width: number } }>) => void;
+let lastResizeObserverCallback: ROCallback | null = null;
+const resizeObserveSpy = vi.fn();
+const resizeDisconnectSpy = vi.fn();
+
+class MockResizeObserver {
+  constructor(cb: ROCallback) {
+    lastResizeObserverCallback = cb;
+  }
+  observe = resizeObserveSpy;
+  unobserve = vi.fn();
+  disconnect = resizeDisconnectSpy;
+}
+
+/** Simulate the preview pane container resizing to `width` px. */
+function fireResize(width: number) {
+  act(() => {
+    lastResizeObserverCallback?.([{ contentRect: { width } }]);
+  });
+}
+
 describe('MarkdownEditor', () => {
   const defaultProps = {
     worktreeId: 'test-worktree-123',
@@ -83,12 +106,16 @@ describe('MarkdownEditor', () => {
     // Mock window event listeners
     window.addEventListener = mockAddEventListener;
     window.removeEventListener = mockRemoveEventListener;
+
+    lastResizeObserverCallback = null;
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
   });
 
   afterEach(() => {
     window.addEventListener = originalAddEventListener;
     window.removeEventListener = originalRemoveEventListener;
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   /**
@@ -1466,6 +1493,90 @@ def hello():
       }).not.toThrow();
 
       await waitForEditorReady();
+    });
+  });
+
+  describe('Inline TOC Sidebar (Issue #1009)', () => {
+    const contentWithHeadings =
+      '# Title\n\nIntro text.\n\n## Section A\n\nBody A.\n\n## Section B\n\nBody B.';
+
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, content: contentWithHeadings }),
+      });
+    });
+
+    it('shows the TOC sidebar and toggle once the pane is wide enough', async () => {
+      render(<MarkdownEditor {...defaultProps} />);
+      await waitForEditorReady();
+
+      fireResize(700);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('markdown-preview-toc')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('markdown-preview-toc-toggle')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Section A' })).toBeInTheDocument();
+    });
+
+    it('hides the TOC sidebar and toggle when the pane is narrower than the threshold', async () => {
+      render(<MarkdownEditor {...defaultProps} />);
+      await waitForEditorReady();
+
+      fireResize(500);
+
+      expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('markdown-preview-toc-toggle')).not.toBeInTheDocument();
+    });
+
+    it('hides the TOC sidebar/toggle for documents with 0-1 headings even when the pane is wide', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, content: mockFileContent }),
+      });
+
+      render(<MarkdownEditor {...defaultProps} />);
+      await waitForEditorReady();
+
+      fireResize(900);
+
+      expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('markdown-preview-toc-toggle')).not.toBeInTheDocument();
+    });
+
+    it('toggles TOC visibility and persists the choice to localStorage', async () => {
+      render(<MarkdownEditor {...defaultProps} />);
+      await waitForEditorReady();
+
+      fireResize(700);
+      await waitFor(() => {
+        expect(screen.getByTestId('markdown-preview-toc')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('markdown-preview-toc-toggle'));
+
+      expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'commandmate:md-toc-visible',
+        'false'
+      );
+    });
+
+    it('restores persisted (hidden) TOC visibility on mount, keeping the toggle available', async () => {
+      localStorageMock.getItem.mockImplementation((key: string) =>
+        key === 'commandmate:md-toc-visible' ? 'false' : null
+      );
+
+      render(<MarkdownEditor {...defaultProps} />);
+      await waitForEditorReady();
+
+      fireResize(700);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('markdown-preview-toc-toggle')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/components/MarkdownPreview.test.tsx
+++ b/tests/unit/components/MarkdownPreview.test.tsx
@@ -99,4 +99,23 @@ describe('MarkdownPreview', () => {
       expect(link.getAttribute('href')).toBe('./readme.md');
     });
   });
+
+  // Issue #1009: headings need a plain (non-prefixed) id so the inline TOC
+  // sidebar's `extractToc`-derived anchors (`#slug`) resolve to the rendered
+  // heading. rehype-slug must run AFTER rehype-sanitize, else sanitize's
+  // clobberPrefix would rename the id to `user-content-slug` and desync it.
+  describe('heading ids (rehype-slug, Issue #1009)', () => {
+    it('assigns a plain slug id to headings, not "user-content-" prefixed', () => {
+      render(<MarkdownPreview content="## Section One" />);
+      const heading = screen.getByRole('heading', { name: 'Section One' });
+      expect(heading).toHaveAttribute('id', 'section-one');
+    });
+
+    it('assigns distinct ids matching document order for duplicate headings', () => {
+      render(<MarkdownPreview content={'## Section\n\ntext\n\n## Section'} />);
+      const headings = screen.getAllByRole('heading', { name: 'Section' });
+      expect(headings[0]).toHaveAttribute('id', 'section');
+      expect(headings[1]).toHaveAttribute('id', 'section-1');
+    });
+  });
 });

--- a/tests/unit/components/worktree/MarkdownToc.test.tsx
+++ b/tests/unit/components/worktree/MarkdownToc.test.tsx
@@ -156,4 +156,30 @@ describe('MarkdownToc', () => {
     ).not.toThrow();
     expect(screen.getByRole('navigation', { name: 'Contents' })).toBeInTheDocument();
   });
+
+  // Issue #1009: the inline worktree preview passes its own scroll pane as
+  // `root` so the scroll-spy tracks that pane instead of the viewport.
+  describe('root prop (Issue #1009)', () => {
+    it('defaults to a null (viewport) root when omitted', () => {
+      render(<MarkdownToc entries={ENTRIES} title="Contents" />);
+      expect(lastObserverOptions?.root).toBeNull();
+    });
+
+    it('passes a custom root through to the IntersectionObserver', () => {
+      const pane = document.createElement('div');
+      render(<MarkdownToc entries={ENTRIES} title="Contents" root={pane} />);
+      expect(lastObserverOptions?.root).toBe(pane);
+    });
+
+    it('re-subscribes the observer when the root changes', () => {
+      const paneA = document.createElement('div');
+      const paneB = document.createElement('div');
+      const { rerender } = render(<MarkdownToc entries={ENTRIES} title="Contents" root={paneA} />);
+      expect(disconnectSpy).not.toHaveBeenCalled();
+
+      rerender(<MarkdownToc entries={ENTRIES} title="Contents" root={paneB} />);
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(lastObserverOptions?.root).toBe(paneB);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

worktree 詳細ページ（例 `/worktrees/anvil-develop`）でマークダウンを開いたときの**インラインプレビュー**（`MarkdownEditor` → `MarkdownPreview`）にもサイド TOC（目次）を表示できるようにする。#1007 で独立ファイルビューワーページに追加した TOC 資産（`extractToc` / `MarkdownToc`）を再利用。関連 Issue: #1009。

## 背景

#1007 の TOC は独立ファイルビューワーページ（チャットのファイルパスから開く全画面ページ）にのみ実装されており、worktree 詳細ページのインラインプレビューには目次が無かった。「全画面時以外（詳細ページのプレビュー）でも目次を使いたい」という要望に対応する。

## 変更内容

- **見出し id 付与（MarkdownPreview）**: `rehype-slug` を **`rehype-sanitize` の後段**に追加（`[rehypeRaw, [rehypeSanitize, SCHEMA], rehypeSlug, rehypeHighlight]`）。
  - sanitize は `clobberPrefix` で既存 `id` を `user-content-<id>` に書き換えるため、slug を後段に置くことで plain な id を付与し、`extractToc` が生成する `#slug` と完全一致させる。`prose-headings:scroll-mt-2` でペイン上端オフセットを確保。
- **スクロールスパイの root 対応（MarkdownToc）**: 任意 prop `root?: HTMLElement | null` を追加し `IntersectionObserver` の `root` に反映。インラインプレビューのスクロールコンテナ（ペイン）を root にできる。未指定時は従来どおりビューポート root ＝ **#1007 の独立ページは無回帰**（後方互換）。
- **プレビューペインの TOC UI（MarkdownEditor）**: 新規 `MarkdownPreviewPane` を追加し、プレビュー描画2箇所（モバイル縦タブ／デスクトップ・横）を差し替え。
  - `ResizeObserver` で**ペイン自身の幅**を計測し、`640px` 以上のときだけサイドバー（`w-56`, `border-l`, sticky）とトグルを表示。狭い split ペインでは広い画面でも自動非表示（ビューポート基準の `lg:` ではなくコンテナ基準）。
  - 見出し 0〜1 件のときはサイドバー/トグルを出さない（no-op ボタンを表示しない）。
  - スクロールコンテナ ref を `MarkdownToc` の `root` に渡し、ペイン内スクロールで現在地ハイライトが機能。
- **トグル＋永続化**: プレビュー右上のトグル（`List` アイコン、`aria-pressed`）。`useLocalStorageState` で **localStorage キー `commandmate:md-toc-visible` を #1007 と共有**（片方の表示/非表示がもう片方にも反映）。キー定義は `src/lib/markdown-toc.ts` に集約し #1007 ページもそれを参照（DRY）。
- **i18n**: 既存の `locales/{en,ja}/worktree.json` の `toc.title/show/hide` を再利用（新規キーなし）。

## スコープ

- 対象: worktree 詳細ページのインラインプレビュー / エディタ split のプレビュー側 / 最大化（全画面）時のプレビュー。
- 対象外: 独立ファイルビューワーページ（#1007 で実装済、後方互換で無回帰）。

## テスト

- 追加/更新ユニットテスト（対象4ファイル 114 tests Pass）:
  - `tests/unit/components/worktree/MarkdownToc.test.tsx`（`root` prop が `IntersectionObserver` root に渡ること 等）
  - `tests/unit/components/MarkdownPreview.test.tsx`（見出しに plain な id が付与＝ `user-content-` にならない、sanitize 回帰なし）
  - `tests/unit/components/MarkdownEditor.test.tsx`（TOC サイドバー表示/幅による自動可否/トグル/localStorage 共有 等）
- 4ゲート（worktree 独立検証, commit `ecea7251`）:
  - `npm run lint` ✅ No ESLint warnings or errors
  - `npx tsc --noEmit` ✅
  - `npm run test:unit` ✅ 462 files / 8300 tests passed
  - `npm run build` ✅

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
