### PR TITLE
fix(ui): インラインMarkdownプレビューのTOC表示しきい値を480pxに調整

### DIFF
--- a/src/components/worktree/MarkdownEditor.tsx
+++ b/src/components/worktree/MarkdownEditor.tsx
@@ -108,9 +108,11 @@ function getInitialViewMode(initialViewMode?: ViewMode): ViewMode {
  * Minimum preview-pane width (px) for the inline TOC sidebar to show
  * (Issue #1009). Measured via `ResizeObserver` on the pane container itself
  * (not the viewport) so the sidebar auto-hides in narrow split-view panes
- * even on a wide screen.
+ * even on a wide screen. Tuned to 480 so the worktree detail page's inline
+ * preview pane (~551px in the default multi-panel layout) shows the TOC; the
+ * narrow `w-48` sidebar keeps the body readable at that width.
  */
-const TOC_SIDEBAR_MIN_WIDTH_PX = 640;
+const TOC_SIDEBAR_MIN_WIDTH_PX = 480;
 
 export interface MarkdownPreviewPaneProps {
   /** Debounced markdown content to render. */
@@ -198,7 +200,7 @@ const MarkdownPreviewPane = memo(function MarkdownPreviewPane({
       {showToc && (
         <aside
           data-testid="markdown-preview-toc"
-          className="w-56 flex-shrink-0 overflow-y-auto border-l border-gray-200 dark:border-gray-700 py-4"
+          className="w-48 flex-shrink-0 overflow-y-auto border-l border-gray-200 dark:border-gray-700 py-4"
         >
           <div className="sticky top-0">
             <MarkdownToc entries={tocEntries} title={tocTitle} headerOffset={0} root={scrollEl} />

--- a/tests/unit/components/MarkdownEditor.test.tsx
+++ b/tests/unit/components/MarkdownEditor.test.tsx
@@ -1524,7 +1524,8 @@ def hello():
       render(<MarkdownEditor {...defaultProps} />);
       await waitForEditorReady();
 
-      fireResize(500);
+      // Below TOC_SIDEBAR_MIN_WIDTH_PX (480): sidebar/toggle must stay hidden.
+      fireResize(400);
 
       expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
       expect(screen.queryByTestId('markdown-preview-toc-toggle')).not.toBeInTheDocument();


### PR DESCRIPTION
## 概要

#1009 で追加した worktree 詳細ページのインライン Markdown プレビューの TOC が、既定レイアウトのプレビューペイン幅（**~551px**）では表示しきい値 **640px** に届かず常に自動非表示になっていた。実機確認で判明（見出し25個・条件は満たすが幅で抑制）。

## 変更内容
- `TOC_SIDEBAR_MIN_WIDTH_PX`: **640 → 480**（詳細ページのインラインペイン ~551px でも目次サイドバーを表示）
- TOC サイドバー幅: **w-56(224px) → w-48(192px)**（本文の可読幅を確保。551px 時 本文 ~340px）
- テスト: 狭幅ケースの `fireResize(500)` → `fireResize(400)`（新しきい値 480 未満で非表示を検証）

## 検証（worktree, commit `86f5ae40`）
- `npm run lint` ✅ / `npx tsc --noEmit` ✅
- `npm run test:unit` ✅ 462 files / 8300 tests
- `npm run build` ✅

Refs #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)