### PR TITLE
fix(ui): PC版アクティビティバーのFilesアイコンをスマホ版のフォルダ型に統一

### DIFF
--- a/src/config/activity-bar-config.ts
+++ b/src/config/activity-bar-config.ts
@@ -13,7 +13,7 @@
  */
 
 import type { ComponentType, SVGProps } from 'react';
-import { File, GitBranch, StickyNote, Calendar, Bot, Timer } from 'lucide-react';
+import { Folder, GitBranch, StickyNote, Calendar, Bot, Timer } from 'lucide-react';
 
 /**
  * Unique identifier for an activity in the Activity Bar.
@@ -38,7 +38,7 @@ export interface ActivityDefinition {
  * navigation order (ArrowDown/ArrowUp).
  */
 export const ACTIVITIES: readonly ActivityDefinition[] = [
-  { id: 'files', label: 'Files', icon: File },
+  { id: 'files', label: 'Files', icon: Folder },
   { id: 'git', label: 'Git', icon: GitBranch },
   { id: 'notes', label: 'Notes', icon: StickyNote },
   { id: 'schedules', label: 'Schedules', icon: Calendar },


### PR DESCRIPTION
## 概要

PC版アクティビティバーの **Files アイコン**をスマホ版に合わせて、より直感的な**フォルダ型**に変更します。

## 背景 / 現状調査

| | 実装 | アイコン | 形状 |
|---|---|---|---|
| **PC版** ActivityBar | `src/config/activity-bar-config.ts` の lucide `File` | `lucide lucide-file` | 📄 折れ角つきの書類（1枚） |
| **スマホ版** TabBar | `src/components/mobile/MobileTabBar.tsx` のインラインSVG（Heroicons folder パス） | フォルダ型 | 📁 フォルダ |

- 両者はアイコンソースが別系統（lucide vs 手書きSVGパス）で、これが不一致の根本原因。
- スマホ版の方がファイルツリーらしく直感的、という要望に合わせて PC 側を**フォルダ型**へ寄せる。

## 変更内容

- `src/config/activity-bar-config.ts`: import と `ACTIVITIES` の `files` 定義を **`File` → `Folder`**（lucide）へ変更。他アイコン（GitBranch / StickyNote / Calendar / Bot / Timer）は lucide のまま一貫。
- `ActivityBar.tsx` は `activity.icon` を汎用描画するため**変更不要**。
- スマホ版（`MobileTabBar`）は既にフォルダ型のため変更なし。

## スコープ

- 対象: PC版 ActivityBar の Files アイコンの見た目のみ。
- 対象外: 挙動・id・キーボードナビゲーション・スマホ版（すべて不変）。

## テスト / 品質（4ゲート、fixブランチで検証）

- `npm run lint` ✅ No ESLint warnings or errors
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅ 462 files / 8,300 tests passed（`ActivityBar.test.tsx` 含む 35 tests Pass）
- `npm run build` ✅
- 既存テストはアイコンの id/label/個数のみ検証しており**アイコン形状は非アサート**のため無回帰。

## 補足

- 本PRは Issue 紐付けなし（軽微なUI改善）。develop-base のため Issue 手動クローズも不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
