### PR TITLE
fix: Codexのページャ/選択リスト状態で選択ウィンドウを表示（codex2/codex3で顕在化）

### DIFF
--- a/src/app/api/worktrees/[id]/current-output/route.ts
+++ b/src/app/api/worktrees/[id]/current-output/route.ts
@@ -122,6 +122,21 @@ export async function GET(
     const isSelectionListActive = statusResult.status === 'waiting'
       && SELECTION_LIST_REASONS.has(statusResult.reason);
 
+    // Issue #1017: Codex pager / edit-previous mode flag. A subset of
+    // isSelectionListActive that additionally tells the client to surface the
+    // pager-specific keys (PgUp/PgDn/Home/End/q) in NavigationButtons.
+    const isPagerActive = statusResult.reason === STATUS_REASON.CODEX_PAGER;
+
+    // Issue #1017 (C-lite): "detection could not classify this frame" signal for the
+    // detection-independent Esc/q escape hatch. reason 'default' is the low-confidence
+    // fallback returned only when no prompt / selection list / thinking / input-prompt
+    // matched — i.e. the session is interactive but stuck in an unrecognized TUI mode.
+    // Normal generation is 'thinking_indicator' (the status bar is present), so this
+    // stays false during ordinary processing and only surfaces the safety net when
+    // detection genuinely gave up.
+    const isUnclassifiedActive = statusResult.status === 'running'
+      && statusResult.reason === STATUS_REASON.DEFAULT;
+
     // Extract realtime snippet (last 100 lines for better context)
     const realtimeSnippet = lines.slice(-100).join('\n');
 
@@ -156,6 +171,10 @@ export async function GET(
       },
       // Issue #473: Selection list active flag for OpenCode TUI navigation
       isSelectionListActive,
+      // Issue #1017: Codex pager/edit-previous mode -> show pager keys in NavigationButtons
+      isPagerActive,
+      // Issue #1017: unclassified interactive state -> show the Esc/q escape hatch
+      isUnclassifiedActive,
       // Issue #138: Server-side response timestamp for duplicate prevention
       lastServerResponseTimestamp,
       // Issue #501, #525: Whether server-side auto-yes poller is active (per-agent)

--- a/src/cli/types/api-responses.ts
+++ b/src/cli/types/api-responses.ts
@@ -83,6 +83,8 @@ export interface CurrentOutputResponse {
   thinkingMessage: string | null;
   cliToolId?: string;
   isSelectionListActive: boolean;
+  /** Issue #1017: Codex pager/edit-previous mode (subset of isSelectionListActive). */
+  isPagerActive?: boolean;
   lastServerResponseTimestamp: number | null;
   serverPollerActive: boolean;
   /** Issue #520: Session status from detectSessionStatus() */

--- a/src/components/worktree/NavigationButtons.tsx
+++ b/src/components/worktree/NavigationButtons.tsx
@@ -10,10 +10,11 @@
  * [DR4-006] No dangerouslySetInnerHTML usage.
  */
 
-import { useCallback, useState, type KeyboardEvent } from 'react';
+import { useCallback, useMemo, useState, type KeyboardEvent } from 'react';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import type { NavigationKey } from '@/lib/tmux/tmux';
-import { KEY_PRESS_FEEDBACK_RESET_MS, NAV_KEY_REFRESH_DELAY_MS } from '@/config/ui-feedback-config';
+import { useSpecialKeys } from '@/hooks/useSpecialKeys';
+import { KEY_PRESS_FEEDBACK_RESET_MS } from '@/config/ui-feedback-config';
 
 export interface NavigationButtonsProps {
   worktreeId: string;
@@ -25,9 +26,16 @@ export interface NavigationButtonsProps {
   instanceId?: string;
   /** Optional callback to trigger immediate terminal refresh after key send */
   onKeysSent?: () => void;
+  /**
+   * Issue #1017: when true, append the Codex pager / edit-previous keys
+   * (PgUp/PgDn/Home/End/q) so the read-only terminal can scroll and quit the
+   * transcript pager. Off by default \u2014 the base arrow/Enter/Esc set is unchanged
+   * for every existing selection-list (e.g. /model) caller.
+   */
+  showPagerKeys?: boolean;
 }
 
-/** Navigation button configuration */
+/** Base navigation button configuration (arrow-key selection lists). */
 const NAVIGATION_BUTTONS: ReadonlyArray<{ key: NavigationKey; label: string; ariaLabel: string }> = [
   { key: 'Left', label: '\u25C0', ariaLabel: 'Left' },
   { key: 'Up', label: '\u25B2', ariaLabel: 'Up' },
@@ -37,34 +45,38 @@ const NAVIGATION_BUTTONS: ReadonlyArray<{ key: NavigationKey; label: string; ari
   { key: 'Escape', label: 'Esc', ariaLabel: 'Escape' },
 ];
 
-export function NavigationButtons({ worktreeId, cliToolId, instanceId, onKeysSent }: NavigationButtonsProps) {
+/**
+ * Issue #1017: Codex pager / edit-previous mode keys, appended when showPagerKeys
+ * is set. PgUp/PgDn/Home/End scroll the transcript; 'q' quits the pager.
+ */
+const PAGER_BUTTONS: ReadonlyArray<{ key: NavigationKey; label: string; ariaLabel: string }> = [
+  { key: 'PageUp', label: 'PgUp', ariaLabel: 'Page Up' },
+  { key: 'PageDown', label: 'PgDn', ariaLabel: 'Page Down' },
+  { key: 'Home', label: 'Home', ariaLabel: 'Home' },
+  { key: 'End', label: 'End', ariaLabel: 'End' },
+  { key: 'q', label: 'q', ariaLabel: 'Quit pager' },
+];
+
+export function NavigationButtons({ worktreeId, cliToolId, instanceId, onKeysSent, showPagerKeys = false }: NavigationButtonsProps) {
   const [activeKey, setActiveKey] = useState<string | null>(null);
 
+  const send = useSpecialKeys(worktreeId, cliToolId, instanceId, onKeysSent);
+
   const sendKeys = useCallback((keys: string[]) => {
-    // Show immediate visual feedback
+    // Show immediate visual feedback, then delegate to the shared sender.
     setActiveKey(keys[0]);
     setTimeout(() => setActiveKey(null), KEY_PRESS_FEEDBACK_RESET_MS);
+    send(keys);
+  }, [send]);
 
-    // Send keys and trigger immediate refresh after a short delay for tmux to process
-    // Issue #869: include instanceId so additional instances target their own session.
-    const body = instanceId && instanceId !== cliToolId
-      ? { cliToolId, keys, instanceId }
-      : { cliToolId, keys };
-    fetch(`/api/worktrees/${encodeURIComponent(worktreeId)}/special-keys`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }).then(() => {
-      // Trigger immediate terminal refresh after 100ms (allow tmux to process the key)
-      if (onKeysSent) {
-        setTimeout(onKeysSent, NAV_KEY_REFRESH_DELAY_MS);
-      }
-    }).catch((err) => {
-      console.error('Failed to send special keys:', err);
-    });
-  }, [worktreeId, cliToolId, instanceId, onKeysSent]);
+  const buttons = useMemo(
+    () => (showPagerKeys ? [...NAVIGATION_BUTTONS, ...PAGER_BUTTONS] : NAVIGATION_BUTTONS),
+    [showPagerKeys],
+  );
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    // Only arrow/Enter/Escape are handled via keyboard; the pager 'q'/PgUp/etc.
+    // remain click-only to avoid capturing the literal 'q' character.
     const keyMap: Record<string, string> = {
       ArrowLeft: 'Left',
       ArrowUp: 'Up',
@@ -82,13 +94,13 @@ export function NavigationButtons({ worktreeId, cliToolId, instanceId, onKeysSen
 
   return (
     <div
-      className="flex items-center gap-1.5 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg"
+      className="flex flex-wrap items-center gap-1.5 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg"
       onKeyDown={handleKeyDown}
       role="toolbar"
       aria-label="TUI Navigation"
     >
       <span className="text-xs text-gray-500 dark:text-gray-400 mx-2">Nav</span>
-      {NAVIGATION_BUTTONS.map(({ key, label, ariaLabel }) => (
+      {buttons.map(({ key, label, ariaLabel }) => (
         <button
           key={key}
           type="button"

--- a/src/components/worktree/TerminalEscapeHatch.tsx
+++ b/src/components/worktree/TerminalEscapeHatch.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+/**
+ * TerminalEscapeHatch — detection-independent Esc/q safety net (Issue #1017, C-lite).
+ *
+ * The read-only TerminalDisplay can only be driven through the selection window
+ * (NavigationButtons / PromptPanel) or the special-keys API. When a CLI drops into
+ * a TUI mode that status detection does not (yet) recognize, none of those surface
+ * and the session becomes unreachable — exactly the failure this issue fixes for
+ * the Codex pager (via CODEX_PAGER_FOOTER_PATTERN).
+ *
+ * This component is the permanent insurance against the NEXT undetected TUI mode:
+ * a minimal Esc / q affordance that the caller renders whenever the session is
+ * interactive but in an unclassified state (no prompt, no selection list). Esc
+ * exits/interrupts most modes; q quits pager-style views. It is intentionally NOT
+ * shown at a normal idle input prompt (status 'ready'), where 'q' would insert the
+ * literal character — the caller gates on that.
+ */
+
+import { useCallback, useState } from 'react';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import type { NavigationKey } from '@/lib/tmux/tmux';
+import { useSpecialKeys } from '@/hooks/useSpecialKeys';
+import { KEY_PRESS_FEEDBACK_RESET_MS } from '@/config/ui-feedback-config';
+
+export interface TerminalEscapeHatchProps {
+  worktreeId: string;
+  cliToolId: CLIToolType;
+  /** Issue #869: agent instance to target (defaults to primary when omitted). */
+  instanceId?: string;
+  /** Trigger an immediate terminal refresh after the key is sent. */
+  onKeysSent?: () => void;
+}
+
+const ESCAPE_KEYS: ReadonlyArray<{ key: NavigationKey; label: string; ariaLabel: string }> = [
+  { key: 'Escape', label: 'Esc', ariaLabel: 'Send Escape' },
+  { key: 'q', label: 'q', ariaLabel: 'Send q (quit)' },
+];
+
+export function TerminalEscapeHatch({ worktreeId, cliToolId, instanceId, onKeysSent }: TerminalEscapeHatchProps) {
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const send = useSpecialKeys(worktreeId, cliToolId, instanceId, onKeysSent);
+
+  const handleClick = useCallback(
+    (key: NavigationKey) => {
+      setActiveKey(key);
+      setTimeout(() => setActiveKey(null), KEY_PRESS_FEEDBACK_RESET_MS);
+      send([key]);
+    },
+    [send],
+  );
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5 py-1.5 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/50 rounded-lg"
+      role="toolbar"
+      aria-label="Terminal escape keys"
+    >
+      <span className="text-xs text-amber-700 dark:text-amber-400 mx-2" title="Send an escape key when the terminal is stuck in a TUI mode">
+        Escape
+      </span>
+      {ESCAPE_KEYS.map(({ key, label, ariaLabel }) => (
+        <button
+          key={key}
+          type="button"
+          className={`min-w-[44px] min-h-[44px] px-3 py-2 text-sm font-medium rounded-md
+            border border-amber-300 dark:border-amber-700
+            focus:outline-none focus:ring-2 focus:ring-amber-500
+            transition-colors duration-75
+            ${activeKey === key
+              ? 'bg-amber-500 text-white border-amber-500 scale-95'
+              : 'bg-white dark:bg-gray-700 hover:bg-amber-50 dark:hover:bg-gray-600 active:bg-amber-100 dark:active:bg-gray-500'
+            }`}
+          aria-label={ariaLabel}
+          onClick={() => handleClick(key)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default TerminalEscapeHatch;

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -28,6 +28,7 @@ import type { AgentInstance, CLIToolType } from '@/lib/cli-tools/types';
 import { TerminalSplitPane } from '@/components/worktree/TerminalSplitPane';
 import { TerminalDisplay } from '@/components/worktree/TerminalDisplay';
 import { NavigationButtons } from '@/components/worktree/NavigationButtons';
+import { TerminalEscapeHatch } from '@/components/worktree/TerminalEscapeHatch';
 import { PromptPanel } from '@/components/worktree/PromptPanel';
 import { MessageInput } from '@/components/worktree/MessageInput';
 import { HistoryPane, splitHistorySlotId } from '@/components/worktree/HistoryPane';
@@ -235,6 +236,17 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   const showNav = terminal.isSelectionListActive;
   const showPrompt = prompt.visible && !autoYesEnabled;
 
+  // Issue #1017 (C-lite): detection-independent Esc/q safety net. Shown only when
+  // the session is interactive but detection could not classify the frame
+  // (isUnclassifiedActive) — the "stuck in an unrecognized TUI mode" case — and no
+  // selection list / prompt panel is already driving it. Stays hidden during normal
+  // generation ('thinking_indicator') and at an idle input prompt ('ready'), so it
+  // is neither noisy nor able to insert a stray 'q' at the composer.
+  const showEscapeHatch =
+    terminal.isUnclassifiedActive &&
+    !showNav &&
+    !showPrompt;
+
   // Issue #743: AI agent status indicator (dot/spinner) for the split header.
   // Uses the same inline span markup as the Mobile canonical implementation
   // (WorktreeDetailRefactored.tsx:1947-1974): title-only a11y (no aria-label,
@@ -423,6 +435,15 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
             cliToolId={cliToolId}
             instanceId={resolvedInstanceId}
             onKeysSent={refresh}
+            showPagerKeys={terminal.isPagerActive}
+          />
+        ) : null}
+        {showEscapeHatch ? (
+          <TerminalEscapeHatch
+            worktreeId={worktreeId}
+            cliToolId={cliToolId}
+            instanceId={resolvedInstanceId}
+            onKeysSent={refresh}
           />
         ) : null}
         {showPrompt ? (
@@ -458,6 +479,8 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
     [
       showNav,
       showPrompt,
+      showEscapeHatch,
+      terminal.isPagerActive,
       worktreeId,
       cliToolId,
       resolvedInstanceId,

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -176,6 +176,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     isMobile,
     isMoveDialogOpen,
     isSelectionListActive,
+    isPagerActive,
     lastAutoResponse,
     loading,
     makeAutoYesToggleHandler,
@@ -544,6 +545,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
                 cliToolId={activeCliTab}
                 instanceId={activeInstanceId}
                 onKeysSent={fetchCurrentOutput}
+                showPagerKeys={isPagerActive}
               />
             </div>
           )}

--- a/src/hooks/useSpecialKeys.ts
+++ b/src/hooks/useSpecialKeys.ts
@@ -1,0 +1,53 @@
+'use client';
+
+/**
+ * useSpecialKeys — shared sender for the special-keys API (Issue #1017).
+ *
+ * Extracted from NavigationButtons so both NavigationButtons (TUI selection-list
+ * navigation) and TerminalEscapeHatch (the detection-independent Esc/q safety net)
+ * post to the same endpoint with identical instance-targeting and refresh behavior,
+ * without duplicating the fetch logic (DRY).
+ *
+ * Issue #869: `instanceId` is included only when it differs from the primary
+ * instance (`=== cliToolId`), preserving byte-for-byte the pre-#869 request body
+ * for every primary-instance send.
+ */
+
+import { useCallback } from 'react';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+import { NAV_KEY_REFRESH_DELAY_MS } from '@/config/ui-feedback-config';
+
+/**
+ * Returns a stable `sendKeys(keys)` callback that POSTs the given tmux key names
+ * to the worktree's special-keys endpoint and, after a short delay for tmux to
+ * process the keys, invokes `onKeysSent` (typically a terminal refresh).
+ */
+export function useSpecialKeys(
+  worktreeId: string,
+  cliToolId: CLIToolType,
+  instanceId?: string,
+  onKeysSent?: () => void,
+): (keys: string[]) => void {
+  return useCallback(
+    (keys: string[]) => {
+      const body = instanceId && instanceId !== cliToolId
+        ? { cliToolId, keys, instanceId }
+        : { cliToolId, keys };
+      fetch(`/api/worktrees/${encodeURIComponent(worktreeId)}/special-keys`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+        .then(() => {
+          // Trigger an immediate terminal refresh once tmux has processed the key.
+          if (onKeysSent) {
+            setTimeout(onKeysSent, NAV_KEY_REFRESH_DELAY_MS);
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to send special keys:', err);
+        });
+    },
+    [worktreeId, cliToolId, instanceId, onKeysSent],
+  );
+}

--- a/src/hooks/useTerminalPanePolling.ts
+++ b/src/hooks/useTerminalPanePolling.ts
@@ -42,6 +42,19 @@ export interface PaneTerminalState {
   isRunning: boolean;
   isThinking: boolean;
   isSelectionListActive: boolean;
+  /**
+   * Issue #1017: Codex pager / edit-previous mode (a subset of
+   * isSelectionListActive). Drives the pager-specific keys in NavigationButtons.
+   */
+  isPagerActive: boolean;
+  /**
+   * Issue #1017: the session is interactive but detection could not classify the
+   * frame (status 'running', reason 'default') — i.e. stuck in an unrecognized TUI
+   * mode. Gates the detection-independent Esc/q escape hatch. Deliberately false
+   * during normal generation (which is 'thinking_indicator') and at an idle input
+   * prompt ('ready'), so the hatch never appears where 'q' would insert text.
+   */
+  isUnclassifiedActive: boolean;
   attaching: boolean;
   autoScroll: boolean;
 }
@@ -63,6 +76,8 @@ interface CurrentOutputResponse {
   realtimeSnippet?: string;
   thinking?: boolean;
   isSelectionListActive?: boolean;
+  isPagerActive?: boolean;
+  isUnclassifiedActive?: boolean;
 }
 
 export interface UseTerminalPanePollingOptions {
@@ -103,6 +118,8 @@ export function useTerminalPanePolling({
     isRunning: false,
     isThinking: false,
     isSelectionListActive: false,
+    isPagerActive: false,
+    isUnclassifiedActive: false,
     attaching: true,
     autoScroll: true,
   }));
@@ -172,6 +189,8 @@ export function useTerminalPanePolling({
           isRunning: data.isRunning ?? false,
           isThinking: data.thinking ?? false,
           isSelectionListActive: data.isSelectionListActive ?? false,
+          isPagerActive: data.isPagerActive ?? false,
+          isUnclassifiedActive: data.isUnclassifiedActive ?? false,
           // First successful fetch flips attaching off.
           attaching: false,
         };
@@ -218,6 +237,8 @@ export function useTerminalPanePolling({
       isRunning: false,
       isThinking: false,
       isSelectionListActive: false,
+      isPagerActive: false,
+      isUnclassifiedActive: false,
       attaching: true,
     }));
     setPrompt({ visible: false, data: null, messageId: null, answering: false });

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -94,6 +94,8 @@ interface CurrentOutputResponse {
   thinking?: boolean;
   /** Issue #473: OpenCode TUI selection list active flag */
   isSelectionListActive?: boolean;
+  /** Issue #1017: Codex pager/edit-previous mode (subset of isSelectionListActive) */
+  isPagerActive?: boolean;
   autoYes?: {
     enabled: boolean;
     expiresAt: number | null;
@@ -193,6 +195,8 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
   const [serverPollerActive, setServerPollerActive] = useState(false);
   // Issue #473: Track OpenCode TUI selection list state
   const [isSelectionListActive, setIsSelectionListActive] = useState(false);
+  // Issue #1017: Track Codex pager/edit-previous mode (drives pager keys on mobile)
+  const [isPagerActive, setIsPagerActive] = useState(false);
   // Issue #314: Track previous auto-yes enabled state for stop reason toast
   const prevAutoYesEnabledRef = useRef<boolean>(false);
   // Issue #314 / #499 Item 5: Pending stop reason toast (deferred until showToast is available)
@@ -537,6 +541,8 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
 
       // Issue #473: Update selection list state from server
       setIsSelectionListActive(data.isSelectionListActive ?? false);
+      // Issue #1017: Update Codex pager/edit-previous mode from server
+      setIsPagerActive(data.isPagerActive ?? false);
 
       // Issue #501: Update last server response timestamp for useAutoYes duplicate prevention
       setLastServerResponseTimestamp(data.lastServerResponseTimestamp ?? null);
@@ -1482,6 +1488,7 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     isMobile,
     isMoveDialogOpen,
     isSelectionListActive,
+    isPagerActive,
     lastAutoResponse,
     loading,
     makeAutoYesToggleHandler,

--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -250,6 +250,38 @@ export const CODEX_SEPARATOR_PATTERN = /^─.*Worked for.*─+$/m;
 export const CODEX_SELECTION_LIST_PATTERN = /press\s+enter\s+to\s+(?:confirm|select)/i;
 
 /**
+ * Codex CLI pager / edit-previous (transcript) mode footer pattern (Issue #1017)
+ *
+ * When Codex enters its transcript pager / "edit previous message" mode, the
+ * bottom of the frame shows scroll / edit key hints INSTEAD of the usual
+ * "model · N% left · path" status bar, e.g.:
+ *   "↑/↓ to scroll   pgup/pgdn to page   home/end to jump"
+ *   "q to quit   esc/← to edit prev   → to edit next   enter to edit message"
+ * together with a scroll-percentage separator ("─ N% ─", NOT "N% left ·").
+ *
+ * Neither CODEX_SELECTION_LIST_PATTERN (which needs "press enter to
+ * confirm/select") nor the "N% left ·" status-bar boundary logic in
+ * status-detector.ts fires here, so the read-only TerminalDisplay is left with no
+ * way to scroll or escape (the reported bug). This pattern recognizes the pager
+ * footer directly — independent of the status bar — so the selection window
+ * (NavigationButtons) can be rendered.
+ *
+ * Matches any of the pager-specific hints (either footer line is sufficient):
+ *   - scroll/page/jump hints: "↑/↓ to scroll" / "pgup/pgdn to page" / "home/end to jump"
+ *   - edit-previous hints:    "esc/← to edit prev" / "→ to edit next" / "enter to edit message"
+ * The two branches are independent so a mangled unicode-arrow footer line is still
+ * caught by the ASCII "to edit prev/next/message" and "pgup/pgdn"/"home/end" hints.
+ *
+ * Does NOT match the genuine "/model" selection list ("press enter to select") —
+ * that footer has no scroll/page/jump or edit-prev/next/message hint — so the
+ * existing CODEX_SELECTION_LIST_PATTERN path is unaffected (no regression).
+ *
+ * No /g flag (S4-5: keeps test() stateless). No nested quantifiers (SEC4-001: ReDoS-safe).
+ */
+export const CODEX_PAGER_FOOTER_PATTERN =
+  /(?:↑\/↓|pgup\/pgdn|home\/end)\s+to\s+(?:scroll|page|jump)|to\s+edit\s+(?:prev|next|message)/i;
+
+/**
  * Pasted text pattern
  *
  * Claude CLI displays this when it detects multi-line text paste in the

--- a/src/lib/detection/status-detector.ts
+++ b/src/lib/detection/status-detector.ts
@@ -24,7 +24,7 @@
  * coupling via a minimal DTO/projection type.
  */
 
-import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN, ANTIGRAVITY_SELECTION_LIST_PATTERN } from './cli-patterns';
+import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CODEX_PAGER_FOOTER_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN, ANTIGRAVITY_SELECTION_LIST_PATTERN } from './cli-patterns';
 import { detectPrompt } from './prompt-detector';
 import type { PromptDetectionResult } from './prompt-detector';
 import type { CLIToolType } from '@/lib/cli-tools/types';
@@ -104,6 +104,8 @@ export const STATUS_REASON = {
   CLAUDE_SELECTION_LIST: 'claude_selection_list',
   COPILOT_SELECTION_LIST: 'copilot_selection_list',
   CODEX_SELECTION_LIST: 'codex_selection_list',
+  /** Issue #1017: Codex pager / edit-previous (transcript) mode. */
+  CODEX_PAGER: 'codex_pager',
   ANTIGRAVITY_SELECTION_LIST: 'antigravity_selection_list',
   OPENCODE_RESPONSE_COMPLETE: 'opencode_response_complete',
   INPUT_PROMPT: 'input_prompt',
@@ -123,6 +125,8 @@ export const SELECTION_LIST_REASONS = new Set<string>([
   STATUS_REASON.CLAUDE_SELECTION_LIST,
   STATUS_REASON.COPILOT_SELECTION_LIST,
   STATUS_REASON.CODEX_SELECTION_LIST,
+  // Issue #1017: Codex pager/edit-previous mode also drives NavigationButtons.
+  STATUS_REASON.CODEX_PAGER,
   STATUS_REASON.ANTIGRAVITY_SELECTION_LIST,
 ]);
 
@@ -219,6 +223,32 @@ export function detectSessionStatus(
       reason: 'thinking_indicator',
       hasActivePrompt: false,
       promptDetection,
+    };
+  }
+
+  // 0.7. Codex: pager / edit-previous (transcript) mode detection (Issue #1017)
+  // Codex's transcript pager renders scroll / edit key-hint footers, e.g.:
+  //   "↑/↓ to scroll   pgup/pgdn to page   home/end to jump"
+  //   "q to quit   esc/← to edit prev   → to edit next   enter to edit message"
+  // together with a scroll-percentage separator ("─ N% ─") in place of the usual
+  // "model · N% left · path" status bar. So neither CODEX_SELECTION_LIST_PATTERN
+  // (footer is "enter to edit message", not "press enter to confirm/select") nor the
+  // status-bar boundary logic in 0.8 / 2.7 fire, leaving the read-only TerminalDisplay
+  // with no way to scroll or escape. Detect the pager footer directly — independent of
+  // the "N% left ·" status bar — and surface it as a selection list so NavigationButtons
+  // render (isSelectionListActive via SELECTION_LIST_REASONS). Checked ahead of
+  // detectPrompt/thinking because the pager has no active y/n prompt and its transcript
+  // content must not be misread as one. CODEX_PAGER_FOOTER_PATTERN does not match the
+  // genuine "/model" selection footer, so the 0.8 path below is unaffected (no regression).
+  if (cliToolId === 'codex' && CODEX_PAGER_FOOTER_PATTERN.test(lastLines)) {
+    const codexPagerPromptOptions = buildDetectPromptOptions(cliToolId);
+    const codexPagerPromptDetection = detectPrompt(stripBoxDrawing(cleanOutput), codexPagerPromptOptions);
+    return {
+      status: 'waiting',
+      confidence: 'high',
+      reason: STATUS_REASON.CODEX_PAGER,
+      hasActivePrompt: false,
+      promptDetection: codexPagerPromptDetection,
     };
   }
 

--- a/src/lib/tmux/tmux.ts
+++ b/src/lib/tmux/tmux.ts
@@ -247,6 +247,10 @@ const ALLOWED_SPECIAL_KEYS = new Set([
   'Up', 'Down', 'Left', 'Right',
   'Enter', 'Space', 'Tab', 'Escape',
   'BSpace', 'DC',  // Backspace, Delete
+  // Issue #1017: Codex pager / edit-previous mode navigation. PageUp/PageDown/Home/End
+  // are tmux named keys; 'q' is the pager's literal "quit" character (sent verbatim by
+  // `tmux send-keys`, no injection risk — single fixed char via execFile, not a shell).
+  'PageUp', 'PageDown', 'Home', 'End', 'q',
 ]);
 
 /** Delay between individual key presses for TUI apps that need processing time (ms). */
@@ -492,7 +496,12 @@ export async function sendSpecialKey(
  * [DR3-001] Named NAVIGATION_KEY_VALUES to avoid collision with existing SPECIAL_KEY_VALUES.
  * [DR2-004] Exported as as const array + type guard (not Set) for immutability guarantee.
  */
-export const NAVIGATION_KEY_VALUES = ['Up', 'Down', 'Left', 'Right', 'Enter', 'Escape', 'Tab', 'BTab'] as const;
+export const NAVIGATION_KEY_VALUES = [
+  'Up', 'Down', 'Left', 'Right', 'Enter', 'Escape', 'Tab', 'BTab',
+  // Issue #1017: Codex pager / edit-previous mode keys surfaced by NavigationButtons.
+  // 'q' is the pager quit key (literal char). PageUp/PageDown/Home/End are tmux named keys.
+  'PageUp', 'PageDown', 'Home', 'End', 'q',
+] as const;
 
 /**
  * Navigation key type derived from NAVIGATION_KEY_VALUES.

--- a/tests/unit/cli-patterns-selection.test.ts
+++ b/tests/unit/cli-patterns-selection.test.ts
@@ -15,6 +15,8 @@ import {
   COPILOT_SELECTION_LIST_PATTERN,
   CLAUDE_SELECTION_LIST_FOOTER,
   ANTIGRAVITY_SELECTION_LIST_PATTERN,
+  CODEX_PAGER_FOOTER_PATTERN,
+  CODEX_SELECTION_LIST_PATTERN,
 } from '@/lib/detection/cli-patterns';
 
 describe('OPENCODE_SELECTION_LIST_PATTERN', () => {
@@ -212,5 +214,39 @@ describe('ANTIGRAVITY_SELECTION_LIST_PATTERN (Issue #995)', () => {
 
   it('should not use the global flag (no /g)', () => {
     expect(ANTIGRAVITY_SELECTION_LIST_PATTERN.global).toBe(false);
+  });
+});
+
+describe('CODEX_PAGER_FOOTER_PATTERN (Issue #1017)', () => {
+  it('should be a RegExp without the global flag (no /g)', () => {
+    expect(CODEX_PAGER_FOOTER_PATTERN).toBeInstanceOf(RegExp);
+    expect(CODEX_PAGER_FOOTER_PATTERN.global).toBe(false);
+  });
+
+  it('should match the pager scroll-hint footer', () => {
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('↑/↓ to scroll   pgup/pgdn to page   home/end to jump')).toBe(true);
+  });
+
+  it('should match the pager edit-previous footer', () => {
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('q to quit   esc/← to edit prev   → to edit next   enter to edit message')).toBe(true);
+  });
+
+  it('should match each pager hint independently (resilient to arrow-glyph loss)', () => {
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('pgup/pgdn to page')).toBe(true);
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('home/end to jump')).toBe(true);
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('esc/← to edit prev')).toBe(true);
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('enter to edit message')).toBe(true);
+  });
+
+  it('should NOT match the genuine /model selection footer (no regression)', () => {
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('Press enter to select reasoning effort, or esc to dismiss.')).toBe(false);
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('press enter to confirm or esc to cancel')).toBe(false);
+    // The /model footer must still be matched by its own pattern.
+    expect(CODEX_SELECTION_LIST_PATTERN.test('Press enter to select reasoning effort, or esc to dismiss.')).toBe(true);
+  });
+
+  it('should NOT match regular conversational output', () => {
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('Here is the implementation of the scroll handler.')).toBe(false);
+    expect(CODEX_PAGER_FOOTER_PATTERN.test('I will edit the file and run the tests.')).toBe(false);
   });
 });

--- a/tests/unit/components/worktree/NavigationButtons.test.tsx
+++ b/tests/unit/components/worktree/NavigationButtons.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for NavigationButtons (Issue #473, #1017)
+ *
+ * Focus: the Issue #1017 pager key set (PgUp/PgDn/Home/End/q) is appended only
+ * when showPagerKeys is set, and clicking a key POSTs it to the special-keys API.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NavigationButtons } from '@/components/worktree/NavigationButtons';
+
+describe('NavigationButtons', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders only the base arrow/Enter/Esc buttons by default', () => {
+    render(<NavigationButtons worktreeId="w-1" cliToolId="codex" />);
+    expect(screen.getByLabelText('Up')).toBeInTheDocument();
+    expect(screen.getByLabelText('Escape')).toBeInTheDocument();
+    // Pager keys absent.
+    expect(screen.queryByLabelText('Page Up')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Quit pager')).not.toBeInTheDocument();
+  });
+
+  it('appends the pager keys (PgUp/PgDn/Home/End/q) when showPagerKeys is set (Issue #1017)', () => {
+    render(<NavigationButtons worktreeId="w-1" cliToolId="codex" showPagerKeys />);
+    expect(screen.getByLabelText('Page Up')).toBeInTheDocument();
+    expect(screen.getByLabelText('Page Down')).toBeInTheDocument();
+    expect(screen.getByLabelText('Home')).toBeInTheDocument();
+    expect(screen.getByLabelText('End')).toBeInTheDocument();
+    expect(screen.getByLabelText('Quit pager')).toBeInTheDocument();
+    // Base keys still present.
+    expect(screen.getByLabelText('Up')).toBeInTheDocument();
+  });
+
+  it('POSTs the pager quit key to the special-keys API', async () => {
+    render(<NavigationButtons worktreeId="w-1" cliToolId="codex" showPagerKeys />);
+    fireEvent.click(screen.getByLabelText('Quit pager'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/worktrees/w-1/special-keys');
+    expect(JSON.parse((options as RequestInit).body as string)).toEqual({ cliToolId: 'codex', keys: ['q'] });
+  });
+
+  it('includes instanceId in the body for a non-primary instance (Issue #869)', async () => {
+    render(<NavigationButtons worktreeId="w-1" cliToolId="codex" instanceId="codex-2" showPagerKeys />);
+    fireEvent.click(screen.getByLabelText('Page Up'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ cliToolId: 'codex', keys: ['PageUp'], instanceId: 'codex-2' });
+  });
+});

--- a/tests/unit/components/worktree/TerminalEscapeHatch.test.tsx
+++ b/tests/unit/components/worktree/TerminalEscapeHatch.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Tests for TerminalEscapeHatch (Issue #1017, C-lite safety net)
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TerminalEscapeHatch } from '@/components/worktree/TerminalEscapeHatch';
+
+describe('TerminalEscapeHatch', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the Esc and q escape keys', () => {
+    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="codex" />);
+    expect(screen.getByLabelText('Send Escape')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send q (quit)')).toBeInTheDocument();
+  });
+
+  it('sends Escape via the special-keys API', async () => {
+    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="codex" />);
+    fireEvent.click(screen.getByLabelText('Send Escape'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/worktrees/w-1/special-keys');
+    expect(JSON.parse((options as RequestInit).body as string)).toEqual({ cliToolId: 'codex', keys: ['Escape'] });
+  });
+
+  it('sends q and targets a non-primary instance (Issue #869)', async () => {
+    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="codex" instanceId="codex-3" />);
+    fireEvent.click(screen.getByLabelText('Send q (quit)'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ cliToolId: 'codex', keys: ['q'], instanceId: 'codex-3' });
+  });
+});

--- a/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
@@ -59,8 +59,19 @@ vi.mock('@/components/worktree/MessageInput', () => ({
 }));
 
 vi.mock('@/components/worktree/NavigationButtons', () => ({
-  NavigationButtons: ({ cliToolId }: { cliToolId: string }) => (
-    <div data-testid="navigation-buttons" data-cli-tool-id={cliToolId} />
+  NavigationButtons: ({ cliToolId, showPagerKeys }: { cliToolId: string; showPagerKeys?: boolean }) => (
+    <div
+      data-testid="navigation-buttons"
+      data-cli-tool-id={cliToolId}
+      data-show-pager-keys={String(showPagerKeys ?? false)}
+    />
+  ),
+}));
+
+// Issue #1017: C-lite escape hatch mock.
+vi.mock('@/components/worktree/TerminalEscapeHatch', () => ({
+  TerminalEscapeHatch: ({ cliToolId }: { cliToolId: string }) => (
+    <div data-testid="terminal-escape-hatch" data-cli-tool-id={cliToolId} />
   ),
 }));
 
@@ -274,6 +285,105 @@ describe('TerminalSplitPaneContent', () => {
       expect(screen.getByTestId('navigation-buttons')).toBeInTheDocument();
     });
     expect(screen.getByTestId('navigation-buttons').getAttribute('data-cli-tool-id')).toBe('codex');
+  });
+
+  it('passes showPagerKeys to NavigationButtons when /current-output reports isPagerActive (Issue #1017)', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({
+        isRunning: true,
+        fullOutput: 'codex pager body',
+        thinking: false,
+        // Codex pager mode: selection list active + pager flag.
+        isSelectionListActive: true,
+        isPagerActive: true,
+        sessionStatus: 'waiting',
+      }),
+    );
+
+    render(
+      <TerminalSplitPaneContent
+        worktreeId="w-1"
+        splitIndex={1}
+        cliToolId="codex"
+        availableInstances={[inst('codex')]}
+        onInstanceChange={vi.fn()}
+        onFocus={vi.fn()}
+        autoYes={{ onToggle: vi.fn() }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('navigation-buttons')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('navigation-buttons').getAttribute('data-show-pager-keys')).toBe('true');
+    // The escape hatch is redundant while NavigationButtons is shown.
+    expect(screen.queryByTestId('terminal-escape-hatch')).not.toBeInTheDocument();
+  });
+
+  it('renders the C-lite escape hatch for an unclassified running session (Issue #1017)', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({
+        isRunning: true,
+        fullOutput: 'stuck in an unknown TUI mode',
+        thinking: false,
+        // No selection list, no prompt, detection could not classify -> stuck/unknown.
+        isSelectionListActive: false,
+        isPagerActive: false,
+        isPromptWaiting: false,
+        isUnclassifiedActive: true,
+      }),
+    );
+
+    render(
+      <TerminalSplitPaneContent
+        worktreeId="w-1"
+        splitIndex={1}
+        cliToolId="codex"
+        availableInstances={[inst('codex')]}
+        onInstanceChange={vi.fn()}
+        onFocus={vi.fn()}
+        autoYes={{ onToggle: vi.fn() }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-escape-hatch')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('terminal-escape-hatch').getAttribute('data-cli-tool-id')).toBe('codex');
+  });
+
+  it('does NOT render the escape hatch when detection classified the frame (e.g. idle prompt)', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({
+        isRunning: true,
+        fullOutput: '› ',
+        thinking: false,
+        isSelectionListActive: false,
+        isPagerActive: false,
+        isPromptWaiting: false,
+        // Classified (idle composer / generation): 'q' would insert a literal char,
+        // so the hatch must stay hidden.
+        isUnclassifiedActive: false,
+      }),
+    );
+
+    render(
+      <TerminalSplitPaneContent
+        worktreeId="w-1"
+        splitIndex={1}
+        cliToolId="codex"
+        availableInstances={[inst('codex')]}
+        onInstanceChange={vi.fn()}
+        onFocus={vi.fn()}
+        autoYes={{ onToggle: vi.fn() }}
+      />,
+    );
+
+    // Message input is unconditional; use it as the "poll landed" anchor.
+    await waitFor(() => {
+      expect(screen.getByTestId('message-input-1')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('terminal-escape-hatch')).not.toBeInTheDocument();
   });
 
   it('renders PromptPanel for splitIndex >= 1 when /current-output reports isPromptWaiting', async () => {

--- a/tests/unit/status-detector-selection.test.ts
+++ b/tests/unit/status-detector-selection.test.ts
@@ -156,16 +156,18 @@ describe('SELECTION_LIST_REASONS Set', () => {
     expect(SELECTION_LIST_REASONS).toBeInstanceOf(Set);
   });
 
-  it('should contain all five selection list reasons', () => {
+  it('should contain all selection list reasons', () => {
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.OPENCODE_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.CLAUDE_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.COPILOT_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.CODEX_SELECTION_LIST)).toBe(true);
     expect(SELECTION_LIST_REASONS.has(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST)).toBe(true);
+    // Issue #1017: Codex pager/edit-previous mode also drives NavigationButtons.
+    expect(SELECTION_LIST_REASONS.has(STATUS_REASON.CODEX_PAGER)).toBe(true);
   });
 
-  it('should have exactly 5 entries', () => {
-    expect(SELECTION_LIST_REASONS.size).toBe(5);
+  it('should have exactly 6 entries', () => {
+    expect(SELECTION_LIST_REASONS.size).toBe(6);
   });
 
   it('should not contain unrelated reasons', () => {
@@ -456,6 +458,117 @@ describe('detectSessionStatus - Codex /model Step 1 model selection (Issue #622)
     const result = detectSessionStatus(output, 'codex');
 
     expect(result.reason).not.toBe(STATUS_REASON.CODEX_SELECTION_LIST);
+  });
+});
+
+// Helper: Build Codex pager / edit-previous (transcript) output (Issue #1017).
+// Unlike buildCodexOutput, the pager renders a scroll-percentage separator
+// ("─ N% ─") and key-hint footer INSTEAD of the "model · N% left · path" bar.
+function buildCodexPagerOutput(footerLines: string[]): string {
+  const transcript = [
+    'user',
+    'Please summarize the previous conversation.',
+    '',
+    'codex',
+    'Here is the full transcript of our conversation so far:',
+    'line 1 of the transcript',
+    'line 2 of the transcript',
+    'line 3 of the transcript',
+  ];
+  const scrollSeparator = '──────────────────────── 2% ────────────────────────';
+  const padding = Array(3).fill('');
+  return [...transcript, scrollSeparator, ...footerLines, ...padding].join('\n');
+}
+
+const CODEX_PAGER_SCROLL_FOOTER = [
+  '↑/↓ to scroll   pgup/pgdn to page   home/end to jump',
+  'q to quit   esc/← to edit prev   → to edit next   enter to edit message',
+];
+
+describe('STATUS_REASON - CODEX_PAGER (Issue #1017)', () => {
+  it('should export CODEX_PAGER constant', () => {
+    expect(STATUS_REASON.CODEX_PAGER).toBe('codex_pager');
+  });
+
+  it('should include CODEX_PAGER in SELECTION_LIST_REASONS (NavigationButtons shown)', () => {
+    expect(SELECTION_LIST_REASONS.has(STATUS_REASON.CODEX_PAGER)).toBe(true);
+  });
+});
+
+describe('detectSessionStatus - Codex pager / edit-previous detection (Issue #1017)', () => {
+  it('should detect the pager scroll/edit footer and return waiting status', () => {
+    const output = buildCodexPagerOutput(CODEX_PAGER_SCROLL_FOOTER);
+    const result = detectSessionStatus(output, 'codex');
+    expect(result.status).toBe('waiting');
+    expect(result.confidence).toBe('high');
+    expect(result.reason).toBe(STATUS_REASON.CODEX_PAGER);
+    expect(result.hasActivePrompt).toBe(false);
+  });
+
+  it('should detect the scroll-hint footer line alone', () => {
+    const output = buildCodexPagerOutput([
+      '↑/↓ to scroll   pgup/pgdn to page   home/end to jump',
+    ]);
+    const result = detectSessionStatus(output, 'codex');
+    expect(result.reason).toBe(STATUS_REASON.CODEX_PAGER);
+    expect(result.status).toBe('waiting');
+  });
+
+  it('should detect the edit-previous footer line alone', () => {
+    const output = buildCodexPagerOutput([
+      'q to quit   esc/← to edit prev   → to edit next   enter to edit message',
+    ]);
+    const result = detectSessionStatus(output, 'codex');
+    expect(result.reason).toBe(STATUS_REASON.CODEX_PAGER);
+    expect(result.status).toBe('waiting');
+  });
+
+  it('should be content-based / instance-independent (primary and additional instances alike)', () => {
+    // detectSessionStatus takes no instance parameter: the same captured pager
+    // frame yields the same result whether it came from codex (primary) or
+    // codex-2 / codex-3. This is the "instance non-dependence" acceptance check.
+    const output = buildCodexPagerOutput(CODEX_PAGER_SCROLL_FOOTER);
+    const primary = detectSessionStatus(output, 'codex');
+    const additional = detectSessionStatus(output, 'codex');
+    expect(primary.reason).toBe(STATUS_REASON.CODEX_PAGER);
+    expect(additional.reason).toBe(primary.reason);
+  });
+
+  it('should NOT detect pager for a normal Codex response (no false positive)', () => {
+    const output = buildCodexOutput([
+      'Here is the implementation:',
+      '```typescript',
+      'function hello() { return "world"; }',
+      '```',
+      '› Write tests for @filename',
+    ]);
+    const result = detectSessionStatus(output, 'codex');
+    expect(result.reason).not.toBe(STATUS_REASON.CODEX_PAGER);
+  });
+
+  it('should NOT reclassify the genuine /model selection list as pager (no regression)', () => {
+    // The /model footer is "press enter to select ... esc to dismiss" — it has no
+    // scroll/page/jump or edit-prev/next/message hint, so it stays CODEX_SELECTION_LIST.
+    const output = buildCodexOutput([
+      'Select Model and Effort',
+      '',
+      '› 1. gpt-5.4 (current)   Latest frontier agentic coding model.',
+      '  2. gpt-5.4-mini        Smaller frontier agentic coding model.',
+      '',
+      'Press enter to select reasoning effort, or esc to dismiss.',
+    ]);
+    const result = detectSessionStatus(output, 'codex');
+    expect(result.reason).toBe(STATUS_REASON.CODEX_SELECTION_LIST);
+    expect(result.reason).not.toBe(STATUS_REASON.CODEX_PAGER);
+  });
+
+  it('should NOT trigger pager detection for non-codex tools', () => {
+    const output = [
+      'q to quit   esc/← to edit prev   → to edit next   enter to edit message',
+      '> ',
+    ].join('\n');
+    const result = detectSessionStatus(output, 'claude');
+    expect(result.reason).not.toBe(STATUS_REASON.CODEX_PAGER);
   });
 });
 

--- a/tests/unit/tmux-navigation.test.ts
+++ b/tests/unit/tmux-navigation.test.ts
@@ -35,8 +35,18 @@ describe('NAVIGATION_KEY_VALUES', () => {
     expect(Array.isArray(NAVIGATION_KEY_VALUES)).toBe(true);
   });
 
-  it('should contain exactly the 8 allowed navigation keys', () => {
-    expect(NAVIGATION_KEY_VALUES).toEqual(['Up', 'Down', 'Left', 'Right', 'Enter', 'Escape', 'Tab', 'BTab']);
+  it('should contain the base navigation keys plus the Issue #1017 pager keys', () => {
+    expect(NAVIGATION_KEY_VALUES).toEqual([
+      'Up', 'Down', 'Left', 'Right', 'Enter', 'Escape', 'Tab', 'BTab',
+      // Issue #1017: Codex pager / edit-previous mode keys.
+      'PageUp', 'PageDown', 'Home', 'End', 'q',
+    ]);
+  });
+
+  it('should include the Codex pager keys (Issue #1017)', () => {
+    for (const key of ['PageUp', 'PageDown', 'Home', 'End', 'q']) {
+      expect(NAVIGATION_KEY_VALUES).toContain(key);
+    }
   });
 
   it('should be distinct from SPECIAL_KEY_VALUES (no name collision)', () => {
@@ -71,6 +81,17 @@ describe('isAllowedSpecialKey', () => {
     expect(isAllowedSpecialKey('UP')).toBe(false);
     expect(isAllowedSpecialKey('down')).toBe(false);
     expect(isAllowedSpecialKey('enter')).toBe(false);
+  });
+
+  it('should accept the Codex pager keys (Issue #1017)', () => {
+    expect(isAllowedSpecialKey('PageUp')).toBe(true);
+    expect(isAllowedSpecialKey('PageDown')).toBe(true);
+    expect(isAllowedSpecialKey('Home')).toBe(true);
+    expect(isAllowedSpecialKey('End')).toBe(true);
+    expect(isAllowedSpecialKey('q')).toBe(true);
+    // Only the single literal 'q' is allowed — not arbitrary letters.
+    expect(isAllowedSpecialKey('Q')).toBe(false);
+    expect(isAllowedSpecialKey('quit')).toBe(false);
   });
 
   it('should reject Space, BSpace, and DC keys (security regression)', () => {


### PR DESCRIPTION
## 概要

Codex CLI が「ページャ／edit-previous」モードのとき、CommandMate の選択ウィンドウ（`NavigationButtons`）が表示されず、読み取り専用ターミナルから操作・脱出できない問題を修正します（#1017）。複数インスタンス運用（codex-2/codex-3）がページャに滞留した際に顕在化していました。

## 根本原因

Codex のページャフッター（`↑/↓ to scroll … enter to edit message`）が検出パターン（`CODEX_SELECTION_LIST_PATTERN` / `codexStatusBarPattern`）に非マッチで、`isSelectionListActive` が false のまま → 選択ウィンドウ非表示。インスタンス固有バグではなく検出カバレッジの欠落。

## 変更内容（A主軸 ＋ C-lite 安全網）

| 区分 | 内容 |
|------|------|
| **A: 検出拡張** | `CODEX_PAGER_FOOTER_PATTERN` 追加、`status-detector` にステータスバー非依存のページャ検出分岐（`reason=CODEX_PAGER`、`SELECTION_LIST_REASONS` 入り）。`/model` 等の `press enter to confirm/select` には非マッチでリグレッションなし |
| **ページャキー** | `NavigationButtons` に `showPagerKeys`（PgUp/PgDn/Home/End/q）、tmux キー allowlist 拡張。PC分割・モバイル両方に配線 |
| **C-lite: 安全網** | 共有 `useSpecialKeys` フック ＋ 新規 `TerminalEscapeHatch`（Esc/q）。「検出が分類できなかった interactive 状態」でのみ表示し、通常生成/アイドルでは非表示にして `q` 誤入力を回避 |
| **API/hooks** | `current-output/route.ts`・`api-responses.ts`・`useTerminalPanePolling.ts`・`useWorktreeDetailController.ts`（モバイル経路の instance 追従含む） |

## テスト

- 新規/更新6本: `cli-patterns-selection` / `status-detector-selection` / `tmux-navigation` / `NavigationButtons` / `TerminalEscapeHatch` / `TerminalSplitPaneContent`
- **全4ゲート合格**: ESLint ✅ / tsc --noEmit ✅ / test:unit ✅（470ファイル・8392テスト）/ build ✅
- 受け入れ基準6項目すべて PASS（検出真陽性・偽陽性なし・インスタンス非依存・リグレッションなし 等）

## スコープ外

- **B（上部インスタンスタブ ↔ 分割 instance セレクタの連動）** は本PR対象外。別Issue化を推奨。

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
