### PR TITLE
fix: History パネルのヘッダー(Message History)を固定しスクロールをヘッダー下に限定

### DIFF
--- a/src/components/worktree/HistoryPane.tsx
+++ b/src/components/worktree/HistoryPane.tsx
@@ -41,13 +41,6 @@ import type { HistoryMatch } from '@/hooks/useHistorySearch';
 // ============================================================================
 
 /**
- * Height of the sticky header in pixels.
- * Used for scroll position calculations and future reference.
- * Note: sticky top-0 does not affect scrollTop calculation as content flows below naturally.
- */
-export const STICKY_HEADER_HEIGHT = 48;
-
-/**
  * Issue #744: id of the per-split slot element that wraps an embedded
  * HistoryPane. `TerminalSplitPaneContent` renders the wrapping `<div>` with this
  * exact `id` so the split-embedded collapse button's `aria-controls` resolves to
@@ -203,12 +196,15 @@ function computeMatchedPairIds(
 // Main Component
 // ============================================================================
 
+// Issue #1019: The outer wrapper no longer scrolls. It only clips its rounded
+// corners (`overflow-hidden`) and lays out the fixed header, fixed search bar
+// and the single inner scroll region as flex rows. Scrolling is delegated to a
+// dedicated inner div (see render) so the header stays pinned above it.
 const BASE_CONTAINER_CLASSES = [
   'h-full',
   'flex',
   'flex-col',
-  'overflow-y-auto',
-  'overflow-x-hidden',
+  'overflow-hidden',
   'bg-gray-900',
   'rounded-lg',
   'border',
@@ -491,13 +487,12 @@ export const HistoryPane = memo(function HistoryPane({
 
   return (
     <div
-      ref={scrollContainerRef}
       role="region"
       aria-label="Message history"
       className={containerClasses}
     >
-      {/* Header */}
-      <div className="sticky top-0 bg-gray-900 border-b border-gray-700 px-4 py-2 z-10 flex items-center justify-between flex-wrap gap-1">
+      {/* Header — fixed row, always pinned at the top (Issue #1019) */}
+      <div className="flex-shrink-0 bg-gray-900 border-b border-gray-700 px-4 py-2 flex items-center justify-between flex-wrap gap-1">
         <h3 className="text-sm font-medium text-gray-300">Message History</h3>
         <div className="flex items-center gap-2 flex-wrap">
           {onHistoryDisplayLimitChange && historyDisplayLimit !== undefined && (
@@ -575,9 +570,9 @@ export const HistoryPane = memo(function HistoryPane({
         </div>
       </div>
 
-      {/* Search bar (toggleable) */}
+      {/* Search bar (toggleable) — fixed row below the header (Issue #1019) */}
       {isSearchOpen && (
-        <div className="sticky top-12 z-10 px-3 py-2 bg-gray-900 border-b border-gray-700">
+        <div className="flex-shrink-0 px-3 py-2 bg-gray-900 border-b border-gray-700">
           <HistorySearchBar
             query={searchQuery}
             onQueryChange={setSearchQuery}
@@ -593,8 +588,17 @@ export const HistoryPane = memo(function HistoryPane({
         </div>
       )}
 
-      {/* Content */}
-      <div className="flex-1 p-4 min-h-0">{renderContent()}</div>
+      {/* Content — the only scroll region. Messages scroll below the fixed
+          header/search bar, never behind them (Issue #1019). scrollContainerRef
+          points here so scroll save/restore (#716) and search scrollIntoView
+          operate on the real scroll element. */}
+      <div
+        ref={scrollContainerRef}
+        data-testid="history-scroll-container"
+        className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden p-4"
+      >
+        {renderContent()}
+      </div>
     </div>
   );
 });

--- a/src/components/worktree/__tests__/HistoryPane.integration.test.tsx
+++ b/src/components/worktree/__tests__/HistoryPane.integration.test.tsx
@@ -339,6 +339,58 @@ describe('HistoryPane Integration', () => {
     });
   });
 
+  describe('Issue #1019: fixed header + isolated scroll region', () => {
+    it('should keep the header outside the scroll container and messages inside it', () => {
+      const messages = [
+        createTestMessage('user', 'Hello', T1, 'user-1'),
+        createTestMessage('assistant', 'Hi there!', T2, 'asst-1'),
+      ];
+
+      render(
+        <HistoryPane
+          messages={messages}
+          worktreeId="test"
+          onFilePathClick={mockOnFilePathClick}
+        />
+      );
+
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+
+      // The header ("Message History") must NOT live inside the scroll region,
+      // otherwise messages would scroll behind it (the Issue #1019 defect).
+      const header = screen.getByText('Message History');
+      expect(scrollContainer.contains(header)).toBe(false);
+
+      // Messages must render inside the scroll region.
+      const pairCard = screen.getByTestId('conversation-pair-card');
+      expect(scrollContainer.contains(pairCard)).toBe(true);
+    });
+
+    it('should keep the search bar outside the scroll container when open', () => {
+      const messages = [
+        createTestMessage('user', 'Hello', T1, 'user-1'),
+        createTestMessage('assistant', 'Hi there!', T2, 'asst-1'),
+      ];
+
+      render(
+        <HistoryPane
+          messages={messages}
+          worktreeId="test"
+          onFilePathClick={mockOnFilePathClick}
+        />
+      );
+
+      // Open the in-pane search bar.
+      fireEvent.click(screen.getByRole('button', { name: /open search/i }));
+
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+      const searchInput = screen.getByLabelText('検索キーワード');
+
+      // The search bar is a fixed row above the scroll region, not inside it.
+      expect(scrollContainer.contains(searchInput)).toBe(false);
+    });
+  });
+
   describe('Issue #725: User only filter', () => {
     it('should hide assistant message section when historyUserOnly is true', () => {
       const messages = [

--- a/tests/unit/components/HistoryPane.test.tsx
+++ b/tests/unit/components/HistoryPane.test.tsx
@@ -282,7 +282,9 @@ describe('HistoryPane', () => {
   });
 
   describe('Independent scrolling', () => {
-    it('should have overflow-y-auto for independent scrolling', () => {
+    // Issue #1019: The header and search bar are fixed rows; only the dedicated
+    // inner scroll container scrolls, so messages never pass behind the header.
+    it('should confine scrolling to the inner scroll container, not the outer region', () => {
       const messages: ChatMessage[] = [
         createTestMessage({ content: 'Test message' }),
       ];
@@ -295,11 +297,17 @@ describe('HistoryPane', () => {
         />
       );
 
+      // The outer region only clips its rounded corners — it must NOT scroll.
       const region = screen.getByRole('region');
-      expect(region.className).toMatch(/overflow/);
+      expect(region.className).toMatch(/overflow-hidden/);
+      expect(region.className).not.toMatch(/overflow-y-auto/);
+
+      // The inner scroll container is the single vertical scroll surface.
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+      expect(scrollContainer.className).toMatch(/overflow-y-auto/);
     });
 
-    it('should have flexible height for scrolling', () => {
+    it('should have flexible height for scrolling on the scroll container', () => {
       const messages: ChatMessage[] = [
         createTestMessage({ content: 'Test message' }),
       ];
@@ -312,8 +320,14 @@ describe('HistoryPane', () => {
         />
       );
 
+      // Outer region keeps the flex column layout that pins the header rows.
       const region = screen.getByRole('region');
-      expect(region.className).toMatch(/h-full|flex|min-h/);
+      expect(region.className).toMatch(/h-full|flex/);
+
+      // Scroll container grows to fill the remaining space (flex-1 min-h-0).
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+      expect(scrollContainer.className).toMatch(/flex-1/);
+      expect(scrollContainer.className).toMatch(/min-h-0/);
     });
   });
 


### PR DESCRIPTION
## 概要

PC版 History パネルで、ヘッダー相当の「Message History」から上下にスクロールされてしまう違和感を修正します（#1019）。ヘッダー（＋検索バー）を固定し、メッセージはヘッダーの下の領域だけでスクロールするようレイアウトを変更しました。

## 根本原因

`HistoryPane.tsx` が「ペイン全体が単一スクロールコンテナ（`overflow-y-auto`）＋ヘッダーは `sticky top-0` / 検索バーは `sticky top-12`」構造だったため、メッセージがヘッダーの背後を通過し、スクロール領域がヘッダーを含むペイン全体に及んでいた。`top-12`（48px）と `STICKY_HEADER_HEIGHT=48` のマジックナンバー結合もあった。

## 変更内容

- **HistoryPane**: 最外層を非スクロール（`flex-col overflow-hidden`）化し、ヘッダー／検索バーを `flex-shrink-0`（`sticky`/`top-0`/`top-12`/`z-10` 撤去）、メッセージを新設の内側スクロール div（`flex-1 min-h-0 overflow-y-auto overflow-x-hidden`）に配置。`scrollContainerRef` を内側 div へ移設。未使用の `STICKY_HEADER_HEIGHT` を撤去。
- **テスト**: `HistoryPane.test.tsx` を新スクロール領域基準に更新（外層＝非スクロール、内層＝`overflow-y-auto/flex-1/min-h-0`）。`__tests__/HistoryPane.integration.test.tsx` に #1019 リグレッションガード追加（ヘッダー/検索バーはスクロール領域の外、メッセージは中）。

## テスト

- **全4ゲート合格**: ESLint ✅ / tsc --noEmit ✅ / test:unit ✅（470ファイル・8392テスト）/ build ✅
- スクロール位置の保存/復元（#716）・検索の scrollIntoView は `scrollContainerRef` の移設後も動作
- **HistoryPane は PC（`TerminalSplitPaneContent`）／モバイル（`WorktreeDetailMobile`）共用**。両方のレンダーテストが green でリグレッションなし

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
