### PR TITLE
fix: History パネルのヘッダーを固定しスクロールをヘッダー下に限定

### DIFF
--- a/src/components/worktree/HistoryPane.tsx
+++ b/src/components/worktree/HistoryPane.tsx
@@ -41,13 +41,6 @@ import type { HistoryMatch } from '@/hooks/useHistorySearch';
 // ============================================================================
 
 /**
- * Height of the sticky header in pixels.
- * Used for scroll position calculations and future reference.
- * Note: sticky top-0 does not affect scrollTop calculation as content flows below naturally.
- */
-export const STICKY_HEADER_HEIGHT = 48;
-
-/**
  * Issue #744: id of the per-split slot element that wraps an embedded
  * HistoryPane. `TerminalSplitPaneContent` renders the wrapping `<div>` with this
  * exact `id` so the split-embedded collapse button's `aria-controls` resolves to
@@ -203,12 +196,15 @@ function computeMatchedPairIds(
 // Main Component
 // ============================================================================
 
+// Issue #1019: The outer wrapper no longer scrolls. It only clips its rounded
+// corners (`overflow-hidden`) and lays out the fixed header, fixed search bar
+// and the single inner scroll region as flex rows. Scrolling is delegated to a
+// dedicated inner div (see render) so the header stays pinned above it.
 const BASE_CONTAINER_CLASSES = [
   'h-full',
   'flex',
   'flex-col',
-  'overflow-y-auto',
-  'overflow-x-hidden',
+  'overflow-hidden',
   'bg-gray-900',
   'rounded-lg',
   'border',
@@ -491,13 +487,12 @@ export const HistoryPane = memo(function HistoryPane({
 
   return (
     <div
-      ref={scrollContainerRef}
       role="region"
       aria-label="Message history"
       className={containerClasses}
     >
-      {/* Header */}
-      <div className="sticky top-0 bg-gray-900 border-b border-gray-700 px-4 py-2 z-10 flex items-center justify-between flex-wrap gap-1">
+      {/* Header — fixed row, always pinned at the top (Issue #1019) */}
+      <div className="flex-shrink-0 bg-gray-900 border-b border-gray-700 px-4 py-2 flex items-center justify-between flex-wrap gap-1">
         <h3 className="text-sm font-medium text-gray-300">Message History</h3>
         <div className="flex items-center gap-2 flex-wrap">
           {onHistoryDisplayLimitChange && historyDisplayLimit !== undefined && (
@@ -575,9 +570,9 @@ export const HistoryPane = memo(function HistoryPane({
         </div>
       </div>
 
-      {/* Search bar (toggleable) */}
+      {/* Search bar (toggleable) — fixed row below the header (Issue #1019) */}
       {isSearchOpen && (
-        <div className="sticky top-12 z-10 px-3 py-2 bg-gray-900 border-b border-gray-700">
+        <div className="flex-shrink-0 px-3 py-2 bg-gray-900 border-b border-gray-700">
           <HistorySearchBar
             query={searchQuery}
             onQueryChange={setSearchQuery}
@@ -593,8 +588,17 @@ export const HistoryPane = memo(function HistoryPane({
         </div>
       )}
 
-      {/* Content */}
-      <div className="flex-1 p-4 min-h-0">{renderContent()}</div>
+      {/* Content — the only scroll region. Messages scroll below the fixed
+          header/search bar, never behind them (Issue #1019). scrollContainerRef
+          points here so scroll save/restore (#716) and search scrollIntoView
+          operate on the real scroll element. */}
+      <div
+        ref={scrollContainerRef}
+        data-testid="history-scroll-container"
+        className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden p-4"
+      >
+        {renderContent()}
+      </div>
     </div>
   );
 });

--- a/src/components/worktree/__tests__/HistoryPane.integration.test.tsx
+++ b/src/components/worktree/__tests__/HistoryPane.integration.test.tsx
@@ -339,6 +339,58 @@ describe('HistoryPane Integration', () => {
     });
   });
 
+  describe('Issue #1019: fixed header + isolated scroll region', () => {
+    it('should keep the header outside the scroll container and messages inside it', () => {
+      const messages = [
+        createTestMessage('user', 'Hello', T1, 'user-1'),
+        createTestMessage('assistant', 'Hi there!', T2, 'asst-1'),
+      ];
+
+      render(
+        <HistoryPane
+          messages={messages}
+          worktreeId="test"
+          onFilePathClick={mockOnFilePathClick}
+        />
+      );
+
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+
+      // The header ("Message History") must NOT live inside the scroll region,
+      // otherwise messages would scroll behind it (the Issue #1019 defect).
+      const header = screen.getByText('Message History');
+      expect(scrollContainer.contains(header)).toBe(false);
+
+      // Messages must render inside the scroll region.
+      const pairCard = screen.getByTestId('conversation-pair-card');
+      expect(scrollContainer.contains(pairCard)).toBe(true);
+    });
+
+    it('should keep the search bar outside the scroll container when open', () => {
+      const messages = [
+        createTestMessage('user', 'Hello', T1, 'user-1'),
+        createTestMessage('assistant', 'Hi there!', T2, 'asst-1'),
+      ];
+
+      render(
+        <HistoryPane
+          messages={messages}
+          worktreeId="test"
+          onFilePathClick={mockOnFilePathClick}
+        />
+      );
+
+      // Open the in-pane search bar.
+      fireEvent.click(screen.getByRole('button', { name: /open search/i }));
+
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+      const searchInput = screen.getByLabelText('検索キーワード');
+
+      // The search bar is a fixed row above the scroll region, not inside it.
+      expect(scrollContainer.contains(searchInput)).toBe(false);
+    });
+  });
+
   describe('Issue #725: User only filter', () => {
     it('should hide assistant message section when historyUserOnly is true', () => {
       const messages = [

--- a/tests/unit/components/HistoryPane.test.tsx
+++ b/tests/unit/components/HistoryPane.test.tsx
@@ -282,7 +282,9 @@ describe('HistoryPane', () => {
   });
 
   describe('Independent scrolling', () => {
-    it('should have overflow-y-auto for independent scrolling', () => {
+    // Issue #1019: The header and search bar are fixed rows; only the dedicated
+    // inner scroll container scrolls, so messages never pass behind the header.
+    it('should confine scrolling to the inner scroll container, not the outer region', () => {
       const messages: ChatMessage[] = [
         createTestMessage({ content: 'Test message' }),
       ];
@@ -295,11 +297,17 @@ describe('HistoryPane', () => {
         />
       );
 
+      // The outer region only clips its rounded corners — it must NOT scroll.
       const region = screen.getByRole('region');
-      expect(region.className).toMatch(/overflow/);
+      expect(region.className).toMatch(/overflow-hidden/);
+      expect(region.className).not.toMatch(/overflow-y-auto/);
+
+      // The inner scroll container is the single vertical scroll surface.
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+      expect(scrollContainer.className).toMatch(/overflow-y-auto/);
     });
 
-    it('should have flexible height for scrolling', () => {
+    it('should have flexible height for scrolling on the scroll container', () => {
       const messages: ChatMessage[] = [
         createTestMessage({ content: 'Test message' }),
       ];
@@ -312,8 +320,14 @@ describe('HistoryPane', () => {
         />
       );
 
+      // Outer region keeps the flex column layout that pins the header rows.
       const region = screen.getByRole('region');
-      expect(region.className).toMatch(/h-full|flex|min-h/);
+      expect(region.className).toMatch(/h-full|flex/);
+
+      // Scroll container grows to fill the remaining space (flex-1 min-h-0).
+      const scrollContainer = screen.getByTestId('history-scroll-container');
+      expect(scrollContainer.className).toMatch(/flex-1/);
+      expect(scrollContainer.className).toMatch(/min-h-0/);
     });
   });
 


### PR DESCRIPTION
## Summary

PC 版 History パネルで、ヘッダー相当の「Message History」から上下にスクロールされてしまう違和感を修正する。従来は「ペイン全体が単一スクロールコンテナ ＋ ヘッダーは `sticky`」構造で、メッセージがヘッダーの**背後を通過**していた。**固定ヘッダー行 ＋ 独立したスクロール領域**のレイアウトに変更し、ヘッダー（＋検索バー）を常に固定、メッセージはその下だけでスクロールするようにした。

Closes #1019

## Changes

### Fixed
- `HistoryPane`: 最外層を非スクロール化（`overflow-y-auto/overflow-x-hidden` → `overflow-hidden`、角丸クリップのみ）。ヘッダー／検索バーの `sticky top-0 / top-12 / z-10` を撤去し `flex-shrink-0` に変更。メッセージ本体を**新設の内側スクロール div**（`flex-1 min-h-0 overflow-y-auto overflow-x-hidden p-4`）に配置し、`scrollContainerRef` をそこへ移設。
- `top-12`（48px）と未使用の `STICKY_HEADER_HEIGHT = 48` のマジックナンバー結合を解消（定数を撤去）。

### Changed
- スクロール位置の保存/復元（#716）・検索の `scrollIntoView` は `scrollContainerRef` 依存のため、ref が実スクロール要素を指すことで動作継続。ヘッダー重なりが消え、`scrollIntoView` のオフセットも単純化。
- `role="region" aria-label="Message history"` は最外層に維持（ヘッダーのコントロールも含めた履歴セクション全体をラベル付け）。

### Tests
- `HistoryPane.test.tsx`「Independent scrolling」を新スクロール領域基準に更新（外層＝非スクロール、内層＝`overflow-y-auto`/`flex-1`/`min-h-0`）。
- `HistoryPane.integration.test.tsx` に Issue #1019 のリグレッションガードを追加（ヘッダー／検索バーはスクロール領域の**外**、メッセージは**中**）。テスト用に `data-testid="history-scroll-container"` を付与。
- `HistoryPane` は PC（`TerminalSplitPaneContent`）／モバイル（`WorktreeDetailMobile`）共用のため、両方をレンダーするテストで検証（リグレッションなし）。

## Test Results

### Unit Tests
```
npm run test:unit
Test Files  470 passed (470)
      Tests  8392 passed (8392)
```

### Lint & Type Check
- ESLint: 0 errors
- TypeScript (`tsc --noEmit`): 0 errors

### Build
```
npm run build
Build successful (exit 0)
```

## Checklist

- [x] Unit tests pass（470 files / 8392 tests）
- [x] Lint check passes
- [x] Type check passes
- [x] Build succeeds
- [x] No console.log in production code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
