### PR TITLE
fix: Timer 発火の送信が History に残らない（send ロジックを共有サービス化）

### DIFF
--- a/src/app/api/worktrees/[id]/send/route.ts
+++ b/src/app/api/worktrees/[id]/send/route.ts
@@ -15,19 +15,14 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getDbInstance } from '@/lib/db/db-instance';
-import { getWorktreeById, createMessage, updateLastUserMessage, clearInProgressMessageId, saveInitialBranch, getInitialBranch, getMessages, deleteMessageById } from '@/lib/db';
+import { getWorktreeById, saveInitialBranch, getInitialBranch } from '@/lib/db';
 import { CLIToolManager } from '@/lib/cli-tools/manager';
-import { CLI_TOOL_IDS, isImageCapableCLITool, isValidInstanceId, type CLIToolType } from '@/lib/cli-tools/types';
-import { startPolling } from '@/lib/polling/response-poller';
-import { savePendingAssistantResponse } from '@/lib/assistant-response-saver';
+import { CLI_TOOL_IDS, isValidInstanceId, type CLIToolType } from '@/lib/cli-tools/types';
+import { sendUserMessage } from '@/lib/session/send-user-message';
 import { getGitStatus } from '@/lib/git/git-utils';
 import { isPathSafe, resolveAndValidateRealPath } from '@/lib/security/path-validator';
-import { sendKeys, sendSpecialKeys } from '@/lib/tmux/tmux';
-import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
 import path from 'path';
 import { createLogger } from '@/lib/logger';
-import { COPILOT_SEND_ENTER_DELAY_MS } from '@/config/copilot-constants';
-import { CopilotTool } from '@/lib/cli-tools/copilot';
 import { AntigravityTool } from '@/lib/cli-tools/antigravity';
 import { validateCopilotModelName, validateAntigravityModelName } from '@/lib/cmate-cli-tool-parser';
 
@@ -252,39 +247,7 @@ export async function POST(
       }
     }
 
-    // Generate timestamp for user message BEFORE saving pending response
-    // This ensures timestamp ordering: assistantResponse < userMessage
-    const userMessageTimestamp = new Date();
-
-    // Save any pending assistant response before sending the new user message
-    // This captures the CLI tool's response to the previous user message
-    try {
-      await savePendingAssistantResponse(db, params.id, cliToolId, userMessageTimestamp, instanceId);
-    } catch (error) {
-      // Log but don't fail - user message should still be saved
-      logger.error('failed-to-save-pending-assistant-response:', { error: error instanceof Error ? error.message : String(error) });
-    }
-
-    // Clean up orphaned user messages (Issue #379: duplicate message prevention)
-    // If the most recent message for this cliToolId is a user message with the
-    // same content, it means the assistant never responded and the user is retrying.
-    // Remove it to prevent duplicates.
-    let orphanedMessageIdToDelete: string | null = null;
-    try {
-      const recentMessages = getMessages(db, params.id, { limit: 1, cliToolId, instanceId });
-      if (
-        recentMessages.length > 0 &&
-        recentMessages[0].role === 'user' &&
-        recentMessages[0].content === trimmedContent
-      ) {
-        orphanedMessageIdToDelete = recentMessages[0].id;
-      }
-    } catch (error) {
-      // Log but don't fail - cleanup candidate discovery is best-effort
-      logger.error('failed-to-detect-orphaned-messages:', { error: error instanceof Error ? error.message : String(error) });
-    }
-
-    // Issue #474: Validate imagePath if provided
+    // Issue #474: Validate imagePath if provided (HTTP-layer validation stays here)
     let absoluteImagePath: string | undefined;
     if (body.imagePath) {
       const validationResult = validateImagePath(body.imagePath, worktree.path);
@@ -294,97 +257,34 @@ export async function POST(
       absoluteImagePath = validationResult;
     }
 
-    // Issue #576: Send /model command before message if model is specified
-    if (body.model && cliToolId === 'copilot') {
-      try {
-        const copilotTool = cliTool as CopilotTool;
-        await copilotTool.sendModelCommand(params.id, body.model, instanceId);
-        logger.info('copilot-model-command-sent', { model: body.model });
-      } catch (error: unknown) {
-        logger.error('failed-to-send-model-command:', { error: error instanceof Error ? error.message : String(error) });
+    // Issue #1028: Delegate the send + history-recording flow to the shared
+    // sendUserMessage service so manual sends and Timer-fired sends (executeTimer)
+    // record identically in chat_messages / Message History.
+    const result = await sendUserMessage(db, {
+      worktreeId: params.id,
+      content: trimmedContent,
+      cliToolId,
+      instanceId,
+      absoluteImagePath,
+      // Issue #576: copilot /model switch (antigravity model is applied at
+      // session start above, not mid-session).
+      copilotModel: cliToolId === 'copilot' ? body.model : undefined,
+    });
+
+    if (!result.ok) {
+      if (result.stage === 'model') {
         return NextResponse.json(
-          { error: `Failed to switch model to ${body.model}: ${getErrorMessage(error)}` },
+          { error: `Failed to switch model to ${body.model}: ${result.error}` },
           { status: 500 }
         );
       }
-    }
-
-    // Send message to CLI tool
-    try {
-      // Issue #474: Image-aware sending
-      if (absoluteImagePath) {
-        if (isImageCapableCLITool(cliTool)) {
-          // Image-capable tool: use native image sending
-          await cliTool.sendMessageWithImage(params.id, trimmedContent, absoluteImagePath, instanceId);
-        } else {
-          // Fallback: embed path in message
-          const messageWithPath = trimmedContent
-            ? `${trimmedContent}\n\n[添付画像: ${absoluteImagePath}]`
-            : `[添付画像: ${absoluteImagePath}]`;
-          await cliTool.sendMessage(params.id, messageWithPath, instanceId);
-        }
-      } else if (cliToolId === 'copilot') {
-        // Copilot: use sendKeys directly to avoid waitForPrompt blocking (#559)
-        // Copilot CLI auto-enters multi-line mode when text exceeds pane width.
-        // In multi-line mode, C-m (bundled with text) adds a newline instead of
-        // submitting. Sending Enter as a separate tmux command after a delay
-        // allows the TUI to process the text first, then accept Enter as submit.
-        const sessionName = cliTool.getSessionName(params.id, instanceId);
-        // Replace newlines with spaces to prevent Copilot CLI multi-line mode
-        const copilotContent = trimmedContent.replace(/\n+/g, ' ').trim();
-        await sendKeys(sessionName, copilotContent, false);
-        await new Promise(resolve => setTimeout(resolve, COPILOT_SEND_ENTER_DELAY_MS));
-        await sendSpecialKeys(sessionName, ['Enter']);
-        invalidateCache(sessionName);
-      } else {
-        await cliTool.sendMessage(params.id, trimmedContent, instanceId);
-      }
-    } catch (error: unknown) {
-      logger.error('failed-to-send-message-to:', { error: error instanceof Error ? error.message : String(error) });
       return NextResponse.json(
-        { error: `Failed to send message to ${cliTool.name}: ${getErrorMessage(error)}` },
+        { error: `Failed to send message to ${cliTool.name}: ${result.error}` },
         { status: 500 }
       );
     }
 
-    // Create user message in database with CLI tool ID
-    // Use the pre-generated timestamp for consistency
-    // [DRY] Use trimmedContent consistently (same value sent to CLI and used for orphan detection)
-    const message = createMessage(db, {
-      worktreeId: params.id,
-      role: 'user',
-      content: trimmedContent,
-      messageType: 'normal',
-      timestamp: userMessageTimestamp,
-      cliToolId,
-      instanceId,
-    });
-
-    // Remove the prior orphan only after the retry message is persisted.
-    // This avoids data loss if send/create fails partway through the request.
-    if (orphanedMessageIdToDelete) {
-      try {
-        const deleted = deleteMessageById(db, orphanedMessageIdToDelete);
-        if (deleted) {
-          logger.info('cleaned-up-orphaned-user');
-        }
-      } catch (error) {
-        // Log but don't fail - cleanup is best-effort
-        logger.error('failed-to-clean-up-orphaned-message:', { error: error instanceof Error ? error.message : String(error) });
-      }
-    }
-
-    // Update last user message for worktree
-    updateLastUserMessage(db, params.id, trimmedContent, userMessageTimestamp);
-
-    // Clear in-progress message ID (session state is managed by savePendingAssistantResponse)
-    clearInProgressMessageId(db, params.id, cliToolId, instanceId);
-    logger.info('cleared-in-progress-message-for');
-
-    // Start polling for CLI tool's response
-    startPolling(params.id, cliToolId, instanceId);
-
-    return NextResponse.json(message, { status: 201 });
+    return NextResponse.json(result.message, { status: 201 });
   } catch (error: unknown) {
     logger.error('error-sending-message:', { error: error instanceof Error ? error.message : String(error) });
     return NextResponse.json(

--- a/src/lib/session/send-user-message.ts
+++ b/src/lib/session/send-user-message.ts
@@ -1,0 +1,204 @@
+/**
+ * Shared user-message send service (Issue #1028).
+ *
+ * Extracts the "send a validated user message and record it in history" flow
+ * that previously lived inline in POST /api/worktrees/[id]/send. Both the send
+ * API route and the Timer manager (executeTimer) call this so timer-fired
+ * messages take the exact same recording path as manual sends and therefore
+ * appear in Message History.
+ *
+ * Responsibilities (in order):
+ *   1. savePendingAssistantResponse  — persist the previous assistant reply
+ *   2. orphan detection              — Issue #379 duplicate-message guard
+ *   3. copilot /model command        — Issue #576 (copilot only)
+ *   4. send to CLI tool              — image / copilot / normal branches
+ *   5. createMessage (role: 'user')  — INSERT INTO chat_messages (History source)
+ *   6. orphan deletion               — remove prior duplicate after persist
+ *   7. updateLastUserMessage
+ *   8. clearInProgressMessageId
+ *   9. startPolling                  — record the assistant response afterwards
+ *
+ * Out of scope (kept in the HTTP layer / caller): request/body validation,
+ * content trimming/size limits, imagePath validation, CLI-tool availability
+ * and session-start (running) checks. The caller passes already-validated input.
+ */
+
+import type Database from 'better-sqlite3';
+import {
+  createMessage,
+  updateLastUserMessage,
+  clearInProgressMessageId,
+  getMessages,
+  deleteMessageById,
+} from '@/lib/db';
+import { CLIToolManager } from '@/lib/cli-tools/manager';
+import { isImageCapableCLITool, type CLIToolType } from '@/lib/cli-tools/types';
+import { startPolling } from '@/lib/polling/response-poller';
+import { savePendingAssistantResponse } from '@/lib/assistant-response-saver';
+import { sendKeys, sendSpecialKeys } from '@/lib/tmux/tmux';
+import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
+import { createLogger } from '@/lib/logger';
+import { COPILOT_SEND_ENTER_DELAY_MS } from '@/config/copilot-constants';
+import type { CopilotTool } from '@/lib/cli-tools/copilot';
+import type { ChatMessage, MessageType } from '@/types/models';
+
+const logger = createLogger('session/send-user-message');
+
+/** Parameters for {@link sendUserMessage}. All values must be pre-validated. */
+export interface SendUserMessageParams {
+  /** Target worktree ID. */
+  worktreeId: string;
+  /** Validated, trimmed message content (non-empty). */
+  content: string;
+  /** Resolved CLI tool ID. */
+  cliToolId: CLIToolType;
+  /** Agent instance ID; defaults to the primary instance (=== cliToolId). */
+  instanceId?: string;
+  /** chat_messages message_type. Defaults to 'normal'. */
+  messageType?: MessageType;
+  /** Validated absolute image path (send API only; Timer never sets this). */
+  absoluteImagePath?: string;
+  /** Validated Copilot model to switch to before sending (send API only). */
+  copilotModel?: string;
+}
+
+/** Result of {@link sendUserMessage}. */
+export type SendUserMessageResult =
+  | { ok: true; message: ChatMessage }
+  | { ok: false; stage: 'model' | 'send'; error: string };
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Send a validated user message to the CLI tool and record it in history.
+ *
+ * On CLI send failure (or copilot /model failure) it returns an `ok: false`
+ * result with the failing stage; the caller decides how to surface the error.
+ * DB record failures throw (same as before the extraction).
+ */
+export async function sendUserMessage(
+  db: Database.Database,
+  params: SendUserMessageParams
+): Promise<SendUserMessageResult> {
+  const { worktreeId, content, cliToolId, instanceId, absoluteImagePath, copilotModel } = params;
+  const messageType: MessageType = params.messageType ?? 'normal';
+
+  const cliTool = CLIToolManager.getInstance().getTool(cliToolId);
+
+  // Generate the user-message timestamp BEFORE saving the pending response so
+  // ordering holds: assistantResponse < userMessage.
+  const userMessageTimestamp = new Date();
+
+  // 1. Save any pending assistant response before sending the new user message.
+  try {
+    await savePendingAssistantResponse(db, worktreeId, cliToolId, userMessageTimestamp, instanceId);
+  } catch (error) {
+    // Log but don't fail - user message should still be saved
+    logger.error('failed-to-save-pending-assistant-response:', { error: getErrorMessage(error) });
+  }
+
+  // 2. Clean up orphaned user messages (Issue #379: duplicate message prevention).
+  // If the most recent message for this cliToolId is a user message with the same
+  // content, the assistant never responded and the user is retrying. Remove it
+  // (only after the retry message is persisted) to prevent duplicates.
+  let orphanedMessageIdToDelete: string | null = null;
+  try {
+    const recentMessages = getMessages(db, worktreeId, { limit: 1, cliToolId, instanceId });
+    if (
+      recentMessages.length > 0 &&
+      recentMessages[0].role === 'user' &&
+      recentMessages[0].content === content
+    ) {
+      orphanedMessageIdToDelete = recentMessages[0].id;
+    }
+  } catch (error) {
+    // Log but don't fail - cleanup candidate discovery is best-effort
+    logger.error('failed-to-detect-orphaned-messages:', { error: getErrorMessage(error) });
+  }
+
+  // 3. Issue #576: Send /model command before message if model is specified (copilot only).
+  if (copilotModel && cliToolId === 'copilot') {
+    try {
+      const copilotTool = cliTool as CopilotTool;
+      await copilotTool.sendModelCommand(worktreeId, copilotModel, instanceId);
+      logger.info('copilot-model-command-sent', { model: copilotModel });
+    } catch (error) {
+      logger.error('failed-to-send-model-command:', { error: getErrorMessage(error) });
+      return { ok: false, stage: 'model', error: getErrorMessage(error) };
+    }
+  }
+
+  // 4. Send message to CLI tool.
+  try {
+    // Issue #474: Image-aware sending
+    if (absoluteImagePath) {
+      if (isImageCapableCLITool(cliTool)) {
+        // Image-capable tool: use native image sending
+        await cliTool.sendMessageWithImage(worktreeId, content, absoluteImagePath, instanceId);
+      } else {
+        // Fallback: embed path in message
+        const messageWithPath = content
+          ? `${content}\n\n[添付画像: ${absoluteImagePath}]`
+          : `[添付画像: ${absoluteImagePath}]`;
+        await cliTool.sendMessage(worktreeId, messageWithPath, instanceId);
+      }
+    } else if (cliToolId === 'copilot') {
+      // Copilot: use sendKeys directly to avoid waitForPrompt blocking (#559).
+      // Copilot CLI auto-enters multi-line mode when text exceeds pane width.
+      // In multi-line mode, C-m (bundled with text) adds a newline instead of
+      // submitting. Sending Enter as a separate tmux command after a delay
+      // allows the TUI to process the text first, then accept Enter as submit.
+      const sessionName = cliTool.getSessionName(worktreeId, instanceId);
+      // Replace newlines with spaces to prevent Copilot CLI multi-line mode
+      const copilotContent = content.replace(/\n+/g, ' ').trim();
+      await sendKeys(sessionName, copilotContent, false);
+      await new Promise(resolve => setTimeout(resolve, COPILOT_SEND_ENTER_DELAY_MS));
+      await sendSpecialKeys(sessionName, ['Enter']);
+      invalidateCache(sessionName);
+    } else {
+      await cliTool.sendMessage(worktreeId, content, instanceId);
+    }
+  } catch (error) {
+    logger.error('failed-to-send-message-to:', { error: getErrorMessage(error) });
+    return { ok: false, stage: 'send', error: getErrorMessage(error) };
+  }
+
+  // 5. Create user message in database (History source: chat_messages).
+  const message = createMessage(db, {
+    worktreeId,
+    role: 'user',
+    content,
+    messageType,
+    timestamp: userMessageTimestamp,
+    cliToolId,
+    instanceId,
+  });
+
+  // 6. Remove the prior orphan only after the retry message is persisted.
+  // This avoids data loss if send/create fails partway through.
+  if (orphanedMessageIdToDelete) {
+    try {
+      const deleted = deleteMessageById(db, orphanedMessageIdToDelete);
+      if (deleted) {
+        logger.info('cleaned-up-orphaned-user');
+      }
+    } catch (error) {
+      // Log but don't fail - cleanup is best-effort
+      logger.error('failed-to-clean-up-orphaned-message:', { error: getErrorMessage(error) });
+    }
+  }
+
+  // 7. Update last user message for worktree.
+  updateLastUserMessage(db, worktreeId, content, userMessageTimestamp);
+
+  // 8. Clear in-progress message ID (session state managed by savePendingAssistantResponse).
+  clearInProgressMessageId(db, worktreeId, cliToolId, instanceId);
+  logger.info('cleared-in-progress-message-for');
+
+  // 9. Start polling for the CLI tool's response.
+  startPolling(worktreeId, cliToolId, instanceId);
+
+  return { ok: true, message };
+}

--- a/src/lib/timer-manager.ts
+++ b/src/lib/timer-manager.ts
@@ -20,6 +20,7 @@ import { CLIToolManager } from './cli-tools/manager';
 import { getDbInstance } from '@/lib/db/db-instance';
 import { createLogger } from '@/lib/logger';
 import { TIMER_CLEANUP_RETENTION_DAYS, TIMER_STATUS } from '@/config/timer-constants';
+import { sendUserMessage } from '@/lib/session/send-user-message';
 import type { CLIToolType } from './cli-tools/types';
 
 const logger = createLogger('timer-manager');
@@ -92,13 +93,27 @@ async function executeTimer(timerId: string): Promise<void> {
     }
 
     updateTimerStatus(db, timerId, 'sending');
-    // [Issue #947] Delegate to the CLI tool's sendMessage so timer sends take the
-    // exact same path as manual sends: per-tool text/Enter separation and waits.
-    // The previous direct sendKeys(sessionName, message, true) batched text+Enter
-    // in a single send-keys; codex's TUI never confirmed the input, leaving the
-    // message typed but unsent. sendMessage resolves the session name from
-    // (worktreeId, instanceId) internally, so claude/codex/gemini all work.
-    await cliTool.sendMessage(timer.worktreeId, timer.message, instanceId);
+    // [Issue #947] Delegate sending so timer sends take the exact same path as
+    // manual sends: per-tool text/Enter separation and waits. The previous direct
+    // sendKeys(sessionName, message, true) batched text+Enter in a single send-keys;
+    // codex's TUI never confirmed the input, leaving the message typed but unsent.
+    // [Issue #1028] Delegate to sendUserMessage (the same service the send API uses)
+    // rather than the low-level cliTool.sendMessage, so timer-fired messages also
+    // record the user message in chat_messages and start response polling —
+    // otherwise they never appear in Message History.
+    const result = await sendUserMessage(db, {
+      worktreeId: timer.worktreeId,
+      content: timer.message,
+      cliToolId: timer.cliToolId as CLIToolType,
+      instanceId,
+    });
+
+    if (!result.ok) {
+      updateTimerStatus(db, timerId, 'failed');
+      logger.error('timer:send-failed', { timerId, stage: result.stage, error: result.error });
+      return;
+    }
+
     updateTimerStatus(db, timerId, 'sent', Date.now());
 
     logger.info('timer:sent', { timerId, worktreeId: timer.worktreeId });

--- a/tests/unit/lib/session/send-user-message.test.ts
+++ b/tests/unit/lib/session/send-user-message.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for the shared user-message send service (Issue #1028).
+ *
+ * Verifies that sendUserMessage performs the full send + history-recording flow
+ * (savePendingAssistantResponse -> orphan detection -> send -> createMessage ->
+ * orphan delete -> updateLastUserMessage -> clearInProgressMessageId ->
+ * startPolling) and preserves the image / copilot / model-command branches that
+ * previously lived inline in POST /api/worktrees/[id]/send.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock logger (inline to avoid hoisting issues)
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn().mockReturnThis(),
+  })),
+}));
+
+// Mock DB layer
+const mockCreateMessage = vi.fn();
+const mockUpdateLastUserMessage = vi.fn();
+const mockClearInProgressMessageId = vi.fn();
+const mockGetMessages = vi.fn().mockReturnValue([]);
+const mockDeleteMessageById = vi.fn().mockReturnValue(true);
+vi.mock('@/lib/db', () => ({
+  createMessage: (...args: unknown[]) => mockCreateMessage(...args),
+  updateLastUserMessage: (...args: unknown[]) => mockUpdateLastUserMessage(...args),
+  clearInProgressMessageId: (...args: unknown[]) => mockClearInProgressMessageId(...args),
+  getMessages: (...args: unknown[]) => mockGetMessages(...args),
+  deleteMessageById: (...args: unknown[]) => mockDeleteMessageById(...args),
+}));
+
+// Mock CLIToolManager
+const mockGetTool = vi.fn();
+vi.mock('@/lib/cli-tools/manager', () => ({
+  CLIToolManager: {
+    getInstance: vi.fn(() => ({
+      getTool: (...args: unknown[]) => mockGetTool(...args),
+    })),
+  },
+}));
+
+// Mock polling
+const mockStartPolling = vi.fn();
+vi.mock('@/lib/polling/response-poller', () => ({
+  startPolling: (...args: unknown[]) => mockStartPolling(...args),
+}));
+
+// Mock assistant response saver
+const mockSavePendingAssistantResponse = vi.fn().mockResolvedValue(null);
+vi.mock('@/lib/assistant-response-saver', () => ({
+  savePendingAssistantResponse: (...args: unknown[]) => mockSavePendingAssistantResponse(...args),
+}));
+
+// Mock tmux (copilot direct-send path)
+const mockSendKeys = vi.fn().mockResolvedValue(undefined);
+const mockSendSpecialKeys = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/tmux/tmux', () => ({
+  sendKeys: (...args: unknown[]) => mockSendKeys(...args),
+  sendSpecialKeys: (...args: unknown[]) => mockSendSpecialKeys(...args),
+}));
+
+const mockInvalidateCache = vi.fn();
+vi.mock('@/lib/tmux/tmux-capture-cache', () => ({
+  invalidateCache: (...args: unknown[]) => mockInvalidateCache(...args),
+}));
+
+// Keep the copilot inter-key delay effectively instant
+vi.mock('@/config/copilot-constants', () => ({
+  COPILOT_SEND_ENTER_DELAY_MS: 0,
+}));
+
+// Import after mocking
+import { sendUserMessage } from '@/lib/session/send-user-message';
+
+// Minimal stand-in for the sqlite Database handle (all DB calls are mocked)
+const mockDb = {} as never;
+
+interface ToolMockOptions {
+  sendMessage?: ReturnType<typeof vi.fn>;
+  sendMessageWithImage?: ReturnType<typeof vi.fn>;
+  supportsImage?: boolean;
+  sendModelCommand?: ReturnType<typeof vi.fn>;
+  getSessionName?: ReturnType<typeof vi.fn>;
+}
+
+function makeTool(opts: ToolMockOptions = {}) {
+  return {
+    name: 'Claude',
+    sendMessage: opts.sendMessage ?? vi.fn().mockResolvedValue(undefined),
+    sendMessageWithImage: opts.sendMessageWithImage ?? vi.fn().mockResolvedValue(undefined),
+    supportsImage: opts.supportsImage !== undefined ? vi.fn(() => opts.supportsImage) : undefined,
+    sendModelCommand: opts.sendModelCommand ?? vi.fn().mockResolvedValue(undefined),
+    getSessionName: opts.getSessionName ?? vi.fn(() => 'session-name'),
+  };
+}
+
+describe('sendUserMessage (Issue #1028)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMessages.mockReturnValue([]);
+    mockSavePendingAssistantResponse.mockResolvedValue(null);
+    mockDeleteMessageById.mockReturnValue(true);
+    mockCreateMessage.mockReturnValue({ id: 'created-msg', role: 'user', content: 'Hello' });
+  });
+
+  it('records a normal message in chat_messages and starts response polling', async () => {
+    const tool = makeTool();
+    mockGetTool.mockReturnValue(tool);
+
+    const result = await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'Hello',
+      cliToolId: 'claude',
+      instanceId: 'claude',
+    });
+
+    // Previous assistant response captured first
+    expect(mockSavePendingAssistantResponse).toHaveBeenCalledWith(
+      mockDb,
+      'wt-1',
+      'claude',
+      expect.any(Date),
+      'claude'
+    );
+    // Sent via the tool
+    expect(tool.sendMessage).toHaveBeenCalledWith('wt-1', 'Hello', 'claude');
+    // Recorded as a user message in history (default messageType 'normal')
+    expect(mockCreateMessage).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        worktreeId: 'wt-1',
+        role: 'user',
+        content: 'Hello',
+        messageType: 'normal',
+        cliToolId: 'claude',
+        instanceId: 'claude',
+        timestamp: expect.any(Date),
+      })
+    );
+    // Response polling started so the assistant reply is recorded too
+    expect(mockStartPolling).toHaveBeenCalledWith('wt-1', 'claude', 'claude');
+    expect(mockClearInProgressMessageId).toHaveBeenCalledWith(mockDb, 'wt-1', 'claude', 'claude');
+    expect(mockUpdateLastUserMessage).toHaveBeenCalledWith(mockDb, 'wt-1', 'Hello', expect.any(Date));
+
+    expect(result).toEqual({ ok: true, message: { id: 'created-msg', role: 'user', content: 'Hello' } });
+  });
+
+  it('honors an explicit messageType override', async () => {
+    mockGetTool.mockReturnValue(makeTool());
+
+    await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'Hi',
+      cliToolId: 'claude',
+      messageType: 'prompt',
+    });
+
+    expect(mockCreateMessage).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ messageType: 'prompt' })
+    );
+  });
+
+  it('deletes an orphaned duplicate user message only after the new message is persisted (Issue #379)', async () => {
+    mockGetTool.mockReturnValue(makeTool());
+    mockGetMessages.mockReturnValue([{ id: 'orphan-1', role: 'user', content: 'Hello' }]);
+
+    await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'Hello',
+      cliToolId: 'claude',
+      instanceId: 'claude',
+    });
+
+    expect(mockDeleteMessageById).toHaveBeenCalledWith(mockDb, 'orphan-1');
+    // Ordering: persist the new message before deleting the orphan
+    const createOrder = mockCreateMessage.mock.invocationCallOrder[0];
+    const deleteOrder = mockDeleteMessageById.mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(deleteOrder);
+  });
+
+  it('does not delete the most recent message when it is not a matching duplicate', async () => {
+    mockGetTool.mockReturnValue(makeTool());
+    mockGetMessages.mockReturnValue([{ id: 'other', role: 'user', content: 'different text' }]);
+
+    await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'Hello',
+      cliToolId: 'claude',
+    });
+
+    expect(mockDeleteMessageById).not.toHaveBeenCalled();
+  });
+
+  it('returns { ok: false, stage: "send" } and skips recording when the CLI send fails', async () => {
+    const tool = makeTool({ sendMessage: vi.fn().mockRejectedValue(new Error('tmux session not found')) });
+    mockGetTool.mockReturnValue(tool);
+
+    const result = await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'Hello',
+      cliToolId: 'claude',
+    });
+
+    expect(result).toEqual({ ok: false, stage: 'send', error: 'tmux session not found' });
+    expect(mockCreateMessage).not.toHaveBeenCalled();
+    expect(mockStartPolling).not.toHaveBeenCalled();
+  });
+
+  it('sends the copilot /model command before the message and records history', async () => {
+    const sendModelCommand = vi.fn().mockResolvedValue(undefined);
+    const tool = makeTool({ sendModelCommand, getSessionName: vi.fn(() => 'copilot-session') });
+    mockGetTool.mockReturnValue(tool);
+
+    const result = await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'do it',
+      cliToolId: 'copilot',
+      instanceId: 'copilot',
+      copilotModel: 'gpt-5',
+    });
+
+    expect(sendModelCommand).toHaveBeenCalledWith('wt-1', 'gpt-5', 'copilot');
+    // Copilot uses the direct sendKeys + separate Enter path (#559), not sendMessage
+    expect(mockSendKeys).toHaveBeenCalledWith('copilot-session', 'do it', false);
+    expect(mockSendSpecialKeys).toHaveBeenCalledWith('copilot-session', ['Enter']);
+    expect(mockInvalidateCache).toHaveBeenCalledWith('copilot-session');
+    expect(mockCreateMessage).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ role: 'user', content: 'do it', cliToolId: 'copilot' })
+    );
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  it('returns { ok: false, stage: "model" } and does not send when the /model command fails', async () => {
+    const sendModelCommand = vi.fn().mockRejectedValue(new Error('model switch failed'));
+    const tool = makeTool({ sendModelCommand, getSessionName: vi.fn(() => 'copilot-session') });
+    mockGetTool.mockReturnValue(tool);
+
+    const result = await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'do it',
+      cliToolId: 'copilot',
+      copilotModel: 'gpt-5',
+    });
+
+    expect(result).toEqual({ ok: false, stage: 'model', error: 'model switch failed' });
+    expect(mockSendKeys).not.toHaveBeenCalled();
+    expect(mockCreateMessage).not.toHaveBeenCalled();
+    expect(mockStartPolling).not.toHaveBeenCalled();
+  });
+
+  it('uses native image sending for image-capable tools', async () => {
+    const sendMessageWithImage = vi.fn().mockResolvedValue(undefined);
+    const tool = makeTool({ sendMessageWithImage, supportsImage: true });
+    mockGetTool.mockReturnValue(tool);
+
+    await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'look at this',
+      cliToolId: 'claude',
+      instanceId: 'claude',
+      absoluteImagePath: '/abs/.commandmate/attachments/img.png',
+    });
+
+    expect(sendMessageWithImage).toHaveBeenCalledWith(
+      'wt-1',
+      'look at this',
+      '/abs/.commandmate/attachments/img.png',
+      'claude'
+    );
+    expect(mockCreateMessage).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ content: 'look at this' })
+    );
+  });
+
+  it('falls back to embedding the image path for non-image-capable tools', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const tool = makeTool({ sendMessage, supportsImage: false });
+    mockGetTool.mockReturnValue(tool);
+
+    await sendUserMessage(mockDb, {
+      worktreeId: 'wt-1',
+      content: 'look',
+      cliToolId: 'claude',
+      absoluteImagePath: '/abs/img.png',
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      'wt-1',
+      'look\n\n[添付画像: /abs/img.png]',
+      undefined
+    );
+  });
+});

--- a/tests/unit/lib/timer-manager.test.ts
+++ b/tests/unit/lib/timer-manager.test.ts
@@ -48,9 +48,8 @@ vi.mock('@/lib/db/timer-db', () => ({
 }));
 
 // Mock CLIToolManager
-// Issue #947: timer-manager now delegates sending to cliTool.sendMessage()
-// (which performs the per-tool text/Enter separation) instead of calling tmux
-// sendKeys() directly.
+// Issue #947: timer-manager delegates sending instead of calling tmux sendKeys()
+// directly. executeTimer still uses the tool for the isRunning() gate.
 const mockGetTool = vi.fn();
 const mockIsRunning = vi.fn().mockResolvedValue(true);
 const mockSendMessage = vi.fn().mockResolvedValue(undefined);
@@ -60,6 +59,14 @@ vi.mock('@/lib/cli-tools/manager', () => ({
       getTool: (...args: unknown[]) => mockGetTool(...args),
     }),
   },
+}));
+
+// Mock the shared send service (Issue #1028)
+// executeTimer now delegates to sendUserMessage so timer-fired messages record
+// in chat_messages / History (createMessage + startPolling) just like manual sends.
+const mockSendUserMessage = vi.fn().mockResolvedValue({ ok: true, message: { id: 'msg-1' } });
+vi.mock('@/lib/session/send-user-message', () => ({
+  sendUserMessage: (...args: unknown[]) => mockSendUserMessage(...args),
 }));
 
 // Import after mocking
@@ -263,9 +270,17 @@ describe('timer-manager', () => {
         timerId,
         'sending'
       );
-      // Issue #947: delegates to cliTool.sendMessage (worktreeId, message,
-      // instanceId) rather than calling tmux sendKeys directly.
-      expect(mockSendMessage).toHaveBeenCalledWith('wt-1', 'Hello', 'claude');
+      // Issue #1028: delegates to sendUserMessage (the shared send+record service)
+      // rather than the low-level cliTool.sendMessage, so timer sends land in History.
+      expect(mockSendUserMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          worktreeId: 'wt-1',
+          content: 'Hello',
+          cliToolId: 'claude',
+          instanceId: 'claude',
+        }
+      );
       expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
         expect.anything(),
         timerId,
@@ -304,9 +319,17 @@ describe('timer-manager', () => {
       await vi.advanceTimersByTimeAsync(200);
 
       expect(mockIsRunning).toHaveBeenCalledWith('wt-1', 'claude-reviewer');
-      // Issue #947: the instanceId is forwarded to sendMessage, which resolves
-      // the instance session internally (same path as manual sends).
-      expect(mockSendMessage).toHaveBeenCalledWith('wt-1', 'Hello', 'claude-reviewer');
+      // Issue #1028: the instanceId is forwarded to sendUserMessage, which
+      // records + sends against the instance session (same path as manual sends).
+      expect(mockSendUserMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          worktreeId: 'wt-1',
+          content: 'Hello',
+          cliToolId: 'claude',
+          instanceId: 'claude-reviewer',
+        }
+      );
     });
 
     it('should set status to no_session when session is not running', async () => {
@@ -343,11 +366,11 @@ describe('timer-manager', () => {
         timerId,
         'no_session'
       );
-      // Should NOT attempt to send when no session is running
-      expect(mockSendMessage).not.toHaveBeenCalled();
+      // Should NOT attempt to send/record when no session is running
+      expect(mockSendUserMessage).not.toHaveBeenCalled();
     });
 
-    it('should set status to failed on send error when session is running', async () => {
+    it('should set status to failed when sendUserMessage reports a send failure', async () => {
       const timerId = 'timer-fail-1';
       const timer = {
         id: timerId,
@@ -369,7 +392,56 @@ describe('timer-manager', () => {
         isRunning: mockIsRunning,
         sendMessage: mockSendMessage,
       });
-      mockSendMessage.mockRejectedValueOnce(new Error('tmux session not found'));
+      // Issue #1028: sendUserMessage returns { ok: false } on send failure
+      // rather than throwing.
+      mockSendUserMessage.mockResolvedValueOnce({
+        ok: false,
+        stage: 'send',
+        error: 'tmux session not found',
+      });
+
+      initTimerManager();
+      scheduleTimer(timerId, 'wt-1', 100);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        timerId,
+        'failed'
+      );
+      // Must NOT mark as sent when the send failed
+      expect(mockUpdateTimerStatus).not.toHaveBeenCalledWith(
+        expect.anything(),
+        timerId,
+        'sent',
+        expect.any(Number)
+      );
+    });
+
+    it('should set status to failed when sendUserMessage throws', async () => {
+      const timerId = 'timer-throw-1';
+      const timer = {
+        id: timerId,
+        worktreeId: 'wt-1',
+        cliToolId: 'claude',
+        instanceId: 'claude',
+        message: 'Hello',
+        delayMs: 300000,
+        scheduledSendTime: Date.now() + 300000,
+        status: 'pending',
+        createdAt: Date.now(),
+        sentAt: null,
+      };
+
+      mockGetPendingTimers.mockReturnValueOnce([]);
+      mockGetTimerById.mockReturnValue(timer);
+      mockIsRunning.mockResolvedValue(true);
+      mockGetTool.mockReturnValue({
+        isRunning: mockIsRunning,
+        sendMessage: mockSendMessage,
+      });
+      mockSendUserMessage.mockRejectedValueOnce(new Error('createMessage failed'));
 
       initTimerManager();
       scheduleTimer(timerId, 'wt-1', 100);


### PR DESCRIPTION
## 概要

アクティビティバーの Timer 機能から送った指示が **History（メッセージ履歴）に残らない**問題を修正します（#1028）。対応B（送信ロジックの共有サービス化）を採用。

## 根本原因

History = `chat_messages` テーブル。通常送信（`/api/worktrees/[id]/send`）は tmux 送信とは別に `createMessage`（user 記録）＋ `startPolling`（assistant 応答記録）を行うが、Timer 発火（`timer-manager.ts executeTimer`）は Issue #947 で `cliTool.sendMessage` に委譲した際、この記録ロジックをコピーしなかったため **user・assistant 応答の両方が History に残らなかった**。

## 変更内容（対応B）

- **新規 `src/lib/session/send-user-message.ts`**: send route L262-385 のインライン記録ロジックを `sendUserMessage()` として抽出（`savePendingAssistantResponse` → send〔画像/Copilot 分岐含む〕→ `createMessage` → `updateLastUserMessage`/orphan 処理 → `startPolling`）。HTTP 層非依存の純粋サービス。
- **`send/route.ts`**: POST を `sendUserMessage()` 利用へリファクタ（挙動不変、-146行）。
- **`timer-manager.ts` `executeTimer`**: `sendUserMessage()` 経由に変更。`timer_messages` の status 遷移（sending/sent/failed）は維持。

→ Timer 送信も **user メッセージと assistant 応答の両方が History に残る**。

## テスト

- 新規/更新: `sendUserMessage` / `executeTimer` のユニット新規9件 + timer 既存更新（計26件）
- **全4ゲート合格**: ESLint ✅ / tsc --noEmit ✅ / test:unit ✅（474ファイル・8431テスト）/ build ✅
- 通常送信のリグレッションなしを base ブランチとの比較で確認（画像添付・Copilot 経路含む）

## 申し送り（スコープ外・別Issue推奨）

- `tests/integration/api-send-cli-tool.test.ts` の1件（`should use claude tool by default`）は **base ブランチでも同一に失敗する既存不具合**（2引数アサート vs コードは3引数目に undefined）。#1028 と無関係のため本PRでは未修正（**CI の test:unit 対象外**）。
- 軽微な挙動差: 不正 imagePath で 400 拒否する際、旧コードは `savePendingAssistantResponse` 後、新コードは保存前に 400 を返す（検証の前倒し）。副作用・データ欠落なし。

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)
