### PR TITLE
feat: ブランチ単位ToDoを3状態化（未着手/仕掛/完了）(#1032)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -73,5 +73,23 @@
     "hideFiles": "Hide files",
     "equalizeWidths": "Equal widths",
     "equalizeWidthsHint": "Equalize terminal widths and reset History width"
+  },
+  "todo": {
+    "addPlaceholder": "Add a todo…",
+    "add": "Add",
+    "empty": "No todos yet.",
+    "loading": "Loading…",
+    "statusTodo": "Todo",
+    "statusDoing": "In progress",
+    "statusDone": "Done",
+    "cycleStatus": "Status: {status} (click to change)",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "delete": "Delete todo",
+    "loadError": "Failed to load todos",
+    "addError": "Failed to add todo",
+    "updateError": "Failed to update todo",
+    "deleteError": "Failed to delete todo",
+    "reorderError": "Failed to reorder todos"
   }
 }

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -73,5 +73,23 @@
     "hideFiles": "ファイルを非表示",
     "equalizeWidths": "均等幅",
     "equalizeWidthsHint": "ターミナル幅を均等にし、履歴幅を初期値に戻す"
+  },
+  "todo": {
+    "addPlaceholder": "ToDoを追加…",
+    "add": "追加",
+    "empty": "ToDoはまだありません。",
+    "loading": "読み込み中…",
+    "statusTodo": "未着手",
+    "statusDoing": "仕掛",
+    "statusDone": "完了",
+    "cycleStatus": "ステータス: {status}（クリックで変更）",
+    "moveUp": "上へ移動",
+    "moveDown": "下へ移動",
+    "delete": "ToDoを削除",
+    "loadError": "ToDoの読み込みに失敗しました",
+    "addError": "ToDoの追加に失敗しました",
+    "updateError": "ToDoの更新に失敗しました",
+    "deleteError": "ToDoの削除に失敗しました",
+    "reorderError": "ToDoの並び替えに失敗しました"
   }
 }

--- a/src/app/api/worktrees/[id]/todos/[todoId]/route.ts
+++ b/src/app/api/worktrees/[id]/todos/[todoId]/route.ts
@@ -14,6 +14,8 @@ import {
   getWorktreeTodoById,
   updateWorktreeTodo,
   deleteWorktreeTodo,
+  isWorktreeTodoStatus,
+  WORKTREE_TODO_STATUSES,
 } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
 import { MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
@@ -24,9 +26,10 @@ const logger = createLogger('api/worktree-todos');
  * PATCH /api/worktrees/:id/todos/:todoId
  * Updates a todo's content and/or done state.
  *
- * Request body:
+ * Request body (at least one of):
  * - content?: string - New content (non-empty, max MAX_TODO_CONTENT_LENGTH chars)
- * - done?: boolean - Completion state
+ * - status?: 'todo' | 'doing' | 'done' - Progress state (Issue #1032)
+ * - done?: boolean - Legacy completion state (mapped to status when status omitted)
  */
 export async function PATCH(
   request: NextRequest,
@@ -52,11 +55,11 @@ export async function PATCH(
     }
 
     const body = await request.json().catch(() => ({}));
-    const { content, done } = body;
+    const { content, done, status } = body;
 
-    if (content === undefined && done === undefined) {
+    if (content === undefined && done === undefined && status === undefined) {
       return NextResponse.json(
-        { error: 'content or done is required' },
+        { error: 'content, status, or done is required' },
         { status: 400 }
       );
     }
@@ -85,7 +88,14 @@ export async function PATCH(
       );
     }
 
-    updateWorktreeTodo(db, params.todoId, { content: trimmed, done });
+    if (status !== undefined && !isWorktreeTodoStatus(status)) {
+      return NextResponse.json(
+        { error: `status must be one of: ${WORKTREE_TODO_STATUSES.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    updateWorktreeTodo(db, params.todoId, { content: trimmed, done, status });
 
     const updatedTodo = getWorktreeTodoById(db, params.todoId);
 

--- a/src/components/worktree/TodoPane.tsx
+++ b/src/components/worktree/TodoPane.tsx
@@ -1,19 +1,26 @@
 /**
- * TodoPane Component (Issue #1015)
+ * TodoPane Component (Issue #1015, 3-state status Issue #1032)
  *
  * Branch (worktree)-scoped ToDo list. Shared by both surfaces:
  *   - PC: Activity Bar `ToDo` activity (WorktreeDetailDesktop.activityContent).
  *   - Mobile: `Tools` tab sub-tab (NotesAndLogsPane).
  *
  * Receives only `worktreeId` and manages its own state via `worktreeTodoApi`.
- * Checkbox-style add / toggle / delete / reorder (up/down). Modeled on the
- * Home TodoWidget and MemoPane conventions.
+ * Each item has a three-state status (todo -> doing -> done) surfaced as a
+ * colored chip that cycles on click; the header shows per-status counts.
+ * Add / delete / reorder (up/down) mirror the Home TodoWidget conventions.
  */
 
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
-import { worktreeTodoApi, type WorktreeTodoItem } from '@/lib/api/todo-api';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  worktreeTodoApi,
+  WORKTREE_TODO_STATUSES,
+  type WorktreeTodoItem,
+  type WorktreeTodoStatus,
+} from '@/lib/api/todo-api';
 import { MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
 
 export interface TodoPaneProps {
@@ -23,15 +30,43 @@ export interface TodoPaneProps {
   className?: string;
 }
 
+/** Chip styling per status (border + text/background), light and dark. */
+const STATUS_CHIP_CLASS: Record<WorktreeTodoStatus, string> = {
+  todo: 'border-gray-300 text-gray-600 dark:border-gray-600 dark:text-gray-300',
+  doing:
+    'border-amber-400 bg-amber-50 text-amber-700 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-300',
+  done: 'border-green-500 bg-green-50 text-green-700 dark:border-green-500/60 dark:bg-green-500/10 dark:text-green-300',
+};
+
+function nextStatus(status: WorktreeTodoStatus): WorktreeTodoStatus {
+  const index = WORKTREE_TODO_STATUSES.indexOf(status);
+  return WORKTREE_TODO_STATUSES[(index + 1) % WORKTREE_TODO_STATUSES.length];
+}
+
 export const TodoPane = React.memo(function TodoPane({
   worktreeId,
   className = '',
 }: TodoPaneProps) {
+  const t = useTranslations('worktree');
   const [todos, setTodos] = useState<WorktreeTodoItem[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const statusLabel = useCallback(
+    (status: WorktreeTodoStatus) => {
+      switch (status) {
+        case 'doing':
+          return t('todo.statusDoing');
+        case 'done':
+          return t('todo.statusDone');
+        default:
+          return t('todo.statusTodo');
+      }
+    },
+    [t],
+  );
 
   const loadTodos = useCallback(async () => {
     setLoading(true);
@@ -40,16 +75,19 @@ export const TodoPane = React.memo(function TodoPane({
       const items = await worktreeTodoApi.list(worktreeId);
       setTodos(items);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load todos');
+      setError(err instanceof Error ? err.message : t('todo.loadError'));
       setTodos([]);
     } finally {
       setLoading(false);
     }
-  }, [worktreeId]);
+  }, [worktreeId, t]);
 
   useEffect(() => {
+    // Reload only when the worktree changes; loadTodos' identity churns with the
+    // translation function, and depending on it would re-fire on every render.
     void loadTodos();
-  }, [loadTodos]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [worktreeId]);
 
   const handleAdd = useCallback(async () => {
     const content = input.trim();
@@ -63,27 +101,32 @@ export const TodoPane = React.memo(function TodoPane({
       setTodos((prev) => [...prev, todo]);
       setInput('');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add todo');
+      setError(err instanceof Error ? err.message : t('todo.addError'));
     } finally {
       setBusy(false);
     }
-  }, [input, busy, worktreeId]);
+  }, [input, busy, worktreeId, t]);
 
-  const handleToggle = useCallback(
+  const handleCycleStatus = useCallback(
     async (todo: WorktreeTodoItem) => {
-      // Optimistic update for snappy checkbox feedback.
+      const next = nextStatus(todo.status);
+      // Optimistic update for snappy feedback; `done` derives from status.
       setTodos((prev) =>
-        prev.map((t) => (t.id === todo.id ? { ...t, done: !t.done } : t)),
+        prev.map((item) =>
+          item.id === todo.id
+            ? { ...item, status: next, done: next === 'done' }
+            : item,
+        ),
       );
       setError(null);
       try {
-        await worktreeTodoApi.update(worktreeId, todo.id, { done: !todo.done });
+        await worktreeTodoApi.update(worktreeId, todo.id, { status: next });
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to update todo');
+        setError(err instanceof Error ? err.message : t('todo.updateError'));
         void loadTodos();
       }
     },
-    [worktreeId, loadTodos],
+    [worktreeId, loadTodos, t],
   );
 
   const handleDelete = useCallback(
@@ -91,12 +134,12 @@ export const TodoPane = React.memo(function TodoPane({
       setError(null);
       try {
         await worktreeTodoApi.remove(worktreeId, todo.id);
-        setTodos((prev) => prev.filter((t) => t.id !== todo.id));
+        setTodos((prev) => prev.filter((item) => item.id !== todo.id));
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to delete todo');
+        setError(err instanceof Error ? err.message : t('todo.deleteError'));
       }
     },
-    [worktreeId],
+    [worktreeId, t],
   );
 
   const handleMove = useCallback(
@@ -110,13 +153,13 @@ export const TodoPane = React.memo(function TodoPane({
       setTodos(next);
       setError(null);
       try {
-        await worktreeTodoApi.reorder(worktreeId, next.map((t) => t.id));
+        await worktreeTodoApi.reorder(worktreeId, next.map((item) => item.id));
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to reorder todos');
+        setError(err instanceof Error ? err.message : t('todo.reorderError'));
         void loadTodos();
       }
     },
-    [todos, worktreeId, loadTodos],
+    [todos, worktreeId, loadTodos, t],
   );
 
   const handleInputKeyDown = useCallback(
@@ -130,7 +173,14 @@ export const TodoPane = React.memo(function TodoPane({
     [handleAdd],
   );
 
-  const remainingCount = todos.filter((t) => !t.done).length;
+  const counts = useMemo(
+    () => ({
+      todo: todos.filter((item) => item.status === 'todo').length,
+      doing: todos.filter((item) => item.status === 'doing').length,
+      done: todos.filter((item) => item.status === 'done').length,
+    }),
+    [todos],
+  );
 
   return (
     <div
@@ -145,7 +195,7 @@ export const TodoPane = React.memo(function TodoPane({
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleInputKeyDown}
           maxLength={MAX_TODO_CONTENT_LENGTH}
-          placeholder="Add a todo…"
+          placeholder={t('todo.addPlaceholder')}
           data-testid="todo-input"
           className="flex-1 min-w-0 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-400"
         />
@@ -156,13 +206,20 @@ export const TodoPane = React.memo(function TodoPane({
           data-testid="todo-add-button"
           className="shrink-0 rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-700 disabled:opacity-50"
         >
-          Add
+          {t('todo.add')}
         </button>
       </div>
 
-      <div className="mb-2 flex justify-end">
-        <span className="text-xs text-gray-400 dark:text-gray-500" data-testid="todo-remaining">
-          {remainingCount} open
+      {/* Per-status counts */}
+      <div className="mb-2 flex justify-end gap-2 text-xs text-gray-400 dark:text-gray-500">
+        <span data-testid="todo-count-todo">
+          {statusLabel('todo')} {counts.todo}
+        </span>
+        <span data-testid="todo-count-doing">
+          {statusLabel('doing')} {counts.doing}
+        </span>
+        <span data-testid="todo-count-done">
+          {statusLabel('done')} {counts.done}
         </span>
       </div>
 
@@ -175,11 +232,11 @@ export const TodoPane = React.memo(function TodoPane({
       {/* Todo list */}
       {loading ? (
         <p className="text-sm text-gray-400 dark:text-gray-500" data-testid="todo-loading">
-          Loading…
+          {t('todo.loading')}
         </p>
       ) : todos.length === 0 ? (
         <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="todo-empty">
-          No todos yet.
+          {t('todo.empty')}
         </p>
       ) : (
         <ul className="space-y-1" data-testid="todo-list">
@@ -189,19 +246,20 @@ export const TodoPane = React.memo(function TodoPane({
               className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/40 group"
               data-testid="todo-item"
             >
-              <label className="shrink-0 inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center sm:min-h-0 sm:min-w-0">
-                <input
-                  type="checkbox"
-                  checked={todo.done}
-                  onChange={() => handleToggle(todo)}
-                  data-testid="todo-checkbox"
-                  aria-label={todo.done ? 'Mark as not done' : 'Mark as done'}
-                  className="h-4 w-4 rounded border-gray-300 text-cyan-600 focus:ring-cyan-400"
-                />
-              </label>
+              <button
+                type="button"
+                onClick={() => handleCycleStatus(todo)}
+                data-testid="todo-status"
+                data-status={todo.status}
+                aria-label={t('todo.cycleStatus', { status: statusLabel(todo.status) })}
+                title={t('todo.cycleStatus', { status: statusLabel(todo.status) })}
+                className={`shrink-0 inline-flex min-h-[44px] items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium sm:min-h-0 ${STATUS_CHIP_CLASS[todo.status]}`}
+              >
+                {statusLabel(todo.status)}
+              </button>
               <span
                 className={`min-w-0 flex-1 break-words text-sm ${
-                  todo.done
+                  todo.status === 'done'
                     ? 'line-through text-gray-400 dark:text-gray-500'
                     : 'text-gray-800 dark:text-gray-200'
                 }`}
@@ -213,7 +271,7 @@ export const TodoPane = React.memo(function TodoPane({
                   type="button"
                   onClick={() => handleMove(index, -1)}
                   disabled={index === 0}
-                  aria-label="Move up"
+                  aria-label={t('todo.moveUp')}
                   data-testid="todo-move-up"
                   className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-30"
                 >
@@ -225,7 +283,7 @@ export const TodoPane = React.memo(function TodoPane({
                   type="button"
                   onClick={() => handleMove(index, 1)}
                   disabled={index === todos.length - 1}
-                  aria-label="Move down"
+                  aria-label={t('todo.moveDown')}
                   data-testid="todo-move-down"
                   className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-30"
                 >
@@ -236,7 +294,7 @@ export const TodoPane = React.memo(function TodoPane({
                 <button
                   type="button"
                   onClick={() => handleDelete(todo)}
-                  aria-label="Delete todo"
+                  aria-label={t('todo.delete')}
                   data-testid="todo-delete"
                   className="inline-flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center text-gray-300 opacity-100 transition-opacity hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400 sm:min-h-0 sm:min-w-0 sm:opacity-0 sm:group-hover:opacity-100"
                 >

--- a/src/lib/api/todo-api.ts
+++ b/src/lib/api/todo-api.ts
@@ -92,11 +92,27 @@ export const todoApi = {
   },
 };
 
+/**
+ * Progress state of a worktree ToDo (Issue #1032).
+ * `todo` = not started, `doing` = in progress, `done` = completed.
+ */
+export type WorktreeTodoStatus = 'todo' | 'doing' | 'done';
+
+/** All valid ToDo statuses, in cycle order (todo -> doing -> done). */
+export const WORKTREE_TODO_STATUSES: readonly WorktreeTodoStatus[] = [
+  'todo',
+  'doing',
+  'done',
+];
+
 /** A worktree(branch)-scoped ToDo item as consumed by the UI (Issue #1015). */
 export interface WorktreeTodoItem {
   id: string;
   worktreeId: string;
   content: string;
+  /** Progress state (Issue #1032). */
+  status: WorktreeTodoStatus;
+  /** Derived convenience flag (`status === 'done'`), kept for compatibility. */
   done: boolean;
   position: number;
 }
@@ -136,7 +152,7 @@ export const worktreeTodoApi = {
   async update(
     worktreeId: string,
     todoId: string,
-    updates: { content?: string; done?: boolean },
+    updates: { content?: string; done?: boolean; status?: WorktreeTodoStatus },
   ): Promise<WorktreeTodoItem> {
     const res = await fetch(
       `/api/worktrees/${encodeURIComponent(worktreeId)}/todos/${encodeURIComponent(todoId)}`,

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -107,8 +107,10 @@ export {
   updateTodo as updateWorktreeTodo,
   deleteTodo as deleteWorktreeTodo,
   reorderTodos as reorderWorktreeTodos,
+  isWorktreeTodoStatus,
+  WORKTREE_TODO_STATUSES,
 } from './worktree-todo-db';
-export type { WorktreeTodo } from './worktree-todo-db';
+export type { WorktreeTodo, WorktreeTodoStatus } from './worktree-todo-db';
 
 // timer-db (Issue #534, #540)
 export {

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -20,6 +20,7 @@ import { v34_migrations } from './v34-repository-todos';
 import { v35_migrations } from './v35-timer-instance-id';
 import { v36_migrations } from './v36-worktree-branch';
 import { v37_migrations } from './v37-worktree-todos';
+import { v38_migrations } from './v38-worktree-todo-status';
 
 /**
  * Complete ordered list of all migrations.
@@ -45,4 +46,5 @@ export const migrations: Migration[] = [
   ...v35_migrations,
   ...v36_migrations,
   ...v37_migrations,
+  ...v38_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 37;
+export const CURRENT_SCHEMA_VERSION = 38;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v38-worktree-todo-status.ts
+++ b/src/lib/db/migrations/v38-worktree-todo-status.ts
@@ -1,0 +1,37 @@
+/** Migration v38: Add status column to worktree_todos (3-state ToDo, Issue #1032).
+ *
+ * Extends the branch-scoped ToDo list (v37) from a binary `done` flag to a
+ * three-state `status` ('todo' = not started / 'doing' = in progress /
+ * 'done' = completed) so progress is distinguishable at a glance.
+ *
+ * `status` becomes the source of truth; the legacy `done` column is retained
+ * (SQLite cannot drop a column without a table rebuild, and keeping it avoids
+ * breaking any raw reader). The DB mapper derives `done := status === 'done'`,
+ * and writers keep the two consistent. Existing rows are backfilled from `done`
+ * (`done=1` -> 'done', `done=0` -> 'todo').
+ */
+
+import type { Migration } from './runner';
+
+export const v38_migrations: Migration[] = [
+  {
+    version: 38,
+    name: 'add-status-to-worktree-todos',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE worktree_todos
+          ADD COLUMN status TEXT NOT NULL DEFAULT 'todo';
+      `);
+
+      // Backfill from the legacy binary flag: completed rows become 'done',
+      // everything else keeps the 'todo' default.
+      db.exec(`
+        UPDATE worktree_todos SET status = 'done' WHERE done = 1;
+      `);
+    },
+    down: () => {
+      // SQLite cannot drop a column without a table rebuild; no-op rollback
+      // (mirrors the v35/v36 column-add migrations).
+    },
+  },
+];

--- a/src/lib/db/worktree-todo-db.ts
+++ b/src/lib/db/worktree-todo-db.ts
@@ -15,12 +15,34 @@ import { randomUUID } from 'crypto';
 import Database from 'better-sqlite3';
 
 /**
+ * Progress state of a worktree ToDo (Issue #1032).
+ * `todo` = not started, `doing` = in progress, `done` = completed.
+ */
+export type WorktreeTodoStatus = 'todo' | 'doing' | 'done';
+
+/** All valid ToDo statuses, in cycle order (todo -> doing -> done). */
+export const WORKTREE_TODO_STATUSES: readonly WorktreeTodoStatus[] = [
+  'todo',
+  'doing',
+  'done',
+];
+
+/** Type guard for the three-state ToDo status. */
+export function isWorktreeTodoStatus(value: unknown): value is WorktreeTodoStatus {
+  return value === 'todo' || value === 'doing' || value === 'done';
+}
+
+/**
  * A single ToDo item scoped to a worktree (branch).
+ *
+ * `status` is the source of truth (Issue #1032); `done` is a derived
+ * convenience flag (`status === 'done'`) retained for backward compatibility.
  */
 export interface WorktreeTodo {
   id: string;
   worktreeId: string;
   content: string;
+  status: WorktreeTodoStatus;
   done: boolean;
   position: number;
   createdAt: Date;
@@ -35,20 +57,35 @@ type WorktreeTodoRow = {
   worktree_id: string;
   content: string;
   done: number;
+  status: string;
   position: number;
   created_at: number;
   updated_at: number;
 };
 
 /**
+ * Resolve a row's persisted status, falling back to the legacy `done` flag when
+ * the value is missing or unrecognized (defensive; the column is NOT NULL with a
+ * 'todo' default and backfilled at migration v38).
+ */
+function resolveStatus(rawStatus: string, done: number): WorktreeTodoStatus {
+  if (isWorktreeTodoStatus(rawStatus)) {
+    return rawStatus;
+  }
+  return done === 1 ? 'done' : 'todo';
+}
+
+/**
  * Map database row to WorktreeTodo model.
  */
 function mapTodoRow(row: WorktreeTodoRow): WorktreeTodo {
+  const status = resolveStatus(row.status, row.done);
   return {
     id: row.id,
     worktreeId: row.worktree_id,
     content: row.content,
-    done: row.done === 1,
+    status,
+    done: status === 'done',
     position: row.position,
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
@@ -63,7 +100,7 @@ export function getTodosByWorktreeId(
   worktreeId: string
 ): WorktreeTodo[] {
   const stmt = db.prepare(`
-    SELECT id, worktree_id, content, done, position, created_at, updated_at
+    SELECT id, worktree_id, content, done, status, position, created_at, updated_at
     FROM worktree_todos
     WHERE worktree_id = ?
     ORDER BY position ASC, created_at ASC
@@ -83,7 +120,7 @@ export function getTodoById(
   todoId: string
 ): WorktreeTodo | null {
   const stmt = db.prepare(`
-    SELECT id, worktree_id, content, done, position, created_at, updated_at
+    SELECT id, worktree_id, content, done, status, position, created_at, updated_at
     FROM worktree_todos
     WHERE id = ?
   `);
@@ -101,23 +138,27 @@ export function createTodo(
   options: {
     content: string;
     position: number;
+    status?: WorktreeTodoStatus;
   }
 ): WorktreeTodo {
   const id = randomUUID();
   const now = Date.now();
+  const status: WorktreeTodoStatus = options.status ?? 'todo';
+  const done = status === 'done' ? 1 : 0;
 
   const stmt = db.prepare(`
-    INSERT INTO worktree_todos (id, worktree_id, content, done, position, created_at, updated_at)
-    VALUES (?, ?, ?, 0, ?, ?, ?)
+    INSERT INTO worktree_todos (id, worktree_id, content, done, status, position, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
-  stmt.run(id, worktreeId, options.content, options.position, now, now);
+  stmt.run(id, worktreeId, options.content, done, status, options.position, now, now);
 
   return {
     id,
     worktreeId,
     content: options.content,
-    done: false,
+    status,
+    done: status === 'done',
     position: options.position,
     createdAt: new Date(now),
     updatedAt: new Date(now),
@@ -125,7 +166,12 @@ export function createTodo(
 }
 
 /**
- * Update an existing todo (content and/or done state).
+ * Update an existing todo (content, status, and/or done state).
+ *
+ * `status` is authoritative. For backward compatibility a legacy `done` boolean
+ * is still accepted and mapped to a status (`true` -> 'done', `false` -> 'todo')
+ * only when `status` is not supplied. The persisted `done` column is always kept
+ * consistent with the resolved status.
  */
 export function updateTodo(
   db: Database.Database,
@@ -133,6 +179,7 @@ export function updateTodo(
   updates: {
     content?: string;
     done?: boolean;
+    status?: WorktreeTodoStatus;
   }
 ): void {
   const now = Date.now();
@@ -144,9 +191,18 @@ export function updateTodo(
     params.push(updates.content);
   }
 
-  if (updates.done !== undefined) {
+  let resolvedStatus: WorktreeTodoStatus | undefined;
+  if (updates.status !== undefined) {
+    resolvedStatus = updates.status;
+  } else if (updates.done !== undefined) {
+    resolvedStatus = updates.done ? 'done' : 'todo';
+  }
+
+  if (resolvedStatus !== undefined) {
+    assignments.push('status = ?');
+    params.push(resolvedStatus);
     assignments.push('done = ?');
-    params.push(updates.done ? 1 : 0);
+    params.push(resolvedStatus === 'done' ? 1 : 0);
   }
 
   params.push(todoId);

--- a/tests/unit/api/worktree-todos.test.ts
+++ b/tests/unit/api/worktree-todos.test.ts
@@ -162,6 +162,7 @@ describe('POST /api/worktrees/:id/todos', () => {
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.todo.content).toBe('Write tests');
+    expect(data.todo.status).toBe('todo');
     expect(data.todo.done).toBe(false);
     expect(data.todo.worktreeId).toBe(wtId);
     expect(data.todo.position).toBe(0);
@@ -224,6 +225,33 @@ describe('PATCH /api/worktrees/:id/todos/:todoId', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.todo.done).toBe(true);
+    expect(data.todo.status).toBe('done');
+  });
+
+  it('updates the status to doing', async () => {
+    const todo = createTodo(db, wtId, { content: 'task', position: 0 });
+    const res = await patch(wtId, todo.id, { status: 'doing' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todo.status).toBe('doing');
+    expect(data.todo.done).toBe(false);
+  });
+
+  it('updates the status to done', async () => {
+    const todo = createTodo(db, wtId, { content: 'task', position: 0 });
+    const res = await patch(wtId, todo.id, { status: 'done' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.todo.status).toBe('done');
+    expect(data.todo.done).toBe(true);
+  });
+
+  it('returns 400 for an invalid status', async () => {
+    const todo = createTodo(db, wtId, { content: 'task', position: 0 });
+    const res = await patch(wtId, todo.id, { status: 'nope' });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain('status');
   });
 
   it('updates content', async () => {

--- a/tests/unit/components/worktree/TodoPane.test.tsx
+++ b/tests/unit/components/worktree/TodoPane.test.tsx
@@ -15,6 +15,7 @@ import { TodoPane } from '@/components/worktree/TodoPane';
 import { worktreeTodoApi, type WorktreeTodoItem } from '@/lib/api/todo-api';
 
 vi.mock('@/lib/api/todo-api', () => ({
+  WORKTREE_TODO_STATUSES: ['todo', 'doing', 'done'],
   worktreeTodoApi: {
     list: vi.fn(),
     create: vi.fn(),
@@ -27,8 +28,8 @@ vi.mock('@/lib/api/todo-api', () => ({
 const mockedApi = vi.mocked(worktreeTodoApi);
 
 const TODOS: WorktreeTodoItem[] = [
-  { id: 't1', worktreeId: 'wt-1', content: 'first task', done: false, position: 0 },
-  { id: 't2', worktreeId: 'wt-1', content: 'second task', done: true, position: 1 },
+  { id: 't1', worktreeId: 'wt-1', content: 'first task', status: 'todo', done: false, position: 0 },
+  { id: 't2', worktreeId: 'wt-1', content: 'second task', status: 'done', done: true, position: 1 },
 ];
 
 beforeEach(() => {
@@ -62,6 +63,7 @@ describe('TodoPane', () => {
       id: 't-new',
       worktreeId: 'wt-1',
       content: 'brand new',
+      status: 'todo',
       done: false,
       position: 0,
     });
@@ -78,17 +80,42 @@ describe('TodoPane', () => {
     expect(await screen.findByText('brand new')).toBeInTheDocument();
   });
 
-  it('toggles a todo done state via worktreeTodoApi.update', async () => {
-    mockedApi.update.mockResolvedValue({ ...TODOS[0], done: true });
+  it('cycles a todo status (todo -> doing) via worktreeTodoApi.update', async () => {
+    mockedApi.update.mockResolvedValue({ ...TODOS[0], status: 'doing' });
     render(<TodoPane worktreeId="wt-1" />);
     await screen.findByText('first task');
 
-    const checkboxes = screen.getAllByTestId('todo-checkbox');
-    fireEvent.click(checkboxes[0]);
+    // t1 starts as 'todo'; one click advances it to 'doing'.
+    const statusButtons = screen.getAllByTestId('todo-status');
+    fireEvent.click(statusButtons[0]);
 
     await waitFor(() => {
-      expect(mockedApi.update).toHaveBeenCalledWith('wt-1', 't1', { done: true });
+      expect(mockedApi.update).toHaveBeenCalledWith('wt-1', 't1', { status: 'doing' });
     });
+  });
+
+  it('cycles a done todo back to todo via worktreeTodoApi.update', async () => {
+    mockedApi.update.mockResolvedValue({ ...TODOS[1], status: 'todo', done: false });
+    render(<TodoPane worktreeId="wt-1" />);
+    await screen.findByText('second task');
+
+    // t2 starts as 'done'; one click wraps around to 'todo'.
+    const statusButtons = screen.getAllByTestId('todo-status');
+    fireEvent.click(statusButtons[1]);
+
+    await waitFor(() => {
+      expect(mockedApi.update).toHaveBeenCalledWith('wt-1', 't2', { status: 'todo' });
+    });
+  });
+
+  it('shows per-status counts (todo/doing/done)', async () => {
+    render(<TodoPane worktreeId="wt-1" />);
+    await screen.findByText('first task');
+
+    // Fixture: t1 = 'todo', t2 = 'done', none 'doing'.
+    expect(screen.getByTestId('todo-count-todo')).toHaveTextContent('1');
+    expect(screen.getByTestId('todo-count-doing')).toHaveTextContent('0');
+    expect(screen.getByTestId('todo-count-done')).toHaveTextContent('1');
   });
 
   it('deletes a todo via worktreeTodoApi.remove', async () => {

--- a/tests/unit/db/migration-v38-worktree-todo-status.test.ts
+++ b/tests/unit/db/migration-v38-worktree-todo-status.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for migration v38 (worktree_todos.status, Issue #1032).
+ *
+ * Three angles:
+ *  1. Fresh DB end state — the full migration chain adds a NOT NULL `status`
+ *     column defaulting to 'todo'.
+ *  2. Backfill — applying v38.up() over a v37-shaped table maps existing rows
+ *     from the legacy binary `done` flag (done=1 -> 'done', done=0 -> 'todo').
+ *  3. Idempotency — re-running the migration chain is a no-op (runner-level).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations, CURRENT_SCHEMA_VERSION, getCurrentVersion } from '@/lib/db/db-migrations';
+import { v38_migrations } from '@/lib/db/migrations/v38-worktree-todo-status';
+
+interface ColumnInfo { name: string; notnull: number; dflt_value: string | null }
+
+function columns(db: Database.Database, table: string): ColumnInfo[] {
+  return db.pragma(`table_info(${table})`) as ColumnInfo[];
+}
+
+describe('migration v38: fresh DB end state', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('brings the schema to v38', () => {
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(38);
+  });
+
+  it('adds a NOT NULL status column defaulting to "todo"', () => {
+    const statusCol = columns(db, 'worktree_todos').find((c) => c.name === 'status');
+    expect(statusCol).toBeDefined();
+    expect(statusCol!.notnull).toBe(1);
+    expect(statusCol!.dflt_value).toContain('todo');
+  });
+
+  it('keeps the legacy done column for backward compatibility', () => {
+    const names = columns(db, 'worktree_todos').map((c) => c.name);
+    expect(names).toContain('done');
+    expect(names).toContain('status');
+  });
+});
+
+describe('migration v38: backfill from the legacy done flag', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    // Reconstruct the v37-shaped table (no status column) to exercise up().
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE worktree_todos (
+        id TEXT PRIMARY KEY,
+        worktree_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        done INTEGER NOT NULL DEFAULT 0,
+        position INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+    const insert = db.prepare(`
+      INSERT INTO worktree_todos (id, worktree_id, content, done, position, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    insert.run('completed', 'wt-1', 'done task', 1, 0, 1, 1);
+    insert.run('open', 'wt-1', 'open task', 0, 1, 1, 1);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('maps done=1 -> "done" and done=0 -> "todo"', () => {
+    v38_migrations[0].up(db);
+
+    const rows = db
+      .prepare('SELECT id, status FROM worktree_todos ORDER BY position ASC')
+      .all() as Array<{ id: string; status: string }>;
+
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r.status]));
+    expect(byId.completed).toBe('done');
+    expect(byId.open).toBe('todo');
+  });
+});
+
+describe('migration v38: idempotency via runner', () => {
+  it('re-running runMigrations is a no-op', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    expect(() => runMigrations(db)).not.toThrow();
+    const names = columns(db, 'worktree_todos').map((c) => c.name);
+    expect(names).toContain('status');
+    db.close();
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 37 after Migration #37 (worktree todos)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(37);
+    it('should be 38 after Migration #38 (worktree todo status)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(38);
     });
   });
 

--- a/tests/unit/lib/worktree-todo-api.test.ts
+++ b/tests/unit/lib/worktree-todo-api.test.ts
@@ -15,6 +15,7 @@ const TODO: WorktreeTodoItem = {
   id: 't1',
   worktreeId: 'wt-1',
   content: 'task',
+  status: 'todo',
   done: false,
   position: 0,
 };
@@ -66,6 +67,14 @@ describe('worktreeTodoApi', () => {
     expect(url).toBe('/api/worktrees/wt-1/todos/t1');
     expect(init.method).toBe('PATCH');
     expect(JSON.parse(init.body)).toEqual({ done: true });
+  });
+
+  it('update() sends a status change', async () => {
+    mockFetchOnce({ todo: { ...TODO, status: 'doing' } });
+    const result = await worktreeTodoApi.update('wt-1', 't1', { status: 'doing' });
+    expect(result.status).toBe('doing');
+    const [, init] = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ status: 'doing' });
   });
 
   it('remove() uses DELETE on the item route', async () => {

--- a/tests/unit/lib/worktree-todo-db.test.ts
+++ b/tests/unit/lib/worktree-todo-db.test.ts
@@ -57,14 +57,22 @@ describe('worktree-todo-db', () => {
     expect(getTodosByWorktreeId(db, worktreeId)).toEqual([]);
   });
 
-  it('creates a todo with done=false by default', () => {
+  it('creates a todo with status "todo" (done=false) by default', () => {
     const todo = createTodo(db, worktreeId, { content: 'Buy milk', position: 0 });
     expect(todo.id).toBeTruthy();
     expect(todo.worktreeId).toBe(worktreeId);
     expect(todo.content).toBe('Buy milk');
+    expect(todo.status).toBe('todo');
     expect(todo.done).toBe(false);
     expect(todo.position).toBe(0);
     expect(todo.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('creates a todo with an explicit status', () => {
+    const todo = createTodo(db, worktreeId, { content: 'WIP', position: 0, status: 'doing' });
+    expect(todo.status).toBe('doing');
+    expect(todo.done).toBe(false);
+    expect(getTodoById(db, todo.id)?.status).toBe('doing');
   });
 
   it('lists todos sorted by position', () => {
@@ -107,12 +115,43 @@ describe('worktree-todo-db', () => {
     expect(getTodoById(db, todo.id)?.content).toBe('new');
   });
 
-  it('toggles done state', () => {
+  it('toggles done state (legacy) and keeps status consistent', () => {
     const todo = createTodo(db, worktreeId, { content: 'task', position: 0 });
     updateTodo(db, todo.id, { done: true });
-    expect(getTodoById(db, todo.id)?.done).toBe(true);
+    let updated = getTodoById(db, todo.id);
+    expect(updated?.done).toBe(true);
+    expect(updated?.status).toBe('done');
     updateTodo(db, todo.id, { done: false });
-    expect(getTodoById(db, todo.id)?.done).toBe(false);
+    updated = getTodoById(db, todo.id);
+    expect(updated?.done).toBe(false);
+    expect(updated?.status).toBe('todo');
+  });
+
+  it('cycles through the three statuses and derives done', () => {
+    const todo = createTodo(db, worktreeId, { content: 'task', position: 0 });
+
+    updateTodo(db, todo.id, { status: 'doing' });
+    let updated = getTodoById(db, todo.id);
+    expect(updated?.status).toBe('doing');
+    expect(updated?.done).toBe(false);
+
+    updateTodo(db, todo.id, { status: 'done' });
+    updated = getTodoById(db, todo.id);
+    expect(updated?.status).toBe('done');
+    expect(updated?.done).toBe(true);
+
+    updateTodo(db, todo.id, { status: 'todo' });
+    updated = getTodoById(db, todo.id);
+    expect(updated?.status).toBe('todo');
+    expect(updated?.done).toBe(false);
+  });
+
+  it('prefers status over the legacy done flag when both are provided', () => {
+    const todo = createTodo(db, worktreeId, { content: 'task', position: 0 });
+    updateTodo(db, todo.id, { status: 'doing', done: true });
+    const updated = getTodoById(db, todo.id);
+    expect(updated?.status).toBe('doing');
+    expect(updated?.done).toBe(false);
   });
 
   it('updates content and done together', () => {


### PR DESCRIPTION
## 概要

ブランチ単位 ToDo（#1015 / `worktree_todos`）を、完了/未完了の二値から **3状態（未着手 `todo` / 仕掛 `doing` / 完了 `done`）** へ拡張し、進捗を一目で把握できるようにする。

Closes #1032

## 変更内容

- **migration v38** (`v38-worktree-todo-status.ts`): `worktree_todos` に `status TEXT NOT NULL DEFAULT 'todo'` を追加。既存データを backfill（`done=1`→`'done'`、他は `'todo'`）。`CURRENT_SCHEMA_VERSION` 37→38。`down()` は SQLite 制約により no-op（v35/v36 踏襲）
- **DB層** (`worktree-todo-db.ts`): `WorktreeTodoStatus` 型・型ガード追加。`status` を真実源とし `done := status==='done'` を mapper で派生（後方互換）。writer は status/done を常に整合
- **API** (`[todoId]/route.ts`): PATCH で `status ∈ {todo, doing, done}` を検証・適用。`done` も後方互換維持
- **APIクライアント** (`todo-api.ts`): `WorktreeTodoItem.status` 追加、`update({ status })` 対応
- **UI** (`TodoPane.tsx`): チェックボックスを 3状態巡回チップ（todo→doing→done）に置換。状態別の色バッジ、ヘッダに状態別件数、done は打ち消し線。ペイン全体を next-intl 化
- **i18n**: `locales/{en,ja}/worktree.json` に `todo` namespace 追加

## 設計判断（Issue の論点を実装時に決定）

- **並び順**: 手動 position を維持（完了の自動下部寄せはしない）— 既存 reorder UX を壊さず驚き最小
- **後方互換**: `done` カラムは残し `status` から派生。既存 API の `done` 参照を破壊しない

## テスト / 品質

- 既存テスト5件更新＋新規 `migration-v38-worktree-todo-status.test.ts`（backfill 検証含む）
- ✅ ESLint: No warnings/errors
- ✅ `tsc --noEmit`: エラーなし
- ✅ `test:unit`: 475 files / 8445 tests passed
- ✅ `npm run build`: 成功

## スコープ外

- ToDo テキストのインライン編集（別Issue）
- Home のリポジトリ単位 ToDo（`repository_todos`）の3状態化

🤖 Generated with [Claude Code](https://claude.com/claude-code)
