### PR TITLE
feat: ブランチ単位ToDoの詳細にコピーボタンを追加 (#1036)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -93,6 +93,7 @@
     "detailLabel": "Detail",
     "detailPlaceholder": "Add notes (optional)…",
     "hasDetail": "Has detail",
+    "copyDetail": "Copy detail",
     "save": "Save",
     "cancel": "Cancel",
     "loadError": "Failed to load todos",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -93,6 +93,7 @@
     "detailLabel": "詳細",
     "detailPlaceholder": "詳細を入力（任意）…",
     "hasDetail": "詳細あり",
+    "copyDetail": "詳細をコピー",
     "save": "保存",
     "cancel": "キャンセル",
     "loadError": "ToDoの読み込みに失敗しました",

--- a/src/components/worktree/TodoPane.tsx
+++ b/src/components/worktree/TodoPane.tsx
@@ -23,6 +23,14 @@ import {
 } from '@/lib/api/todo-api';
 import { MAX_TODO_CONTENT_LENGTH, MAX_TODO_DETAIL_LENGTH } from '@/config/todo-config';
 import { Modal } from '@/components/ui/Modal';
+import { CopyButton } from '@/components/common/CopyButton';
+
+/**
+ * Restyle CopyButton for the light/dark TodoPane modal — its defaults assume a
+ * dark code-block surface. `!` wins over the component's own base color classes.
+ */
+const COPY_DETAIL_BUTTON_CLASS =
+  '!border-gray-300 !bg-white !text-gray-600 hover:!bg-gray-50 dark:!border-gray-600 dark:!bg-gray-900 dark:!text-gray-300 dark:hover:!bg-gray-800';
 
 export interface TodoPaneProps {
   /** Worktree ID to scope the todo list to. */
@@ -395,8 +403,17 @@ export const TodoPane = React.memo(function TodoPane({
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-              {t('todo.detailLabel')}
+            <span className="flex items-center justify-between gap-2">
+              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                {t('todo.detailLabel')}
+              </span>
+              {editDetail.trim() !== '' && (
+                <CopyButton
+                  text={editDetail}
+                  label={t('todo.copyDetail')}
+                  className={COPY_DETAIL_BUTTON_CLASS}
+                />
+              )}
             </span>
             <textarea
               value={editDetail}

--- a/tests/unit/components/worktree/TodoPane.test.tsx
+++ b/tests/unit/components/worktree/TodoPane.test.tsx
@@ -14,6 +14,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TodoPane } from '@/components/worktree/TodoPane';
 import { worktreeTodoApi, type WorktreeTodoItem } from '@/lib/api/todo-api';
 
+// Hoisted so the vi.mock factory (itself hoisted above imports) can reference it.
+const { mockCopyToClipboard } = vi.hoisted(() => ({ mockCopyToClipboard: vi.fn() }));
+
 vi.mock('@/lib/api/todo-api', () => ({
   WORKTREE_TODO_STATUSES: ['todo', 'doing', 'done'],
   worktreeTodoApi: {
@@ -23,6 +26,11 @@ vi.mock('@/lib/api/todo-api', () => ({
     remove: vi.fn(),
     reorder: vi.fn(),
   },
+}));
+
+// CopyButton delegates to copyToClipboard; mock it so the detail copy is observable.
+vi.mock('@/lib/clipboard-utils', () => ({
+  copyToClipboard: mockCopyToClipboard,
 }));
 
 const mockedApi = vi.mocked(worktreeTodoApi);
@@ -35,7 +43,11 @@ const TODOS: WorktreeTodoItem[] = [
 beforeEach(() => {
   vi.clearAllMocks();
   mockedApi.list.mockResolvedValue(TODOS);
+  mockCopyToClipboard.mockResolvedValue(undefined);
 });
+
+/** aria-label the CopyButton exposes for the detail copy action (mocked i18n key). */
+const COPY_DETAIL_LABEL = 'worktree.todo.copyDetail';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -248,5 +260,49 @@ describe('TodoPane', () => {
       expect(screen.queryByTestId('todo-edit-content')).not.toBeInTheDocument();
     });
     expect(mockedApi.update).not.toHaveBeenCalled();
+  });
+
+  it('copies the detail from the editor via CopyButton (Issue #1036)', async () => {
+    render(<TodoPane worktreeId="wt-1" />);
+    await screen.findByText('second task');
+
+    // t2 carries detail 'some notes'; open its editor.
+    fireEvent.click(screen.getAllByTestId('todo-content')[1]);
+    await screen.findByTestId('todo-edit-detail');
+
+    fireEvent.click(screen.getByRole('button', { name: COPY_DETAIL_LABEL }));
+
+    await waitFor(() => {
+      expect(mockCopyToClipboard).toHaveBeenCalledWith('some notes');
+    });
+  });
+
+  it('hides the copy button when the edited detail is empty (Issue #1036)', async () => {
+    render(<TodoPane worktreeId="wt-1" />);
+    await screen.findByText('first task');
+
+    // t1 has an empty detail; the copy affordance must not appear.
+    fireEvent.click(screen.getAllByTestId('todo-content')[0]);
+    await screen.findByTestId('todo-edit-content');
+
+    expect(screen.queryByRole('button', { name: COPY_DETAIL_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('reveals the copy button once a detail is typed for an empty todo (Issue #1036)', async () => {
+    render(<TodoPane worktreeId="wt-1" />);
+    await screen.findByText('first task');
+
+    fireEvent.click(screen.getAllByTestId('todo-content')[0]);
+    await screen.findByTestId('todo-edit-detail');
+    expect(screen.queryByRole('button', { name: COPY_DETAIL_LABEL })).not.toBeInTheDocument();
+
+    // Copy targets the live editor value, not just the persisted detail.
+    fireEvent.change(screen.getByTestId('todo-edit-detail'), { target: { value: 'freshly typed' } });
+
+    fireEvent.click(await screen.findByRole('button', { name: COPY_DETAIL_LABEL }));
+
+    await waitFor(() => {
+      expect(mockCopyToClipboard).toHaveBeenCalledWith('freshly typed');
+    });
   });
 });


### PR DESCRIPTION
## 概要

ブランチ単位 ToDo（#1015）の各項目の **詳細（detail, #1034）** を、ワンクリックでクリップボードにコピーできるようにする。

Closes #1036

## 変更内容（UIのみ）

- **UI** (`TodoPane.tsx`): 編集モーダルの詳細欄に `CopyButton` を配置し、詳細本文をコピー（詳細が空のときは非表示）
- 既存 `src/components/common/CopyButton.tsx` / `src/lib/clipboard-utils.ts` を再利用。**スマホ（HTTP）では textarea+execCommand フォールバック**で動作
- **i18n**: `locales/{en,ja}/worktree.json` に `todo.copyDetail`（"Copy detail" / "詳細をコピー"）追加
- **テスト**: `TodoPane.test.tsx` にコピー導線テスト3件追加（詳細あり→copyToClipboard呼出 / 空→非表示 / 入力後→ライブ値コピー）

## 設計判断

- Issue推奨の **①編集モーダル内配置のみ**を採用（受け入れ条件を全て満たす最小構成）
- **②一覧行クイックコピーは見送り**（リスト行は既に item 全体が button のため nested-button 問題、CopyButton の意匠不整合を回避）
- **migration/DB/API 変更なし**

## 品質（orchestrator 検証）
- ✅ ESLint: No warnings/errors
- ✅ `tsc --noEmit`: エラーなし
- ✅ `test:unit`: 476 files / 8474 tests passed（TodoPane 18/18）
- ✅ `npm run build`: Compiled successfully

## スコープ外
- Home のリポジトリ単位 ToDo（`repository_todos`）
- `CopyButton` 内部文言（"Copy"/"Copied"）の i18n 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)
