### PR TITLE
feat: セマンティックデザイントークン基盤の導入 (#1041)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,74 @@
+# デザインシステム（セマンティックトークン）
+
+CommandMate の色は **CSS 変数（セマンティックトークン）** で一元管理する。
+Tailwind からは `bg-background` / `bg-surface` / `text-accent-500` のようなセマンティック
+クラスで参照し、`gray-*` / `cyan-*` / `blue-*` の直書きは原則禁止とする。
+
+- トークン定義: [`src/app/globals.css`](../src/app/globals.css)（`:root` = ライト、`.dark` = ダーク）
+- Tailwind への登録: [`tailwind.config.js`](../tailwind.config.js) の `theme.extend.colors`
+- 初出: Issue #1041（基盤導入。既存コンポーネントの一括置換は #1045 で実施）
+
+> このトークン基盤の導入では **見た目を変えない**。各トークンの値は現行 Tailwind シェードの
+> 実効値を写し取っている（例: `--background`(light) = `gray-50`）。
+
+## トークン一覧
+
+値は `rgb(...)` 合成のため **RGB チャンネル値（スペース区切り）** で定義する。
+末尾に対応する現行 Tailwind シェードを併記する。
+
+| トークン | ライト（`:root`） | ダーク（`.dark`） | 用途 |
+|---------|------------------|------------------|------|
+| `--background` | gray-50 | `#0f1117`（旧 `cmd-bg-dark`） | ページ背景 |
+| `--foreground` | gray-900 | gray-100 | 基本文字色 |
+| `--surface` | white | gray-800 | カード・パネル背景 |
+| `--surface-foreground` | gray-900 | gray-100 | サーフェス上の文字色 |
+| `--surface-2` | gray-50 | gray-900 | 一段深いサーフェス |
+| `--muted` | gray-100 | gray-800 | 補助背景 |
+| `--muted-foreground` | gray-500 | gray-400 | 補助文字 |
+| `--border` | gray-200 | gray-700 | 境界線 |
+| `--input` | gray-300 | gray-600 | フォーム枠 |
+| `--ring` | cyan-500 | cyan-500 | フォーカスリング |
+| `--accent-50`〜`--accent-700` | cyan-50〜700 | cyan-50〜700 | アクセント（cyan スケール） |
+| `--success` | green-500 | green-500 | 成功 |
+| `--warning` | amber-500 | amber-500 | 警告 |
+| `--danger` | red-500 | red-500 | エラー・破壊的操作 |
+| `--info` | blue-500 | blue-500 | 情報 |
+
+`--accent-*` と `--success` / `--warning` / `--danger` / `--info` はライト・ダークで同値だが、
+将来のモード別調整を容易にするため両ブロックに明示的に定義している。
+
+## Tailwind クラス対応
+
+| CSS 変数 | Tailwind クラス例 |
+|---------|------------------|
+| `--background` | `bg-background` |
+| `--foreground` | `text-foreground` |
+| `--surface` / `--surface-foreground` / `--surface-2` | `bg-surface` / `text-surface-foreground` / `bg-surface-2` |
+| `--muted` / `--muted-foreground` | `bg-muted` / `text-muted-foreground` |
+| `--border` | `border-border` |
+| `--input` | `border-input` |
+| `--ring` | `ring-ring` / `focus:ring-ring` |
+| `--accent-500` | `bg-accent-500` / `text-accent-500` |
+| `--success` / `--warning` / `--danger` / `--info` | `text-success` / `bg-danger` など |
+
+各色は `rgb(var(--token) / <alpha-value>)` 形式で登録しているため、
+`bg-surface/80` のように **透過度指定** がそのまま使える。
+
+## 使用ルール
+
+1. **新規・変更するスタイルはセマンティックトークン経由で指定する**
+   （`bg-white dark:bg-gray-800` ではなく `bg-surface`）。
+2. トークンはライト/ダーク両モードで自動的に切り替わるため、**`dark:` バリアントは原則不要**。
+3. 新しい意味的な色が必要になったら、直書きを増やさず **まずトークンを追加** する。
+
+## 直書き色の禁止と例外
+
+`gray-*` / `cyan-*` / `blue-*` 等の **直書きカラークラスは原則禁止**。以下は例外として許容する。
+
+- **モードに依存しない固定色**: ブランド固定のシンタックスハイライト（`.prose pre` の
+  `#0d1117` 等）、ターミナル配色、`::highlight()` 検索ハイライト。
+- **意味的にトークン化されていない一過性の装飾**: 追加のトークン化が過剰と判断できる箇所。
+  この場合もライト/ダーク両対応を保つこと。
+- **サードパーティ由来のクラス**: xterm.js / highlight.js 等が要求する固定クラス。
+
+例外を用いる場合は、その色がなぜトークン化に馴染まないかを PR で説明すること。

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -22,6 +22,7 @@
 | `src/lib/db/db-instance.ts` | DBインスタンス管理（getEnv().CM_DB_PATH使用） |
 | `src/config/system-directories.ts` | システムディレクトリ定数（SYSTEM_DIRECTORIES、isSystemDirectory()） |
 | `src/config/status-colors.ts` | ステータス色の一元管理 |
+| `src/app/globals.css` / `tailwind.config.js` | セマンティックデザイントークン（CSS変数）の定義・登録（Issue #1041）。詳細は [docs/design-system.md](./design-system.md) を参照 |
 | `src/lib/detection/cli-patterns.ts` | CLIツール別パターン定義（Issue #212: PASTED_TEXT_PATTERN定数追加、skipPatterns拡張。**Issue #265: セッションエラーパターン追加** - CLAUDE_SESSION_ERROR_PATTERNS/CLAUDE_SESSION_ERROR_REGEX_PATTERNSでセッション起動失敗検出。**Issue #379: OpenCodeパターン追加** - OPENCODE_PROMPT_PATTERN/OPENCODE_PROMPT_AFTER_RESPONSE/OPENCODE_THINKING_PATTERN/OPENCODE_LOADING_PATTERN/OPENCODE_RESPONSE_COMPLETE/OPENCODE_PROCESSING_INDICATOR/OPENCODE_SEPARATOR_PATTERN/OPENCODE_SKIP_PATTERNS定数、detectThinking()/getCliToolPatterns()/buildDetectPromptOptions()にcase 'opencode'追加、buildDetectPromptOptions('opencode')はrequireDefaultIndicator:false）。CLIツール別パターン定義、COPILOT_SELECTION_LIST_PATTERN（Issue #547）、COPILOT_SKIP_PATTERNS拡張（Issue #565）。**Issue #988: ANTIGRAVITY_PROMPT_PATTERN/ANTIGRAVITY_THINKING_PATTERN/ANTIGRAVITY_SEPARATOR_PATTERN/ANTIGRAVITY_SKIP_PATTERNS追加、detectThinking()/getCliToolPatterns()にcase 'antigravity'追加。buildDetectPromptOptions()はagy追加せず（標準">"インジケータ使用＝default正）** |
 | `src/lib/pasted-text-helper.ts` | Pasted text検知とEnter再送の共通ヘルパー（Issue #212: detectAndResendIfPastedText関数、リトライロジック、構造化ログ）。Pasted text検知・Enter再送 |
 | `src/lib/clipboard-utils.ts` | クリップボードコピーユーティリティ（stripAnsi利用、空文字バリデーション、Issue #211） |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,64 @@
 
 @layer base {
   /*
+   * [Issue #1041] Semantic design tokens.
+   * Values are RGB channel triplets (not hex) so Tailwind can synthesize alpha
+   * via `rgb(var(--token) / <alpha-value>)`. Each value mirrors the current
+   * effective Tailwind shade (noted in the trailing comment) so this issue
+   * changes no visuals — component migration to these tokens lands in #1045.
+   * See docs/design-system.md for naming rules and the hardcoded-color policy.
+   */
+  :root {
+    --background: 249 250 251; /* gray-50 */
+    --foreground: 17 24 39; /* gray-900 */
+    --surface: 255 255 255; /* white */
+    --surface-foreground: 17 24 39; /* gray-900 */
+    --surface-2: 249 250 251; /* gray-50 */
+    --muted: 243 244 246; /* gray-100 */
+    --muted-foreground: 107 114 128; /* gray-500 */
+    --border: 229 231 235; /* gray-200 */
+    --input: 209 213 219; /* gray-300 */
+    --ring: 6 182 212; /* cyan-500 */
+    --accent-50: 236 254 255; /* cyan-50 */
+    --accent-100: 207 250 254; /* cyan-100 */
+    --accent-200: 165 243 252; /* cyan-200 */
+    --accent-300: 103 232 249; /* cyan-300 */
+    --accent-400: 34 211 238; /* cyan-400 */
+    --accent-500: 6 182 212; /* cyan-500 */
+    --accent-600: 8 145 178; /* cyan-600 */
+    --accent-700: 14 116 144; /* cyan-700 */
+    --success: 34 197 94; /* green-500 */
+    --warning: 245 158 11; /* amber-500 */
+    --danger: 239 68 68; /* red-500 */
+    --info: 59 130 246; /* blue-500 */
+  }
+
+  .dark {
+    --background: 15 17 23; /* #0f1117 (legacy cmd-bg-dark) */
+    --foreground: 243 244 246; /* gray-100 */
+    --surface: 31 41 55; /* gray-800 */
+    --surface-foreground: 243 244 246; /* gray-100 */
+    --surface-2: 17 24 39; /* gray-900 */
+    --muted: 31 41 55; /* gray-800 */
+    --muted-foreground: 156 163 175; /* gray-400 */
+    --border: 55 65 81; /* gray-700 */
+    --input: 75 85 99; /* gray-600 */
+    --ring: 6 182 212; /* cyan-500 */
+    --accent-50: 236 254 255; /* cyan-50 */
+    --accent-100: 207 250 254; /* cyan-100 */
+    --accent-200: 165 243 252; /* cyan-200 */
+    --accent-300: 103 232 249; /* cyan-300 */
+    --accent-400: 34 211 238; /* cyan-400 */
+    --accent-500: 6 182 212; /* cyan-500 */
+    --accent-600: 8 145 178; /* cyan-600 */
+    --accent-700: 14 116 144; /* cyan-700 */
+    --success: 34 197 94; /* green-500 */
+    --warning: 245 158 11; /* amber-500 */
+    --danger: 239 68 68; /* red-500 */
+    --info: 59 130 246; /* blue-500 */
+  }
+
+  /*
    * [Issue #915] PC display size (案A: rem カスケード).
    * Applied to <html data-pc-size> on PC only (see PcDisplaySizeProvider).
    * rem-based Tailwind spacing/typography scales with the root font-size;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className="min-h-screen bg-gray-50 dark:bg-cmd-bg-dark">
+      <body className="min-h-screen bg-background">
         <AppProviders locale={locale} messages={messages as Record<string, unknown>} timeZone={timeZone} authEnabled={!!process.env.CM_AUTH_TOKEN_HASH}>
           {children}
         </AppProviders>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -23,7 +23,7 @@ export interface MainLayoutProps {
  */
 export function MainLayout({ children }: MainLayoutProps) {
   return (
-    <div className="h-screen bg-gray-50 dark:bg-cmd-bg-dark flex flex-col overflow-hidden">
+    <div className="h-screen bg-background flex flex-col overflow-hidden">
       <main className="flex-1 min-h-0 overflow-auto">
         {children}
       </main>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,17 +9,36 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: {
-          50: '#ecfeff',   // cyan-50
-          100: '#cffafe',  // cyan-100
-          200: '#a5f3fc',  // cyan-200
-          300: '#67e8f9',  // cyan-300
-          400: '#22d3ee',  // cyan-400 (dark mode accent)
-          500: '#06b6d4',  // cyan-500
-          600: '#0891b2',  // cyan-600 (light mode accent)
-          700: '#0e7490',  // cyan-700
+        // [Issue #1041] Semantic tokens backed by CSS variables (see src/app/globals.css).
+        // The `<alpha-value>` placeholder lets Tailwind compose opacity utilities.
+        background: 'rgb(var(--background) / <alpha-value>)',
+        foreground: 'rgb(var(--foreground) / <alpha-value>)',
+        surface: {
+          DEFAULT: 'rgb(var(--surface) / <alpha-value>)',
+          foreground: 'rgb(var(--surface-foreground) / <alpha-value>)',
+          2: 'rgb(var(--surface-2) / <alpha-value>)',
         },
-        'cmd-bg-dark': '#0f1117',
+        muted: {
+          DEFAULT: 'rgb(var(--muted) / <alpha-value>)',
+          foreground: 'rgb(var(--muted-foreground) / <alpha-value>)',
+        },
+        border: 'rgb(var(--border) / <alpha-value>)',
+        input: 'rgb(var(--input) / <alpha-value>)',
+        ring: 'rgb(var(--ring) / <alpha-value>)',
+        accent: {
+          50: 'rgb(var(--accent-50) / <alpha-value>)',
+          100: 'rgb(var(--accent-100) / <alpha-value>)',
+          200: 'rgb(var(--accent-200) / <alpha-value>)',
+          300: 'rgb(var(--accent-300) / <alpha-value>)',
+          400: 'rgb(var(--accent-400) / <alpha-value>)',
+          500: 'rgb(var(--accent-500) / <alpha-value>)',
+          600: 'rgb(var(--accent-600) / <alpha-value>)',
+          700: 'rgb(var(--accent-700) / <alpha-value>)',
+        },
+        success: 'rgb(var(--success) / <alpha-value>)',
+        warning: 'rgb(var(--warning) / <alpha-value>)',
+        danger: 'rgb(var(--danger) / <alpha-value>)',
+        info: 'rgb(var(--info) / <alpha-value>)',
       },
       animation: {
         'slide-in': 'slide-in 0.3s ease-out',

--- a/tests/unit/config/dark-mode-foundation.test.ts
+++ b/tests/unit/config/dark-mode-foundation.test.ts
@@ -22,20 +22,18 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(content).toContain("darkMode: 'class'");
     });
 
-    it('should define primary color palette with cyan values', () => {
+    it('should register the accent scale via CSS variables (migrated from primary in Issue #1041)', () => {
       const content = fs.readFileSync(configPath, 'utf-8');
-      // Check for cyan-50 hex value
-      expect(content).toContain('#ecfeff');
-      // Check for cyan-400 hex value
-      expect(content).toContain('#22d3ee');
-      // Check for cyan-600 hex value
-      expect(content).toContain('#0891b2');
+      // The former `primary` cyan palette is now the semantic `accent` scale,
+      // backed by CSS variables. Hex values live in globals.css instead.
+      expect(content).toContain('rgb(var(--accent-500) / <alpha-value>)');
+      expect(content).not.toContain('primary:');
     });
 
-    it('should define cmd-bg-dark custom color', () => {
+    it('should no longer define the cmd-bg-dark color (absorbed into --background in Issue #1041)', () => {
       const content = fs.readFileSync(configPath, 'utf-8');
-      expect(content).toContain("'cmd-bg-dark'");
-      expect(content).toContain('#0f1117');
+      expect(content).not.toContain('cmd-bg-dark');
+      expect(content).toContain('rgb(var(--background) / <alpha-value>)');
     });
   });
 
@@ -47,14 +45,12 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(content).toContain('suppressHydrationWarning');
     });
 
-    it('should have dark:bg-cmd-bg-dark on body', () => {
+    it('should use the semantic bg-background token on body (Issue #1041)', () => {
       const content = fs.readFileSync(layoutPath, 'utf-8');
-      expect(content).toContain('dark:bg-cmd-bg-dark');
-    });
-
-    it('should maintain bg-gray-50 for light mode on body', () => {
-      const content = fs.readFileSync(layoutPath, 'utf-8');
-      expect(content).toContain('bg-gray-50');
+      // Replaces the former `bg-gray-50 dark:bg-cmd-bg-dark`; --background carries
+      // the same effective values (gray-50 light / #0f1117 dark).
+      expect(content).toContain('bg-background');
+      expect(content).not.toContain('cmd-bg-dark');
     });
   });
 

--- a/tests/unit/config/design-tokens.test.ts
+++ b/tests/unit/config/design-tokens.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the semantic design token foundation (Issue #1041).
+ *
+ * Verifies that:
+ *  - globals.css defines every token in both `:root` (light) and `.dark`,
+ *    using RGB channel values that mirror the current effective shades.
+ *  - tailwind.config.js registers each token as a `rgb(var(--token) / <alpha-value>)`
+ *    color and no longer exposes the removed `primary` / `cmd-bg-dark` colors.
+ *  - the body background was migrated to the `bg-background` token.
+ *  - no source references the removed `bg-primary-*` / `bg-cmd-bg-dark` classes.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import resolveConfig from 'tailwindcss/resolveConfig';
+
+const ROOT = path.resolve(__dirname, '../../..');
+
+/** Tokens whose value differs between light and dark modes. */
+const MODE_VARYING: Record<string, { light: string; dark: string }> = {
+  '--background': { light: '249 250 251', dark: '15 17 23' },
+  '--foreground': { light: '17 24 39', dark: '243 244 246' },
+  '--surface': { light: '255 255 255', dark: '31 41 55' },
+  '--surface-foreground': { light: '17 24 39', dark: '243 244 246' },
+  '--surface-2': { light: '249 250 251', dark: '17 24 39' },
+  '--muted': { light: '243 244 246', dark: '31 41 55' },
+  '--muted-foreground': { light: '107 114 128', dark: '156 163 175' },
+  '--border': { light: '229 231 235', dark: '55 65 81' },
+  '--input': { light: '209 213 219', dark: '75 85 99' },
+};
+
+/** Tokens with identical values in both modes (defined in both blocks). */
+const MODE_INVARIANT: Record<string, string> = {
+  '--ring': '6 182 212',
+  '--accent-50': '236 254 255',
+  '--accent-100': '207 250 254',
+  '--accent-200': '165 243 252',
+  '--accent-300': '103 232 249',
+  '--accent-400': '34 211 238',
+  '--accent-500': '6 182 212',
+  '--accent-600': '8 145 178',
+  '--accent-700': '14 116 144',
+  '--success': '34 197 94',
+  '--warning': '245 158 11',
+  '--danger': '239 68 68',
+  '--info': '59 130 246',
+};
+
+function extractBlock(css: string, selector: string): string {
+  // Tokens contain no nested braces, so a non-greedy `{ ... }` match is safe.
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  expect(match, `Expected a "${selector}" block in globals.css`).not.toBeNull();
+  return match![1];
+}
+
+function hasToken(block: string, name: string, value: string): boolean {
+  return new RegExp(`${name}\\s*:\\s*${value}\\s*;`).test(block);
+}
+
+describe('Design tokens (Issue #1041)', () => {
+  describe('globals.css token definitions', () => {
+    let root: string;
+    let dark: string;
+
+    beforeAll(() => {
+      const css = fs.readFileSync(path.join(ROOT, 'src/app/globals.css'), 'utf-8');
+      root = extractBlock(css, ':root');
+      dark = extractBlock(css, '.dark');
+    });
+
+    it('defines all mode-varying tokens with the correct light values in :root', () => {
+      for (const [name, { light }] of Object.entries(MODE_VARYING)) {
+        expect(hasToken(root, name, light), `${name} (light) = ${light}`).toBe(true);
+      }
+    });
+
+    it('defines all mode-varying tokens with the correct dark values in .dark', () => {
+      for (const [name, { dark: value }] of Object.entries(MODE_VARYING)) {
+        expect(hasToken(dark, name, value), `${name} (dark) = ${value}`).toBe(true);
+      }
+    });
+
+    it('defines every mode-invariant token in BOTH :root and .dark', () => {
+      for (const [name, value] of Object.entries(MODE_INVARIANT)) {
+        expect(hasToken(root, name, value), `${name} (:root) = ${value}`).toBe(true);
+        expect(hasToken(dark, name, value), `${name} (.dark) = ${value}`).toBe(true);
+      }
+    });
+
+    it('uses RGB channel triplets (not hex) so <alpha-value> composition works', () => {
+      expect(root).not.toMatch(/--[a-z0-9-]+\s*:\s*#/i);
+      expect(dark).not.toMatch(/--[a-z0-9-]+\s*:\s*#/i);
+    });
+  });
+
+  describe('tailwind.config.js color registration', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const config = require(path.join(ROOT, 'tailwind.config.js'));
+    const colors = resolveConfig(config).theme.colors as Record<string, unknown>;
+
+    it('registers scalar semantic colors as rgb(var(--token) / <alpha-value>)', () => {
+      expect(colors.background).toBe('rgb(var(--background) / <alpha-value>)');
+      expect(colors.foreground).toBe('rgb(var(--foreground) / <alpha-value>)');
+      expect(colors.border).toBe('rgb(var(--border) / <alpha-value>)');
+      expect(colors.input).toBe('rgb(var(--input) / <alpha-value>)');
+      expect(colors.ring).toBe('rgb(var(--ring) / <alpha-value>)');
+      expect(colors.success).toBe('rgb(var(--success) / <alpha-value>)');
+      expect(colors.warning).toBe('rgb(var(--warning) / <alpha-value>)');
+      expect(colors.danger).toBe('rgb(var(--danger) / <alpha-value>)');
+      expect(colors.info).toBe('rgb(var(--info) / <alpha-value>)');
+    });
+
+    it('registers nested surface/muted/accent scales', () => {
+      const surface = colors.surface as Record<string, string>;
+      expect(surface.DEFAULT).toBe('rgb(var(--surface) / <alpha-value>)');
+      expect(surface.foreground).toBe('rgb(var(--surface-foreground) / <alpha-value>)');
+      expect(surface['2']).toBe('rgb(var(--surface-2) / <alpha-value>)');
+
+      const muted = colors.muted as Record<string, string>;
+      expect(muted.DEFAULT).toBe('rgb(var(--muted) / <alpha-value>)');
+      expect(muted.foreground).toBe('rgb(var(--muted-foreground) / <alpha-value>)');
+
+      const accent = colors.accent as Record<string, string>;
+      for (const shade of [50, 100, 200, 300, 400, 500, 600, 700]) {
+        expect(accent[String(shade)]).toBe(`rgb(var(--accent-${shade}) / <alpha-value>)`);
+      }
+    });
+
+    it('no longer exposes the removed primary / cmd-bg-dark colors', () => {
+      expect(colors.primary).toBeUndefined();
+      expect(colors['cmd-bg-dark']).toBeUndefined();
+    });
+  });
+
+  describe('source migration', () => {
+    it('migrates the root layout body to bg-background', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/app/layout.tsx'), 'utf-8');
+      expect(content).toContain('bg-background');
+      expect(content).not.toContain('cmd-bg-dark');
+    });
+
+    it('has no source references to the removed bg-primary-* / bg-cmd-bg-dark classes', () => {
+      const offenders: string[] = [];
+      const walk = (dir: string) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(full);
+          } else if (/\.(tsx?|css)$/.test(entry.name)) {
+            const text = fs.readFileSync(full, 'utf-8');
+            if (/bg-cmd-bg-dark/.test(text) || /\bbg-primary-\d/.test(text)) {
+              offenders.push(path.relative(ROOT, full));
+            }
+          }
+        }
+      };
+      walk(path.join(ROOT, 'src'));
+      expect(offenders, `Found removed color classes in: ${offenders.join(', ')}`).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
UIモダン化 Phase 1 (#1040) の基盤 Issue #1041。色・背景・境界線を CSS 変数ベースの
セマンティックトークンに集約し、Tailwind から `bg-background` / `bg-surface` /
`text-accent-500` 等で参照できる基盤を整備します。**視覚的な変化はありません(no-op)** —
現行の実効値をトークンに写し取っています。

## 変更点
- `src/app/globals.css`: `:root`(light) / `.dark`(dark) に semantic トークンを RGB チャンネル値で定義
- `tailwind.config.js`: `primary`(cyan) / `cmd-bg-dark` を削除し semantic 色(`<alpha-value>` 対応)を登録
- `src/app/layout.tsx` / `src/components/layout/MainLayout.tsx`: body 背景を `bg-background` に統一
- `docs/design-system.md`(新規): トークン一覧・使用ルール
- テスト: `design-tokens.test.ts` 追加、`dark-mode-foundation.test.ts` 更新

## テスト
- `npx tsc --noEmit`: パス
- `npm run lint`: パス
- `npm run test:unit`: 8482 passed

## 関連
Closes #1041 / 親 #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
