### PR TITLE
feat: globals.css の @apply クラス廃止・cvaプリミティブ自己完結化 (#1048)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,69 +139,11 @@
     content: none;
   }
 
-  /* Card component base */
-  .card {
-    @apply bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm;
-  }
-
-  .card-hover {
-    @apply transition-shadow duration-200 hover:shadow-md;
-  }
-
-  /* Button base styles */
-  .btn {
-    @apply inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2;
-  }
-
-  .btn-primary {
-    @apply bg-accent-600 dark:bg-accent-500 text-white hover:bg-accent-700 dark:hover:bg-accent-600 focus:ring-ring;
-  }
-
-  .btn-secondary {
-    @apply bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600 focus:ring-gray-500;
-  }
-
-  .btn-danger {
-    @apply bg-red-600 text-white hover:bg-red-700 focus:ring-red-500;
-  }
-
-  .btn-sm {
-    @apply px-3 py-1.5 text-sm;
-  }
-
-  .btn-lg {
-    @apply px-6 py-3 text-lg;
-  }
-
-  /* Badge styles */
-  .badge {
-    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
-  }
-
-  .badge-success {
-    @apply bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300;
-  }
-
-  .badge-warning {
-    @apply bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-300;
-  }
-
-  .badge-error {
-    @apply bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-300;
-  }
-
-  .badge-info {
-    @apply bg-accent-100 dark:bg-accent-900 text-accent-800 dark:text-accent-300;
-  }
-
-  .badge-gray {
-    @apply bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-300;
-  }
-
-  /* Input styles */
-  .input {
-    @apply w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring;
-  }
+  /*
+   * [Issue #1048] Legacy @apply component classes were removed here to
+   * eliminate the style-definition double structure; their Tailwind classes
+   * now live directly in the cva primitives under src/components/ui/.
+   */
 
   /* Container utilities */
   .container-custom {

--- a/src/components/external-apps/ExternalAppForm.tsx
+++ b/src/components/external-apps/ExternalAppForm.tsx
@@ -9,7 +9,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Button, Input, Modal, Switch, Textarea } from '@/components/ui';
+import { Button, Input, Modal, Switch, Textarea, inputVariants } from '@/components/ui';
+import { cn } from '@/lib/utils/cn';
 import {
   validateFormData,
   VALID_APP_TYPES,
@@ -329,7 +330,7 @@ export function ExternalAppForm({
               id="appType"
               value={appType}
               onChange={(e) => setAppType(e.target.value as ExternalAppType)}
-              className={`input w-full ${errors.appType ? 'border-red-500' : ''}`}
+              className={cn(inputVariants(), errors.appType && 'border-red-500')}
               disabled={isSubmitting}
             >
               <option value="">Select app type...</option>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -9,20 +9,23 @@ import { cn } from '@/lib/utils/cn';
 
 export type BadgeVariant = 'success' | 'warning' | 'error' | 'info' | 'gray';
 
-const badgeVariants = cva('badge', {
-  variants: {
-    variant: {
-      success: 'badge-success',
-      warning: 'badge-warning',
-      error: 'badge-error',
-      info: 'badge-info',
-      gray: 'badge-gray',
+const badgeVariants = cva(
+  'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium',
+  {
+    variants: {
+      variant: {
+        success: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300',
+        warning: 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-300',
+        error: 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-300',
+        info: 'bg-accent-100 dark:bg-accent-900 text-accent-800 dark:text-accent-300',
+        gray: 'bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-300',
+      },
     },
-  },
-  defaultVariants: {
-    variant: 'gray',
-  },
-});
+    defaultVariants: {
+      variant: 'gray',
+    },
+  }
+);
 
 const dotColorStyles: Record<BadgeVariant, string> = {
   success: 'bg-green-600',

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -10,31 +10,36 @@ import { cn } from '@/lib/utils/cn';
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
-const buttonVariants = cva('btn', {
-  variants: {
-    variant: {
-      primary: 'btn-primary',
-      secondary: 'btn-secondary',
-      danger: 'btn-danger',
-      ghost:
-        'bg-transparent text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-gray-500',
+const buttonVariants = cva(
+  'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-accent-600 dark:bg-accent-500 text-white hover:bg-accent-700 dark:hover:bg-accent-600 focus:ring-ring',
+        secondary:
+          'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-gray-600 focus:ring-gray-500',
+        danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+        ghost:
+          'bg-transparent text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-gray-500',
+      },
+      size: {
+        sm: 'px-3 py-1.5 text-sm',
+        md: '',
+        lg: 'px-6 py-3 text-lg',
+      },
+      fullWidth: {
+        true: 'w-full',
+        false: '',
+      },
     },
-    size: {
-      sm: 'btn-sm',
-      md: '',
-      lg: 'btn-lg',
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+      fullWidth: false,
     },
-    fullWidth: {
-      true: 'w-full',
-      false: '',
-    },
-  },
-  defaultVariants: {
-    variant: 'primary',
-    size: 'md',
-    fullWidth: false,
-  },
-});
+  }
+);
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -7,24 +7,27 @@ import React from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils/cn';
 
-const cardVariants = cva('card', {
-  variants: {
-    hover: {
-      true: 'card-hover',
-      false: '',
+const cardVariants = cva(
+  'bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm',
+  {
+    variants: {
+      hover: {
+        true: 'transition-shadow duration-200 hover:shadow-md',
+        false: '',
+      },
+      padding: {
+        none: '',
+        sm: 'p-3',
+        md: 'p-4',
+        lg: 'p-6',
+      },
     },
-    padding: {
-      none: '',
-      sm: 'p-3',
-      md: 'p-4',
-      lg: 'p-6',
+    defaultVariants: {
+      hover: false,
+      padding: 'md',
     },
-  },
-  defaultVariants: {
-    hover: false,
-    padding: 'md',
-  },
-});
+  }
+);
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   hover?: boolean;

--- a/src/components/worktree/LogViewer.tsx
+++ b/src/components/worktree/LogViewer.tsx
@@ -7,7 +7,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Card, CardHeader, CardTitle, CardContent, Button, Badge } from '@/components/ui';
+import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Input } from '@/components/ui';
 import { ToastContainer, useToast } from '@/components/common/Toast';
 import { worktreeApi, handleApiError } from '@/lib/api-client';
 import { copyToClipboard } from '@/lib/clipboard-utils';
@@ -337,13 +337,13 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
               {/* Search Controls */}
               <div className="flex items-center gap-2">
                 <div className="relative flex-1">
-                  <input
+                  <Input
                     type="text"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     onKeyDown={handleSearchKeyDown}
                     placeholder="Search in log file..."
-                    className="input w-full pr-20"
+                    className="w-full pr-20"
                   />
                   {matches.length > 0 && (
                     <div className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-500">

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -84,6 +84,15 @@ export interface WorktreeDetailRefactoredProps {
  */
 const NOOP_SELECTED_AGENTS_CHANGE = (): void => {};
 
+/**
+ * Mobile bottom-anchored layout offsets (both include the iOS safe-area inset).
+ * The MobileTabBar is 4rem tall and the fixed MessageInput sits directly above
+ * it; the scrollable content reserves 12rem so nothing is hidden behind the
+ * input stack + tab bar.
+ */
+const MOBILE_MESSAGE_INPUT_BOTTOM = 'calc(4rem + env(safe-area-inset-bottom, 0px))';
+const MOBILE_CONTENT_BOTTOM_PADDING = 'calc(12rem + env(safe-area-inset-bottom, 0px))';
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -477,7 +486,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         <main
           className="flex-1 overflow-y-auto"
           style={{
-            paddingBottom: 'calc(12rem + env(safe-area-inset-bottom, 0px))',
+            paddingBottom: MOBILE_CONTENT_BOTTOM_PADDING,
           }}
         >
           <MobileContent
@@ -535,7 +544,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         {/* Message Input - fixed above tab bar */}
         <div
           className="fixed left-0 right-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 z-30"
-          style={{ bottom: 'calc(4rem + env(safe-area-inset-bottom, 0px))' }}
+          style={{ bottom: MOBILE_MESSAGE_INPUT_BOTTOM }}
         >
           {/* Issue #473: Navigation buttons for OpenCode TUI selection list (mobile) */}
           {isSelectionListActive && (

--- a/src/components/worktree/WorktreeList.tsx
+++ b/src/components/worktree/WorktreeList.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Star } from 'lucide-react';
 import { WorktreeCard } from './WorktreeCard';
-import { Button, Badge } from '@/components/ui';
+import { Button, Badge, Input } from '@/components/ui';
 import { worktreeApi, repositoryApi, handleApiError, type RepositorySummary, type ExcludedRepository } from '@/lib/api-client';
 import { useWebSocket, type WebSocketMessage, type SessionStatusPayload, type BroadcastPayload } from '@/hooks/useWebSocket';
 import type { Worktree } from '@/types/models';
@@ -342,12 +342,12 @@ Type "delete" to confirm:`;
 
       {/* Search Bar - First */}
       <div className="flex flex-col sm:flex-row gap-3">
-        <input
+        <Input
           type="text"
           placeholder="Search worktrees..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="input flex-1"
+          className="flex-1"
         />
       </div>
 

--- a/tests/unit/components/ui/Badge.test.tsx
+++ b/tests/unit/components/ui/Badge.test.tsx
@@ -10,20 +10,23 @@ import { render, screen } from '@testing-library/react';
 import { Badge } from '@/components/ui/Badge';
 
 describe('Badge', () => {
-  it('renders base badge class and defaults to the gray variant', () => {
+  it('renders base classes and defaults to the gray variant', () => {
     render(<Badge data-testid="badge">Neutral</Badge>);
     const cls = screen.getByTestId('badge').className;
-    expect(cls).toContain('badge');
-    expect(cls).toContain('badge-gray');
+    // base classes (inlined from the former .badge @apply utility, Issue #1048)
+    expect(cls).toContain('rounded-full');
+    expect(cls).toContain('inline-flex');
+    // gray variant
+    expect(cls).toContain('bg-gray-100');
   });
 
   it.each([
-    ['success', 'badge-success'],
-    ['warning', 'badge-warning'],
-    ['error', 'badge-error'],
-    ['info', 'badge-info'],
-    ['gray', 'badge-gray'],
-  ] as const)('applies the %s variant class', (variant, expected) => {
+    ['success', 'bg-green-100'],
+    ['warning', 'bg-yellow-100'],
+    ['error', 'bg-red-100'],
+    ['info', 'bg-accent-100'],
+    ['gray', 'bg-gray-100'],
+  ] as const)('applies the %s variant classes', (variant, expected) => {
     render(
       <Badge data-testid="badge" variant={variant}>
         {variant}
@@ -56,7 +59,7 @@ describe('Badge', () => {
       </Badge>
     );
     const cls = screen.getByTestId('badge').className;
-    expect(cls).toContain('badge-success');
+    expect(cls).toContain('bg-green-100');
     expect(cls).toContain('ml-2');
   });
 });

--- a/tests/unit/components/ui/Button.test.tsx
+++ b/tests/unit/components/ui/Button.test.tsx
@@ -14,21 +14,25 @@ function classesOf(text: string): string[] {
 }
 
 describe('Button', () => {
-  it('renders base btn class and defaults to the primary variant / md size', () => {
+  it('renders base classes and defaults to the primary variant / md size', () => {
     render(<Button>Go</Button>);
     const cls = classesOf('Go');
-    expect(cls).toContain('btn');
-    expect(cls).toContain('btn-primary');
-    // md size contributes no extra size class
-    expect(cls).not.toContain('btn-sm');
-    expect(cls).not.toContain('btn-lg');
+    // base classes (inlined from the former .btn @apply utility, Issue #1048)
+    expect(cls).toContain('inline-flex');
+    expect(cls).toContain('rounded-md');
+    // primary variant
+    expect(cls).toContain('bg-accent-600');
+    // md size keeps the base px-4 padding and adds no sm/lg override
+    expect(cls).toContain('px-4');
+    expect(cls).not.toContain('px-3');
+    expect(cls).not.toContain('px-6');
   });
 
   it.each([
-    ['primary', 'btn-primary'],
-    ['secondary', 'btn-secondary'],
-    ['danger', 'btn-danger'],
-  ] as const)('applies the %s variant class', (variant, expected) => {
+    ['primary', 'bg-accent-600'],
+    ['secondary', 'bg-gray-200'],
+    ['danger', 'bg-red-600'],
+  ] as const)('applies the %s variant classes', (variant, expected) => {
     render(
       <Button variant={variant}>{variant}</Button>
     );
@@ -48,9 +52,9 @@ describe('Button', () => {
   });
 
   it.each([
-    ['sm', 'btn-sm'],
-    ['lg', 'btn-lg'],
-  ] as const)('applies the %s size class', (size, expected) => {
+    ['sm', 'text-sm'],
+    ['lg', 'text-lg'],
+  ] as const)('applies the %s size classes', (size, expected) => {
     render(<Button size={size}>{size}</Button>);
     expect(classesOf(size)).toContain(expected);
   });
@@ -76,12 +80,13 @@ describe('Button', () => {
   });
 
   it('merges a custom className with last-wins for conflicts', () => {
-    render(<Button className="btn-primary text-black">custom</Button>);
+    // primary sets bg-accent-600; a custom bg utility must win via tailwind-merge
+    render(<Button className="bg-black">custom</Button>);
     const cls = classesOf('custom');
-    // custom class is appended
-    expect(cls).toContain('text-black');
-    // base btn class preserved
-    expect(cls).toContain('btn');
+    expect(cls).toContain('bg-black');
+    expect(cls).not.toContain('bg-accent-600');
+    // base classes preserved
+    expect(cls).toContain('inline-flex');
   });
 
   it('forwards native button props such as type and onClick', () => {

--- a/tests/unit/components/ui/Card.test.tsx
+++ b/tests/unit/components/ui/Card.test.tsx
@@ -16,21 +16,24 @@ import {
 } from '@/components/ui/Card';
 
 describe('Card', () => {
-  it('renders base card class and default md padding', () => {
+  it('renders base classes and default md padding', () => {
     render(<Card data-testid="card">body</Card>);
     const el = screen.getByTestId('card');
-    expect(el.className).toContain('card');
+    // base classes (inlined from the former .card @apply utility, Issue #1048)
+    expect(el.className).toContain('rounded-lg');
+    expect(el.className).toContain('border');
+    expect(el.className).toContain('bg-white');
     expect(el.className).toContain('p-4');
-    expect(el.className).not.toContain('card-hover');
+    expect(el.className).not.toContain('hover:shadow-md');
   });
 
-  it('adds card-hover when hover is set', () => {
+  it('adds the hover transition classes when hover is set', () => {
     render(
       <Card data-testid="card" hover>
         body
       </Card>
     );
-    expect(screen.getByTestId('card').className).toContain('card-hover');
+    expect(screen.getByTestId('card').className).toContain('hover:shadow-md');
   });
 
   it.each([

--- a/tests/unit/config/dark-mode-foundation.test.ts
+++ b/tests/unit/config/dark-mode-foundation.test.ts
@@ -75,61 +75,83 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(cssContent).toContain('bg-[#0d1117]');
     });
 
-    it('should have dark: variants for .card component', () => {
-      expect(cssContent).toContain('dark:bg-gray-900');
-      expect(cssContent).toContain('dark:border-gray-700');
-    });
-
-    it('should have accent tokens for .btn-primary', () => {
-      expect(cssContent).toContain('bg-accent-600');
-      expect(cssContent).toContain('dark:bg-accent-500');
-    });
-
-    it('should have dark: variants for .btn-secondary', () => {
-      expect(cssContent).toContain('dark:bg-gray-700');
-      expect(cssContent).toContain('dark:text-gray-100');
-    });
-
-    it('should have accent tokens for .badge-info', () => {
-      expect(cssContent).toContain('bg-accent-100');
-      expect(cssContent).toContain('dark:bg-accent-900');
-      expect(cssContent).toContain('text-accent-800');
-      expect(cssContent).toContain('dark:text-accent-300');
-    });
-
-    it('should have dark: variants for .badge-success', () => {
-      expect(cssContent).toContain('dark:bg-green-900');
-      expect(cssContent).toContain('dark:text-green-300');
-    });
-
-    it('should have dark: variants for .badge-warning', () => {
-      expect(cssContent).toContain('dark:bg-yellow-900');
-      expect(cssContent).toContain('dark:text-yellow-300');
-    });
-
-    it('should have dark: variants for .badge-error', () => {
-      expect(cssContent).toContain('dark:bg-red-900');
-      expect(cssContent).toContain('dark:text-red-300');
-    });
-
-    it('should have dark: variants for .badge-gray', () => {
-      expect(cssContent).toContain('dark:bg-gray-800');
-      expect(cssContent).toContain('dark:text-gray-300');
-    });
-
     it('should have dark: variants for inline code in .prose', () => {
       expect(cssContent).toContain('dark:bg-gray-800');
       expect(cssContent).toContain('dark:text-gray-200');
     });
 
-    it('should have ring token for .input focus ring', () => {
-      expect(cssContent).toContain('focus:ring-ring');
-      expect(cssContent).toContain('focus:border-ring');
+    it('should no longer define the legacy @apply component classes (Issue #1048)', () => {
+      // .card/.btn*/.badge*/.input moved into the cva primitives to remove the
+      // style-definition double structure. globals.css must not redefine them.
+      expect(cssContent).not.toMatch(/\.card\s*\{/);
+      expect(cssContent).not.toMatch(/\.btn(-\w+)?\s*\{/);
+      expect(cssContent).not.toMatch(/\.badge(-\w+)?\s*\{/);
+      expect(cssContent).not.toMatch(/\.input\s*\{/);
     });
 
-    it('should have dark: variants for .input', () => {
-      expect(cssContent).toContain('dark:border-gray-600');
-      expect(cssContent).toContain('dark:bg-gray-800');
+    it('should keep the semantic --input / --surface tokens with a dark override', () => {
+      // The Input primitive relies on border-input / bg-surface, whose dark
+      // values come from the .dark override block.
+      expect(cssContent).toContain('--input:');
+      expect(cssContent).toContain('--surface:');
+      expect(cssContent).toContain('.dark {');
+    });
+  });
+
+  describe('UI primitives dark mode (Issue #1048: @apply → cva)', () => {
+    // The dark-mode component styling now lives in the cva primitives rather
+    // than in globals.css @apply classes.
+    const readPrimitive = (rel: string): string =>
+      fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+    it('Button primary keeps accent tokens with dark variant', () => {
+      const content = readPrimitive('src/components/ui/Button.tsx');
+      expect(content).toContain('bg-accent-600');
+      expect(content).toContain('dark:bg-accent-500');
+    });
+
+    it('Button secondary keeps dark variants', () => {
+      const content = readPrimitive('src/components/ui/Button.tsx');
+      expect(content).toContain('dark:bg-gray-700');
+      expect(content).toContain('dark:text-gray-100');
+    });
+
+    it('Card keeps dark background/border variants', () => {
+      const content = readPrimitive('src/components/ui/Card.tsx');
+      expect(content).toContain('dark:bg-gray-900');
+      expect(content).toContain('dark:border-gray-700');
+    });
+
+    it('Badge info keeps accent tokens with dark variants', () => {
+      const content = readPrimitive('src/components/ui/Badge.tsx');
+      expect(content).toContain('bg-accent-100');
+      expect(content).toContain('dark:bg-accent-900');
+      expect(content).toContain('text-accent-800');
+      expect(content).toContain('dark:text-accent-300');
+    });
+
+    it('Badge success/warning/error/gray keep dark variants', () => {
+      const content = readPrimitive('src/components/ui/Badge.tsx');
+      expect(content).toContain('dark:bg-green-900');
+      expect(content).toContain('dark:text-green-300');
+      expect(content).toContain('dark:bg-yellow-900');
+      expect(content).toContain('dark:text-yellow-300');
+      expect(content).toContain('dark:bg-red-900');
+      expect(content).toContain('dark:text-red-300');
+      expect(content).toContain('dark:bg-gray-800');
+      expect(content).toContain('dark:text-gray-300');
+    });
+
+    it('Input keeps the semantic focus ring tokens', () => {
+      const content = readPrimitive('src/components/ui/Input.tsx');
+      expect(content).toContain('focus:ring-ring');
+      expect(content).toContain('focus:border-ring');
+    });
+
+    it('Input uses semantic border-input / bg-surface tokens', () => {
+      const content = readPrimitive('src/components/ui/Input.tsx');
+      expect(content).toContain('border-input');
+      expect(content).toContain('bg-surface');
     });
   });
 


### PR DESCRIPTION
## 概要
UIモダン化 Phase 3 (#1040) の Issue #1048。親 #1040 の課題#7「スタイル定義の二重構造」を解消します。
`globals.css` の `@apply` コンポーネントクラスを削除し、cva プリミティブを自己完結化します。

## 変更点(本PRのコア)
- `src/app/globals.css`: `.btn` / `.btn-primary|secondary|danger|sm|lg` / `.card` / `.card-hover` / `.badge*` / `.input` の `@apply` 定義を削除
- `src/components/ui/{Button,Card,Badge}.tsx`: 旧 `@apply` の実クラスを cva 定義へ**同値で内挿**(下記の通り検証済、視覚不変)
- `src/components/worktree/{WorktreeDetailRefactored,LogViewer,WorktreeList}.tsx` / `external-apps/ExternalAppForm.tsx`: プリミティブへ移行 + マジックナンバー入りインライン style を定数化
- 対応するプリミティブ単体テスト・スナップショットを更新

## 検証
- `npx tsc --noEmit`: パス / `npm run lint`: パス / `npm run test:unit`: 8584 passed
- **削除クラスの参照 0**: `src/` 全体(#1047 移行済ページ含む)で `.btn*/.card*/.badge*/.input` の使用が残っていないことを grep 確認
- **内挿の同値性**: 旧 `globals.css` @apply 定義と新 cva クラス文字列が一致(primary=`bg-accent-600 dark:bg-accent-500 ... focus:ring-ring` 等、Button/Card/Badge 全variant)→ 見た目は不変

## スコープ分割(#1061)
`worktree/`(約238) / `mobile/`(6) / `sidebar/`(4) / `common/`(8) の**生UIの一括プリミティブ移行**は、
規模(計~256 button)と敏感な画面(ターミナル/git panel)での回帰リスクを考慮し **#1061 へ分割**しました。
これらは削除済クラスに依存しておらず(生Tailwind直書き)、機能・表示は正常です。

## 関連
Closes #1048 / 親 #1040 / フォローアップ #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
