### PR TITLE
feat: サーフェス・奥行きを再設計しモダンダークテーマへ刷新 (#1049)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,20 +6,24 @@
   /*
    * [Issue #1041] Semantic design tokens.
    * Values are RGB channel triplets (not hex) so Tailwind can synthesize alpha
-   * via `rgb(var(--token) / <alpha-value>)`. Each value mirrors the current
-   * effective Tailwind shade (noted in the trailing comment) so this issue
-   * changes no visuals — component migration to these tokens lands in #1045.
+   * via `rgb(var(--token) / <alpha-value>)`.
    * See docs/design-system.md for naming rules and the hardcoded-color policy.
+   *
+   * [Issue #1049] Surface/depth revision — the FIRST intentional visual change.
+   * background/surface/surface-2/border now form a deliberate elevation ladder
+   * (deep base → subtly-lifted surface → recessed secondary → hairline border)
+   * so screens read as layered rather than "flat gray boxes". Body text keeps
+   * WCAG AA (>=4.5:1) and auxiliary text >=3:1 against these surfaces.
    */
   :root {
-    --background: 249 250 251; /* gray-50 */
+    --background: 255 255 255; /* pure white page */
     --foreground: 17 24 39; /* gray-900 */
-    --surface: 255 255 255; /* white */
+    --surface: 248 250 252; /* slate-50 — subtly grayed panel */
     --surface-foreground: 17 24 39; /* gray-900 */
-    --surface-2: 249 250 251; /* gray-50 */
+    --surface-2: 241 245 249; /* slate-100 — recessed secondary */
     --muted: 243 244 246; /* gray-100 */
     --muted-foreground: 107 114 128; /* gray-500 */
-    --border: 229 231 235; /* gray-200 */
+    --border: 226 232 240; /* slate-200 — hairline */
     --input: 209 213 219; /* gray-300 */
     --ring: 6 182 212; /* cyan-500 */
     --accent-50: 236 254 255; /* cyan-50 */
@@ -40,14 +44,14 @@
   }
 
   .dark {
-    --background: 15 17 23; /* #0f1117 (legacy cmd-bg-dark) */
+    --background: 10 12 18; /* #0a0c12 — deep base */
     --foreground: 243 244 246; /* gray-100 */
-    --surface: 31 41 55; /* gray-800 */
+    --surface: 20 24 33; /* #141821 — subtly lifted card */
     --surface-foreground: 243 244 246; /* gray-100 */
-    --surface-2: 17 24 39; /* gray-900 */
+    --surface-2: 15 18 26; /* #0f121a — recessed secondary */
     --muted: 31 41 55; /* gray-800 */
     --muted-foreground: 156 163 175; /* gray-400 */
-    --border: 55 65 81; /* gray-700 */
+    --border: 42 48 62; /* #2a303e — hairline */
     --input: 75 85 99; /* gray-600 */
     --ring: 6 182 212; /* cyan-500 */
     --accent-50: 236 254 255; /* cyan-50 */
@@ -91,24 +95,28 @@
     @apply text-gray-900 dark:text-gray-100 antialiased;
   }
 
+  /*
+   * [Issue #1049] Heading hierarchy: bolder, tighter display headings (h1/h2)
+   * step down to semibold section headings (h3/h4). tracking-tight throughout.
+   */
   h1, h2, h3, h4, h5, h6 {
     @apply font-semibold tracking-tight;
   }
 
   h1 {
-    @apply text-3xl md:text-4xl;
+    @apply text-3xl md:text-4xl font-bold leading-tight;
   }
 
   h2 {
-    @apply text-2xl md:text-3xl;
+    @apply text-2xl md:text-3xl font-bold leading-tight;
   }
 
   h3 {
-    @apply text-xl md:text-2xl;
+    @apply text-xl md:text-2xl leading-snug;
   }
 
   h4 {
-    @apply text-lg md:text-xl;
+    @apply text-lg md:text-xl leading-snug;
   }
 }
 

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -288,7 +288,7 @@ export default function SessionsPage() {
                   <Link
                     key={wt.id}
                     href={`/worktrees/${wt.id}`}
-                    className="block bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 hover:border-accent-300 dark:hover:border-accent-700 transition-colors"
+                    className="block bg-surface rounded-lg p-4 border border-border shadow-sm hover:border-accent-300 dark:hover:border-accent-700 transition-colors"
                     data-testid={`session-item-${wt.id}`}
                   >
                     {/* Row 1: Name, Agent statuses */}

--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -200,7 +200,7 @@ export function TodoWidget() {
             onChange={(e) => setSelectedRepoId(e.target.value)}
             disabled={!hasRepositories}
             data-testid="todo-repo-select"
-            className="min-w-0 flex-1 truncate rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-50 sm:flex-initial sm:max-w-[16rem]"
+            className="min-w-0 flex-1 truncate rounded-md border border-input bg-surface dark:bg-surface-2 px-2 py-1 text-sm text-surface-foreground disabled:opacity-50 sm:flex-initial sm:max-w-[16rem]"
           >
             {repositories.map((repo) => (
               <option key={repo.id} value={repo.id}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,7 +43,7 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
   const pathname = usePathname();
 
   return (
-    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-50">
+    <header className="sticky top-0 z-50 border-b border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md">
       <div className="container-custom">
         <div className="flex items-center justify-between h-16">
           {/* Logo and Title */}

--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -47,7 +47,7 @@ export function GlobalMobileNav() {
   return (
     <nav
       data-testid="global-mobile-nav"
-      className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 z-50 safe-area-bottom"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md safe-area-bottom"
     >
       <div className="flex items-center justify-around h-14">
         {MOBILE_NAV_TABS.map((tab) => {

--- a/src/components/review/TemplateTab.tsx
+++ b/src/components/review/TemplateTab.tsx
@@ -248,7 +248,7 @@ export default function TemplateTab() {
 
       {/* Create form (only shown when under limit) */}
       {templates.length < MAX_TEMPLATES && (
-        <div className="p-4 bg-gray-50 dark:bg-gray-800/50 border dark:border-gray-700 rounded-lg" data-testid="create-form">
+        <div className="p-4 bg-surface border border-border rounded-lg shadow-sm" data-testid="create-form">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">New Template</h3>
           <div className="space-y-3">
             <Input

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -7,10 +7,25 @@ import React from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils/cn';
 
+/*
+ * [Issue #1049] Base uses semantic surface/border tokens so the depth-token
+ * revision propagates without per-card edits. `variant` adds depth:
+ *  - elevated: subtle top-lit gradient + stronger shadow (focal panels)
+ *  - interactive: accent hairline + slight lift on hover (clickable cards)
+ */
 const cardVariants = cva(
-  'bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm',
+  'bg-surface text-surface-foreground rounded-lg border border-border shadow-sm',
   {
     variants: {
+      variant: {
+        default: '',
+        elevated: 'bg-gradient-to-b from-surface to-surface-2 shadow-md',
+        interactive:
+          'cursor-pointer transition-all duration-200 ' +
+          'hover:border-accent-500 hover:shadow-md hover:-translate-y-0.5 ' +
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ' +
+          'focus-visible:border-accent-500 focus-visible:shadow-md focus-visible:-translate-y-0.5',
+      },
       hover: {
         true: 'transition-shadow duration-200 hover:shadow-md',
         false: '',
@@ -23,6 +38,7 @@ const cardVariants = cva(
       },
     },
     defaultVariants: {
+      variant: 'default',
       hover: false,
       padding: 'md',
     },
@@ -30,6 +46,7 @@ const cardVariants = cva(
 );
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'default' | 'elevated' | 'interactive';
   hover?: boolean;
   padding?: 'none' | 'sm' | 'md' | 'lg';
   children: React.ReactNode;
@@ -40,13 +57,14 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
  *
  * @example
  * ```tsx
- * <Card hover padding="md">
+ * <Card variant="elevated" padding="md">
  *   <h3>Card Title</h3>
  *   <p>Card content</p>
  * </Card>
  * ```
  */
 export function Card({
+  variant = 'default',
   hover = false,
   padding = 'md',
   className = '',
@@ -54,7 +72,7 @@ export function Card({
   ...props
 }: CardProps) {
   return (
-    <div className={cn(cardVariants({ hover, padding }), className)} {...props}>
+    <div className={cn(cardVariants({ variant, hover, padding }), className)} {...props}>
       {children}
     </div>
   );
@@ -84,7 +102,7 @@ export interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement>
 
 export function CardTitle({ className = '', children, ...props }: CardTitleProps) {
   return (
-    <h3 className={cn('text-lg font-semibold text-gray-900 dark:text-gray-100', className)} {...props}>
+    <h3 className={cn('text-lg font-semibold text-surface-foreground', className)} {...props}>
       {children}
     </h3>
   );
@@ -114,7 +132,7 @@ export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export function CardFooter({ className = '', children, ...props }: CardFooterProps) {
   return (
-    <div className={cn('mt-4 pt-4 border-t border-gray-200 dark:border-gray-700', className)} {...props}>
+    <div className={cn('mt-4 pt-4 border-t border-border', className)} {...props}>
       {children}
     </div>
   );

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -9,7 +9,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils/cn';
 
 const inputVariants = cva(
-  'flex w-full rounded-md border border-input bg-surface text-surface-foreground shadow-sm ' +
+  'flex w-full rounded-md border border-input bg-surface dark:bg-surface-2 text-surface-foreground shadow-sm ' +
     'placeholder:text-muted-foreground ' +
     'focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring ' +
     'disabled:cursor-not-allowed disabled:opacity-50',

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -23,7 +23,7 @@ export const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-surface px-3 py-2 text-sm text-surface-foreground shadow-sm',
+      'flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-surface dark:bg-surface-2 px-3 py-2 text-sm text-surface-foreground shadow-sm',
       'placeholder:text-muted-foreground',
       'focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring',
       'disabled:cursor-not-allowed disabled:opacity-50',

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -22,7 +22,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         ref={ref}
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-surface px-3 py-2 text-sm text-surface-foreground shadow-sm',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-surface dark:bg-surface-2 px-3 py-2 text-sm text-surface-foreground shadow-sm',
           'placeholder:text-muted-foreground',
           'focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring',
           'disabled:cursor-not-allowed disabled:opacity-50',

--- a/tests/unit/GlobalMobileNav.test.tsx
+++ b/tests/unit/GlobalMobileNav.test.tsx
@@ -103,4 +103,13 @@ describe('GlobalMobileNav', () => {
     expect(nav.className).toContain('fixed');
     expect(nav.className).toContain('bottom-0');
   });
+
+  it('should apply a translucent backdrop-blur bar with an opaque fallback (Issue #1049)', () => {
+    render(<GlobalMobileNav />);
+    const cls = screen.getByTestId('global-mobile-nav').className;
+    expect(cls).toContain('bg-background');
+    expect(cls).toContain('supports-[backdrop-filter]:bg-background/80');
+    expect(cls).toContain('backdrop-blur-md');
+    expect(cls).toContain('border-border');
+  });
 });

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -99,4 +99,16 @@ describe('Header', () => {
     const nav = screen.getByRole('navigation');
     expect(nav).toBeDefined();
   });
+
+  it('should apply a translucent backdrop-blur header with an opaque fallback (Issue #1049)', () => {
+    const { container } = render(<Header />);
+    const header = container.querySelector('header');
+    expect(header).not.toBeNull();
+    const cls = header!.className;
+    // opaque fallback + translucent-only-when-supported + blur + hairline token
+    expect(cls).toContain('bg-background');
+    expect(cls).toContain('supports-[backdrop-filter]:bg-background/80');
+    expect(cls).toContain('backdrop-blur-md');
+    expect(cls).toContain('border-border');
+  });
 });

--- a/tests/unit/components/ui/Card.test.tsx
+++ b/tests/unit/components/ui/Card.test.tsx
@@ -19,10 +19,10 @@ describe('Card', () => {
   it('renders base classes and default md padding', () => {
     render(<Card data-testid="card">body</Card>);
     const el = screen.getByTestId('card');
-    // base classes (inlined from the former .card @apply utility, Issue #1048)
+    // base now uses semantic surface/border tokens (Issue #1049)
     expect(el.className).toContain('rounded-lg');
-    expect(el.className).toContain('border');
-    expect(el.className).toContain('bg-white');
+    expect(el.className).toContain('border-border');
+    expect(el.className).toContain('bg-surface');
     expect(el.className).toContain('p-4');
     expect(el.className).not.toContain('hover:shadow-md');
   });
@@ -34,6 +34,52 @@ describe('Card', () => {
       </Card>
     );
     expect(screen.getByTestId('card').className).toContain('hover:shadow-md');
+  });
+
+  it('renders the elevated variant with a gradient and stronger shadow (Issue #1049)', () => {
+    render(
+      <Card data-testid="card" variant="elevated">
+        body
+      </Card>
+    );
+    const cls = screen.getByTestId('card').className;
+    expect(cls).toContain('bg-gradient-to-b');
+    expect(cls).toContain('from-surface');
+    expect(cls).toContain('to-surface-2');
+    expect(cls).toContain('shadow-md');
+  });
+
+  it('renders the interactive variant with accent hover border and lift (Issue #1049)', () => {
+    render(
+      <Card data-testid="card" variant="interactive">
+        body
+      </Card>
+    );
+    const cls = screen.getByTestId('card').className;
+    expect(cls).toContain('hover:border-accent-500');
+    expect(cls).toContain('hover:-translate-y-0.5');
+    expect(cls).toContain('transition-all');
+  });
+
+  it('interactive variant is keyboard-focusable: cursor + focus-visible mirrors hover (Issue #1049)', () => {
+    render(
+      <Card data-testid="card" variant="interactive">
+        body
+      </Card>
+    );
+    const cls = screen.getByTestId('card').className;
+    expect(cls).toContain('cursor-pointer');
+    expect(cls).toContain('focus-visible:ring-ring');
+    expect(cls).toContain('focus-visible:border-accent-500');
+    expect(cls).toContain('focus-visible:-translate-y-0.5');
+    expect(cls).toContain('focus-visible:shadow-md');
+  });
+
+  it('defaults to the default variant with no elevated/interactive classes', () => {
+    render(<Card data-testid="card">body</Card>);
+    const cls = screen.getByTestId('card').className;
+    expect(cls).not.toContain('bg-gradient-to-b');
+    expect(cls).not.toContain('hover:border-accent-500');
   });
 
   it.each([

--- a/tests/unit/components/ui/Input.test.tsx
+++ b/tests/unit/components/ui/Input.test.tsx
@@ -44,6 +44,14 @@ describe('Input', () => {
     expect(screen.getByLabelText('c').className).toContain('max-w-md');
   });
 
+  it('recedes to surface-2 in dark so it sinks within a surface card (Issue #1049)', () => {
+    render(<Input aria-label="d" />);
+    const cls = screen.getByLabelText('d').className;
+    // light keeps bg-surface; dark drops to the recessed surface-2 fill
+    expect(cls).toContain('bg-surface');
+    expect(cls).toContain('dark:bg-surface-2');
+  });
+
   it('forwards ref to the input element', () => {
     function Wrapper() {
       const ref = useRef<HTMLInputElement>(null);

--- a/tests/unit/config/dark-mode-foundation.test.ts
+++ b/tests/unit/config/dark-mode-foundation.test.ts
@@ -116,10 +116,12 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(content).toContain('dark:text-gray-100');
     });
 
-    it('Card keeps dark background/border variants', () => {
+    it('Card uses semantic surface/border tokens (migrated in Issue #1049)', () => {
+      // The hardcoded dark:bg-gray-900 / dark:border-gray-700 were replaced by
+      // bg-surface / border-border so the depth-token revision propagates.
       const content = readPrimitive('src/components/ui/Card.tsx');
-      expect(content).toContain('dark:bg-gray-900');
-      expect(content).toContain('dark:border-gray-700');
+      expect(content).toContain('bg-surface');
+      expect(content).toContain('border-border');
     });
 
     it('Badge info keeps accent tokens with dark variants', () => {
@@ -148,10 +150,12 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(content).toContain('focus:border-ring');
     });
 
-    it('Input uses semantic border-input / bg-surface tokens', () => {
+    it('Input uses semantic border-input / bg-surface tokens and recedes to surface-2 in dark (Issue #1049)', () => {
       const content = readPrimitive('src/components/ui/Input.tsx');
       expect(content).toContain('border-input');
       expect(content).toContain('bg-surface');
+      // dark recede so an Input inside a bg-surface Card is distinguishable
+      expect(content).toContain('dark:bg-surface-2');
     });
   });
 

--- a/tests/unit/config/design-tokens.test.ts
+++ b/tests/unit/config/design-tokens.test.ts
@@ -19,16 +19,20 @@ import resolveConfig from 'tailwindcss/resolveConfig';
 
 const ROOT = path.resolve(__dirname, '../../..');
 
-/** Tokens whose value differs between light and dark modes. */
+/**
+ * Tokens whose value differs between light and dark modes.
+ * background/surface/surface-2/border were revised in Issue #1049 to form a
+ * deliberate depth ladder (the first intentional visual change).
+ */
 const MODE_VARYING: Record<string, { light: string; dark: string }> = {
-  '--background': { light: '249 250 251', dark: '15 17 23' },
+  '--background': { light: '255 255 255', dark: '10 12 18' },
   '--foreground': { light: '17 24 39', dark: '243 244 246' },
-  '--surface': { light: '255 255 255', dark: '31 41 55' },
+  '--surface': { light: '248 250 252', dark: '20 24 33' },
   '--surface-foreground': { light: '17 24 39', dark: '243 244 246' },
-  '--surface-2': { light: '249 250 251', dark: '17 24 39' },
+  '--surface-2': { light: '241 245 249', dark: '15 18 26' },
   '--muted': { light: '243 244 246', dark: '31 41 55' },
   '--muted-foreground': { light: '107 114 128', dark: '156 163 175' },
-  '--border': { light: '229 231 235', dark: '55 65 81' },
+  '--border': { light: '226 232 240', dark: '42 48 62' },
   '--input': { light: '209 213 219', dark: '75 85 99' },
 };
 

--- a/tests/unit/config/surface-depth.test.ts
+++ b/tests/unit/config/surface-depth.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the surface/depth revision (Issue #1049 — first intentional visual change).
+ *
+ * Rather than re-pinning exact RGB triplets (design-tokens.test.ts already does
+ * that), these assertions codify the *intent*: background/surface/surface-2/border
+ * must form a deliberate elevation ladder in each mode, and heading typography
+ * must express a weight hierarchy. This keeps future token tweaks honest without
+ * freezing specific shades.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../..');
+
+function extractBlock(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  expect(match, `Expected a "${selector}" block in globals.css`).not.toBeNull();
+  return match![1];
+}
+
+/** Parse an `--token: r g b;` triplet and return its channel sum (a luminance proxy). */
+function channelSum(block: string, token: string): number {
+  const m = block.match(new RegExp(`${token}\\s*:\\s*(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*;`));
+  expect(m, `Expected ${token} in the block`).not.toBeNull();
+  return Number(m![1]) + Number(m![2]) + Number(m![3]);
+}
+
+describe('Surface depth ladder (Issue #1049)', () => {
+  let css: string;
+  let root: string;
+  let dark: string;
+
+  beforeAll(() => {
+    css = fs.readFileSync(path.join(ROOT, 'src/app/globals.css'), 'utf-8');
+    root = extractBlock(css, ':root');
+    dark = extractBlock(css, '.dark');
+  });
+
+  describe('dark mode (elevation = brighter)', () => {
+    it('layers background < surface-2 < surface (deep base rises to lifted card)', () => {
+      const bg = channelSum(dark, '--background');
+      const s2 = channelSum(dark, '--surface-2');
+      const surface = channelSum(dark, '--surface');
+      expect(bg).toBeLessThan(s2);
+      expect(s2).toBeLessThan(surface);
+    });
+
+    it('draws the border as a hairline lighter than the surface it delineates', () => {
+      expect(channelSum(dark, '--surface')).toBeLessThan(channelSum(dark, '--border'));
+    });
+  });
+
+  describe('light mode (pure-white page, subtly grayed panels)', () => {
+    it('uses a pure white background', () => {
+      expect(channelSum(root, '--background')).toBe(765);
+    });
+
+    it('recesses surface below background and surface-2 below surface', () => {
+      const bg = channelSum(root, '--background');
+      const surface = channelSum(root, '--surface');
+      const s2 = channelSum(root, '--surface-2');
+      expect(surface).toBeLessThan(bg);
+      expect(s2).toBeLessThan(surface);
+    });
+  });
+
+  describe('heading typography hierarchy', () => {
+    it('keeps tracking-tight on all headings', () => {
+      expect(css).toMatch(/h1,\s*h2,\s*h3,\s*h4,\s*h5,\s*h6\s*\{[^}]*tracking-tight/);
+    });
+
+    it('makes h1 and h2 bold display headings', () => {
+      expect(css).toMatch(/h1\s*\{[^}]*font-bold/);
+      expect(css).toMatch(/h2\s*\{[^}]*font-bold/);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
UIモダン化 Phase 4 (#1040) の Issue #1049。**本Issueから意図的に見た目が変わります**。
一様な灰色の箱の羅列から、深み・奥行き・ヘアラインのあるモダンダーク/ライトテーマへ刷新します。

## 変更点
- `globals.css`: `:root`(light) / `.dark` の semantic トークン値を刷新
  - dark: background `#0a0c12`(深いbase) / surface `#141821`(微リフト) / surface-2 `#0f121a`(recessed) / border `#2a303e`(ヘアライン)
  - light: 純白 background / slate-50 surface / slate-200 ヘアライン
- `Header.tsx` / `GlobalMobileNav.tsx`: 半透明 + `backdrop-blur-md`(`supports-[backdrop-filter]` フォールバック付)
- `Card.tsx`: `elevated` / `interactive`(hover lift + border accent + キーボード focus)variant を追加
- 見出し h1-h4 のタイポグラフィ調整

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`: 全 pass
- **コントラスト(WCAG AA)を数値検証**: dark fg/bg 17.8:1・muted-fg/surface 7.0:1、light muted-fg/surface 4.6:1 等すべて基準超過
- **敵対的レビュー(3観点+検証)**で確定した 3件(medium 1 / low 2)を反映:
  1. 背景反転による主要コンテンツカードの溶け込み → sessions/home/review のカードを `bg-surface`/`border-border`/`shadow-sm` へ移行
  2. ダークで Card と内包 Input のフィル一致 → 入力を `dark:bg-surface-2`(凹み)へ
  3. Card `interactive` のキーボード非対応 → `cursor-pointer` + `focus-visible:` 状態を追加

## 残置(広域トークン化で追って対応)
- review の内部チップ badge / インラインコントロール、sessions のステータスバッジ等の細粒度パネル。
  いずれも `bg-white dark:bg-gray-800` 直書きだが機能・可読性は正常(#1045 系の広域トークン化で吸収)。

## 関連
Closes #1049 / 親 #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
