### PR TITLE
feat: モーション基盤とマイクロインタラクションを追加 (#1050)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -262,3 +262,65 @@ import { Skeleton } from '@/components/ui';
 
 <Skeleton className="h-4 w-32" />
 ```
+
+---
+
+## モーション (Motion, Issue #1050)
+
+マイクロインタラクションは **[`tailwindcss-animate`](https://github.com/jamiebuilds/tailwindcss-animate)**
+で統一する。`framer-motion` は採用しない（バンドル軽量・Server Components 相性）。
+
+### 規約（duration / easing）
+
+| トークン | 値 | 用途 |
+|---------|-----|------|
+| `--motion-duration-fast` | 150ms | hover / 状態遷移・小さな要素 |
+| `--motion-duration-base` | 200ms | Modal・ドロップダウンの開閉（標準） |
+| `--motion-duration-slow` | 300ms | 一覧の stagger 入場など |
+| `--motion-ease-out` | `cubic-bezier(0.16, 1, 0.3, 1)` | 入場（enter）基調 |
+| `--motion-stagger-step` | 40ms | 一覧 stagger の 1 件あたり遅延 |
+
+- 定義: [`src/app/globals.css`](../src/app/globals.css) の `:root`（モード非依存のため 1 箇所）。
+- Tailwind からは `duration-150` / `duration-200` / `duration-300` で参照する
+  （`tailwindcss-animate` の `duration-*` は `animation-duration` にも適用される）。
+- easing は入場を `ease-out` 基調とし、急に現れる印象を避ける。
+
+### enter / exit の標準パターン
+
+- **Modal**（`src/components/ui/Modal.tsx`）: `data-state="open"` を付与し、
+  `data-[state=open]:animate-in fade-in-0 zoom-in-95 duration-200`（fade + scale）。
+  パネルは閉時に unmount するため入場アニメは **マウント時のみ発火**する。
+- **MobilePromptSheet**（`src/components/mobile/MobilePromptSheet.tsx`）: 既存の
+  `usePromptAnimation` による slide-up（`translate-y-full → 0`）の enter/exit を踏襲。
+- **Radix プリミティブ**（Select / DropdownMenu / Tooltip）: Radix の `data-state`
+  （`open` / `closed` / Tooltip は `delayed-open`）と `data-side` に連動して
+  `animate-in` / `animate-out` + `fade` + `zoom-95` + `slide-in-from-*` を適用。
+  Radix が閉時も要素を保持するため exit アニメが再生される。
+
+### 一覧の stagger
+
+`src/lib/utils/stagger.ts` の `STAGGER_ENTER_CLASS` + `staggerDelay(index)` を使う。
+
+- `fill-mode-backwards` で遅延中のみ開始フレーム（不可視）を保持し、入場後は素の
+  スタイルへ戻す（後続の hover lift を上書きしない）。
+- 最大 10 件程度まで `animation-delay` を段階付与し、それ以降は 0ms。
+- **再ポーリングで再発火させない**: 一覧項目は必ず**安定したキー**（例: `wt.id`）を
+  付ける。DOM ノードが再利用される限り、CSS アニメは再生されない。`key={index}` の
+  ような不安定キーは禁止。
+
+### hover lift / active press
+
+- インタラクティブな **Card** は `interactive` prop（`hover:-translate-y-0.5 hover:shadow-lg`
+  + `active:translate-y-0`）。装飾のみの影は従来どおり `hover` prop。
+- **Button** は既定で hover lift + active press を持つ（無効時は付与しない）。
+
+### 適用しない領域（重要）
+
+- **ターミナル出力・仮想スクロール領域にはモーションを適用しない**（パフォーマンス優先）。
+  xterm.js 描画や `@tanstack/react-virtual` の行にアニメーションクラスを付けないこと。
+
+### `prefers-reduced-motion`
+
+OS の「視差効果を減らす（reduce motion）」設定時は、[`src/app/globals.css`](../src/app/globals.css)
+末尾のグローバル `@media (prefers-reduced-motion: reduce)` が全アニメーション/トランジションを
+実質無効化する。コンポーネント側でこのメディアクエリを再実装しないこと。

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.35",
         "tailwindcss": "^3.4.18",
+        "tailwindcss-animate": "^1.0.7",
         "tsc-alias": "~1.8.16",
         "tsx": "^4.20.6",
         "typescript": "^5.5.0",
@@ -13821,6 +13822,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.35",
     "tailwindcss": "^3.4.18",
+    "tailwindcss-animate": "^1.0.7",
     "tsc-alias": "~1.8.16",
     "tsx": "^4.20.6",
     "typescript": "^5.5.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,18 @@
     --warning: 245 158 11; /* amber-500 */
     --danger: 239 68 68; /* red-500 */
     --info: 59 130 246; /* blue-500 */
+
+    /*
+     * [Issue #1050] Motion tokens. Mode-independent, so defined once on :root.
+     * Durations map to the tailwindcss-animate `duration-*` scale used across
+     * Modal / Radix data-state primitives / list stagger. Easing is ease-out
+     * biased for entrances. See docs/design-system.md (Motion section).
+     */
+    --motion-duration-fast: 150ms;
+    --motion-duration-base: 200ms;
+    --motion-duration-slow: 300ms;
+    --motion-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --motion-stagger-step: 40ms;
   }
 
   .dark {
@@ -328,5 +340,26 @@
     border: none;
     border-top: 1px solid rgb(51 65 85);
     margin: 0.8em 0;
+  }
+}
+
+/*
+ * [Issue #1050] Reduced-motion utility.
+ * Honors the OS "reduce motion" setting by neutralizing all animations and
+ * transitions globally. Declared as plain CSS (outside @layer) so the
+ * !important reset reliably wins over both core Tailwind and
+ * tailwindcss-animate utilities. Keep this the single source of truth for
+ * motion suppression — components should not re-implement the media query.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    animation-delay: 0ms !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import { AppShell } from '@/components/layout';
 import { Button, Card } from '@/components/ui';
 import { HomeSessionSummary } from '@/components/home/HomeSessionSummary';
 import { TodoWidget } from '@/components/home/TodoWidget';
+import { STAGGER_ENTER_CLASS, staggerDelay } from '@/lib/utils/stagger';
 import type { Worktree } from '@/types/models';
 
 /**
@@ -170,17 +171,18 @@ export default function Home() {
 
         {/* Shortcut Cards */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-          {SHORTCUT_CARDS.map((card) => (
+          {SHORTCUT_CARDS.map((card, index) => (
             <Link
               key={card.href}
               href={card.href}
-              className="group block"
+              className="group block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               data-testid={`shortcut-${card.title.toLowerCase()}`}
             >
               <Card
-                hover
+                interactive
                 padding="lg"
-                className="h-full transition-all hover:border-accent-300 dark:hover:border-accent-700"
+                style={{ animationDelay: staggerDelay(index) }}
+                className={`h-full hover:border-accent-300 dark:hover:border-accent-700 motion-safe:group-focus-visible:-translate-y-0.5 ${STAGGER_ENTER_CLASS}`}
               >
                 <div className="text-gray-400 dark:text-gray-500 group-hover:text-accent-600 dark:group-hover:text-accent-400 transition-colors mb-3">
                   {card.icon}

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui';
 import { compareByTimestamp } from '@/lib/sidebar-utils';
 import { formatRelativeTime } from '@/lib/date-utils';
+import { STAGGER_ENTER_CLASS, staggerDelay } from '@/lib/utils/stagger';
 import {
   MESSAGE_PREVIEW_MAX_LENGTH_PC,
   MESSAGE_PREVIEW_MAX_LENGTH_SP,
@@ -119,6 +120,9 @@ const DEFAULT_BADGE_CLASS = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:tex
 
 export default function SessionsPage() {
   const { worktrees, isLoading, error } = useWorktreesCacheContext();
+  // [Issue #1050] Whether we have any data to keep mounted. Based on the raw
+  // (unfiltered) list so an active text filter never unmounts the list.
+  const hasWorktrees = worktrees.length > 0;
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('lastSent');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
@@ -253,29 +257,35 @@ export default function SessionsPage() {
           </button>
         </div>
 
-        {/* Loading */}
-        {isLoading && (
-          <div className="text-gray-500 dark:text-gray-400" data-testid="sessions-loading">
-            Loading sessions...
-          </div>
-        )}
-
-        {/* Error */}
-        {error && (
-          <div className="text-red-500 dark:text-red-400" data-testid="sessions-error">
-            Failed to load sessions: {error.message}
-          </div>
-        )}
-
-        {/* Session list */}
-        {!isLoading && !error && (
-          <div className="space-y-2" data-testid="sessions-list">
-            {filteredAndSorted.length === 0 ? (
-              <div className="text-gray-500 dark:text-gray-400 py-8 text-center" data-testid="sessions-empty">
-                {filterText ? 'No matching sessions found.' : 'No sessions yet.'}
+        {/*
+          * [Issue #1050] Keep the list mounted across transient polling errors.
+          * `worktrees` comes from a shared polling cache; a temporary fetch
+          * failure (e.g. server rebuild) must NOT unmount the list, otherwise
+          * the next successful poll remounts it and re-fires the entrance
+          * stagger. Mirrors the #266 SF-IMP-001 "don't collapse the tree on a
+          * transient error" pattern: show a non-blocking banner when we already
+          * have data, and only surface a blocking error/loading state when we
+          * have nothing to show.
+          */}
+        {hasWorktrees ? (
+          <>
+            {/* Non-blocking error banner (data already visible below) */}
+            {error && (
+              <div
+                className="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-400"
+                role="status"
+                data-testid="sessions-error-banner"
+              >
+                Failed to refresh sessions: {error.message}
               </div>
-            ) : (
-              filteredAndSorted.map((wt: Worktree) => {
+            )}
+            <div className="space-y-2" data-testid="sessions-list">
+              {filteredAndSorted.length === 0 ? (
+                <div className="text-gray-500 dark:text-gray-400 py-8 text-center" data-testid="sessions-empty">
+                  No matching sessions found.
+                </div>
+              ) : (
+                filteredAndSorted.map((wt: Worktree, index: number) => {
                 const agents = wt.selectedAgents ?? DEFAULT_SELECTED_AGENTS;
                 const sanitizedMessage = wt.lastUserMessage
                   ? sanitizePreview(wt.lastUserMessage)
@@ -285,10 +295,13 @@ export default function SessionsPage() {
                   : null;
 
                 return (
+                  // [Issue #1050] Stable key (wt.id) keeps the entrance stagger
+                  // from re-firing on polling re-renders.
                   <Link
                     key={wt.id}
                     href={`/worktrees/${wt.id}`}
-                    className="block bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 hover:border-accent-300 dark:hover:border-accent-700 transition-colors"
+                    style={{ animationDelay: staggerDelay(index) }}
+                    className={`block bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 hover:border-accent-300 dark:hover:border-accent-700 transition-colors ${STAGGER_ENTER_CLASS}`}
                     data-testid={`session-item-${wt.id}`}
                   >
                     {/* Row 1: Name, Agent statuses */}
@@ -366,8 +379,28 @@ export default function SessionsPage() {
                   </Link>
                 );
               })
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            {/* No data yet: loading / blocking error / empty are mutually exclusive. */}
+            {isLoading && (
+              <div className="text-gray-500 dark:text-gray-400" data-testid="sessions-loading">
+                Loading sessions...
+              </div>
             )}
-          </div>
+            {!isLoading && error && (
+              <div className="text-red-500 dark:text-red-400" data-testid="sessions-error">
+                Failed to load sessions: {error.message}
+              </div>
+            )}
+            {!isLoading && !error && (
+              <div className="text-gray-500 dark:text-gray-400 py-8 text-center" data-testid="sessions-empty">
+                {filterText ? 'No matching sessions found.' : 'No sessions yet.'}
+              </div>
+            )}
+          </>
         )}
       </div>
     </AppShell>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,7 +11,9 @@ export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2',
+  // [Issue #1050] transition-all (was transition-colors) so the hover lift /
+  // active press below animate smoothly. Reduced-motion handled in globals.css.
+  'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2',
   {
     variants: {
       variant: {
@@ -73,6 +75,11 @@ export function Button({
 
   const classes = cn(
     buttonVariants({ variant, size, fullWidth }),
+    // [Issue #1050] Unified hover lift + active press. Skipped when disabled so
+    // inert buttons don't move on hover. Gated behind motion-safe so the
+    // transform is suppressed under prefers-reduced-motion (the globals.css
+    // reset only neutralizes duration/delay, not transform).
+    !isDisabled && 'motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0',
     isDisabled && 'opacity-50 cursor-not-allowed',
     className
   );

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -15,6 +15,15 @@ const cardVariants = cva(
         true: 'transition-shadow duration-200 hover:shadow-md',
         false: '',
       },
+      // [Issue #1050] Interactive cards (clickable shortcuts, links) get a
+      // hover lift + active press. Kept separate from `hover` (shadow-only) so
+      // non-interactive cards stay flat. The translate is gated behind
+      // motion-safe so it is suppressed under prefers-reduced-motion (the
+      // globals.css reset neutralizes duration/delay, not transform).
+      interactive: {
+        true: 'cursor-pointer transition-all duration-200 hover:shadow-lg active:shadow-md motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0',
+        false: '',
+      },
       padding: {
         none: '',
         sm: 'p-3',
@@ -24,6 +33,7 @@ const cardVariants = cva(
     },
     defaultVariants: {
       hover: false,
+      interactive: false,
       padding: 'md',
     },
   }
@@ -31,6 +41,7 @@ const cardVariants = cva(
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   hover?: boolean;
+  interactive?: boolean;
   padding?: 'none' | 'sm' | 'md' | 'lg';
   children: React.ReactNode;
 }
@@ -48,13 +59,14 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export function Card({
   hover = false,
+  interactive = false,
   padding = 'md',
   className = '',
   children,
   ...props
 }: CardProps) {
   return (
-    <div className={cn(cardVariants({ hover, padding }), className)} {...props}>
+    <div className={cn(cardVariants({ hover, interactive, padding }), className)} {...props}>
       {children}
     </div>
   );

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -27,6 +27,12 @@ export const DropdownMenuContent = React.forwardRef<
       style={{ zIndex: Z_INDEX.POPOVER }}
       className={cn(
         'min-w-[8rem] overflow-hidden rounded-md border border-border bg-surface p-1 text-surface-foreground shadow-lg',
+        // [Issue #1050] Radix data-state driven enter/exit (fade + zoom + slide-from-side).
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -95,8 +95,10 @@ export function Modal({
   return createPortal(
     <div className="fixed inset-0 overflow-y-auto" style={{ zIndex: Z_INDEX.MODAL }}>
       {/* Backdrop - Issue #104: skip onClick if disableClose is true */}
+      {/* [Issue #1050] data-state drives the fade-in enter animation (mount-only). */}
       <div
-        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        data-state="open"
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-200"
         onClick={disableClose ? undefined : onClose}
       />
 
@@ -104,10 +106,16 @@ export function Modal({
       <div className="relative flex min-h-full items-center justify-center p-2 sm:p-4">
         <div
           ref={modalRef}
+          data-state="open"
+          data-testid="modal-panel"
           className={cn(
             'relative w-full',
             modalSizeVariants({ size }),
-            'max-h-[calc(100vh-1rem)] sm:max-h-[calc(100vh-2rem)] flex flex-col bg-white dark:bg-gray-900 rounded-lg shadow-xl transform transition-all'
+            'max-h-[calc(100vh-1rem)] sm:max-h-[calc(100vh-2rem)] flex flex-col bg-white dark:bg-gray-900 rounded-lg shadow-xl transform transition-all',
+            // [Issue #1050] fade + scale enter on mount. Runs once per open (the
+            // panel unmounts on close via `if (!isOpen) return null`), so
+            // parent re-renders do not re-fire the animation.
+            'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:duration-200'
           )}
         >
           {/* Header */}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -51,6 +51,12 @@ export const SelectContent = React.forwardRef<
       style={{ zIndex: Z_INDEX.POPOVER }}
       className={cn(
         'relative max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-hidden rounded-md border border-border bg-surface text-surface-foreground shadow-lg',
+        // [Issue #1050] Radix data-state driven enter/exit (fade + zoom + slide-from-side).
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1',
         className

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -26,6 +26,14 @@ export const TooltipContent = React.forwardRef<
       style={{ zIndex: Z_INDEX.POPOVER }}
       className={cn(
         'overflow-hidden rounded-md bg-foreground px-2.5 py-1.5 text-xs text-background shadow-md',
+        // [Issue #1050] Enter applied unconditionally so both instant-open and
+        // delayed-open animate; exit gated on data-[state=closed]. Matches the
+        // shadcn/ui default (the Tooltip data-state is delayed-open/instant-open,
+        // never plain "open").
+        'animate-in fade-in-0 zoom-in-95',
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/src/lib/utils/stagger.ts
+++ b/src/lib/utils/stagger.ts
@@ -1,0 +1,41 @@
+/**
+ * [Issue #1050] List entrance stagger helpers.
+ *
+ * Combines tailwindcss-animate entrance classes with a per-item animation
+ * delay. `fill-mode-backwards` holds the hidden start frame only during the
+ * delay window and reverts to base styles once the entrance finishes, so a
+ * later `:hover` transform (e.g. interactive cards) is not clobbered by the
+ * animation's fill state.
+ *
+ * Re-render safety: the animation is bound to element mount. As long as list
+ * items keep stable React keys (their DOM nodes are reconciled, not remounted),
+ * a polling / WebSocket re-render does NOT restart the entrance animation.
+ */
+
+/** Entrance animation classes shared by staggered lists. */
+export const STAGGER_ENTER_CLASS =
+  'animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300';
+
+/** Delay between consecutive items, in milliseconds. */
+export const STAGGER_STEP_MS = 40;
+
+/** Only the first N items are staggered; the rest share a zero delay. */
+export const STAGGER_MAX_ITEMS = 10;
+
+/**
+ * Compute the `animation-delay` for a list item at `index`.
+ *
+ * Returns `undefined` (i.e. no delay / 0ms) for the first item and for items
+ * beyond {@link STAGGER_MAX_ITEMS}, so long lists don't accrue a large trailing
+ * delay.
+ */
+export function staggerDelay(
+  index: number,
+  stepMs: number = STAGGER_STEP_MS,
+  maxItems: number = STAGGER_MAX_ITEMS
+): string | undefined {
+  if (!Number.isFinite(index) || index <= 0 || index >= maxItems) {
+    return undefined;
+  }
+  return `${index * stepMs}ms`;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,5 +83,9 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography'),
+    // [Issue #1050] Micro-interaction utilities (animate-in/out, fade/zoom/slide,
+    // fill-mode, animation delay/duration) used by Modal, Radix data-state
+    // primitives, and list stagger. framer-motion intentionally not used.
+    require('tailwindcss-animate'),
   ],
 }

--- a/tests/unit/SessionsPage.test.tsx
+++ b/tests/unit/SessionsPage.test.tsx
@@ -338,6 +338,79 @@ describe('SessionsPage', () => {
     });
   });
 
+  describe('entrance stagger (Issue #1050)', () => {
+    it('applies stagger entrance classes with an incremental delay per item', () => {
+      mockWorktrees = [
+        createWorktree({ id: 'wt-1', lastUserMessageAt: '2026-04-03T10:00:00Z' }),
+        createWorktree({ id: 'wt-2', lastUserMessageAt: '2026-04-02T10:00:00Z' }),
+        createWorktree({ id: 'wt-3', lastUserMessageAt: '2026-04-01T10:00:00Z' }),
+      ];
+
+      render(<SessionsPage />);
+
+      const first = screen.getByTestId('session-item-wt-1');
+      const second = screen.getByTestId('session-item-wt-2');
+      const third = screen.getByTestId('session-item-wt-3');
+
+      // Entrance animation classes present on every item
+      expect(first.className).toContain('animate-in');
+      expect(first.className).toContain('fill-mode-backwards');
+
+      // First item: no delay; subsequent items: 40ms increments
+      expect(first.style.animationDelay).toBe('');
+      expect(second.style.animationDelay).toBe('40ms');
+      expect(third.style.animationDelay).toBe('80ms');
+    });
+
+    it('does NOT re-fire the entrance animation on a polling re-render (stable keys)', () => {
+      mockWorktrees = [
+        createWorktree({ id: 'wt-1', lastUserMessage: 'first', lastUserMessageAt: '2026-04-03T10:00:00Z' }),
+        createWorktree({ id: 'wt-2', lastUserMessage: 'second', lastUserMessageAt: '2026-04-02T10:00:00Z' }),
+      ];
+
+      const { rerender } = render(<SessionsPage />);
+      const before = screen.getByTestId('session-item-wt-1');
+
+      // Simulate a polling update: same worktree ids, changed payload.
+      mockWorktrees = [
+        createWorktree({ id: 'wt-1', lastUserMessage: 'first (updated)', lastUserMessageAt: '2026-04-03T10:05:00Z' }),
+        createWorktree({ id: 'wt-2', lastUserMessage: 'second', lastUserMessageAt: '2026-04-02T10:00:00Z' }),
+      ];
+      rerender(<SessionsPage />);
+      const after = screen.getByTestId('session-item-wt-1');
+
+      // Same DOM node is reused (not remounted) → CSS entrance animation cannot
+      // restart. This is the guard against animations re-firing on each poll.
+      expect(after).toBe(before);
+      expect(after.className).toContain('animate-in');
+    });
+
+    it('keeps the list mounted (no re-fire) through a transient polling error', () => {
+      mockWorktrees = [
+        createWorktree({ id: 'wt-1', lastUserMessageAt: '2026-04-03T10:00:00Z' }),
+      ];
+      const { rerender } = render(<SessionsPage />);
+      const before = screen.getByTestId('session-item-wt-1');
+      expect(screen.getByTestId('sessions-list')).toBeDefined();
+
+      // Transient poll failure (e.g. server rebuild): data still present, error set.
+      mockError = new Error('fetch failed');
+      rerender(<SessionsPage />);
+
+      // The list stays mounted with the SAME DOM node (animation cannot re-fire),
+      // and the error surfaces as a non-blocking banner rather than replacing it.
+      const during = screen.getByTestId('session-item-wt-1');
+      expect(during).toBe(before);
+      expect(screen.getByTestId('sessions-error-banner')).toBeDefined();
+      expect(screen.queryByTestId('sessions-error')).toBeNull();
+
+      // Recovery poll: error clears, list node still identical.
+      mockError = null;
+      rerender(<SessionsPage />);
+      expect(screen.getByTestId('session-item-wt-1')).toBe(before);
+    });
+  });
+
   describe('existing functionality preserved', () => {
     it('should filter by name or repository', () => {
       mockWorktrees = [

--- a/tests/unit/components/ui/Button.test.tsx
+++ b/tests/unit/components/ui/Button.test.tsx
@@ -72,6 +72,22 @@ describe('Button', () => {
     expect(btn.className).toContain('cursor-not-allowed');
   });
 
+  it('applies motion-safe hover-lift / active-press interaction classes when enabled (Issue #1050)', () => {
+    render(<Button>Go</Button>);
+    const cls = classesOf('Go');
+    // motion-safe: so the transform is suppressed under prefers-reduced-motion
+    expect(cls).toContain('motion-safe:hover:-translate-y-0.5');
+    expect(cls).toContain('motion-safe:active:translate-y-0');
+    // transition-all (not transition-colors) so transform animates
+    expect(cls).toContain('transition-all');
+  });
+
+  it('omits the hover-lift interaction when disabled (Issue #1050)', () => {
+    render(<Button disabled>off</Button>);
+    const cls = classesOf('off');
+    expect(cls).not.toContain('motion-safe:hover:-translate-y-0.5');
+  });
+
   it('shows a spinner and disables the button while loading', () => {
     render(<Button loading>loading</Button>);
     const btn = screen.getByRole('button', { name: 'loading' });

--- a/tests/unit/components/ui/Card.test.tsx
+++ b/tests/unit/components/ui/Card.test.tsx
@@ -36,6 +36,25 @@ describe('Card', () => {
     expect(screen.getByTestId('card').className).toContain('hover:shadow-md');
   });
 
+  it('adds motion-safe hover-lift / active-press classes when interactive is set (Issue #1050)', () => {
+    render(
+      <Card data-testid="card" interactive>
+        body
+      </Card>
+    );
+    const cls = screen.getByTestId('card').className;
+    // motion-safe: so the transform is suppressed under prefers-reduced-motion
+    expect(cls).toContain('motion-safe:hover:-translate-y-0.5');
+    expect(cls).toContain('hover:shadow-lg');
+    expect(cls).toContain('motion-safe:active:translate-y-0');
+    expect(cls).toContain('cursor-pointer');
+  });
+
+  it('stays flat (no lift) when interactive is not set', () => {
+    render(<Card data-testid="card">body</Card>);
+    expect(screen.getByTestId('card').className).not.toContain('translate-y-0.5');
+  });
+
   it.each([
     ['none', ''],
     ['sm', 'p-3'],

--- a/tests/unit/components/ui/DropdownMenu.test.tsx
+++ b/tests/unit/components/ui/DropdownMenu.test.tsx
@@ -100,4 +100,12 @@ describe('DropdownMenu', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByRole('menu')).toBeInTheDocument();
   });
+
+  it('applies Radix data-state enter/exit animation classes to the content (Issue #1050)', () => {
+    render(<Fixture defaultOpen />);
+    const cls = screen.getByRole('menu').className;
+    expect(cls).toContain('data-[state=open]:animate-in');
+    expect(cls).toContain('data-[state=closed]:animate-out');
+    expect(cls).toContain('data-[side=bottom]:slide-in-from-top-2');
+  });
 });

--- a/tests/unit/components/ui/Modal.test.tsx
+++ b/tests/unit/components/ui/Modal.test.tsx
@@ -9,6 +9,45 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { Modal } from '@/components/ui/Modal';
 
+// [Issue #1050] Motion foundation: data-state + enter animation.
+describe('Modal (Issue #1050 motion)', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = 'unset';
+  });
+
+  it('exposes data-state="open" and fade+scale enter classes on the panel when open', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Anim">
+        <p>content</p>
+      </Modal>
+    );
+    const panel = screen.getByTestId('modal-panel');
+    expect(panel).toHaveAttribute('data-state', 'open');
+    const cls = panel.className;
+    expect(cls).toContain('data-[state=open]:animate-in');
+    expect(cls).toContain('data-[state=open]:fade-in-0');
+    expect(cls).toContain('data-[state=open]:zoom-in-95');
+  });
+
+  it('transitions from an open panel to no panel when closed', () => {
+    const { rerender } = render(
+      <Modal isOpen onClose={() => {}} title="Anim">
+        <p>content</p>
+      </Modal>
+    );
+    expect(screen.getByTestId('modal-panel')).toHaveAttribute('data-state', 'open');
+
+    rerender(
+      <Modal isOpen={false} onClose={() => {}} title="Anim">
+        <p>content</p>
+      </Modal>
+    );
+    // Closed modals unmount, so the panel (and its data-state) is gone.
+    expect(screen.queryByTestId('modal-panel')).toBeNull();
+  });
+});
+
 afterEach(() => {
   cleanup();
   document.body.style.overflow = 'unset';

--- a/tests/unit/components/ui/Select.test.tsx
+++ b/tests/unit/components/ui/Select.test.tsx
@@ -116,4 +116,12 @@ describe('Select', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByRole('listbox')).toBeNull();
   });
+
+  it('applies Radix data-state enter/exit animation classes to the content (Issue #1050)', () => {
+    render(<Fixture defaultOpen />);
+    const cls = screen.getByRole('listbox').className;
+    expect(cls).toContain('data-[state=open]:animate-in');
+    expect(cls).toContain('data-[state=closed]:animate-out');
+    expect(cls).toContain('data-[side=bottom]:slide-in-from-top-2');
+  });
 });

--- a/tests/unit/components/ui/Tooltip.test.tsx
+++ b/tests/unit/components/ui/Tooltip.test.tsx
@@ -52,4 +52,20 @@ describe('Tooltip', () => {
     fireEvent.blur(trigger);
     expect(screen.queryByRole('tooltip')).toBeNull();
   });
+
+  it('applies an unconditional enter and a closed-gated exit to the content (Issue #1050)', () => {
+    render(<Fixture defaultOpen />);
+    // Radix's role="tooltip" is the visually-hidden a11y copy; the styled,
+    // visible content is the element carrying our base `bg-foreground` class.
+    const content = document.querySelector('.bg-foreground');
+    expect(content).not.toBeNull();
+    const cls = content!.className;
+    // Enter is unconditional so instant-open (not just delayed-open) animates.
+    expect(cls).toContain('animate-in');
+    expect(cls).toContain('fade-in-0');
+    expect(cls).toContain('zoom-in-95');
+    expect(cls).not.toContain('data-[state=delayed-open]:animate-in');
+    // Exit is gated on the closed state.
+    expect(cls).toContain('data-[state=closed]:animate-out');
+  });
 });

--- a/tests/unit/motion-foundation.test.ts
+++ b/tests/unit/motion-foundation.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Motion foundation tests (Issue #1050).
+ *
+ * Verifies the build-visible / static-file acceptance criteria:
+ * - tailwindcss-animate is registered as a Tailwind plugin
+ * - a prefers-reduced-motion rule exists in globals.css
+ * - the shared stagger helper caps and increments delays correctly
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  STAGGER_ENTER_CLASS,
+  STAGGER_MAX_ITEMS,
+  STAGGER_STEP_MS,
+  staggerDelay,
+} from '@/lib/utils/stagger';
+
+const root = process.cwd();
+
+function read(relative: string): string {
+  return readFileSync(path.join(root, relative), 'utf8');
+}
+
+describe('tailwindcss-animate registration', () => {
+  it('registers the plugin in tailwind.config.js', () => {
+    const config = read('tailwind.config.js');
+    expect(config).toContain('tailwindcss-animate');
+  });
+
+  it('lists tailwindcss-animate as a dependency in package.json', () => {
+    const pkg = JSON.parse(read('package.json')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const all = { ...pkg.dependencies, ...pkg.devDependencies };
+    expect(all['tailwindcss-animate']).toBeDefined();
+  });
+});
+
+describe('prefers-reduced-motion support', () => {
+  it('includes a reduce-motion media query in globals.css', () => {
+    const css = read('src/app/globals.css');
+    expect(css).toContain('prefers-reduced-motion: reduce');
+    // The blanket rule neutralizes animations and transitions.
+    expect(css).toMatch(/animation-duration:\s*0\.01ms\s*!important/);
+    expect(css).toMatch(/transition-duration:\s*0\.01ms\s*!important/);
+  });
+
+  it('defines motion duration tokens on :root', () => {
+    const css = read('src/app/globals.css');
+    expect(css).toContain('--motion-duration-base');
+    expect(css).toContain('--motion-ease-out');
+  });
+});
+
+describe('staggerDelay', () => {
+  it('returns no delay for the first item', () => {
+    expect(staggerDelay(0)).toBeUndefined();
+  });
+
+  it('increments by the step for subsequent items', () => {
+    expect(staggerDelay(1)).toBe(`${STAGGER_STEP_MS}ms`);
+    expect(staggerDelay(3)).toBe(`${3 * STAGGER_STEP_MS}ms`);
+  });
+
+  it('caps: items at or beyond the max get no delay', () => {
+    expect(staggerDelay(STAGGER_MAX_ITEMS)).toBeUndefined();
+    expect(staggerDelay(STAGGER_MAX_ITEMS + 5)).toBeUndefined();
+  });
+
+  it('is robust to non-finite / negative indices', () => {
+    expect(staggerDelay(-1)).toBeUndefined();
+    expect(staggerDelay(NaN)).toBeUndefined();
+  });
+
+  it('exposes entrance classes using fill-mode-backwards (hover-safe)', () => {
+    expect(STAGGER_ENTER_CLASS).toContain('animate-in');
+    expect(STAGGER_ENTER_CLASS).toContain('fill-mode-backwards');
+  });
+});


### PR DESCRIPTION
## 概要
UIモダン化 Phase 4 (#1040) の Issue #1050。`tailwindcss-animate` を導入し、
統一されたマイクロインタラクション(enter/exit・hover lift・stagger)を実装します。

## 変更点
- 依存: `tailwindcss-animate`(framer-motion は不採用/軽量方針)
- Modal / MobilePromptSheet の enter/exit、Radix data-state 連動(DropdownMenu/Select/Tooltip)
- 一覧の stagger(`src/lib/utils/stagger.ts`、sessions/home)、Button/Card の hover lift
- `prefers-reduced-motion(reduce)` で全モーション無効化
- **ターミナル出力・仮想スクロールには非適用**(TerminalDisplay 未変更)

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`(8618 passed): 全 pass
- **敵対的レビュー(3観点+検証, 9エージェント)**: 確定6件(全 low)を反映
  - reduced-motion で hover-lift の translate が漏れる → Button/Card を `motion-safe:` 化
  - sessions のエラー復帰で stagger 再発火 → list をマウント維持しエラーは非ブロッキングバナー(#266 SF-IMP-001 パターン)
  - Tooltip instant-open で enter が効かない → enter を無条件化、exit のみ data-[state=closed] ゲート
  - home ショートカットカードの focus parity → focus-visible ring 追加
  - (現状維持) Modal は enter-only、ContextMenu の animate-in 有効化は意図通り
- develop(#1049 マージ済)を取り込み、`Card.tsx`(variant×interactive を両立、interactive の translate も motion-safe 化)/ `sessions/page.tsx`(bg-surface + stagger)/ Card テストの競合を統合解決

## 関連
Closes #1050 / 親 #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
