### PR TITLE
feat: Home をダッシュボード(bentoグリッド)化 (#1052)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,107 +2,34 @@
  * Home Page (/)
  *
  * Issue #600: UX refresh - Mission Control / Inbox.
- * Provides session summary and shortcut cards to specialized screens.
+ * Issue #1052: Bento-grid dashboard — Session Overview + Recent sessions,
+ * ToDo, and compact quick actions arranged in a CSS grid on desktop and a
+ * single stacked column on mobile (Tailwind breakpoints, no useIsMobile JS
+ * branch). The welcome banner stays outside the grid at the top.
  *
- * Previously contained RepositoryManager, WorktreeList, ExternalAppsManager.
- * These have been moved to their respective dedicated pages:
- * - RepositoryManager -> /repositories
- * - WorktreeList -> /sessions
- * - ExternalAppsManager -> /more
+ * Session data is read from the shared worktrees cache
+ * (`useWorktreesCacheContext`) instead of a page-local fetch, keeping a single
+ * poller against `/api/worktrees` (Issue #709) and adding no new API.
  */
 
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import { AppShell } from '@/components/layout';
-import { Button, Card } from '@/components/ui';
-import { HomeSessionSummary } from '@/components/home/HomeSessionSummary';
+import { Button } from '@/components/ui';
+import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
+import { SessionOverviewTile } from '@/components/home/SessionOverviewTile';
 import { TodoWidget } from '@/components/home/TodoWidget';
-import { STAGGER_ENTER_CLASS, staggerDelay } from '@/lib/utils/stagger';
-import type { Worktree } from '@/types/models';
+import { HomeQuickActions } from '@/components/home/HomeQuickActions';
 
 /**
  * localStorage key for dismissing the welcome banner.
  */
 const BANNER_DISMISSED_KEY = 'commandmate-home-banner-dismissed';
 
-/**
- * Shortcut card data for navigation.
- */
-const SHORTCUT_CARDS = [
-  {
-    title: 'Chat',
-    description: 'Talk to a local CLI assistant scoped to a repository',
-    href: '/chat',
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Sessions',
-    description: 'View and manage all worktree sessions',
-    href: '/sessions',
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Repositories',
-    description: 'Manage repositories and worktrees',
-    href: '/repositories',
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Review',
-    description: 'Review done, approval, and stalled sessions',
-    href: '/review',
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-      </svg>
-    ),
-  },
-  {
-    title: 'More',
-    description: 'Settings, external apps, and help',
-    href: '/more',
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
-    ),
-  },
-];
-
 export default function Home() {
-  const [worktrees, setWorktrees] = useState<Worktree[]>([]);
+  const { worktrees } = useWorktreesCacheContext();
   const [bannerDismissed, setBannerDismissed] = useState(true);
-
-  // Load worktrees for session summary
-  useEffect(() => {
-    async function fetchWorktrees() {
-      try {
-        const response = await fetch('/api/worktrees');
-        if (response.ok) {
-          const data = await response.json();
-          setWorktrees(data.worktrees ?? []);
-        }
-      } catch {
-        // Silently handle fetch errors on home page
-      }
-    }
-    fetchWorktrees();
-  }, []);
 
   // Check banner dismissed state
   useEffect(() => {
@@ -122,7 +49,7 @@ export default function Home() {
   return (
     <AppShell>
       <div className="container-custom py-8 overflow-auto h-full">
-        {/* Welcome banner (dismissible) */}
+        {/* Welcome banner (dismissible) — kept outside the bento grid */}
         {!bannerDismissed && (
           <div
             data-testid="welcome-banner"
@@ -157,41 +84,23 @@ export default function Home() {
           </p>
         </div>
 
-        {/* Session Summary */}
-        <div className="mb-8">
-          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">Session Overview</h2>
-          <HomeSessionSummary worktrees={worktrees} />
-        </div>
+        {/* Bento grid: 12-col on desktop, single stacked column on mobile.
+            DOM order (mobile stack): Session Overview → ToDo → Quick actions. */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-12" data-testid="home-bento-grid">
+          {/* Session Overview + Recent sessions — large tile */}
+          <div className="md:col-span-8">
+            <SessionOverviewTile worktrees={worktrees} />
+          </div>
 
-        {/* ToDo */}
-        <div className="mb-8">
-          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">ToDo</h2>
-          <TodoWidget />
-        </div>
+          {/* ToDo — medium tile */}
+          <div className="md:col-span-4">
+            <TodoWidget />
+          </div>
 
-        {/* Shortcut Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-          {SHORTCUT_CARDS.map((card, index) => (
-            <Link
-              key={card.href}
-              href={card.href}
-              className="group block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              data-testid={`shortcut-${card.title.toLowerCase()}`}
-            >
-              <Card
-                interactive
-                padding="lg"
-                style={{ animationDelay: staggerDelay(index) }}
-                className={`h-full hover:border-accent-300 dark:hover:border-accent-700 motion-safe:group-focus-visible:-translate-y-0.5 ${STAGGER_ENTER_CLASS}`}
-              >
-                <div className="text-gray-400 dark:text-gray-500 group-hover:text-accent-600 dark:group-hover:text-accent-400 transition-colors mb-3">
-                  {card.icon}
-                </div>
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">{card.title}</h3>
-                <p className="text-xs text-gray-500 dark:text-gray-400">{card.description}</p>
-              </Card>
-            </Link>
-          ))}
+          {/* Quick actions — compact icon row spanning the full width */}
+          <div className="md:col-span-12">
+            <HomeQuickActions />
+          </div>
         </div>
       </div>
     </AppShell>

--- a/src/components/home/HomeQuickActions.tsx
+++ b/src/components/home/HomeQuickActions.tsx
@@ -1,0 +1,102 @@
+/**
+ * HomeQuickActions Component
+ *
+ * Issue #1052: Home bento grid — compact quick-action tiles (Chat / Sessions /
+ * Repositories / Review / More) shrunk into an icon-forward row. Replaces the
+ * previous full-width shortcut cards with descriptions.
+ */
+
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui';
+import { STAGGER_ENTER_CLASS, staggerDelay } from '@/lib/utils/stagger';
+
+interface QuickAction {
+  title: string;
+  href: string;
+  icon: React.ReactNode;
+}
+
+const QUICK_ACTIONS: QuickAction[] = [
+  {
+    title: 'Chat',
+    href: '/chat',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Sessions',
+    href: '/sessions',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Repositories',
+    href: '/repositories',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Review',
+    href: '/review',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'More',
+    href: '/more',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+  },
+];
+
+export function HomeQuickActions() {
+  return (
+    <div
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5"
+      data-testid="home-quick-actions"
+    >
+      {QUICK_ACTIONS.map((action, index) => (
+        <Link
+          key={action.href}
+          href={action.href}
+          aria-label={action.title}
+          className="group block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          data-testid={`quick-action-${action.title.toLowerCase()}`}
+        >
+          <Card
+            interactive
+            padding="sm"
+            style={{ animationDelay: staggerDelay(index) }}
+            className={`flex h-full flex-col items-center justify-center gap-1.5 py-3 text-center hover:border-accent-300 dark:hover:border-accent-700 ${STAGGER_ENTER_CLASS}`}
+          >
+            <span className="text-gray-400 dark:text-gray-500 group-hover:text-accent-600 dark:group-hover:text-accent-400 transition-colors">
+              {action.icon}
+            </span>
+            <span className="text-xs font-medium text-gray-900 dark:text-gray-100">
+              {action.title}
+            </span>
+          </Card>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/home/HomeSessionSummary.tsx
+++ b/src/components/home/HomeSessionSummary.tsx
@@ -2,7 +2,9 @@
  * HomeSessionSummary Component
  *
  * Issue #600: UX refresh - Running/Waiting session count display for Home screen.
- * Client-side aggregate from worktrees API response.
+ * Issue #1052: Rendered as compact inline stats inside the Session Overview
+ * bento tile (no longer a standalone 2-card grid). Client-side aggregate from
+ * worktrees API response.
  *
  * Security [DR4-005]: Counts are for display only, not access control.
  */
@@ -10,7 +12,6 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { Card } from '@/components/ui';
 import type { Worktree } from '@/types/models';
 
 export interface HomeSessionSummaryProps {
@@ -19,7 +20,7 @@ export interface HomeSessionSummaryProps {
 }
 
 /**
- * Displays Running and Waiting session counts.
+ * Displays Running and Waiting session counts as compact inline stats.
  */
 export function HomeSessionSummary({ worktrees }: HomeSessionSummaryProps) {
   const { runningCount, waitingCount } = useMemo(() => {
@@ -37,19 +38,19 @@ export function HomeSessionSummary({ worktrees }: HomeSessionSummaryProps) {
   }, [worktrees]);
 
   return (
-    <div className="grid grid-cols-2 gap-4" data-testid="home-session-summary">
-      <Card>
-        <div className="text-sm text-gray-500 dark:text-gray-400">Running</div>
+    <div className="grid grid-cols-2 gap-3" data-testid="home-session-summary">
+      <div className="rounded-lg border border-border bg-surface-2 px-3 py-2">
+        <div className="text-xs text-gray-500 dark:text-gray-400">Running</div>
         <div className="text-2xl font-bold text-green-600 dark:text-green-400" data-testid="running-count">
           {runningCount}
         </div>
-      </Card>
-      <Card>
-        <div className="text-sm text-gray-500 dark:text-gray-400">Waiting</div>
+      </div>
+      <div className="rounded-lg border border-border bg-surface-2 px-3 py-2">
+        <div className="text-xs text-gray-500 dark:text-gray-400">Waiting</div>
         <div className="text-2xl font-bold text-amber-600 dark:text-amber-400" data-testid="waiting-count">
           {waitingCount}
         </div>
-      </Card>
+      </div>
     </div>
   );
 }

--- a/src/components/home/RecentSessionsList.tsx
+++ b/src/components/home/RecentSessionsList.tsx
@@ -1,0 +1,94 @@
+/**
+ * RecentSessionsList Component
+ *
+ * Issue #1052: Home bento grid — "Recent sessions" tile content.
+ * Renders the most recently active worktrees (top N by recency) as links to
+ * their detail page. Reuses the shared worktrees data (no new API); recency is
+ * derived from `lastUserMessageAt` with a fallback to `updatedAt`.
+ */
+
+'use client';
+
+import React, { useMemo } from 'react';
+import Link from 'next/link';
+import { compareByTimestamp } from '@/lib/sidebar-utils';
+import { formatRelativeTime } from '@/lib/date-utils';
+import type { Worktree } from '@/types/models';
+
+export interface RecentSessionsListProps {
+  /** Worktrees to pick the most recent sessions from */
+  worktrees: Worktree[];
+  /** Max number of sessions to show (default 5) */
+  limit?: number;
+}
+
+/** Recency signal for a worktree: last user message, falling back to update time. */
+function recencyOf(wt: Worktree): Date | string | undefined {
+  return wt.lastUserMessageAt ?? wt.updatedAt;
+}
+
+/** Small status dot reflecting whether the session is active/waiting. */
+function statusDotClass(wt: Worktree): string {
+  if (wt.isWaitingForResponse) {
+    return 'bg-amber-500 dark:bg-amber-400';
+  }
+  if (wt.isSessionRunning) {
+    return 'bg-green-500 dark:bg-green-400';
+  }
+  return 'bg-gray-300 dark:bg-gray-600';
+}
+
+export function RecentSessionsList({ worktrees, limit = 5 }: RecentSessionsListProps) {
+  const recent = useMemo(() => {
+    return [...worktrees]
+      .sort((a, b) => compareByTimestamp(recencyOf(a), recencyOf(b)))
+      .slice(0, limit);
+  }, [worktrees, limit]);
+
+  if (recent.length === 0) {
+    return (
+      <p
+        className="text-sm text-gray-500 dark:text-gray-400"
+        data-testid="recent-sessions-empty"
+      >
+        No recent sessions yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-1" data-testid="recent-sessions">
+      {recent.map((wt) => {
+        const recency = recencyOf(wt);
+        const relativeTime = recency ? formatRelativeTime(String(recency)) : '';
+        return (
+          <li key={wt.id}>
+            <Link
+              href={`/worktrees/${wt.id}`}
+              data-testid={`recent-session-${wt.id}`}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span
+                className={`h-2 w-2 shrink-0 rounded-full ${statusDotClass(wt)}`}
+                aria-hidden="true"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {wt.repositoryDisplayName ?? wt.repositoryName}
+                </span>
+                <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+                  {wt.name}
+                </span>
+              </span>
+              {relativeTime && (
+                <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+                  {relativeTime}
+                </span>
+              )}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/home/SessionOverviewTile.tsx
+++ b/src/components/home/SessionOverviewTile.tsx
@@ -1,0 +1,49 @@
+/**
+ * SessionOverviewTile Component
+ *
+ * Issue #1052: Home bento grid — large "Session Overview" tile combining the
+ * Running/Waiting counts with a list of the most recent sessions. Pure display
+ * component: worktrees are passed in from the shared cache (no new API).
+ */
+
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui';
+import { HomeSessionSummary } from '@/components/home/HomeSessionSummary';
+import { RecentSessionsList } from '@/components/home/RecentSessionsList';
+import type { Worktree } from '@/types/models';
+
+export interface SessionOverviewTileProps {
+  /** Worktrees to render counts and recent sessions from */
+  worktrees: Worktree[];
+}
+
+export function SessionOverviewTile({ worktrees }: SessionOverviewTileProps) {
+  return (
+    <Card variant="elevated" className="h-full" data-testid="session-overview-tile">
+      <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+        Session Overview
+      </h2>
+
+      <HomeSessionSummary worktrees={worktrees} />
+
+      <div className="mt-4 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Recent sessions
+        </h3>
+        <Link
+          href="/sessions"
+          className="text-xs text-accent-600 hover:underline dark:text-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+          data-testid="session-overview-view-all"
+        >
+          View all
+        </Link>
+      </div>
+      <div className="mt-2">
+        <RecentSessionsList worktrees={worktrees} />
+      </div>
+    </Card>
+  );
+}

--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -184,7 +184,12 @@ export function TodoWidget() {
   const hasRepositories = repositories.length > 0;
 
   return (
-    <Card data-testid="home-todo-widget">
+    <Card className="h-full" data-testid="home-todo-widget">
+      {/* Tile heading — parity with the Session Overview tile (Issue #1052). */}
+      <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+        ToDo
+      </h2>
+
       {/* Repository selector + remaining count.
           Mobile: stack vertically so the select can use the full width; the
           `N open` count drops to its own line. Desktop (>= sm): unchanged

--- a/tests/unit/components/home/HomeQuickActions.test.tsx
+++ b/tests/unit/components/home/HomeQuickActions.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for HomeQuickActions (Issue #1052).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { HomeQuickActions } from '@/components/home/HomeQuickActions';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('HomeQuickActions', () => {
+  it('renders all five quick actions', () => {
+    render(<HomeQuickActions />);
+    expect(screen.getByTestId('home-quick-actions')).toBeDefined();
+    for (const key of ['chat', 'sessions', 'repositories', 'review', 'more']) {
+      expect(screen.getByTestId(`quick-action-${key}`)).toBeDefined();
+    }
+  });
+
+  it('points each action to the correct route', () => {
+    render(<HomeQuickActions />);
+    const expected: Record<string, string> = {
+      chat: '/chat',
+      sessions: '/sessions',
+      repositories: '/repositories',
+      review: '/review',
+      more: '/more',
+    };
+    for (const [key, href] of Object.entries(expected)) {
+      expect(screen.getByTestId(`quick-action-${key}`).getAttribute('href')).toBe(href);
+    }
+  });
+});

--- a/tests/unit/components/home/RecentSessionsList.test.tsx
+++ b/tests/unit/components/home/RecentSessionsList.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for RecentSessionsList (Issue #1052).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { RecentSessionsList } from '@/components/home/RecentSessionsList';
+import type { Worktree } from '@/types/models';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+function createMockWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'test-id',
+    name: 'test',
+    path: '/test',
+    repositoryPath: '/repo',
+    repositoryName: 'TestRepo',
+    ...overrides,
+  };
+}
+
+describe('RecentSessionsList', () => {
+  it('renders empty state when there are no worktrees', () => {
+    render(<RecentSessionsList worktrees={[]} />);
+    expect(screen.getByTestId('recent-sessions-empty')).toBeDefined();
+    expect(screen.queryByTestId('recent-sessions')).toBeNull();
+  });
+
+  it('links each recent session to its worktree detail page', () => {
+    const worktrees = [
+      createMockWorktree({ id: 'wt-1', name: 'feature/a' }),
+      createMockWorktree({ id: 'wt-2', name: 'feature/b' }),
+    ];
+    render(<RecentSessionsList worktrees={worktrees} />);
+    const link1 = screen.getByTestId('recent-session-wt-1');
+    const link2 = screen.getByTestId('recent-session-wt-2');
+    expect(link1.getAttribute('href')).toBe('/worktrees/wt-1');
+    expect(link2.getAttribute('href')).toBe('/worktrees/wt-2');
+  });
+
+  it('sorts by recency (newest first) using lastUserMessageAt', () => {
+    const worktrees = [
+      createMockWorktree({ id: 'old', lastUserMessageAt: new Date('2026-01-01T00:00:00Z') }),
+      createMockWorktree({ id: 'new', lastUserMessageAt: new Date('2026-06-01T00:00:00Z') }),
+      createMockWorktree({ id: 'mid', lastUserMessageAt: new Date('2026-03-01T00:00:00Z') }),
+    ];
+    render(<RecentSessionsList worktrees={worktrees} />);
+    const items = screen.getAllByTestId(/^recent-session-/);
+    expect(items.map((el) => el.getAttribute('href'))).toEqual([
+      '/worktrees/new',
+      '/worktrees/mid',
+      '/worktrees/old',
+    ]);
+  });
+
+  it('caps the number of sessions to the given limit', () => {
+    const worktrees = Array.from({ length: 8 }, (_, i) =>
+      createMockWorktree({ id: `wt-${i}`, lastUserMessageAt: new Date(2026, 0, i + 1) }),
+    );
+    render(<RecentSessionsList worktrees={worktrees} limit={3} />);
+    expect(screen.getAllByTestId(/^recent-session-/)).toHaveLength(3);
+  });
+
+  it('defaults the limit to 5', () => {
+    const worktrees = Array.from({ length: 8 }, (_, i) =>
+      createMockWorktree({ id: `wt-${i}`, lastUserMessageAt: new Date(2026, 0, i + 1) }),
+    );
+    render(<RecentSessionsList worktrees={worktrees} />);
+    expect(screen.getAllByTestId(/^recent-session-/)).toHaveLength(5);
+  });
+});

--- a/tests/unit/components/home/SessionOverviewTile.test.tsx
+++ b/tests/unit/components/home/SessionOverviewTile.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for SessionOverviewTile (Issue #1052).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { SessionOverviewTile } from '@/components/home/SessionOverviewTile';
+import type { Worktree } from '@/types/models';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+function createMockWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'test-id',
+    name: 'test',
+    path: '/test',
+    repositoryPath: '/repo',
+    repositoryName: 'TestRepo',
+    ...overrides,
+  };
+}
+
+describe('SessionOverviewTile', () => {
+  it('renders the tile with running/waiting counts', () => {
+    const worktrees = [
+      createMockWorktree({ id: '1', isSessionRunning: true, isWaitingForResponse: true }),
+      createMockWorktree({ id: '2', isSessionRunning: true, isWaitingForResponse: false }),
+    ];
+    render(<SessionOverviewTile worktrees={worktrees} />);
+    expect(screen.getByTestId('session-overview-tile')).toBeDefined();
+    expect(screen.getByTestId('running-count').textContent).toBe('2');
+    expect(screen.getByTestId('waiting-count').textContent).toBe('1');
+  });
+
+  it('renders the recent sessions list with links', () => {
+    const worktrees = [createMockWorktree({ id: 'wt-1' })];
+    render(<SessionOverviewTile worktrees={worktrees} />);
+    expect(screen.getByTestId('recent-session-wt-1').getAttribute('href')).toBe('/worktrees/wt-1');
+  });
+
+  it('shows an empty state and zero counts when there are no sessions', () => {
+    render(<SessionOverviewTile worktrees={[]} />);
+    expect(screen.getByTestId('running-count').textContent).toBe('0');
+    expect(screen.getByTestId('waiting-count').textContent).toBe('0');
+    expect(screen.getByTestId('recent-sessions-empty')).toBeDefined();
+  });
+
+  it('links "View all" to the sessions page', () => {
+    render(<SessionOverviewTile worktrees={[]} />);
+    expect(screen.getByTestId('session-overview-view-all').getAttribute('href')).toBe('/sessions');
+  });
+});


### PR DESCRIPTION
## 概要
UIモダン化 Phase 4 (#1040) の Issue #1052。Home を縦積みから **bento グリッド**へ再構成し、
「エージェントCLIのコントロールプレーン」らしいダッシュボードにします。

## 変更点
- `src/app/page.tsx`: 12カラム CSS Grid で bento 配置。モバイルは1カラム縦積み(Session Overview → ToDo → クイックアクション)
- 新規タイル: `SessionOverviewTile`(Running/Waiting + 直近セッション)/ `RecentSessionsList` / `HomeQuickActions`
- `HomeSessionSummary` を統計タイルへ調整
- **新規 API なし**(既存 sessions フック/API を再利用)、既存機能(ToDo/カウント)維持、空状態対応

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`: 全 pass
- **敵対的レビュー(3観点+検証, 7エージェント)**: 確定3件(全 low)を反映
  - TodoWidget Card に `h-full`(空状態でタイル底を揃える)/ ToDo タイルに見出しを追加(Session Overview とパリティ)
  - (コールドロード時の一瞬の空表示は既存挙動のため対象外)

## 関連
Closes #1052 / 親 #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
