### PR TITLE
feat: コマンドパレット(⌘K)を追加 (#1053)

### DIFF
--- a/locales/en/commandPalette.json
+++ b/locales/en/commandPalette.json
@@ -1,0 +1,26 @@
+{
+  "title": "Command palette",
+  "placeholder": "Type a command or search...",
+  "empty": "No results found.",
+  "loading": "Loading worktrees...",
+  "groups": {
+    "navigation": "Navigation",
+    "worktrees": "Worktrees",
+    "actions": "Actions"
+  },
+  "nav": {
+    "home": "Home",
+    "chat": "Chat",
+    "sessions": "Sessions",
+    "repositories": "Repositories",
+    "review": "Review",
+    "more": "More"
+  },
+  "actions": {
+    "toLight": "Switch to light theme",
+    "toDark": "Switch to dark theme",
+    "displaySizePrefix": "Display size"
+  },
+  "mobileTrigger": "Open command palette",
+  "mobileLabel": "Search"
+}

--- a/locales/ja/commandPalette.json
+++ b/locales/ja/commandPalette.json
@@ -1,0 +1,26 @@
+{
+  "title": "コマンドパレット",
+  "placeholder": "コマンドを入力または検索...",
+  "empty": "該当する項目がありません。",
+  "loading": "ワークツリーを読み込み中...",
+  "groups": {
+    "navigation": "ナビゲーション",
+    "worktrees": "ワークツリー",
+    "actions": "アクション"
+  },
+  "nav": {
+    "home": "ホーム",
+    "chat": "チャット",
+    "sessions": "セッション",
+    "repositories": "リポジトリ",
+    "review": "レビュー",
+    "more": "その他"
+  },
+  "actions": {
+    "toLight": "ライトテーマに切り替え",
+    "toDark": "ダークテーマに切り替え",
+    "displaySizePrefix": "表示サイズ"
+  },
+  "mobileTrigger": "コマンドパレットを開く",
+  "mobileLabel": "検索"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "better-sqlite3": "^12.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "commander": "^14.0.2",
         "croner": "^10.0.1",
         "date-fns": "^4.1.0",
@@ -2302,6 +2303,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -5711,6 +5748,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "better-sqlite3": "^12.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "commander": "^14.0.2",
     "croner": "^10.0.1",
     "date-fns": "^4.1.0",

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -1,0 +1,309 @@
+/**
+ * CommandPalette (Issue #1053)
+ *
+ * A global ⌘K / Ctrl+K command palette (cmdk) mounted once under AppShell.
+ * Provides three command groups:
+ *   - Navigation: jump to the main screens.
+ *   - Worktrees: incremental search over repository + branch, read from the
+ *     shared WorktreesCache (always fresh + auto-retried, single poller per
+ *     Issue #709); the group is omitted while the cache reports an error.
+ *   - Actions: theme toggle and PC display-size switching.
+ *
+ * The single global keyboard listener lives here so it does not conflict with
+ * existing per-view shortcuts. It never opens while the user is typing in an
+ * input/textarea/contentEditable or the worktree terminal pane (role="log").
+ *
+ * SSR-safe: 'use client', and `document` is only referenced after mount inside
+ * an effect / the portal (which renders only when `mounted && open`).
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useTheme } from 'next-themes';
+import { Command } from 'cmdk';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import { Z_INDEX } from '@/config/z-index';
+import { useCommandPalette } from '@/contexts/CommandPaletteContext';
+import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
+import { useOptionalWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
+import { PC_DISPLAY_SIZE_ORDER } from '@/hooks/usePcDisplaySize';
+
+/** Navigation targets shown in the palette (mirrors Header / GlobalMobileNav). */
+const NAV_ITEMS = [
+  { key: 'home', href: '/' },
+  { key: 'chat', href: '/chat' },
+  { key: 'sessions', href: '/sessions' },
+  { key: 'repositories', href: '/repositories' },
+  { key: 'review', href: '/review' },
+  { key: 'more', href: '/more' },
+] as const;
+
+/**
+ * Whether a keyboard event target is a text-entry context where ⌘K must NOT
+ * hijack the keystroke: form fields, contentEditable, or the terminal output
+ * pane (a focusable `role="log"` div that captures keystrokes).
+ *
+ * Exported for unit testing.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  // Worktree terminal output pane captures keystrokes while focused.
+  if (target.closest('[role="log"]')) return true;
+  return false;
+}
+
+const ITEM_CLASS = cn(
+  'flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm',
+  'text-gray-700 dark:text-gray-200',
+  'data-[selected=true]:bg-accent-600/10 data-[selected=true]:text-accent-700',
+  'dark:data-[selected=true]:text-accent-300'
+);
+
+/**
+ * Global command palette. Renders nothing until opened.
+ */
+export function CommandPalette() {
+  const { open, setOpen } = useCommandPalette();
+  const router = useRouter();
+  const t = useTranslations('commandPalette');
+  const tCommon = useTranslations('common');
+  const { theme, setTheme } = useTheme();
+  const { setSize, isMobile } = usePcDisplaySizeContext();
+  // Read from the shared worktrees cache (always fresh + auto-retried). Optional
+  // so the palette degrades gracefully when no provider is present (unit tests).
+  const worktreesCache = useOptionalWorktreesCacheContext();
+
+  const [mounted, setMounted] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Element focused before the palette opened, restored on close (a11y).
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Keep the latest open state readable from the stable keyboard listener.
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  // Only reference `document` after mount (SSR safety).
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Single global keyboard listener: ⌘K / Ctrl+K toggles, Escape closes.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const isToggle =
+        (event.key === 'k' || event.key === 'K') &&
+        (event.metaKey || event.ctrlKey);
+
+      if (isToggle) {
+        // When open, ⌘K always closes (even from the palette's own input).
+        if (openRef.current) {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen(false);
+          return;
+        }
+        // When closed, do not steal the keystroke from a text-entry context.
+        if (isTypingTarget(event.target)) return;
+        event.preventDefault();
+        setOpen(true);
+        return;
+      }
+
+      // While open, swallow Escape so nested overlays don't also react to it.
+      if (event.key === 'Escape' && openRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(false);
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [setOpen]);
+
+  // Move focus into the search input on open (so type-to-filter / arrows /
+  // Enter work immediately without a click); restore focus to the previously
+  // focused element on close.
+  useEffect(() => {
+    if (open) {
+      previouslyFocusedRef.current =
+        (document.activeElement as HTMLElement | null) ?? null;
+      inputRef.current?.focus();
+    } else if (previouslyFocusedRef.current) {
+      previouslyFocusedRef.current.focus?.();
+      previouslyFocusedRef.current = null;
+    }
+  }, [open]);
+
+  // Reset the query each time the palette opens.
+  useEffect(() => {
+    if (open) setSearch('');
+  }, [open]);
+
+  const runCommand = useCallback(
+    (action: () => void) => {
+      setOpen(false);
+      action();
+    },
+    [setOpen]
+  );
+
+  if (!mounted || !open) return null;
+
+  const isDark = theme === 'dark';
+  const worktrees = worktreesCache?.worktrees ?? [];
+  const worktreesError = worktreesCache?.error ?? null;
+  const worktreesLoading = worktreesCache?.isLoading ?? false;
+  // On error, fall back to Navigation-only (the cache keeps polling and will
+  // repopulate the group once a later poll succeeds).
+  const showWorktrees = !worktreesError && worktrees.length > 0;
+  const showWorktreesLoading =
+    !worktreesError && worktreesLoading && worktrees.length === 0;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 overflow-y-auto"
+      style={{ zIndex: Z_INDEX.MODAL }}
+      data-testid="command-palette"
+    >
+      {/* Backdrop — fade-in on mount (shared motion tokens, Issue #1050). */}
+      <div
+        data-state="open"
+        aria-hidden="true"
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-200"
+        onClick={() => setOpen(false)}
+      />
+
+      <div className="relative flex min-h-full items-start justify-center p-4 pt-[15vh]">
+        <div
+          data-state="open"
+          data-testid="command-palette-panel"
+          className={cn(
+            'relative w-full max-w-lg overflow-hidden rounded-lg border border-border bg-white shadow-xl dark:bg-gray-900',
+            'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:duration-200'
+          )}
+        >
+          <Command
+            label={t('title')}
+            className={cn(
+              'flex flex-col',
+              '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-2',
+              '[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-gray-500'
+            )}
+          >
+            <div className="flex items-center gap-2 border-b border-border px-3">
+              <Search size={16} strokeWidth={2} aria-hidden="true" className="shrink-0 text-gray-400" />
+              <Command.Input
+                ref={inputRef}
+                value={search}
+                onValueChange={setSearch}
+                placeholder={t('placeholder')}
+                data-testid="command-palette-input"
+                className="flex-1 bg-transparent py-3 text-sm text-gray-900 outline-none placeholder:text-gray-400 dark:text-gray-100"
+              />
+            </div>
+
+            <Command.List className="max-h-[min(60vh,360px)] overflow-y-auto p-2">
+              <Command.Empty
+                data-testid="command-palette-empty"
+                className="py-6 text-center text-sm text-gray-500"
+              >
+                {t('empty')}
+              </Command.Empty>
+
+              {showWorktreesLoading && (
+                <Command.Loading
+                  data-testid="command-palette-loading"
+                  className="py-6 text-center text-sm text-gray-500"
+                >
+                  {t('loading')}
+                </Command.Loading>
+              )}
+
+              <Command.Group heading={t('groups.navigation')}>
+                {NAV_ITEMS.map((item) => {
+                  const label = t(`nav.${item.key}`);
+                  return (
+                    <Command.Item
+                      key={item.key}
+                      value={`nav ${label} ${item.href}`}
+                      onSelect={() => runCommand(() => router.push(item.href))}
+                      className={ITEM_CLASS}
+                    >
+                      {label}
+                    </Command.Item>
+                  );
+                })}
+              </Command.Group>
+
+              {showWorktrees && (
+                <Command.Group heading={t('groups.worktrees')}>
+                  {worktrees.map((wt) => {
+                    const repo = wt.repositoryDisplayName || wt.repositoryName || '';
+                    const branch = wt.branch || wt.name;
+                    return (
+                      <Command.Item
+                        key={wt.id}
+                        value={`worktree ${repo} ${branch} ${wt.name} ${wt.id}`}
+                        onSelect={() =>
+                          runCommand(() => router.push(`/worktrees/${wt.id}`))
+                        }
+                        className={ITEM_CLASS}
+                      >
+                        <span className="truncate">{branch}</span>
+                        {repo && (
+                          <span className="ml-auto truncate pl-2 text-xs text-gray-400">
+                            {repo}
+                          </span>
+                        )}
+                      </Command.Item>
+                    );
+                  })}
+                </Command.Group>
+              )}
+
+              <Command.Group heading={t('groups.actions')}>
+                <Command.Item
+                  value={`action theme ${isDark ? 'light' : 'dark'}`}
+                  onSelect={() =>
+                    runCommand(() => setTheme(isDark ? 'light' : 'dark'))
+                  }
+                  className={ITEM_CLASS}
+                >
+                  {isDark ? t('actions.toLight') : t('actions.toDark')}
+                </Command.Item>
+
+                {!isMobile &&
+                  PC_DISPLAY_SIZE_ORDER.map((size) => (
+                    <Command.Item
+                      key={size}
+                      value={`action displaysize ${size} ${tCommon(`displaySize.${size}`)}`}
+                      onSelect={() => runCommand(() => setSize(size))}
+                      className={ITEM_CLASS}
+                    >
+                      {t('actions.displaySizePrefix')}: {tCommon(`displaySize.${size}`)}
+                    </Command.Item>
+                  ))}
+              </Command.Group>
+            </Command.List>
+          </Command>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default CommandPalette;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -18,6 +18,7 @@ import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
+import { CommandPalette } from '@/components/common/CommandPalette';
 import { Z_INDEX } from '@/config/z-index';
 
 // ============================================================================
@@ -130,6 +131,9 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
 
         {/* Global mobile nav (bottom tab bar) */}
         {showGlobalNav && <GlobalMobileNav />}
+
+        {/* Global command palette (⌘K / Ctrl+K) - single instance (Issue #1053) */}
+        <CommandPalette />
       </div>
     );
   }
@@ -180,6 +184,9 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
           {children}
         </main>
       </div>
+
+      {/* Global command palette (⌘K / Ctrl+K) - single instance (Issue #1053) */}
+      <CommandPalette />
     </div>
   );
 });

--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -13,7 +13,9 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, MessageSquare, AlignJustify, CircleCheck, MoreHorizontal } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Home, MessageSquare, AlignJustify, CircleCheck, MoreHorizontal, Search } from 'lucide-react';
+import { useCommandPalette } from '@/contexts/CommandPaletteContext';
 
 /**
  * Mobile navigation tab definition.
@@ -43,6 +45,8 @@ const MOBILE_NAV_TABS: MobileNavTab[] = [
  */
 export function GlobalMobileNav() {
   const pathname = usePathname();
+  const { setOpen } = useCommandPalette();
+  const t = useTranslations('commandPalette');
 
   return (
     <nav
@@ -67,6 +71,18 @@ export function GlobalMobileNav() {
             </Link>
           );
         })}
+
+        {/* Command palette trigger (Issue #1053) */}
+        <button
+          type="button"
+          data-testid="mobile-command-palette-trigger"
+          onClick={() => setOpen(true)}
+          aria-label={t('mobileTrigger')}
+          className="flex flex-col items-center justify-center flex-1 h-full text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+        >
+          <Search size={20} aria-hidden="true" />
+          <span className="mt-1">{t('mobileLabel')}</span>
+        </button>
       </div>
     </nav>
   );

--- a/src/components/providers/AppProviders.tsx
+++ b/src/components/providers/AppProviders.tsx
@@ -16,6 +16,7 @@ import { ThemeProvider } from 'next-themes';
 import { SidebarProvider } from '@/contexts/SidebarContext';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { PcDisplaySizeProvider } from '@/contexts/PcDisplaySizeContext';
+import { CommandPaletteProvider } from '@/contexts/CommandPaletteContext';
 import { WorktreesCacheProvider } from '@/components/providers/WorktreesCacheProvider';
 
 interface AppProvidersProps {
@@ -44,7 +45,9 @@ export function AppProviders({ children, locale, messages, timeZone, authEnabled
           <PcDisplaySizeProvider>
             <SidebarProvider>
               <WorktreesCacheProvider>
-                {children}
+                <CommandPaletteProvider>
+                  {children}
+                </CommandPaletteProvider>
               </WorktreesCacheProvider>
             </SidebarProvider>
           </PcDisplaySizeProvider>

--- a/src/contexts/CommandPaletteContext.tsx
+++ b/src/contexts/CommandPaletteContext.tsx
@@ -1,0 +1,67 @@
+/**
+ * CommandPaletteContext (Issue #1053)
+ *
+ * Shares the open/closed state of the global command palette (⌘K / Ctrl+K) so
+ * that a single palette instance (mounted in AppShell) can be opened both by the
+ * global keyboard shortcut and by the mobile bottom-nav trigger.
+ *
+ * The context has a non-throwing default so components remain usable without an
+ * explicit provider (e.g. isolated unit tests) — matching PcDisplaySizeContext.
+ */
+
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/** Context value for the command palette open state. */
+export interface CommandPaletteContextValue {
+  /** Whether the palette is currently open. */
+  open: boolean;
+  /** Set the open state explicitly. */
+  setOpen: (open: boolean) => void;
+  /** Toggle the open state. */
+  toggle: () => void;
+}
+
+const DEFAULT_CONTEXT_VALUE: CommandPaletteContextValue = {
+  open: false,
+  setOpen: () => {},
+  toggle: () => {},
+};
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue>(
+  DEFAULT_CONTEXT_VALUE
+);
+
+/**
+ * Provider that owns the palette open state.
+ */
+export function CommandPaletteProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  const value = useMemo<CommandPaletteContextValue>(
+    () => ({ open, setOpen, toggle }),
+    [open, toggle]
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+    </CommandPaletteContext.Provider>
+  );
+}
+
+/**
+ * Access the command palette open state.
+ */
+export function useCommandPalette(): CommandPaletteContextValue {
+  return useContext(CommandPaletteContext);
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,7 +22,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   }
 
   // Load all namespace files and merge them
-  const [common, worktree, autoYes, error, prompt, auth, schedule] = await Promise.all([
+  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette] = await Promise.all([
     import(`../locales/${locale}/common.json`),
     import(`../locales/${locale}/worktree.json`),
     import(`../locales/${locale}/autoYes.json`),
@@ -30,6 +30,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
     import(`../locales/${locale}/prompt.json`),
     import(`../locales/${locale}/auth.json`),
     import(`../locales/${locale}/schedule.json`),
+    import(`../locales/${locale}/commandPalette.json`),
   ]);
 
   return {
@@ -44,6 +45,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
       prompt: prompt.default,
       auth: auth.default,
       schedule: schedule.default,
+      commandPalette: commandPalette.default,
     },
   };
 });

--- a/tests/unit/AppShell-layout.test.tsx
+++ b/tests/unit/AppShell-layout.test.tsx
@@ -53,6 +53,12 @@ vi.mock('@/components/layout/Header', () => ({
   Header: () => <div data-testid="header">Header</div>,
 }));
 
+// Mock CommandPalette (Issue #1053) - it is mounted by AppShell but needs
+// router/theme context; this layout test only cares about shell structure.
+vi.mock('@/components/common/CommandPalette', () => ({
+  CommandPalette: () => <div data-testid="command-palette-mock" />,
+}));
+
 // Mock z-index config
 vi.mock('@/config/z-index', () => ({
   Z_INDEX: { SIDEBAR: 30 },

--- a/tests/unit/components/common/CommandPalette.test.tsx
+++ b/tests/unit/components/common/CommandPalette.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * Unit tests for CommandPalette (Issue #1053)
+ *
+ * Covers: open/close via ⌘K / Ctrl+K, the typing-context guard, Escape,
+ * focus-on-open + focus-restore-on-close, Navigation / Worktrees / Actions
+ * groups, incremental search filtering, the empty & loading states, the
+ * shared-cache data source (including the error fallback), and the mobile
+ * bottom-nav trigger.
+ *
+ * next-intl is globally mocked (tests/setup.ts) to echo the full key, so
+ * assertions reference keys like `commandPalette.nav.sessions`.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react';
+
+// --- Mocks -----------------------------------------------------------------
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/',
+}));
+
+let currentTheme = 'dark';
+const setThemeMock = vi.fn((value: string) => {
+  currentTheme = value;
+});
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: currentTheme, setTheme: setThemeMock }),
+}));
+
+const setSizeMock = vi.fn();
+let ctxIsMobile = false;
+vi.mock('@/contexts/PcDisplaySizeContext', () => ({
+  usePcDisplaySizeContext: () => ({
+    size: 'medium',
+    setSize: setSizeMock,
+    isMobile: ctxIsMobile,
+    factor: 1,
+    isAvailable: false,
+  }),
+}));
+
+interface MockCache {
+  worktrees: Array<Record<string, unknown>>;
+  repositories: unknown[];
+  isLoading: boolean;
+  error: Error | null;
+  refresh: () => void;
+}
+let mockCache: MockCache | null;
+vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
+  useOptionalWorktreesCacheContext: () => mockCache,
+}));
+
+import { CommandPalette, isTypingTarget } from '@/components/common/CommandPalette';
+import { CommandPaletteProvider } from '@/contexts/CommandPaletteContext';
+import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
+
+const SAMPLE_WORKTREES = [
+  { id: 'wt-login', name: 'feature/login', branch: 'feature/login', repositoryName: 'MyApp' },
+  { id: 'wt-dark', name: 'feature/dark-mode', branch: 'feature/dark-mode', repositoryName: 'MyApp' },
+];
+
+function makeCache(overrides: Partial<MockCache> = {}): MockCache {
+  return {
+    worktrees: SAMPLE_WORKTREES,
+    repositories: [],
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderPalette() {
+  return render(
+    <CommandPaletteProvider>
+      <CommandPalette />
+    </CommandPaletteProvider>
+  );
+}
+
+function pressKey(target: EventTarget, init: KeyboardEventInit) {
+  act(() => {
+    target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }));
+  });
+}
+
+describe('CommandPalette (Issue #1053)', () => {
+  beforeEach(() => {
+    currentTheme = 'dark';
+    ctxIsMobile = false;
+    mockCache = makeCache();
+    pushMock.mockClear();
+    setThemeMock.mockClear();
+    setSizeMock.mockClear();
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // --- isTypingTarget --------------------------------------------------------
+
+  describe('isTypingTarget', () => {
+    it('treats form fields, contentEditable and the terminal log as typing targets', () => {
+      const input = document.createElement('input');
+      const textarea = document.createElement('textarea');
+      const select = document.createElement('select');
+      const editable = document.createElement('div');
+      Object.defineProperty(editable, 'isContentEditable', { value: true });
+      const terminal = document.createElement('div');
+      terminal.setAttribute('role', 'log');
+      const inner = document.createElement('span');
+      terminal.appendChild(inner);
+
+      expect(isTypingTarget(input)).toBe(true);
+      expect(isTypingTarget(textarea)).toBe(true);
+      expect(isTypingTarget(select)).toBe(true);
+      expect(isTypingTarget(editable)).toBe(true);
+      expect(isTypingTarget(terminal)).toBe(true);
+      expect(isTypingTarget(inner)).toBe(true); // nested inside role="log"
+    });
+
+    it('does not treat plain elements or null as typing targets', () => {
+      expect(isTypingTarget(document.createElement('div'))).toBe(false);
+      expect(isTypingTarget(document.createElement('button'))).toBe(false);
+      expect(isTypingTarget(null)).toBe(false);
+    });
+  });
+
+  // --- Open / close ----------------------------------------------------------
+
+  it('renders nothing when closed', () => {
+    renderPalette();
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+  });
+
+  it('opens on Cmd+K and closes on a second Cmd+K (toggle)', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+  });
+
+  it('opens on Ctrl+K (Windows)', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', ctrlKey: true });
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+    pressKey(window, { key: 'Escape' });
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    const overlay = screen.getByTestId('command-palette').firstChild as HTMLElement;
+    fireEvent.click(overlay);
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+  });
+
+  it('does NOT open while an input is focused (no shortcut hijack)', () => {
+    renderPalette();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    pressKey(input, { key: 'k', metaKey: true });
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+    input.remove();
+  });
+
+  it('does NOT open while the terminal log pane is focused', () => {
+    renderPalette();
+    const terminal = document.createElement('div');
+    terminal.setAttribute('role', 'log');
+    terminal.tabIndex = 0;
+    document.body.appendChild(terminal);
+    terminal.focus();
+    pressKey(terminal, { key: 'k', metaKey: true });
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+    terminal.remove();
+  });
+
+  // --- Focus management ------------------------------------------------------
+
+  it('focuses the search input on open so the keyboard works immediately', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(document.activeElement).toBe(screen.getByTestId('command-palette-input'));
+  });
+
+  it('restores focus to the previously focused element on close', () => {
+    renderPalette();
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(document.activeElement).toBe(screen.getByTestId('command-palette-input'));
+
+    pressKey(window, { key: 'Escape' });
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  // --- Navigation group ------------------------------------------------------
+
+  it('renders navigation items and pushes the route on select', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+
+    const sessions = screen.getByText('commandPalette.nav.sessions');
+    fireEvent.click(sessions);
+
+    expect(pushMock).toHaveBeenCalledWith('/sessions');
+    // palette closes after running a command
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+  });
+
+  it('keyboard nav works after open without a click (auto-focused input + Enter)', async () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+
+    const input = screen.getByTestId('command-palette-input') as HTMLInputElement;
+    // The input is auto-focused, so keystrokes reach cmdk without a click.
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: 'sessions' } });
+    await waitFor(() => {
+      expect(screen.queryByText('commandPalette.nav.home')).toBeNull();
+    });
+
+    // Enter on the focused element selects the single filtered item.
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' });
+    expect(pushMock).toHaveBeenCalledWith('/sessions');
+  });
+
+  it('filters items by the search query', async () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    const input = screen.getByTestId('command-palette-input');
+    fireEvent.change(input, { target: { value: 'sessions' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('commandPalette.nav.sessions')).toBeInTheDocument();
+      expect(screen.queryByText('commandPalette.nav.home')).toBeNull();
+    });
+  });
+
+  it('shows the empty state when nothing matches', async () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    const input = screen.getByTestId('command-palette-input');
+    fireEvent.change(input, { target: { value: 'zzz-no-match-zzz' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('command-palette-empty')).toBeInTheDocument();
+    });
+  });
+
+  // --- Worktrees group (shared cache) ---------------------------------------
+
+  it('renders worktrees from the shared cache and navigates on select', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+
+    const branch = screen.getByText('feature/login');
+    fireEvent.click(branch);
+    expect(pushMock).toHaveBeenCalledWith('/worktrees/wt-login');
+  });
+
+  it('reflects a later cache update (new worktree becomes searchable)', () => {
+    mockCache = makeCache({
+      worktrees: [
+        ...SAMPLE_WORKTREES,
+        { id: 'wt-new', name: 'feature/added-later', branch: 'feature/added-later', repositoryName: 'MyApp' },
+      ],
+    });
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.getByText('feature/added-later')).toBeInTheDocument();
+  });
+
+  it('falls back to Navigation-only when the cache reports an error', () => {
+    mockCache = makeCache({ worktrees: [], error: new Error('boom') });
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+
+    expect(screen.getByText('commandPalette.nav.sessions')).toBeInTheDocument();
+    expect(screen.queryByText('feature/login')).toBeNull();
+    expect(screen.queryByText('commandPalette.groups.worktrees')).toBeNull();
+  });
+
+  it('hides worktrees on cache error even if stale data is present', () => {
+    mockCache = makeCache({ error: new Error('boom') }); // worktrees still populated
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.queryByText('feature/login')).toBeNull();
+  });
+
+  it('shows a loading row while the cache is loading with no data yet', () => {
+    mockCache = makeCache({ worktrees: [], isLoading: true });
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.getByTestId('command-palette-loading')).toBeInTheDocument();
+  });
+
+  it('degrades gracefully when no cache provider is present (null context)', () => {
+    mockCache = null;
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    // Navigation still works; no worktrees group
+    expect(screen.getByText('commandPalette.nav.sessions')).toBeInTheDocument();
+    expect(screen.queryByText('commandPalette.groups.worktrees')).toBeNull();
+  });
+
+  // --- Actions group ---------------------------------------------------------
+
+  it('toggles the theme from the Actions group', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    // dark theme -> offers "switch to light"
+    fireEvent.click(screen.getByText('commandPalette.actions.toLight'));
+    expect(setThemeMock).toHaveBeenCalledWith('light');
+  });
+
+  it('offers PC display-size actions on desktop and applies them', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    // label: "commandPalette.actions.displaySizePrefix: common.displaySize.small"
+    fireEvent.click(
+      screen.getByText(/displaySizePrefix.*common\.displaySize\.small/)
+    );
+    expect(setSizeMock).toHaveBeenCalledWith('small');
+  });
+
+  it('hides display-size actions on mobile', () => {
+    ctxIsMobile = true;
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.queryByText(/common\.displaySize\.small/)).toBeNull();
+    // theme action is still available on mobile
+    expect(screen.getByText('commandPalette.actions.toLight')).toBeInTheDocument();
+  });
+
+  // --- Mobile trigger --------------------------------------------------------
+
+  it('opens the palette from the mobile bottom-nav trigger', () => {
+    render(
+      <CommandPaletteProvider>
+        <GlobalMobileNav />
+        <CommandPalette />
+      </CommandPaletteProvider>
+    );
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+    fireEvent.click(screen.getByTestId('mobile-command-palette-trigger'));
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/i18n/command-palette-keys.test.ts
+++ b/tests/unit/i18n/command-palette-keys.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit-level i18n parity test for the command palette namespace (Issue #1053).
+ *
+ * `src/i18n.ts` has no onError / getMessageFallback, so a missing key in one
+ * locale would surface the raw key string in production and go undetected.
+ * This test enforces full deep-key parity for the `commandPalette` namespace
+ * across en / ja, mirroring the existing toc-keys / todo-tab-keys parity tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../../locales');
+
+function loadCommandPalette(locale: string): Record<string, unknown> {
+  const filePath = path.join(LOCALES_DIR, locale, 'commandPalette.json');
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+/** Collect all dot-joined leaf key paths from a nested object. */
+function leafKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const full = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return leafKeys(value as Record<string, unknown>, full);
+    }
+    return [full];
+  });
+}
+
+describe('command palette i18n keys (Issue #1053)', () => {
+  it.each(['en', 'ja'])('%s/commandPalette.json has non-empty values for every leaf', (locale) => {
+    const dict = loadCommandPalette(locale);
+    const keys = leafKeys(dict);
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      const value = key
+        .split('.')
+        .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)[part], dict);
+      expect(value, `${locale}: ${key}`).toBeTruthy();
+    }
+  });
+
+  it('en and ja expose the identical set of keys (parity)', () => {
+    const en = leafKeys(loadCommandPalette('en')).sort();
+    const ja = leafKeys(loadCommandPalette('ja')).sort();
+    expect(en).toEqual(ja);
+  });
+
+  it('includes the core navigation / group / action keys', () => {
+    const en = loadCommandPalette('en');
+    const keys = leafKeys(en);
+    for (const expected of [
+      'placeholder',
+      'empty',
+      'groups.navigation',
+      'groups.worktrees',
+      'groups.actions',
+      'nav.sessions',
+      'actions.toLight',
+      'actions.toDark',
+      'mobileTrigger',
+    ]) {
+      expect(keys).toContain(expected);
+    }
+  });
+});


### PR DESCRIPTION
## 概要
UIモダン化 Phase 4 (#1040) の Issue #1053。`cmdk` による**コマンドパレット(⌘K)**を追加します。
⌘K(mac)/Ctrl+K(win)で画面遷移・worktree ジャンプ・テーマ/表示サイズ切替を一元操作できます。

## 変更点
- `src/components/common/CommandPalette.tsx`(新規)+ `CommandPaletteContext.tsx`(新規)、`AppShell` 直下にマウント
- コマンド: Navigation(各画面)/ Worktrees(リポジトリ+ブランチ検索→詳細)/ Actions(テーマ・表示サイズ)
- **input/textarea/contentEditable/ターミナル(role="log")フォーカス中は非発火**、キーボードリスナーは単一ソース
- i18n `locales/{en,ja}/commandPalette.json`、Modal 相当の z-index、SSR 安全('use client')
- モバイルは `GlobalMobileNav` に起動導線

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`: 全 pass
- **敵対的レビュー(3観点+検証, 11エージェント)**で確定7件を反映:
  - **[HIGH] open 時に入力へフォーカス**していなかった(bare `<Command>` は auto-focus しない)ため、⌘K 後に type/矢印/Enter が全て効かずキーボード操作が死んでいた → open で `inputRef.focus()`(+ close で元要素へフォーカス復帰)。テストも open→操作の形へ修正
  - [MEDIUM] Worktrees の一回限り private fetch → `useOptionalWorktreesCacheContext()` 再利用(最新化+再試行、error→Navigation fallback)
  - [LOW] Escape の preventDefault/stopPropagation、focus 復帰、loading 状態/未使用キーの整理

## 関連
Closes #1053 / 親 #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
