### PR TITLE
feat: エージェント/セッションステータスの視覚を強化 (#1051)

### DIFF
--- a/docs/features/sidebar-status-indicator.md
+++ b/docs/features/sidebar-status-indicator.md
@@ -11,13 +11,41 @@
 
 ## ステータス一覧
 
+**サイドバー / Home / Sessions** の表示は共通プリミティブ `StatusDot`
+（`src/components/ui/StatusDot.tsx`, Issue #1051）が担う。
+`running` / `generating` は発光ドット + ゆっくりしたパルス（+ モーション凍結時も残る
+リングで `ready` と区別）、`waiting` は amber の弱い点滅、その他は静的ドット。
+
+下表は **StatusDot（サイドバー / Home / Sessions）** の表示を示す。
+
 | ステータス | 表示 | 色 | 説明 |
 |-----------|------|-----|------|
 | `idle` | ● | グレー | セッション未起動 |
 | `ready` | ● | 緑 | 入力プロンプト表示中（新しいメッセージ入力可能） |
-| `running` | ⟳ | 青スピナー | Claude処理中（思考インジケータ表示中） |
-| `waiting` | ● | 黄 | ユーザー入力待ち（yes/no、選択肢など） |
-| `generating` | ⟳ | 青スピナー | レスポンス生成中 |
+| `running` | ● 発光・パルス（リング） | 緑グロー | Claude処理中（思考インジケータ表示中） |
+| `waiting` | ● 弱点滅 | amber | ユーザー入力待ち（yes/no、選択肢など） |
+| `generating` | ● 発光・パルス（リング） | 緑グロー | レスポンス生成中 |
+
+> **モーション**: パルス／点滅は CSS の infinite アニメーション（`animate-status-glow` /
+> `animate-status-blink`, `tailwind.config.js`）で実装し、ポーリング再描画でリセットされない。
+> OS の「視差効果を減らす」設定時は `globals.css`（Issue #1050）が全アニメを無効化し、
+> 静的ドットへフォールバックする（このとき `running` はリングで `ready` と識別できる）。
+
+### 表示の適用範囲と既知の不整合（Issue #1051 時点）
+
+Issue #1051 の StatusDot 化は **サイドバー / Home / Sessions のみ**。以下は今回移行しておらず、
+**従来の `src/config/status-colors.ts`（`MOBILE_STATUS_CONFIG` / `DESKTOP_STATUS_CONFIG`）** のままで、
+今後の追随対象。全面的な表示統一はまだ達成していない点に注意。
+
+| 箇所 | `running` / `generating` | `waiting` |
+|------|--------------------------|-----------|
+| サイドバー / Home / Sessions（StatusDot） | 緑グロー + パルス（発光ドット） | amber（`bg-warning`）・弱点滅 |
+| worktree詳細（`WorktreeDetailRefactored` 等）・`MobileHeader` | 青スピナー（`border-info`, `animate-spin`） | 黄（`bg-yellow-500`）・静的 |
+
+- **`running` の色/表現差**: StatusDot 側は緑の発光ドット、worktree詳細/MobileHeader 側は青スピナーのまま。
+- **`waiting` の色差**: StatusDot は amber（`bg-warning`）、worktree詳細/MobileHeader は `bg-yellow-500`。
+  さらに `Terminal.tsx` / `MobileTabBar.tsx` は `bg-yellow-500` をハードコードしている。
+  完全統一には `status-colors.ts` とこれらのハードコード双方の変更が必要なため、追随作業まで保留。
 
 ## ブランチ左の集約ステータスアイコン（Issue #867）
 
@@ -31,8 +59,8 @@
 waiting > running / generating > ready > idle
 ```
 
-- いずれかのエージェントが `waiting` なら `waiting`（黄ドット）。
-- `waiting` がなく `running` または `generating` があればスピナー（`running` を優先）。
+- いずれかのエージェントが `waiting` なら `waiting`（amber ドット・弱点滅）。
+- `waiting` がなく `running` または `generating` があれば発光ドット（`running` を優先）。
 - 上記がなく `ready` があれば `ready`（緑ドット）。
 - それ以外は `idle`（グレードット）。
 
@@ -108,10 +136,10 @@ yes/no確認や選択肢を表示している場合：
 
 ## 検出優先順位
 
-1. **インタラクティブプロンプト** → `waiting` (黄)
-2. **思考インジケータ** → `running` (スピナー)
+1. **インタラクティブプロンプト** → `waiting` (黄・弱点滅)
+2. **思考インジケータ** → `running` (緑・発光パルス)
 3. **入力プロンプトのみ** → `ready` (緑)
-4. **それ以外** → `running` (スピナー) - 処理中と推定
+4. **それ以外** → `running` (緑・発光パルス) - 処理中と推定
 
 ## ポーリング間隔
 
@@ -136,7 +164,8 @@ yes/no確認や選択肢を表示している場合：
 - `src/app/api/worktrees/[id]/current-output/route.ts` - リアルタイム出力取得
 
 ### フロントエンド
-- `src/components/sidebar/BranchStatusIndicator.tsx` - ステータスインジケーターコンポーネント
+- `src/components/ui/StatusDot.tsx` - 共通ステータスドット（発光・パルス・点滅、Issue #1051）
+- `src/components/sidebar/BranchStatusIndicator.tsx` - StatusDot を用いたインジケーター
 - `src/types/sidebar.ts` - ステータス判定ロジック
 - `src/contexts/WorktreeSelectionContext.tsx` - ポーリング管理
 

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -111,6 +111,7 @@
 | `src/hooks/useFileSearch.ts` | 検索状態管理フック（debounce処理、API呼び出し、結果管理） |
 | `src/components/worktree/MoveDialog.tsx` | ファイル移動先選択ダイアログ（Issue #162: ディレクトリツリーブラウザ、ルート選択、ネスト対応、updateTreeNode/findNodeByPath抽出） |
 | `src/components/ui/Modal.tsx` | モーダルダイアログコンポーネント（Issue #299: z-[9999]ハードコード除去、Z_INDEX.MODAL使用に統一） |
+| `src/components/ui/StatusDot.tsx` | 共通ステータスドット（Issue #1051: running/generating=緑グロー+パルス+静的リング(reduced-motion凍結時もreadyと識別)、waiting=amber弱点滅、idle/ready/error+未知state=静的、size sm/md/lg。infinite CSSアニメでポーリング非リセット、reduced-motionはglobals.css準拠。適用はサイドバー/Home/Sessionsのみ、worktree詳細/MobileHeaderは従来spinner据置） |
 | `src/components/common/FullScreenModal.tsx` | モバイル向けフルスクリーンモーダルシェル（Issue #825: slide-up、右上クローズ、sticky footer、visualViewportでキーボード回避、focus時scrollIntoView） |
 | `src/components/common/Toast.tsx` | トースト通知コンポーネント（Issue #299: z-50ハードコード除去、Z_INDEX.TOAST使用に統一） |
 | `src/components/worktree/ContextMenu.tsx` | ファイル/ディレクトリコンテキストメニュー（Issue #162: 「移動」メニュー項目追加、FolderInputアイコン、onMoveコールバック。Issue #299: z-50除去、Z_INDEX.CONTEXT_MENU使用） |

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -29,6 +29,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  StatusDot,
 } from '@/components/ui';
 import { compareByTimestamp } from '@/lib/sidebar-utils';
 import { formatRelativeTime } from '@/lib/date-utils';
@@ -40,6 +41,7 @@ import {
 } from '@/config/message-preview-config';
 import type { SortKey, SortDirection } from '@/lib/sidebar-utils';
 import type { Worktree } from '@/types/models';
+import type { CLIToolType } from '@/lib/cli-tools/types';
 import type { BranchStatus } from '@/types/sidebar';
 
 // ============================================================================
@@ -74,21 +76,18 @@ const DEFAULT_STATUS_PRIORITY = 4;
 // Helpers
 // ============================================================================
 
-/** Small CLI status dot for Sessions list */
+/** Small CLI status dot for Sessions list (Issue #1051: shared StatusDot). */
 function CliDot({ status, label }: { status: BranchStatus; label: string }) {
-  const config = SIDEBAR_STATUS_CONFIG[status];
-  const title = `${label}: ${config.label}`;
-  const base = 'w-2.5 h-2.5 rounded-full flex-shrink-0';
+  const title = `${label}: ${SIDEBAR_STATUS_CONFIG[status].label}`;
+  return <StatusDot status={status} size="md" label={title} />;
+}
 
-  if (config.type === 'spinner') {
-    return (
-      <span
-        className={`${base} border-2 border-t-transparent animate-spin ${config.className}`}
-        title={title}
-      />
-    );
-  }
-  return <span className={`${base} ${config.className}`} title={title} />;
+/** Whether any selected agent is actively working (running/generating). */
+function isWorktreeActive(wt: Worktree, agents: readonly CLIToolType[]): boolean {
+  return agents.some((agent) => {
+    const s = deriveCliStatus(wt.sessionStatusByCli?.[agent]);
+    return s === 'running' || s === 'generating';
+  });
 }
 
 /** Status display labels */
@@ -293,6 +292,12 @@ export default function SessionsPage() {
                 const relativeTime = wt.lastUserMessageAt
                   ? formatRelativeTime(String(wt.lastUserMessageAt))
                   : null;
+                // [Issue #1051] Active (running) cards get an accent border +
+                // subtle glow so a working session stands out at a glance.
+                const isActive = isWorktreeActive(wt, agents);
+                const cardStateClasses = isActive
+                  ? 'border-accent-500/40 shadow-[0_0_16px_-4px_rgb(var(--accent-500)/0.45)] hover:border-accent-400'
+                  : 'border-border shadow-sm hover:border-accent-300 dark:hover:border-accent-700';
 
                 return (
                   // [Issue #1050] Stable key (wt.id) keeps the entrance stagger
@@ -301,7 +306,7 @@ export default function SessionsPage() {
                     key={wt.id}
                     href={`/worktrees/${wt.id}`}
                     style={{ animationDelay: staggerDelay(index) }}
-                    className={`block bg-surface rounded-lg p-4 border border-border shadow-sm hover:border-accent-300 dark:hover:border-accent-700 transition-colors ${STAGGER_ENTER_CLASS}`}
+                    className={`block bg-surface rounded-lg p-4 border transition-colors ${cardStateClasses} ${STAGGER_ENTER_CLASS}`}
                     data-testid={`session-item-${wt.id}`}
                   >
                     {/* Row 1: Name, Agent statuses */}

--- a/src/components/home/HomeSessionSummary.tsx
+++ b/src/components/home/HomeSessionSummary.tsx
@@ -10,7 +10,7 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { Card } from '@/components/ui';
+import { Card, StatusDot } from '@/components/ui';
 import type { Worktree } from '@/types/models';
 
 export interface HomeSessionSummaryProps {
@@ -38,14 +38,22 @@ export function HomeSessionSummary({ worktrees }: HomeSessionSummaryProps) {
 
   return (
     <div className="grid grid-cols-2 gap-4" data-testid="home-session-summary">
-      <Card>
-        <div className="text-sm text-gray-500 dark:text-gray-400">Running</div>
+      {/* Issue #1051: status-colored left accent + a StatusDot that only "comes
+          alive" (glow/blink) while the corresponding count is non-zero. */}
+      <Card className="border-l-2 border-l-success/70">
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <StatusDot status={runningCount > 0 ? 'running' : 'idle'} size="sm" label="Running" />
+          Running
+        </div>
         <div className="text-2xl font-bold text-green-600 dark:text-green-400" data-testid="running-count">
           {runningCount}
         </div>
       </Card>
-      <Card>
-        <div className="text-sm text-gray-500 dark:text-gray-400">Waiting</div>
+      <Card className="border-l-2 border-l-warning/70">
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <StatusDot status={waitingCount > 0 ? 'waiting' : 'idle'} size="sm" label="Waiting" />
+          Waiting
+        </div>
         <div className="text-2xl font-bold text-amber-600 dark:text-amber-400" data-testid="waiting-count">
           {waitingCount}
         </div>

--- a/src/components/sidebar/BranchStatusIndicator.tsx
+++ b/src/components/sidebar/BranchStatusIndicator.tsx
@@ -2,16 +2,16 @@
  * BranchStatusIndicator Component
  *
  * Displays a colored dot indicating the branch's current status.
- * Includes animation for active states.
- *
- * SF1: Uses centralized status colors from @/config/status-colors
+ * Delegates rendering to the shared StatusDot primitive (Issue #1051): active
+ * states (running/generating) glow and pulse, waiting blinks, and the rest are
+ * static dots.
  */
 
 'use client';
 
 import React, { memo } from 'react';
 import type { BranchStatus } from '@/types/sidebar';
-import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
+import { StatusDot } from '@/components/ui/StatusDot';
 
 // ============================================================================
 // Types
@@ -46,35 +46,14 @@ export const BranchStatusIndicator = memo(function BranchStatusIndicator({
   status,
   label,
 }: BranchStatusIndicatorProps) {
-  const config = SIDEBAR_STATUS_CONFIG[status];
-  // Issue #867: prefer the caller-supplied breakdown label when present.
-  const accessibleLabel = label ?? config.label;
-
-  if (config.type === 'spinner') {
-    return (
-      <span
-        data-testid="status-indicator"
-        className={`
-          w-3 h-3 rounded-full flex-shrink-0
-          border-2 border-t-transparent
-          ${config.className}
-          animate-spin
-        `}
-        title={accessibleLabel}
-        aria-label={accessibleLabel}
-      />
-    );
-  }
-
+  // Issue #867: `label` (per-agent breakdown) overrides the default; StatusDot
+  // falls back to the status's own label when omitted.
   return (
-    <span
+    <StatusDot
       data-testid="status-indicator"
-      className={`
-        w-3 h-3 rounded-full flex-shrink-0
-        ${config.className}
-      `}
-      title={accessibleLabel}
-      aria-label={accessibleLabel}
+      status={status}
+      label={label}
+      size="lg"
     />
   );
 });

--- a/src/components/ui/StatusDot.tsx
+++ b/src/components/ui/StatusDot.tsx
@@ -1,0 +1,125 @@
+/**
+ * StatusDot Component (Issue #1051)
+ *
+ * A small colored status dot with "living" motion for active states:
+ * - running / generating: green dot with a pulsing box-shadow glow + a static
+ *   ring halo (so it stays distinct from `ready` even when motion is frozen)
+ * - waiting: amber dot with a weak blink
+ * - ready: static green dot
+ * - idle: static gray dot
+ * - error: static red dot
+ * - unknown state: static gray fallback
+ *
+ * Colors/semantics stay aligned with @/config/status-colors and
+ * docs/features/sidebar-status-indicator.md (running=green, waiting=amber,
+ * error=red). Animations are infinite CSS classes (see tailwind.config.js), so
+ * polling re-renders never restart them. OS "reduce motion" is honored globally
+ * in globals.css, which freezes the animation to a static dot.
+ */
+
+import React from 'react';
+import { cn } from '@/lib/utils/cn';
+
+export type StatusDotStatus =
+  | 'idle'
+  | 'ready'
+  | 'running'
+  | 'waiting'
+  | 'generating'
+  | 'error';
+
+export type StatusDotSize = 'sm' | 'md' | 'lg';
+
+interface StatusDotVisual {
+  /** Color utility classes. Glow states also set `text-*` so the box-shadow
+   * (which uses `currentColor`) matches the dot color. */
+  colorClass: string;
+  /** Optional infinite animation utility. */
+  animationClass?: string;
+  /** Default accessible label. */
+  label: string;
+}
+
+const STATUS_DOT_CONFIG: Record<StatusDotStatus, StatusDotVisual> = {
+  idle: { colorClass: 'bg-muted-foreground', label: 'Idle' },
+  ready: { colorClass: 'bg-success', label: 'Ready' },
+  // running/generating add a static `ring` as a MOTION-INDEPENDENT
+  // differentiator: the pulsing glow (animate-status-glow) sets box-shadow
+  // directly and overrides the ring while animating, but when the pulse is
+  // frozen by prefers-reduced-motion the ring box-shadow remains — so a
+  // "running" dot keeps a green halo that the static green `ready` dot never
+  // has, and the two are never pixel-identical.
+  running: {
+    colorClass: 'bg-success text-success ring-2 ring-success/40',
+    animationClass: 'animate-status-glow',
+    label: 'Running',
+  },
+  generating: {
+    colorClass: 'bg-success text-success ring-2 ring-success/40',
+    animationClass: 'animate-status-glow',
+    label: 'Generating',
+  },
+  waiting: {
+    colorClass: 'bg-warning',
+    animationClass: 'animate-status-blink',
+    label: 'Waiting for response',
+  },
+  error: { colorClass: 'bg-danger', label: 'Error' },
+};
+
+/** Fallback for unrecognized state values (edge case: unknown status → gray). */
+const FALLBACK_VISUAL: StatusDotVisual = {
+  colorClass: 'bg-muted-foreground',
+  label: 'Unknown',
+};
+
+const SIZE_CLASSES: Record<StatusDotSize, string> = {
+  sm: 'w-2 h-2',
+  md: 'w-2.5 h-2.5',
+  lg: 'w-3 h-3',
+};
+
+export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Current status. Unrecognized values fall back to a gray dot. */
+  status: StatusDotStatus;
+  /** Dot size. Defaults to `md`. */
+  size?: StatusDotSize;
+  /** Accessible label override for `title` / `aria-label`. Falls back to the
+   * status's default label when omitted. */
+  label?: string;
+}
+
+/**
+ * StatusDot renders a colored status dot with motion for active states.
+ *
+ * @example
+ * ```tsx
+ * <StatusDot status="running" size="lg" />
+ * <StatusDot status="waiting" label="Claude: waiting, Codex: idle" />
+ * ```
+ */
+export function StatusDot({
+  status,
+  size = 'md',
+  label,
+  className,
+  ...rest
+}: StatusDotProps) {
+  const visual = STATUS_DOT_CONFIG[status] ?? FALLBACK_VISUAL;
+  const accessibleLabel = label ?? visual.label;
+
+  return (
+    <span
+      className={cn(
+        'inline-block flex-shrink-0 rounded-full',
+        SIZE_CLASSES[size],
+        visual.colorClass,
+        visual.animationClass,
+        className
+      )}
+      title={accessibleLabel}
+      aria-label={accessibleLabel}
+      {...rest}
+    />
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -12,6 +12,9 @@ export type { CardProps, CardHeaderProps, CardTitleProps, CardContentProps, Card
 export { Badge } from './Badge';
 export type { BadgeProps, BadgeVariant } from './Badge';
 
+export { StatusDot } from './StatusDot';
+export type { StatusDotProps, StatusDotStatus, StatusDotSize } from './StatusDot';
+
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -68,6 +68,12 @@ module.exports = {
       animation: {
         'slide-in': 'slide-in 0.3s ease-out',
         'slide-up': 'slide-up 0.25s ease-out',
+        // [Issue #1051] StatusDot "living" states. Infinite CSS animations so
+        // polling re-renders never restart them (no JS/inline-style keying).
+        // OS "reduce motion" is honored globally in globals.css (#1050), which
+        // freezes these to a static dot — do not re-implement the media query.
+        'status-glow': 'status-glow 2.4s ease-in-out infinite',
+        'status-blink': 'status-blink 1.6s ease-in-out infinite',
       },
       keyframes: {
         'slide-in': {
@@ -77,6 +83,17 @@ module.exports = {
         'slide-up': {
           '0%': { transform: 'translateY(100%)' },
           '100%': { transform: 'translateY(0)' },
+        },
+        // Pulsing box-shadow glow keyed to the dot's own color via currentColor,
+        // so a single keyframe works for any status color (running=green).
+        'status-glow': {
+          '0%, 100%': { boxShadow: '0 0 3px 0 currentColor', opacity: '0.85' },
+          '50%': { boxShadow: '0 0 8px 2px currentColor', opacity: '1' },
+        },
+        // Weak amber blink for the waiting state.
+        'status-blink': {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.45' },
         },
       },
     },

--- a/tests/unit/components/sidebar/BranchListItem.test.tsx
+++ b/tests/unit/components/sidebar/BranchListItem.test.tsx
@@ -183,7 +183,7 @@ describe('BranchListItem', () => {
       expect(screen.queryByLabelText('CLI tool status')).not.toBeInTheDocument();
     });
 
-    it('should reflect running status with spinner styling', () => {
+    it('should reflect running status with a glowing dot (Issue #1051)', () => {
       render(
         <BranchListItem
           branch={{ ...defaultBranch, cliStatus: { claude: 'running', codex: 'idle' } }}
@@ -193,7 +193,7 @@ describe('BranchListItem', () => {
       );
 
       const claudeDot = screen.getByLabelText(/Claude:/);
-      expect(claudeDot.className).toMatch(/animate-spin/);
+      expect(claudeDot.className).toMatch(/animate-status-glow/);
     });
 
     it('should render vibe-local status dot dynamically (Issue #368)', () => {
@@ -253,8 +253,8 @@ describe('BranchListItem', () => {
       );
 
       const indicator = screen.getByTestId('status-indicator');
-      // waiting renders as a static yellow dot (no spinner).
-      expect(indicator.className).toMatch(/bg-yellow-500/);
+      // waiting renders as an amber dot that blinks (never spins).
+      expect(indicator.className).toMatch(/bg-warning/);
       expect(indicator.className).not.toMatch(/animate-spin/);
     });
 
@@ -271,7 +271,7 @@ describe('BranchListItem', () => {
       );
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/animate-spin/);
+      expect(indicator.className).toMatch(/animate-status-glow/);
     });
 
     it('should expose the per-agent breakdown via the indicator label', () => {

--- a/tests/unit/components/sidebar/BranchStatusIndicator.test.tsx
+++ b/tests/unit/components/sidebar/BranchStatusIndicator.test.tsx
@@ -40,28 +40,28 @@ describe('BranchStatusIndicator', () => {
       render(<BranchStatusIndicator status="idle" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/bg-gray-500|gray/);
+      expect(indicator.className).toMatch(/bg-muted-foreground|gray/);
     });
 
-    it('should have blue spinner for running status', () => {
+    it('should have green (success) color for running status (Issue #1051)', () => {
       render(<BranchStatusIndicator status="running" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/border-info/);
+      expect(indicator.className).toMatch(/bg-success/);
     });
 
-    it('should have yellow color for waiting status', () => {
+    it('should have amber (warning) color for waiting status (Issue #1051)', () => {
       render(<BranchStatusIndicator status="waiting" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/bg-yellow-500|yellow|amber/);
+      expect(indicator.className).toMatch(/bg-warning|yellow|amber/);
     });
 
-    it('should have blue spinner for generating status', () => {
+    it('should have green (success) color for generating status (Issue #1051)', () => {
       render(<BranchStatusIndicator status="generating" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/border-info/);
+      expect(indicator.className).toMatch(/bg-success/);
     });
   });
 
@@ -70,28 +70,30 @@ describe('BranchStatusIndicator', () => {
       render(<BranchStatusIndicator status="idle" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).not.toMatch(/animate-spin/);
+      expect(indicator.className).not.toMatch(/animate-status/);
     });
 
-    it('should spin for running status (spinner)', () => {
+    it('should glow/pulse for running status (Issue #1051)', () => {
       render(<BranchStatusIndicator status="running" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/animate-spin/);
+      expect(indicator.className).toMatch(/animate-status-glow/);
     });
 
-    it('should not animate for waiting status (dot)', () => {
+    it('should blink for waiting status (Issue #1051)', () => {
       render(<BranchStatusIndicator status="waiting" />);
 
       const indicator = screen.getByTestId('status-indicator');
+      // Waiting blinks (weak) but never spins.
+      expect(indicator.className).toMatch(/animate-status-blink/);
       expect(indicator.className).not.toMatch(/animate-spin/);
     });
 
-    it('should spin for generating status (spinner)', () => {
+    it('should glow/pulse for generating status (Issue #1051)', () => {
       render(<BranchStatusIndicator status="generating" />);
 
       const indicator = screen.getByTestId('status-indicator');
-      expect(indicator.className).toMatch(/animate-spin/);
+      expect(indicator.className).toMatch(/animate-status-glow/);
     });
   });
 

--- a/tests/unit/components/ui/StatusDot.test.tsx
+++ b/tests/unit/components/ui/StatusDot.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for StatusDot primitive (Issue #1051)
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusDot } from '@/components/ui/StatusDot';
+import type { StatusDotStatus } from '@/components/ui/StatusDot';
+
+describe('StatusDot', () => {
+  describe('Rendering', () => {
+    it('renders a span with the base dot classes', () => {
+      render(<StatusDot status="idle" data-testid="dot" />);
+      const dot = screen.getByTestId('dot');
+      expect(dot.tagName.toLowerCase()).toBe('span');
+      expect(dot.className).toContain('rounded-full');
+      expect(dot.className).toContain('inline-block');
+    });
+
+    it('renders the four primary states (running/waiting/idle/error)', () => {
+      const states: StatusDotStatus[] = ['running', 'waiting', 'idle', 'error'];
+      states.forEach((status) => {
+        const { unmount } = render(<StatusDot status={status} data-testid="dot" />);
+        expect(screen.getByTestId('dot')).toBeInTheDocument();
+        unmount();
+      });
+    });
+  });
+
+  describe('Status colors', () => {
+    it.each([
+      ['idle', 'bg-muted-foreground'],
+      ['ready', 'bg-success'],
+      ['running', 'bg-success'],
+      ['generating', 'bg-success'],
+      ['waiting', 'bg-warning'],
+      ['error', 'bg-danger'],
+    ] as const)('applies the %s color class', (status, expected) => {
+      render(<StatusDot status={status} data-testid="dot" />);
+      expect(screen.getByTestId('dot').className).toContain(expected);
+    });
+  });
+
+  describe('Motion', () => {
+    it('applies the pulsing glow animation for running', () => {
+      render(<StatusDot status="running" data-testid="dot" />);
+      const cls = screen.getByTestId('dot').className;
+      // currentColor-based glow needs text color to match the dot color
+      expect(cls).toContain('animate-status-glow');
+      expect(cls).toContain('text-success');
+    });
+
+    it('applies the pulsing glow animation for generating', () => {
+      render(<StatusDot status="generating" data-testid="dot" />);
+      expect(screen.getByTestId('dot').className).toContain('animate-status-glow');
+    });
+
+    it('applies the weak blink animation for waiting', () => {
+      render(<StatusDot status="waiting" data-testid="dot" />);
+      expect(screen.getByTestId('dot').className).toContain('animate-status-blink');
+    });
+
+    it.each(['idle', 'ready', 'error'] as const)(
+      'does not animate the static %s state',
+      (status) => {
+        render(<StatusDot status={status} data-testid="dot" />);
+        const cls = screen.getByTestId('dot').className;
+        expect(cls).not.toContain('animate-status-glow');
+        expect(cls).not.toContain('animate-status-blink');
+      }
+    );
+  });
+
+  describe('Reduced-motion differentiation', () => {
+    // The pulsing glow can be frozen by prefers-reduced-motion, so running must
+    // stay distinct from the static green `ready` dot via a motion-independent
+    // ring halo (persists even when the animation is neutralized).
+    it.each(['running', 'generating'] as const)(
+      'gives %s a static ring halo independent of motion',
+      (status) => {
+        render(<StatusDot status={status} data-testid="dot" />);
+        const cls = screen.getByTestId('dot').className;
+        expect(cls).toContain('ring-2');
+        expect(cls).toContain('ring-success');
+      }
+    );
+
+    it('does not give the static ready dot a ring (stays distinct from running)', () => {
+      render(<StatusDot status="ready" data-testid="dot" />);
+      const cls = screen.getByTestId('dot').className;
+      expect(cls).toContain('bg-success');
+      expect(cls).not.toContain('ring-2');
+    });
+  });
+
+  describe('Unknown state fallback (edge case)', () => {
+    it('falls back to a gray dot for an unknown state', () => {
+      render(<StatusDot status={'bogus' as StatusDotStatus} data-testid="dot" />);
+      const cls = screen.getByTestId('dot').className;
+      expect(cls).toContain('bg-muted-foreground');
+      expect(cls).not.toContain('animate-status-glow');
+      expect(cls).not.toContain('animate-status-blink');
+    });
+
+    it('uses the "Unknown" label for an unknown state', () => {
+      render(<StatusDot status={'bogus' as StatusDotStatus} data-testid="dot" />);
+      expect(screen.getByTestId('dot').getAttribute('aria-label')).toBe('Unknown');
+    });
+  });
+
+  describe('Sizing', () => {
+    it('defaults to the md size', () => {
+      render(<StatusDot status="idle" data-testid="dot" />);
+      expect(screen.getByTestId('dot').className).toContain('w-2.5');
+    });
+
+    it.each([
+      ['sm', 'w-2'],
+      ['md', 'w-2.5'],
+      ['lg', 'w-3'],
+    ] as const)('applies the %s size', (size, expected) => {
+      render(<StatusDot status="idle" size={size} data-testid="dot" />);
+      expect(screen.getByTestId('dot').className).toContain(expected);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('uses the default label for title and aria-label', () => {
+      render(<StatusDot status="waiting" data-testid="dot" />);
+      const dot = screen.getByTestId('dot');
+      expect(dot.getAttribute('title')).toBe('Waiting for response');
+      expect(dot.getAttribute('aria-label')).toBe('Waiting for response');
+    });
+
+    it('overrides the label when one is provided', () => {
+      render(
+        <StatusDot status="running" label="Claude: running, Codex: idle" data-testid="dot" />
+      );
+      const dot = screen.getByTestId('dot');
+      expect(dot.getAttribute('title')).toBe('Claude: running, Codex: idle');
+      expect(dot.getAttribute('aria-label')).toBe('Claude: running, Codex: idle');
+    });
+  });
+
+  describe('Custom className', () => {
+    it('merges a custom className with the dot classes', () => {
+      render(<StatusDot status="idle" className="ml-2" data-testid="dot" />);
+      const cls = screen.getByTestId('dot').className;
+      expect(cls).toContain('ml-2');
+      expect(cls).toContain('rounded-full');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
UIモダン化 Phase 4 (#1040) の Issue #1051。エージェント/セッションのステータス表示を
「生きている感」のある表現へ強化します。

## 変更点
- `src/components/ui/StatusDot.tsx`(新規): state=running/waiting/idle/error。running はグロー+パルス+**静的リング halo**、waiting は amber 弱点滅
- サイドバー(`BranchStatusIndicator`)/ Home(`HomeSessionSummary`)/ Sessions を StatusDot 化
- `prefers-reduced-motion` でパルス停止、ポーリングで再発火しない CSS infinite アニメ

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`(8655 passed): 全 pass
- **敵対的レビュー(3観点+検証, 8エージェント)**で確定4件を反映:
  - [MEDIUM] reduced-motion で running が ready と識別不能になる問題 → **静的リング halo** で motion 非依存に区別
  - [MEDIUM/LOW] 同一 running が緑ドット(サイドバー/Home/Sessions)と青スピナー(worktree詳細/MobileHeader)に割れる件 → worktree 詳細は複雑なため今回移行せず、`docs/features/sidebar-status-indicator.md` を**実態に合わせて訂正**(全面統一は未達・今後の追随対象と明記)。waiting の hue ズレも注記
- develop(#1052 マージ済)を取り込み、`HomeSessionSummary.tsx` の競合を統合解決(#1052 の bento インライン統計構造に #1051 の StatusDot を接ぎ木)

## 関連
Closes #1051 / 親 #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
