### PR TITLE
fix: サイドバーがヘッダーに遮蔽される左上レイアウト破綻を修正 (#1070)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -153,8 +153,9 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
             ref={sidebarRef}
             data-testid="sidebar-container"
             className={`
-              fixed left-0 top-0 h-full
-              border-r border-gray-200 dark:border-gray-600
+              fixed left-0
+              ${showGlobalNav ? 'top-16 h-[calc(100vh-4rem)]' : 'top-0 h-full'}
+              border-r border-border
               ${SIDEBAR_TRANSITION}
               ${isOpen ? 'translate-x-0' : '-translate-x-full'}
             `}

--- a/tests/unit/AppShell-layout.test.tsx
+++ b/tests/unit/AppShell-layout.test.tsx
@@ -124,4 +124,47 @@ describe('AppShell with useLayoutConfig', () => {
     render(<AppShell><div>Content</div></AppShell>);
     expect(screen.getByTestId('sidebar-container')).toBeDefined();
   });
+
+  // Issue #1070: fixed sidebar must not sit under the sticky header.
+  it('should offset the desktop sidebar below the header when showGlobalNav is true', () => {
+    mockIsMobile.mockReturnValue(false);
+    mockLayoutConfig.mockReturnValue({
+      showSidebar: true,
+      showGlobalNav: true,
+      showLocalNav: false,
+      autoCollapseSidebar: false,
+    });
+    render(<AppShell><div>Content</div></AppShell>);
+    const aside = screen.getByTestId('sidebar-container');
+    expect(aside).toHaveClass('top-16', 'h-[calc(100vh-4rem)]');
+    expect(aside).not.toHaveClass('top-0', 'h-full');
+  });
+
+  it('should keep the desktop sidebar full-height when the header is hidden (showGlobalNav false)', () => {
+    mockIsMobile.mockReturnValue(false);
+    mockLayoutConfig.mockReturnValue({
+      showSidebar: true,
+      showGlobalNav: false,
+      showLocalNav: true,
+      autoCollapseSidebar: false,
+    });
+    render(<AppShell><div>Content</div></AppShell>);
+    const aside = screen.getByTestId('sidebar-container');
+    expect(aside).toHaveClass('top-0', 'h-full');
+    expect(aside).not.toHaveClass('top-16', 'h-[calc(100vh-4rem)]');
+  });
+
+  it('should use the semantic border-border token on the desktop sidebar', () => {
+    mockIsMobile.mockReturnValue(false);
+    mockLayoutConfig.mockReturnValue({
+      showSidebar: true,
+      showGlobalNav: true,
+      showLocalNav: false,
+      autoCollapseSidebar: false,
+    });
+    render(<AppShell><div>Content</div></AppShell>);
+    const aside = screen.getByTestId('sidebar-container');
+    expect(aside).toHaveClass('border-border');
+    expect(aside).not.toHaveClass('border-gray-200', 'dark:border-gray-600');
+  });
 });


### PR DESCRIPTION
## 概要
UI磨き込み Phase 5 (#1068) の Issue #1070。半透明ヘッダー(sticky z-50 backdrop-blur)が
固定サイドバーの先頭64px(「Branches」見出し+ツールバー行)を遮蔽し、クリック不能領域+
ブラー越しの灰色の滲みが全PC画面の左上に常時発生する問題を修正します。

## 変更点
- `AppShell.tsx`: `showGlobalNav` 時に `<aside>` を `top-16 h-[calc(100vh-4rem)]`(ヘッダー高オフセット)、Header 非表示画面では従来の `top-0 h-full` を維持
- `border-gray-200 dark:border-gray-600` → `border-border`(トークン化)
- サイドバーの折りたたみ/リサイズ/paddingLeft 連動ロジックには一切触れていない

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`: 全 pass(AppShell-layout テスト更新)

## 関連
Closes #1070 / 親 #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)
