### PR TITLE
feat: テーマ既定を system 化しヘッダーにトグルを追加 (#1071)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,12 @@
    * WCAG AA (>=4.5:1) and auxiliary text >=3:1 against these surfaces.
    */
   :root {
+    /*
+     * [Issue #1071] Declare color-scheme so the UA themes native controls
+     * (select dropdowns, scrollbars, form widgets) to match the active theme
+     * instead of rendering light-on-dark (or vice versa).
+     */
+    color-scheme: light;
     --background: 255 255 255; /* pure white page */
     --foreground: 17 24 39; /* gray-900 */
     --surface: 248 250 252; /* slate-50 — subtly grayed panel */
@@ -56,6 +62,7 @@
   }
 
   .dark {
+    color-scheme: dark; /* [Issue #1071] see :root note */
     --background: 10 12 18; /* #0a0c12 — deep base */
     --foreground: 243 244 246; /* gray-100 */
     --surface: 20 24 33; /* #141821 — subtly lifted card */

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Folder, Github } from 'lucide-react';
 import { PcDisplaySizeSelector } from './PcDisplaySizeSelector';
+import { ThemeToggle } from '@/components/common/ThemeToggle';
 
 export interface HeaderProps {
   title?: string;
@@ -76,6 +77,8 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
             })}
             {/* PC display size selector (Issue #915) - hidden on mobile */}
             <PcDisplaySizeSelector />
+            {/* Theme toggle promoted to the header (Issue #1071) */}
+            <ThemeToggle />
             <a
               href="https://github.com/kewton/MyCodeBranchDesk"
               target="_blank"

--- a/src/components/providers/AppProviders.tsx
+++ b/src/components/providers/AppProviders.tsx
@@ -40,7 +40,7 @@ interface AppProvidersProps {
 export function AppProviders({ children, locale, messages, timeZone, authEnabled = false }: AppProvidersProps) {
   return (
     <NextIntlClientProvider locale={locale} messages={messages} timeZone={timeZone}>
-      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <AuthProvider authEnabled={authEnabled}>
           <PcDisplaySizeProvider>
             <SidebarProvider>

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -24,6 +24,11 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Mock next-themes so the header-mounted ThemeToggle (Issue #1071) renders deterministically
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'dark', setTheme: vi.fn() }),
+}));
+
 import { Header } from '@/components/layout/Header';
 
 describe('Header', () => {
@@ -98,6 +103,11 @@ describe('Header', () => {
     render(<Header />);
     const nav = screen.getByRole('navigation');
     expect(nav).toBeDefined();
+  });
+
+  it('should render the ThemeToggle in the header (Issue #1071)', () => {
+    render(<Header />);
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
   });
 
   it('should apply a translucent backdrop-blur header with an opaque fallback (Issue #1049)', () => {

--- a/tests/unit/config/dark-mode-foundation.test.ts
+++ b/tests/unit/config/dark-mode-foundation.test.ts
@@ -96,6 +96,17 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(cssContent).toContain('--surface:');
       expect(cssContent).toContain('.dark {');
     });
+
+    it('should declare color-scheme on both :root and .dark (Issue #1071: native chrome)', () => {
+      // color-scheme tells the UA to theme native controls (select dropdowns,
+      // scrollbars, form widgets) so they don't render light-on-dark.
+      const rootBlock = cssContent.match(/:root\s*\{([^}]*)\}/);
+      const darkBlock = cssContent.match(/\.dark\s*\{([^}]*)\}/);
+      expect(rootBlock, 'expected a :root block').not.toBeNull();
+      expect(darkBlock, 'expected a .dark block').not.toBeNull();
+      expect(rootBlock![1]).toMatch(/color-scheme:\s*light;/);
+      expect(darkBlock![1]).toMatch(/color-scheme:\s*dark;/);
+    });
   });
 
   describe('UI primitives dark mode (Issue #1048: @apply → cva)', () => {
@@ -172,14 +183,16 @@ describe('Dark Mode Foundation (Issue #424)', () => {
       expect(content).toContain('attribute="class"');
     });
 
-    it('should configure ThemeProvider with defaultTheme="dark"', () => {
+    it('should configure ThemeProvider with defaultTheme="system" (Issue #1071: follow OS)', () => {
       const content = fs.readFileSync(providersPath, 'utf-8');
-      expect(content).toContain('defaultTheme="dark"');
+      expect(content).toContain('defaultTheme="system"');
+      expect(content).not.toContain('defaultTheme="dark"');
     });
 
-    it('should configure ThemeProvider with enableSystem={false}', () => {
+    it('should enable system theme detection (Issue #1071)', () => {
       const content = fs.readFileSync(providersPath, 'utf-8');
-      expect(content).toContain('enableSystem={false}');
+      expect(content).toContain('enableSystem');
+      expect(content).not.toContain('enableSystem={false}');
     });
 
     it('should place ThemeProvider inside NextIntlClientProvider and outside AuthProvider', () => {


### PR DESCRIPTION
## 概要
UI磨き込み Phase 5 (#1068) の Issue #1071。テーマ初期値を OS 追従(system)にし、
テーマトグルをヘッダーへ昇格。あわせて `color-scheme` を宣言してネイティブコントロールの
OS クローム事故を防止します。

## 変更点
- `AppProviders.tsx`: `defaultTheme="system" enableSystem`(強制ダークの解消)
- `Header.tsx`: 右クラスタに ghost の ThemeToggle(既存コンポーネント再利用)を追加
- `globals.css`: `:root { color-scheme: light }` / `.dark { color-scheme: dark }`

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`: 全 pass(Header/dark-mode-foundation テスト更新)
- 注: ライトモードの完成度は #1074/#1075/#1073(Phase B)で担保。本 PR は既定とトグルのみ

## 関連
Closes #1071 / 親 #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)
