### PR TITLE
fix: useIsMobile を matchMedia ベースにし混成レイアウトバグを解消 (#1069)

### DIFF
--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,8 +1,10 @@
 /**
  * useIsMobile Hook
  *
- * Detects if the current viewport is mobile-sized
- * Based on window width compared to a breakpoint (default: 768px)
+ * Detects if the current viewport is mobile-sized using `matchMedia`, so the
+ * breakpoint is evaluated against the CSS viewport — exactly like Tailwind's
+ * `md:` — rather than the layout width, which can diverge from the CSS viewport
+ * under zoom, WebView, and device-emulation environments (Issue #1069).
  */
 
 'use client';
@@ -55,24 +57,21 @@ export function useIsMobile(options: UseIsMobileOptions = {}): boolean {
   const [isMobile, setIsMobile] = useState<boolean>(false);
 
   useEffect(() => {
-    /**
-     * Check if current window width is below breakpoint
-     */
-    const checkIsMobile = (): boolean => {
-      return window.innerWidth < breakpoint;
+    // `max-width: breakpoint - 1` is the exact complement of Tailwind's `md:`
+    // (`min-width: breakpoint`); for the default 768 this is `max-width: 767px`.
+    const mediaQuery = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+
+    // Sync state on mount (after hydration is complete)
+    setIsMobile(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
     };
 
-    // Update state on mount (after hydration is complete)
-    setIsMobile(checkIsMobile());
-
-    const handleResize = () => {
-      setIsMobile(checkIsMobile());
-    };
-
-    window.addEventListener('resize', handleResize);
+    mediaQuery.addEventListener('change', handleChange);
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      mediaQuery.removeEventListener('change', handleChange);
     };
   }, [breakpoint]);
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -34,6 +34,59 @@ beforeAll(() => {
       }
     };
   }
+
+  // Polyfill window.matchMedia for jsdom (Issue #1069). jsdom does not
+  // implement it, so hooks that switched from window.innerWidth to matchMedia
+  // (e.g. useIsMobile) would throw. This lightweight stub evaluates the
+  // min-/max-width bounds of a query against window.innerWidth and re-evaluates
+  // on window `resize`, translating each crossing into a `change` event — so
+  // component tests that drive layout by mutating innerWidth + dispatching
+  // `resize` keep working without per-file matchMedia mocks.
+  if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+    const evaluate = (query: string): boolean => {
+      const maxMatch = query.match(/max-width:\s*(\d+(?:\.\d+)?)px/);
+      const minMatch = query.match(/min-width:\s*(\d+(?:\.\d+)?)px/);
+      const width = window.innerWidth;
+      if (maxMatch && width > Number(maxMatch[1])) return false;
+      if (minMatch && width < Number(minMatch[1])) return false;
+      return Boolean(maxMatch || minMatch);
+    };
+
+    window.matchMedia = (query: string): MediaQueryList => {
+      const listeners = new Set<(event: MediaQueryListEvent) => void>();
+      let matches = evaluate(query);
+      const onResize = () => {
+        const next = evaluate(query);
+        if (next !== matches) {
+          matches = next;
+          const event = { matches, media: query } as MediaQueryListEvent;
+          listeners.forEach((listener) => listener(event));
+        }
+      };
+      window.addEventListener('resize', onResize);
+
+      return {
+        media: query,
+        get matches() {
+          return matches;
+        },
+        onchange: null,
+        addEventListener: (type: string, listener: (event: MediaQueryListEvent) => void) => {
+          if (type === 'change') listeners.add(listener);
+        },
+        removeEventListener: (type: string, listener: (event: MediaQueryListEvent) => void) => {
+          if (type === 'change') listeners.delete(listener);
+        },
+        addListener: (listener: (event: MediaQueryListEvent) => void) => {
+          listeners.add(listener);
+        },
+        removeListener: (listener: (event: MediaQueryListEvent) => void) => {
+          listeners.delete(listener);
+        },
+        dispatchEvent: () => false,
+      } as unknown as MediaQueryList;
+    };
+  }
 });
 
 afterEach(() => {

--- a/tests/unit/hooks/useIsMobile.test.ts
+++ b/tests/unit/hooks/useIsMobile.test.ts
@@ -1,7 +1,10 @@
 /**
  * Tests for useIsMobile hook
  *
- * Tests mobile detection based on window width
+ * Tests mobile detection based on `matchMedia` (Issue #1069). jsdom does not
+ * implement `window.matchMedia`, so it is mocked with a controllable stub that
+ * evaluates a `(max-width: Npx)` query against a virtual viewport width and
+ * dispatches `change` events when that width crosses the breakpoint.
  * @vitest-environment jsdom
  */
 
@@ -9,167 +12,244 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useIsMobile, MOBILE_BREAKPOINT } from '@/hooks/useIsMobile';
 
-describe('useIsMobile', () => {
-  // Store original innerWidth
-  let originalInnerWidth: number;
+interface MockMediaQueryList {
+  media: string;
+  maxWidth: number;
+  matches: boolean;
+  listeners: Set<(event: MediaQueryListEvent) => void>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+}
 
+/** Virtual CSS-viewport width that the mocked `matchMedia` evaluates against. */
+let currentWidth = 1024;
+/** All MediaQueryList objects created by the mock in the current test. */
+let mediaQueryLists: MockMediaQueryList[] = [];
+
+/** Extract the pixel value from a `(max-width: Npx)` media query. */
+function parseMaxWidth(query: string): number {
+  const match = query.match(/max-width:\s*(\d+)px/);
+  return match ? Number(match[1]) : NaN;
+}
+
+/** Build a fresh `window.matchMedia` mock backed by `mediaQueryLists`. */
+function createMatchMedia() {
+  return vi.fn((query: string): MediaQueryList => {
+    const maxWidth = parseMaxWidth(query);
+    const mql: MockMediaQueryList = {
+      media: query,
+      maxWidth,
+      matches: currentWidth <= maxWidth,
+      listeners: new Set(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    mql.addEventListener.mockImplementation(
+      (type: string, listener: (event: MediaQueryListEvent) => void) => {
+        if (type === 'change') mql.listeners.add(listener);
+      }
+    );
+    mql.removeEventListener.mockImplementation(
+      (type: string, listener: (event: MediaQueryListEvent) => void) => {
+        if (type === 'change') mql.listeners.delete(listener);
+      }
+    );
+    mediaQueryLists.push(mql);
+    return mql as unknown as MediaQueryList;
+  });
+}
+
+/**
+ * Change the virtual viewport width and dispatch `change` events to every
+ * MediaQueryList whose match result flips as a result.
+ */
+function setViewportWidth(width: number) {
+  currentWidth = width;
+  for (const mql of mediaQueryLists) {
+    const nextMatches = width <= mql.maxWidth;
+    if (nextMatches !== mql.matches) {
+      mql.matches = nextMatches;
+      const event = { matches: nextMatches, media: mql.media } as MediaQueryListEvent;
+      mql.listeners.forEach((listener) => listener(event));
+    }
+  }
+}
+
+describe('useIsMobile', () => {
   beforeEach(() => {
-    originalInnerWidth = window.innerWidth;
+    currentWidth = 1024;
+    mediaQueryLists = [];
+    vi.stubGlobal('matchMedia', createMatchMedia());
   });
 
   afterEach(() => {
-    // Restore original width
-    Object.defineProperty(window, 'innerWidth', {
-      value: originalInnerWidth,
-      writable: true,
-    });
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
-  /**
-   * Helper to set window width
-   */
-  function setWindowWidth(width: number) {
-    Object.defineProperty(window, 'innerWidth', {
-      value: width,
-      writable: true,
+  describe('SSR / initial state', () => {
+    it('seeds state with false on the first render even on a mobile viewport', () => {
+      // The SSR-safe invariant: the useState seed is false so the server render
+      // and the first client render agree (no hydration mismatch). Detection
+      // happens in useEffect, which only runs on the client after hydration.
+      setViewportWidth(390);
+      const renders: boolean[] = [];
+      renderHook(() => {
+        const value = useIsMobile();
+        renders.push(value);
+        return value;
+      });
+      expect(renders[0]).toBe(false);
+      expect(renders[renders.length - 1]).toBe(true);
     });
-  }
 
-  /**
-   * Helper to trigger resize event
-   */
-  function triggerResize() {
-    window.dispatchEvent(new Event('resize'));
-  }
+    it('does not call matchMedia during the initial render (only in effect)', () => {
+      // Server-side there is no matchMedia; the hook must not touch it during
+      // render. renderHook flushes effects, so by the end it has been called,
+      // but never before the first render committed.
+      setViewportWidth(1024);
+      const { result } = renderHook(() => useIsMobile());
+      expect(result.current).toBe(false);
+    });
+  });
 
   describe('Initial state', () => {
-    it('should return true when window width is less than breakpoint', () => {
-      setWindowWidth(500);
+    it('returns true when the viewport matches the mobile query', () => {
+      setViewportWidth(500);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(true);
     });
 
-    it('should return false when window width is greater than or equal to breakpoint', () => {
-      setWindowWidth(1024);
+    it('returns false when the viewport is at desktop width', () => {
+      setViewportWidth(1024);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(false);
     });
 
-    it('should return false when window width equals breakpoint exactly', () => {
-      setWindowWidth(MOBILE_BREAKPOINT);
+    it('returns false at exactly the breakpoint (768px)', () => {
+      setViewportWidth(MOBILE_BREAKPOINT);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(false);
     });
 
-    it('should return true when window width is just below breakpoint', () => {
-      setWindowWidth(MOBILE_BREAKPOINT - 1);
+    it('returns true just below the breakpoint (767px)', () => {
+      setViewportWidth(MOBILE_BREAKPOINT - 1);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(true);
     });
   });
 
-  describe('Resize handling', () => {
-    it('should update when window is resized to mobile width', () => {
-      // Start with desktop width
-      setWindowWidth(1024);
+  describe('Media query string', () => {
+    it('queries (max-width: 767px) — the exact complement of Tailwind md:', () => {
+      renderHook(() => useIsMobile());
+      expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 767px)');
+    });
+
+    it('does not use fractional pixel values', () => {
+      renderHook(() => useIsMobile());
+      const query = (window.matchMedia as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(query).not.toContain('.');
+    });
+  });
+
+  describe('change handling', () => {
+    it('updates to mobile when the query starts matching', () => {
+      setViewportWidth(1024);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(false);
 
-      // Resize to mobile
       act(() => {
-        setWindowWidth(500);
-        triggerResize();
+        setViewportWidth(500);
       });
 
       expect(result.current).toBe(true);
     });
 
-    it('should update when window is resized to desktop width', () => {
-      // Start with mobile width
-      setWindowWidth(500);
+    it('updates to desktop when the query stops matching', () => {
+      setViewportWidth(500);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(true);
 
-      // Resize to desktop
       act(() => {
-        setWindowWidth(1024);
-        triggerResize();
+        setViewportWidth(1024);
       });
 
       expect(result.current).toBe(false);
     });
 
-    it('should not change state when staying within mobile range', () => {
-      // Start with mobile width
-      setWindowWidth(400);
+    it('stays mobile while resizing within the mobile range', () => {
+      setViewportWidth(400);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(true);
 
-      // Resize but stay mobile
       act(() => {
-        setWindowWidth(600);
-        triggerResize();
+        setViewportWidth(600);
       });
 
       expect(result.current).toBe(true);
     });
 
-    it('should not change state when staying within desktop range', () => {
-      // Start with desktop width
-      setWindowWidth(1024);
+    it('stays desktop while resizing within the desktop range', () => {
+      setViewportWidth(1024);
       const { result } = renderHook(() => useIsMobile());
       expect(result.current).toBe(false);
 
-      // Resize but stay desktop
       act(() => {
-        setWindowWidth(1200);
-        triggerResize();
+        setViewportWidth(1200);
       });
 
       expect(result.current).toBe(false);
+    });
+
+    it('registers a change listener via addEventListener', () => {
+      renderHook(() => useIsMobile());
+      expect(mediaQueryLists).toHaveLength(1);
+      expect(mediaQueryLists[0].addEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function)
+      );
     });
   });
 
   describe('Cleanup', () => {
-    it('should remove resize listener on unmount', () => {
-      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
-
-      setWindowWidth(1024);
+    it('removes the change listener on unmount', () => {
       const { unmount } = renderHook(() => useIsMobile());
+      expect(mediaQueryLists).toHaveLength(1);
 
       unmount();
 
-      expect(removeEventListenerSpy).toHaveBeenCalledWith(
-        'resize',
+      expect(mediaQueryLists[0].removeEventListener).toHaveBeenCalledWith(
+        'change',
         expect.any(Function)
       );
-
-      removeEventListenerSpy.mockRestore();
     });
   });
 
   describe('Breakpoint value', () => {
-    it('should use 768 as the default breakpoint', () => {
+    it('uses 768 as the default breakpoint', () => {
       expect(MOBILE_BREAKPOINT).toBe(768);
     });
   });
 
   describe('Custom breakpoint', () => {
-    it('should accept custom breakpoint', () => {
-      setWindowWidth(900);
+    it('generates a (max-width: breakpoint-1) query', () => {
+      renderHook(() => useIsMobile({ breakpoint: 1024 }));
+      expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 1023px)');
+    });
+
+    it('returns true when the viewport is below the custom breakpoint', () => {
+      setViewportWidth(900);
       const { result } = renderHook(() => useIsMobile({ breakpoint: 1024 }));
       expect(result.current).toBe(true);
     });
 
-    it('should work correctly with custom breakpoint on resize', () => {
-      setWindowWidth(900);
+    it('reacts to change events with the custom breakpoint', () => {
+      setViewportWidth(900);
       const { result } = renderHook(() => useIsMobile({ breakpoint: 1024 }));
       expect(result.current).toBe(true);
 
       act(() => {
-        setWindowWidth(1100);
-        triggerResize();
+        setViewportWidth(1100);
       });
 
       expect(result.current).toBe(false);


### PR DESCRIPTION
## 概要
UI磨き込み Phase 5 (#1068) の Issue #1069(**実バグ修正**)。`useIsMobile` の
`window.innerWidth` 依存を `matchMedia` ベースへ変更します。

## 背景
innerWidth と CSS ビューポートが乖離する環境で、Tailwind(CSSビューポート基準の `md:`)と
JS分岐(innerWidth基準)が食い違い「CSSはモバイル・JSはデスクトップ」の混成レイアウトになる。
- 実測(Playwright モバイルエミュレーション 390px幅): `window.innerWidth`=**846** / `documentElement.clientWidth`=**390**

## 変更点
- `src/hooks/useIsMobile.ts`: `window.matchMedia('(max-width: ${breakpoint-1}px)')`(既定 767px = `md:` の正確な補集合)。`change` イベント購読+cleanup。SSR 初期値 false・`MOBILE_BREAKPOINT` export・`breakpoint` オプションは維持
- `tests/setup.ts`: matchMedia モックを追加
- `tests/unit/hooks/useIsMobile.test.ts`: モックで matches 切替・cleanup を検証

## 検証
- `npx tsc --noEmit` / `npm run lint` / `npm run test:unit`: 全 pass
- `useIsMobile.ts` に `innerWidth` 参照 0 件(grep)

## 関連
Closes #1069 / 親 #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)
