### PR TITLE
feat(ui): ライトモードのエレベーション階梯を反転(グレー地+白カード+2層影) (#1074)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,12 @@
    * (deep base → subtly-lifted surface → recessed secondary → hairline border)
    * so screens read as layered rather than "flat gray boxes". Body text keeps
    * WCAG AA (>=4.5:1) and auxiliary text >=3:1 against these surfaces.
+   *
+   * [Issue #1074] Light ladder INVERTED to match dark's intent: the page is a
+   * near-white gray (--background), cards are pure white (--surface, brightest
+   * top-lit layer) and the secondary surface is a recessed well (--surface-2,
+   * darkest). Reads as "white card floats above a gray page": surface-2 <
+   * background < surface. Not a monotone mirror of dark — dark unchanged.
    */
   :root {
     /*
@@ -22,11 +28,11 @@
      * instead of rendering light-on-dark (or vice versa).
      */
     color-scheme: light;
-    --background: 255 255 255; /* pure white page */
+    --background: 250 250 251; /* near-white gray page [#1074] */
     --foreground: 17 24 39; /* gray-900 */
-    --surface: 248 250 252; /* slate-50 — subtly grayed panel */
+    --surface: 255 255 255; /* white card — brightest, top-lit [#1074] */
     --surface-foreground: 17 24 39; /* gray-900 */
-    --surface-2: 241 245 249; /* slate-100 — recessed secondary */
+    --surface-2: 244 246 250; /* recessed well — darkest light surface [#1074] */
     --muted: 243 244 246; /* gray-100 */
     --muted-foreground: 107 114 128; /* gray-500 */
     --border: 226 232 240; /* slate-200 — hairline */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,15 @@ module.exports = {
         danger: 'rgb(var(--danger) / <alpha-value>)',
         info: 'rgb(var(--info) / <alpha-value>)',
       },
+      // [Issue #1074] Light mode inverted to a gray page with white cards, so
+      // shadow-sm must read as a real 2-layer elevation instead of the flat
+      // Tailwind default (`0 1px 2px 0 rgb(0 0 0 / 0.05)`). The slate tint
+      // (rgb(15 23 42)) is near-invisible on the dark #0a0c12 base, so dark is
+      // unchanged (dark separates surfaces by border, not shadow). md/lg stay
+      // Tailwind defaults — this issue is scoped to sm.
+      boxShadow: {
+        sm: '0 1px 2px rgb(15 23 42 / 0.06), 0 1px 1px rgb(15 23 42 / 0.04)',
+      },
       animation: {
         'slide-in': 'slide-in 0.3s ease-out',
         'slide-up': 'slide-up 0.25s ease-out',

--- a/tests/unit/config/design-tokens.test.ts
+++ b/tests/unit/config/design-tokens.test.ts
@@ -23,13 +23,16 @@ const ROOT = path.resolve(__dirname, '../../..');
  * Tokens whose value differs between light and dark modes.
  * background/surface/surface-2/border were revised in Issue #1049 to form a
  * deliberate depth ladder (the first intentional visual change).
+ * Issue #1074 inverted the LIGHT ladder: the page is now a near-white gray
+ * (--background), cards are pure white (--surface, brightest), and the
+ * secondary surface is a recessed well (--surface-2, darkest). Dark unchanged.
  */
 const MODE_VARYING: Record<string, { light: string; dark: string }> = {
-  '--background': { light: '255 255 255', dark: '10 12 18' },
+  '--background': { light: '250 250 251', dark: '10 12 18' },
   '--foreground': { light: '17 24 39', dark: '243 244 246' },
-  '--surface': { light: '248 250 252', dark: '20 24 33' },
+  '--surface': { light: '255 255 255', dark: '20 24 33' },
   '--surface-foreground': { light: '17 24 39', dark: '243 244 246' },
-  '--surface-2': { light: '241 245 249', dark: '15 18 26' },
+  '--surface-2': { light: '244 246 250', dark: '15 18 26' },
   '--muted': { light: '243 244 246', dark: '31 41 55' },
   '--muted-foreground': { light: '107 114 128', dark: '156 163 175' },
   '--border': { light: '226 232 240', dark: '42 48 62' },
@@ -137,6 +140,20 @@ describe('Design tokens (Issue #1041)', () => {
     it('no longer exposes the removed primary / cmd-bg-dark colors', () => {
       expect(colors.primary).toBeUndefined();
       expect(colors['cmd-bg-dark']).toBeUndefined();
+    });
+
+    // [Issue #1074] The light page went gray + white cards, so shadow-sm must
+    // read as a real 2-layer elevation (was the flat Tailwind default
+    // `0 1px 2px 0 rgb(0 0 0 / 0.05)`). boxShadow is mode-independent; the
+    // slate tint is near-invisible on the dark #0a0c12 base so dark is unchanged.
+    it('defines a custom 2-layer boxShadow.sm (Issue #1074)', () => {
+      const boxShadow = resolveConfig(config).theme.boxShadow as Record<string, string>;
+      const sm = boxShadow.sm;
+      expect(sm).toBeDefined();
+      // No longer the flat single-layer Tailwind default.
+      expect(sm).not.toBe('0 1px 2px 0 rgb(0 0 0 / 0.05)');
+      // Two comma-separated shadow layers.
+      expect(sm.split('),').length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/tests/unit/config/surface-depth.test.ts
+++ b/tests/unit/config/surface-depth.test.ts
@@ -30,6 +30,30 @@ function channelSum(block: string, token: string): number {
   return Number(m![1]) + Number(m![2]) + Number(m![3]);
 }
 
+/** Parse an `--token: r g b;` triplet into [r, g, b] (0-255). */
+function channels(block: string, token: string): [number, number, number] {
+  const m = block.match(new RegExp(`${token}\\s*:\\s*(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*;`));
+  expect(m, `Expected ${token} in the block`).not.toBeNull();
+  return [Number(m![1]), Number(m![2]), Number(m![3])];
+}
+
+/** WCAG 2.1 relative luminance for an sRGB triplet (0-255). */
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const lin = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** WCAG contrast ratio between two sRGB triplets (>= 1). */
+function contrastRatio(a: [number, number, number], b: [number, number, number]): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
 describe('Surface depth ladder (Issue #1049)', () => {
   let css: string;
   let root: string;
@@ -55,17 +79,72 @@ describe('Surface depth ladder (Issue #1049)', () => {
     });
   });
 
-  describe('light mode (pure-white page, subtly grayed panels)', () => {
-    it('uses a pure white background', () => {
-      expect(channelSum(root, '--background')).toBe(765);
+  // [Issue #1074] The light ladder was INVERTED: instead of a pure-white page
+  // with recessed gray panels, the page is a near-white gray, cards are pure
+  // white (the brightest, top-lit layer), and the secondary surface is a
+  // recessed well (the darkest). This is NOT a monotone mirror of dark
+  // (dark: bg < surface-2 < surface); light reads as "white card floats above a
+  // gray page, wells sink below it": surface-2 < background < surface.
+  describe('light mode (gray page, white cards float, wells recess) — Issue #1074', () => {
+    it('uses a near-white gray page background (no longer pure white)', () => {
+      expect(channelSum(root, '--background')).toBeLessThan(765);
     });
 
-    it('recesses surface below background and surface-2 below surface', () => {
+    it('makes the card surface the brightest, top-lit layer (pure white)', () => {
+      expect(channelSum(root, '--surface')).toBe(765);
+    });
+
+    it('floats the white card above the gray page (background < surface)', () => {
+      expect(channelSum(root, '--background')).toBeLessThan(channelSum(root, '--surface'));
+    });
+
+    it('recesses the secondary surface below both the card and the page (sunken well)', () => {
       const bg = channelSum(root, '--background');
       const surface = channelSum(root, '--surface');
       const s2 = channelSum(root, '--surface-2');
-      expect(surface).toBeLessThan(bg);
       expect(s2).toBeLessThan(surface);
+      expect(s2).toBeLessThan(bg);
+    });
+  });
+
+  // [Issue #1074] Contrast contract mirrors the #1049 policy stated in
+  // globals.css: body text (foreground) >= 4.5:1 (WCAG AA), auxiliary text
+  // (muted-foreground) >= 3:1. muted-foreground additionally clears 4.5:1 on the
+  // page and card; on the recessed well it is auxiliary-only (>= 3:1).
+  describe('light mode contrast (WCAG) — Issue #1074', () => {
+    const AA_BODY = 4.5;
+    const AA_AUX = 3;
+    let fg: [number, number, number];
+    let mfg: [number, number, number];
+
+    beforeAll(() => {
+      fg = channels(root, '--foreground');
+      mfg = channels(root, '--muted-foreground');
+    });
+
+    it('keeps foreground body text >= 4.5:1 on every light surface', () => {
+      for (const token of ['--background', '--surface', '--surface-2'] as const) {
+        expect(
+          contrastRatio(fg, channels(root, token)),
+          `foreground on ${token}`,
+        ).toBeGreaterThanOrEqual(AA_BODY);
+      }
+    });
+
+    it('keeps muted-foreground >= 4.5:1 on the page and the white card', () => {
+      for (const token of ['--background', '--surface'] as const) {
+        expect(
+          contrastRatio(mfg, channels(root, token)),
+          `muted-foreground on ${token}`,
+        ).toBeGreaterThanOrEqual(AA_BODY);
+      }
+    });
+
+    it('keeps muted-foreground >= 3:1 (auxiliary) on the recessed well surface-2', () => {
+      expect(
+        contrastRatio(mfg, channels(root, '--surface-2')),
+        'muted-foreground on --surface-2',
+      ).toBeGreaterThanOrEqual(AA_AUX);
     });
   });
 


### PR DESCRIPTION
## 概要

Issue #1074（親 #1068 / Phase B）。light モードを「白ページ+凹む灰カード」から Vercel/Linear 型の **「グレー地ページ+白カード+2層影」** へ反転し、dark(#1049)と対のエレベーションモデルにする。

light 階梯: `--surface-2(740) < --background(751) < --surface(765)`（白カードが浮き、well が沈む）。dark の単調ミラーではなく、dark は完全不変。

## 変更内容（トークン値と影の定義に限定）

| ファイル | 変更 |
|---------|------|
| `src/app/globals.css` | `:root` 反転: `--background 255→250 250 251` / `--surface 248 250 252→255 255 255` / `--surface-2 241 245 249→244 246 250`。**`.dark` 無変更** |
| `tailwind.config.js` | `theme.extend.boxShadow.sm` を2層で新規追加（`0 1px 2px rgb(15 23 42/0.06), 0 1px 1px rgb(15 23 42/0.04)`）。md/lg は Tailwind 既定 |
| `tests/unit/config/design-tokens.test.ts` | MODE_VARYING の light 値更新 + boxShadow.sm 2層検証追加 |
| `tests/unit/config/surface-depth.test.ts` | light 意図反転（bg<surface）+ WCAG コントラスト検証追加 |

`Card.tsx` は elevated グラデ（from-surface to-surface-2）が反転後も自然な top-lit のため無変更。

## コントラスト（#1049 の2層ポリシー準拠）

- foreground(gray-900): 全 light 面で ≥4.5:1（本文AA、最小 ~16:1）
- muted-foreground(gray-500): page/card で ≥4.5:1、recessed well(surface-2) で ≥3:1（補助テキスト、~4.47:1）

## 品質ゲート

- ✅ `npx tsc --noEmit`
- ✅ `npm run lint`（No warnings/errors）
- ✅ `npm run test:unit`（8719/8719 pass）
- ✅ `npm run build`
- ✅ dark トークン不変（dark-mode-foundation + MODE_VARYING dark green）

## スコープ外（フォローアップ別Issue）

生 `bg-gray-50`（~85箇所: MessageList / files / MobileHeader / login 等）はトークン非経由のためグレー地に追従せず gray-on-gray。本PRは #1074 スコープ（トークン+影）に限定。

## 手動確認（要レビュアー実施）

- [ ] light で「グレー地に白カードが浮く」階層が主要画面で成立
- [ ] dark の見た目が変わっていない
- [ ] before/after スクリーンショット（Home / Sessions, light）添付

Refs #1074（base=develop のため自動クローズされない。develop→main マージ後に手動クローズ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)