### PR TITLE
feat(ui): ⌘K パレットを Raycast 級に強化（アイコン/StatusDot/kbd/Recents/ヘッダー導線）(#1077)

### DIFF
--- a/locales/en/commandPalette.json
+++ b/locales/en/commandPalette.json
@@ -1,9 +1,11 @@
 {
   "title": "Command palette",
   "placeholder": "Type a command or search...",
+  "searchAction": "Search…",
   "empty": "No results found.",
   "loading": "Loading worktrees...",
   "groups": {
+    "recent": "Recent",
     "navigation": "Navigation",
     "worktrees": "Worktrees",
     "actions": "Actions"
@@ -19,7 +21,17 @@
   "actions": {
     "toLight": "Switch to light theme",
     "toDark": "Switch to dark theme",
-    "displaySizePrefix": "Display size"
+    "displaySizePrefix": "Display size",
+    "syncRepositories": "Sync repositories",
+    "syncSuccess": "Repositories synced",
+    "syncError": "Failed to sync repositories",
+    "switchLanguage": "Switch language",
+    "openGitHub": "Open GitHub"
+  },
+  "footer": {
+    "navigate": "Navigate",
+    "select": "Select",
+    "close": "Close"
   },
   "mobileTrigger": "Open command palette",
   "mobileLabel": "Search"

--- a/locales/ja/commandPalette.json
+++ b/locales/ja/commandPalette.json
@@ -1,9 +1,11 @@
 {
   "title": "コマンドパレット",
   "placeholder": "コマンドを入力または検索...",
+  "searchAction": "検索…",
   "empty": "該当する項目がありません。",
   "loading": "ワークツリーを読み込み中...",
   "groups": {
+    "recent": "最近",
     "navigation": "ナビゲーション",
     "worktrees": "ワークツリー",
     "actions": "アクション"
@@ -19,7 +21,17 @@
   "actions": {
     "toLight": "ライトテーマに切り替え",
     "toDark": "ダークテーマに切り替え",
-    "displaySizePrefix": "表示サイズ"
+    "displaySizePrefix": "表示サイズ",
+    "syncRepositories": "リポジトリを同期",
+    "syncSuccess": "リポジトリを同期しました",
+    "syncError": "リポジトリの同期に失敗しました",
+    "switchLanguage": "言語を切り替え",
+    "openGitHub": "GitHub を開く"
+  },
+  "footer": {
+    "navigate": "移動",
+    "select": "実行",
+    "close": "閉じる"
   },
   "mobileTrigger": "コマンドパレットを開く",
   "mobileLabel": "検索"

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -1,20 +1,23 @@
 /**
- * CommandPalette (Issue #1053)
+ * CommandPalette (Issue #1053, enhanced #1077)
  *
  * A global ⌘K / Ctrl+K command palette (cmdk) mounted once under AppShell.
- * Provides three command groups:
- *   - Navigation: jump to the main screens.
+ * Command groups:
+ *   - Recent: MRU of the last executed commands (empty query only, localStorage).
+ *   - Navigation: jump to the main screens (lucide icons).
  *   - Worktrees: incremental search over repository + branch, read from the
  *     shared WorktreesCache (always fresh + auto-retried, single poller per
- *     Issue #709); the group is omitted while the cache reports an error.
- *   - Actions: theme toggle and PC display-size switching.
+ *     Issue #709); each row shows a StatusDot (Issue #1051). Running sessions
+ *     sort first; the group is omitted while the cache reports an error.
+ *   - Actions: theme toggle, PC display-size switching, repository sync,
+ *     language switch, open GitHub.
  *
  * The single global keyboard listener lives here so it does not conflict with
  * existing per-view shortcuts. It never opens while the user is typing in an
  * input/textarea/contentEditable or the worktree terminal pane (role="log").
  *
- * SSR-safe: 'use client', and `document` is only referenced after mount inside
- * an effect / the portal (which renders only when `mounted && open`).
+ * SSR-safe: 'use client', and `document` / `localStorage` are only referenced
+ * after mount inside an effect / the portal (which renders only when mounted).
  */
 
 'use client';
@@ -25,13 +28,35 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import { Command } from 'cmdk';
-import { Search } from 'lucide-react';
+import {
+  type LucideIcon,
+  Search,
+  Home,
+  MessageSquare,
+  AlignJustify,
+  FolderGit2,
+  CircleCheck,
+  MoreHorizontal,
+  GitBranch,
+  Sun,
+  Moon,
+  Monitor,
+  RefreshCw,
+  Languages,
+  Github,
+} from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 import { Z_INDEX } from '@/config/z-index';
 import { useCommandPalette } from '@/contexts/CommandPaletteContext';
 import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
 import { useOptionalWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { PC_DISPLAY_SIZE_ORDER } from '@/hooks/usePcDisplaySize';
+import { useLocaleSwitch } from '@/hooks/useLocaleSwitch';
+import { repositoryApi } from '@/lib/api-client';
+import { StatusDot, type StatusDotStatus } from '@/components/ui/StatusDot';
+import { Kbd } from '@/components/ui/Kbd';
+import { useToast, ToastContainer } from '@/components/common/Toast';
+import type { Worktree } from '@/types/models';
 
 /** Navigation targets shown in the palette (mirrors Header / GlobalMobileNav). */
 const NAV_ITEMS = [
@@ -42,6 +67,85 @@ const NAV_ITEMS = [
   { key: 'review', href: '/review' },
   { key: 'more', href: '/more' },
 ] as const;
+
+/** lucide icon per navigation target (GlobalMobileNav set + Chat / Repos). */
+const NAV_ICONS: Record<string, LucideIcon> = {
+  home: Home,
+  chat: MessageSquare,
+  sessions: AlignJustify,
+  repositories: FolderGit2,
+  review: CircleCheck,
+  more: MoreHorizontal,
+};
+
+/** localStorage key + cap for the Recent (MRU) group. */
+const RECENTS_KEY = 'cm.palette.recents';
+const RECENTS_MAX = 8;
+/** Max worktrees shown in the group while the query is empty. */
+const WORKTREES_EMPTY_LIMIT = 8;
+
+/** A recorded command, replayed from the Recent group. */
+type RecentEntry =
+  | { kind: 'nav'; id: string }
+  | { kind: 'worktree'; id: string }
+  | { kind: 'action'; id: string };
+
+function isRecentEntry(value: unknown): value is RecentEntry {
+  if (!value || typeof value !== 'object') return false;
+  const { kind, id } = value as Record<string, unknown>;
+  return (
+    (kind === 'nav' || kind === 'worktree' || kind === 'action') &&
+    typeof id === 'string'
+  );
+}
+
+function loadRecents(): RecentEntry[] {
+  try {
+    const raw = localStorage.getItem(RECENTS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRecentEntry).slice(0, RECENTS_MAX);
+  } catch {
+    return [];
+  }
+}
+
+function pushRecent(prev: RecentEntry[], entry: RecentEntry): RecentEntry[] {
+  const deduped = prev.filter(
+    (e) => !(e.kind === entry.kind && e.id === entry.id)
+  );
+  const next = [entry, ...deduped].slice(0, RECENTS_MAX);
+  try {
+    localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+  } catch {
+    // ignore quota / disabled storage
+  }
+  return next;
+}
+
+/**
+ * Derive a StatusDot status from a worktree's live session flags (same
+ * precedence as the sidebar: waiting > processing > running > idle).
+ */
+function worktreeStatus(wt: Worktree): StatusDotStatus {
+  if (wt.isWaitingForResponse) return 'waiting';
+  if (wt.isProcessing) return 'running';
+  if (wt.isSessionRunning) return 'ready';
+  return 'idle';
+}
+
+/** Sort: running sessions first, then most-recently-updated. */
+function sortWorktrees(worktrees: Worktree[]): Worktree[] {
+  return [...worktrees].sort((a, b) => {
+    const ar = a.isSessionRunning ? 1 : 0;
+    const br = b.isSessionRunning ? 1 : 0;
+    if (ar !== br) return br - ar;
+    const at = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+    const bt = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+    return bt - at;
+  });
+}
 
 /**
  * Whether a keyboard event target is a text-entry context where ⌘K must NOT
@@ -62,13 +166,32 @@ export function isTypingTarget(target: EventTarget | null): boolean {
 
 const ITEM_CLASS = cn(
   'flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm',
-  'text-gray-700 dark:text-gray-200',
-  'data-[selected=true]:bg-accent-600/10 data-[selected=true]:text-accent-700',
+  'text-foreground',
+  'data-[selected=true]:bg-accent-500/15 data-[selected=true]:text-accent-700',
   'dark:data-[selected=true]:text-accent-300'
 );
 
+const ICON_CLASS = 'shrink-0 text-muted-foreground';
+
+/** A palette action descriptor, rendered in Actions and replayable from Recent. */
+interface ActionDescriptor {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  run: () => void;
+}
+
+/** A resolved Recent row (dead entries resolve to null and are skipped). */
+interface RecentRow {
+  id: string;
+  value: string;
+  node: React.ReactNode;
+  onSelect: () => void;
+}
+
 /**
- * Global command palette. Renders nothing until opened.
+ * Global command palette. Renders a persistent (portal) toast container plus,
+ * while open, the palette dialog.
  */
 export function CommandPalette() {
   const { open, setOpen } = useCommandPalette();
@@ -77,12 +200,15 @@ export function CommandPalette() {
   const tCommon = useTranslations('common');
   const { theme, setTheme } = useTheme();
   const { setSize, isMobile } = usePcDisplaySizeContext();
+  const { currentLocale, switchLocale } = useLocaleSwitch();
   // Read from the shared worktrees cache (always fresh + auto-retried). Optional
   // so the palette degrades gracefully when no provider is present (unit tests).
   const worktreesCache = useOptionalWorktreesCacheContext();
+  const { toasts, showToast, removeToast } = useToast();
 
   const [mounted, setMounted] = useState(false);
   const [search, setSearch] = useState('');
+  const [recents, setRecents] = useState<RecentEntry[]>([]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   // Element focused before the palette opened, restored on close (a11y).
@@ -135,173 +261,370 @@ export function CommandPalette() {
 
   // Move focus into the search input on open (so type-to-filter / arrows /
   // Enter work immediately without a click); restore focus to the previously
-  // focused element on close.
+  // focused element on close. Also (re)load Recents from storage on open.
   useEffect(() => {
     if (open) {
       previouslyFocusedRef.current =
         (document.activeElement as HTMLElement | null) ?? null;
       inputRef.current?.focus();
+      setSearch('');
+      setRecents(loadRecents());
     } else if (previouslyFocusedRef.current) {
       previouslyFocusedRef.current.focus?.();
       previouslyFocusedRef.current = null;
     }
   }, [open]);
 
-  // Reset the query each time the palette opens.
-  useEffect(() => {
-    if (open) setSearch('');
-  }, [open]);
-
   const runCommand = useCallback(
-    (action: () => void) => {
+    (action: () => void, recent?: RecentEntry) => {
+      if (recent) setRecents((prev) => pushRecent(prev, recent));
       setOpen(false);
       action();
     },
     [setOpen]
   );
 
-  if (!mounted || !open) return null;
+  const handleSyncRepositories = useCallback(async () => {
+    try {
+      await repositoryApi.sync();
+      await worktreesCache?.refresh?.();
+      showToast(t('actions.syncSuccess'), 'success');
+    } catch {
+      showToast(t('actions.syncError'), 'error');
+    }
+  }, [worktreesCache, showToast, t]);
 
   const isDark = theme === 'dark';
-  const worktrees = worktreesCache?.worktrees ?? [];
+  const isEmptyQuery = search.trim() === '';
+
   const worktreesError = worktreesCache?.error ?? null;
   const worktreesLoading = worktreesCache?.isLoading ?? false;
   // On error, fall back to Navigation-only (the cache keeps polling and will
   // repopulate the group once a later poll succeeds).
-  const showWorktrees = !worktreesError && worktrees.length > 0;
+  const worktrees = worktreesError ? [] : worktreesCache?.worktrees ?? [];
+  const showWorktrees = worktrees.length > 0;
   const showWorktreesLoading =
     !worktreesError && worktreesLoading && worktrees.length === 0;
 
+  const sortedWorktrees = sortWorktrees(worktrees);
+  const visibleWorktrees = isEmptyQuery
+    ? sortedWorktrees.slice(0, WORKTREES_EMPTY_LIMIT)
+    : sortedWorktrees;
+
+  // Actions available in the current context (mobile hides display-size).
+  const actions: ActionDescriptor[] = [
+    {
+      id: 'theme',
+      label: isDark ? t('actions.toLight') : t('actions.toDark'),
+      icon: isDark ? Sun : Moon,
+      run: () => setTheme(isDark ? 'light' : 'dark'),
+    },
+    ...(!isMobile
+      ? PC_DISPLAY_SIZE_ORDER.map((size) => ({
+          id: `displaysize:${size}`,
+          label: `${t('actions.displaySizePrefix')}: ${tCommon(`displaySize.${size}`)}`,
+          icon: Monitor,
+          run: () => setSize(size),
+        }))
+      : []),
+    {
+      id: 'sync',
+      label: t('actions.syncRepositories'),
+      icon: RefreshCw,
+      run: () => {
+        void handleSyncRepositories();
+      },
+    },
+    {
+      id: 'locale',
+      label: t('actions.switchLanguage'),
+      icon: Languages,
+      run: () => switchLocale(currentLocale === 'ja' ? 'en' : 'ja'),
+    },
+    {
+      id: 'github',
+      label: t('actions.openGitHub'),
+      icon: Github,
+      run: () =>
+        window.open(
+          'https://github.com/kewton/MyCodeBranchDesk',
+          '_blank',
+          'noopener,noreferrer'
+        ),
+    },
+  ];
+
+  // Resolve Recent entries against the CURRENT data; skip dead entries
+  // (removed worktrees, actions unavailable in this context).
+  const recentRows: RecentRow[] = isEmptyQuery
+    ? recents
+        .map((entry): RecentRow | null => {
+          if (entry.kind === 'nav') {
+            const nav = NAV_ITEMS.find((n) => n.key === entry.id);
+            if (!nav) return null;
+            const Icon = NAV_ICONS[nav.key];
+            const label = t(`nav.${nav.key}`);
+            return {
+              id: `nav-${nav.key}`,
+              value: `recent nav ${nav.key}`,
+              node: (
+                <>
+                  {Icon && <Icon size={16} className={ICON_CLASS} aria-hidden="true" />}
+                  <span className="truncate">{label}</span>
+                </>
+              ),
+              onSelect: () =>
+                runCommand(() => router.push(nav.href), { kind: 'nav', id: nav.key }),
+            };
+          }
+          if (entry.kind === 'worktree') {
+            const wt = worktrees.find((w) => w.id === entry.id);
+            if (!wt) return null;
+            const repo = wt.repositoryDisplayName || wt.repositoryName || '';
+            const branch = wt.branch || wt.name;
+            return {
+              id: `worktree-${wt.id}`,
+              value: `recent worktree ${wt.id}`,
+              node: (
+                <>
+                  <GitBranch size={16} className={ICON_CLASS} aria-hidden="true" />
+                  <span className="truncate">{branch}</span>
+                  {repo && (
+                    <span className="ml-auto truncate pl-2 text-xs text-muted-foreground">
+                      {repo}
+                    </span>
+                  )}
+                  <StatusDot
+                    status={worktreeStatus(wt)}
+                    size="sm"
+                    className={repo ? 'ml-2' : 'ml-auto'}
+                  />
+                </>
+              ),
+              onSelect: () =>
+                runCommand(() => router.push(`/worktrees/${wt.id}`), {
+                  kind: 'worktree',
+                  id: wt.id,
+                }),
+            };
+          }
+          const action = actions.find((a) => a.id === entry.id);
+          if (!action) return null;
+          const Icon = action.icon;
+          return {
+            id: `action-${action.id}`,
+            value: `recent action ${action.id}`,
+            node: (
+              <>
+                <Icon size={16} className={ICON_CLASS} aria-hidden="true" />
+                <span className="truncate">{action.label}</span>
+              </>
+            ),
+            onSelect: () =>
+              runCommand(action.run, { kind: 'action', id: action.id }),
+          };
+        })
+        .filter((row): row is RecentRow => row !== null)
+    : [];
+
+  if (!mounted) return null;
+
   return createPortal(
-    <div
-      className="fixed inset-0 overflow-y-auto"
-      style={{ zIndex: Z_INDEX.MODAL }}
-      data-testid="command-palette"
-    >
-      {/* Backdrop — fade-in on mount (shared motion tokens, Issue #1050). */}
-      <div
-        data-state="open"
-        aria-hidden="true"
-        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-200"
-        onClick={() => setOpen(false)}
-      />
-
-      <div className="relative flex min-h-full items-start justify-center p-4 pt-[15vh]">
+    <>
+      {open && (
         <div
-          data-state="open"
-          data-testid="command-palette-panel"
-          className={cn(
-            'relative w-full max-w-lg overflow-hidden rounded-lg border border-border bg-white shadow-xl dark:bg-gray-900',
-            'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:duration-200'
-          )}
+          className="fixed inset-0 overflow-y-auto"
+          style={{ zIndex: Z_INDEX.MODAL }}
+          data-testid="command-palette"
         >
-          <Command
-            label={t('title')}
-            className={cn(
-              'flex flex-col',
-              '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-2',
-              '[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-gray-500'
-            )}
-          >
-            <div className="flex items-center gap-2 border-b border-border px-3">
-              <Search size={16} strokeWidth={2} aria-hidden="true" className="shrink-0 text-gray-400" />
-              <Command.Input
-                ref={inputRef}
-                value={search}
-                onValueChange={setSearch}
-                placeholder={t('placeholder')}
-                data-testid="command-palette-input"
-                className="flex-1 bg-transparent py-3 text-sm text-gray-900 outline-none placeholder:text-gray-400 dark:text-gray-100"
-              />
-            </div>
+          {/* Backdrop — fade-in on mount (shared motion tokens, Issue #1050). */}
+          <div
+            data-state="open"
+            aria-hidden="true"
+            className="fixed inset-0 bg-black/40 backdrop-blur-sm transition-opacity data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-200"
+            onClick={() => setOpen(false)}
+          />
 
-            <Command.List className="max-h-[min(60vh,360px)] overflow-y-auto p-2">
-              <Command.Empty
-                data-testid="command-palette-empty"
-                className="py-6 text-center text-sm text-gray-500"
+          <div className="relative flex min-h-full items-start justify-center p-4 pt-[15vh]">
+            <div
+              data-state="open"
+              data-testid="command-palette-panel"
+              className={cn(
+                'relative w-full max-w-lg overflow-hidden rounded-xl bg-surface/95 shadow-2xl ring-1 ring-border backdrop-blur-xl',
+                'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:duration-200'
+              )}
+            >
+              <Command
+                label={t('title')}
+                className={cn(
+                  'flex flex-col',
+                  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-2',
+                  '[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground'
+                )}
               >
-                {t('empty')}
-              </Command.Empty>
+                <div className="flex items-center gap-2 border-b border-border px-3">
+                  <Search
+                    size={16}
+                    strokeWidth={2}
+                    aria-hidden="true"
+                    className="shrink-0 text-muted-foreground"
+                  />
+                  <Command.Input
+                    ref={inputRef}
+                    value={search}
+                    onValueChange={setSearch}
+                    placeholder={t('placeholder')}
+                    data-testid="command-palette-input"
+                    className="flex-1 bg-transparent py-3 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                  />
+                </div>
 
-              {showWorktreesLoading && (
-                <Command.Loading
-                  data-testid="command-palette-loading"
-                  className="py-6 text-center text-sm text-gray-500"
-                >
-                  {t('loading')}
-                </Command.Loading>
-              )}
+                <Command.List className="max-h-[min(60vh,360px)] overflow-y-auto p-2">
+                  <Command.Empty
+                    data-testid="command-palette-empty"
+                    className="py-6 text-center text-sm text-muted-foreground"
+                  >
+                    {t('empty')}
+                  </Command.Empty>
 
-              <Command.Group heading={t('groups.navigation')}>
-                {NAV_ITEMS.map((item) => {
-                  const label = t(`nav.${item.key}`);
-                  return (
-                    <Command.Item
-                      key={item.key}
-                      value={`nav ${label} ${item.href}`}
-                      onSelect={() => runCommand(() => router.push(item.href))}
-                      className={ITEM_CLASS}
+                  {showWorktreesLoading && (
+                    <Command.Loading
+                      data-testid="command-palette-loading"
+                      className="py-6 text-center text-sm text-muted-foreground"
                     >
-                      {label}
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
+                      {t('loading')}
+                    </Command.Loading>
+                  )}
 
-              {showWorktrees && (
-                <Command.Group heading={t('groups.worktrees')}>
-                  {worktrees.map((wt) => {
-                    const repo = wt.repositoryDisplayName || wt.repositoryName || '';
-                    const branch = wt.branch || wt.name;
-                    return (
-                      <Command.Item
-                        key={wt.id}
-                        value={`worktree ${repo} ${branch} ${wt.name} ${wt.id}`}
-                        onSelect={() =>
-                          runCommand(() => router.push(`/worktrees/${wt.id}`))
-                        }
-                        className={ITEM_CLASS}
-                      >
-                        <span className="truncate">{branch}</span>
-                        {repo && (
-                          <span className="ml-auto truncate pl-2 text-xs text-gray-400">
-                            {repo}
-                          </span>
-                        )}
-                      </Command.Item>
-                    );
-                  })}
-                </Command.Group>
-              )}
+                  {recentRows.length > 0 && (
+                    <Command.Group heading={t('groups.recent')}>
+                      {recentRows.map((row) => (
+                        <Command.Item
+                          key={row.id}
+                          value={row.value}
+                          onSelect={row.onSelect}
+                          className={ITEM_CLASS}
+                        >
+                          {row.node}
+                        </Command.Item>
+                      ))}
+                    </Command.Group>
+                  )}
 
-              <Command.Group heading={t('groups.actions')}>
-                <Command.Item
-                  value={`action theme ${isDark ? 'light' : 'dark'}`}
-                  onSelect={() =>
-                    runCommand(() => setTheme(isDark ? 'light' : 'dark'))
-                  }
-                  className={ITEM_CLASS}
-                >
-                  {isDark ? t('actions.toLight') : t('actions.toDark')}
-                </Command.Item>
+                  <Command.Group heading={t('groups.navigation')}>
+                    {NAV_ITEMS.map((item) => {
+                      const label = t(`nav.${item.key}`);
+                      const Icon = NAV_ICONS[item.key];
+                      return (
+                        <Command.Item
+                          key={item.key}
+                          value={`nav ${label} ${item.href}`}
+                          onSelect={() =>
+                            runCommand(() => router.push(item.href), {
+                              kind: 'nav',
+                              id: item.key,
+                            })
+                          }
+                          className={ITEM_CLASS}
+                        >
+                          {Icon && (
+                            <Icon size={16} className={ICON_CLASS} aria-hidden="true" />
+                          )}
+                          <span className="truncate">{label}</span>
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
 
-                {!isMobile &&
-                  PC_DISPLAY_SIZE_ORDER.map((size) => (
-                    <Command.Item
-                      key={size}
-                      value={`action displaysize ${size} ${tCommon(`displaySize.${size}`)}`}
-                      onSelect={() => runCommand(() => setSize(size))}
-                      className={ITEM_CLASS}
-                    >
-                      {t('actions.displaySizePrefix')}: {tCommon(`displaySize.${size}`)}
-                    </Command.Item>
-                  ))}
-              </Command.Group>
-            </Command.List>
-          </Command>
+                  {showWorktrees && (
+                    <Command.Group heading={t('groups.worktrees')}>
+                      {visibleWorktrees.map((wt) => {
+                        const repo =
+                          wt.repositoryDisplayName || wt.repositoryName || '';
+                        const branch = wt.branch || wt.name;
+                        return (
+                          <Command.Item
+                            key={wt.id}
+                            value={`worktree ${repo} ${branch} ${wt.name} ${wt.id}`}
+                            onSelect={() =>
+                              runCommand(() => router.push(`/worktrees/${wt.id}`), {
+                                kind: 'worktree',
+                                id: wt.id,
+                              })
+                            }
+                            className={ITEM_CLASS}
+                          >
+                            <GitBranch
+                              size={16}
+                              className={ICON_CLASS}
+                              aria-hidden="true"
+                            />
+                            <span className="truncate">{branch}</span>
+                            {repo && (
+                              <span className="ml-auto truncate pl-2 text-xs text-muted-foreground">
+                                {repo}
+                              </span>
+                            )}
+                            <StatusDot
+                              status={worktreeStatus(wt)}
+                              size="sm"
+                              className={repo ? 'ml-2' : 'ml-auto'}
+                            />
+                          </Command.Item>
+                        );
+                      })}
+                    </Command.Group>
+                  )}
+
+                  <Command.Group heading={t('groups.actions')}>
+                    {actions.map((action) => {
+                      const Icon = action.icon;
+                      return (
+                        <Command.Item
+                          key={action.id}
+                          value={`action ${action.id} ${action.label}`}
+                          onSelect={() =>
+                            runCommand(action.run, {
+                              kind: 'action',
+                              id: action.id,
+                            })
+                          }
+                          className={ITEM_CLASS}
+                        >
+                          <Icon size={16} className={ICON_CLASS} aria-hidden="true" />
+                          <span className="truncate">{action.label}</span>
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                </Command.List>
+
+                {/* Keyboard hint footer (Issue #1077). */}
+                <div className="flex items-center gap-3 border-t border-border bg-surface-2 px-3 py-2 text-[11px] text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Kbd>↑</Kbd>
+                    <Kbd>↓</Kbd>
+                    {t('footer.navigate')}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Kbd>↵</Kbd>
+                    {t('footer.select')}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Kbd>esc</Kbd>
+                    {t('footer.close')}
+                  </span>
+                </div>
+              </Command>
+            </div>
+          </div>
         </div>
-      </div>
-    </div>,
+      )}
+
+      {/* Persistent so a toast (e.g. Sync repositories) survives the palette
+          closing after the command runs. */}
+      <ToastContainer toasts={toasts} onClose={removeToast} />
+    </>,
     document.body
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,9 +11,12 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Folder, Github } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Folder, Github, Search } from 'lucide-react';
 import { PcDisplaySizeSelector } from './PcDisplaySizeSelector';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
+import { Kbd } from '@/components/ui/Kbd';
+import { useCommandPalette } from '@/contexts/CommandPaletteContext';
 
 export interface HeaderProps {
   title?: string;
@@ -42,6 +45,18 @@ const NAV_ITEMS: Array<{ label: string; href: string; isActive: (pathname: strin
  */
 export function Header({ title = 'CommandMate' }: HeaderProps) {
   const pathname = usePathname();
+  const t = useTranslations('commandPalette');
+  const { setOpen } = useCommandPalette();
+
+  // Platform-specific modifier resolved after mount to avoid SSR hydration
+  // mismatch (server can't know the OS). Null until then → no key badge shown.
+  const [modKey, setModKey] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    const isMac =
+      typeof navigator !== 'undefined' &&
+      /Mac|iPhone|iPad|iPod/i.test(navigator.platform || '');
+    setModKey(isMac ? '⌘' : 'Ctrl');
+  }, []);
 
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md">
@@ -75,6 +90,23 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
                 </Link>
               );
             })}
+            {/* ⌘K command palette entry point (Issue #1077) - desktop only */}
+            <button
+              type="button"
+              data-testid="header-command-palette-trigger"
+              onClick={() => setOpen(true)}
+              aria-label={t('mobileTrigger')}
+              className="hidden md:inline-flex items-center gap-2 rounded-lg border border-border bg-surface px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-surface-2 transition-colors"
+            >
+              <Search size={16} strokeWidth={2} aria-hidden="true" className="shrink-0" />
+              <span>{t('searchAction')}</span>
+              {modKey && (
+                <span className="flex items-center gap-0.5">
+                  <Kbd>{modKey}</Kbd>
+                  <Kbd>K</Kbd>
+                </span>
+              )}
+            </button>
             {/* PC display size selector (Issue #915) - hidden on mobile */}
             <PcDisplaySizeSelector />
             {/* Theme toggle promoted to the header (Issue #1071) */}

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -1,0 +1,39 @@
+/**
+ * Kbd (Issue #1077)
+ *
+ * A small keyboard-key badge for rendering shortcut hints (e.g. ⌘, K, esc).
+ * Semantic-token based so it follows the theme; reused by the command palette
+ * footer / header pill and the chat composer hint (Issue #1080).
+ */
+
+import React from 'react';
+import { cn } from '@/lib/utils/cn';
+
+export interface KbdProps extends React.HTMLAttributes<HTMLElement> {
+  children: React.ReactNode;
+}
+
+/**
+ * Inline keyboard-key badge.
+ *
+ * @example
+ * ```tsx
+ * <Kbd>⌘</Kbd><Kbd>K</Kbd>
+ * ```
+ */
+export function Kbd({ className, children, ...rest }: KbdProps) {
+  return (
+    <kbd
+      className={cn(
+        'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-border bg-surface px-1',
+        'font-mono text-[10px] font-medium leading-none text-muted-foreground',
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+export default Kbd;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -64,3 +64,7 @@ export {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from './DropdownMenu';
+
+// Keyboard-key badge (Issue #1077)
+export { Kbd } from './Kbd';
+export type { KbdProps } from './Kbd';

--- a/tests/unit/components/common/CommandPalette.test.tsx
+++ b/tests/unit/components/common/CommandPalette.test.tsx
@@ -57,9 +57,26 @@ vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
   useOptionalWorktreesCacheContext: () => mockCache,
 }));
 
+// Enhancements (Issue #1077): repository sync + language switch actions.
+const { repositorySyncMock, switchLocaleMock } = vi.hoisted(() => ({
+  repositorySyncMock: vi.fn(),
+  switchLocaleMock: vi.fn(),
+}));
+vi.mock('@/lib/api-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api-client')>();
+  return {
+    ...actual,
+    repositoryApi: { ...actual.repositoryApi, sync: repositorySyncMock },
+  };
+});
+vi.mock('@/hooks/useLocaleSwitch', () => ({
+  useLocaleSwitch: () => ({ currentLocale: 'en', switchLocale: switchLocaleMock }),
+}));
+
 import { CommandPalette, isTypingTarget } from '@/components/common/CommandPalette';
 import { CommandPaletteProvider } from '@/contexts/CommandPaletteContext';
 import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
+import { Header } from '@/components/layout/Header';
 
 const SAMPLE_WORKTREES = [
   { id: 'wt-login', name: 'feature/login', branch: 'feature/login', repositoryName: 'MyApp' },
@@ -99,6 +116,16 @@ describe('CommandPalette (Issue #1053)', () => {
     pushMock.mockClear();
     setThemeMock.mockClear();
     setSizeMock.mockClear();
+    switchLocaleMock.mockClear();
+    repositorySyncMock.mockReset();
+    repositorySyncMock.mockResolvedValue({
+      success: true,
+      message: '',
+      worktreeCount: 0,
+      repositoryCount: 0,
+      repositories: [],
+    });
+    localStorage.clear();
     vi.stubGlobal(
       'ResizeObserver',
       class {
@@ -380,5 +407,64 @@ describe('CommandPalette (Issue #1053)', () => {
     expect(screen.queryByTestId('command-palette')).toBeNull();
     fireEvent.click(screen.getByTestId('mobile-command-palette-trigger'));
     expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+  });
+
+  // --- Enhancements (Issue #1077) -------------------------------------------
+
+  it('renders the keyboard-hint footer', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.getByText('commandPalette.footer.navigate')).toBeInTheDocument();
+    expect(screen.getByText('commandPalette.footer.select')).toBeInTheDocument();
+    expect(screen.getByText('commandPalette.footer.close')).toBeInTheDocument();
+  });
+
+  it('opens the palette from the header search pill', () => {
+    render(
+      <CommandPaletteProvider>
+        <Header />
+        <CommandPalette />
+      </CommandPaletteProvider>
+    );
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+    fireEvent.click(screen.getByTestId('header-command-palette-trigger'));
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+  });
+
+  it('syncs repositories from the Actions group and shows a success toast', async () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+
+    fireEvent.click(screen.getByText('commandPalette.actions.syncRepositories'));
+    expect(repositorySyncMock).toHaveBeenCalledTimes(1);
+    // The toast survives the palette closing (persistent ToastContainer).
+    expect(
+      await screen.findByText('commandPalette.actions.syncSuccess')
+    ).toBeInTheDocument();
+  });
+
+  it('records an executed command and surfaces it in the Recent group on reopen', () => {
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    fireEvent.click(screen.getByText('commandPalette.nav.sessions'));
+    expect(pushMock).toHaveBeenCalledWith('/sessions');
+
+    // Reopen: the executed command now appears under the Recent group too.
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.getByText('commandPalette.groups.recent')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('commandPalette.nav.sessions').length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('ignores a recent entry whose worktree no longer exists', () => {
+    localStorage.setItem(
+      'cm.palette.recents',
+      JSON.stringify([{ kind: 'worktree', id: 'wt-gone' }])
+    );
+    renderPalette();
+    pressKey(window, { key: 'k', metaKey: true });
+    // The only recent entry is a dead worktree → no Recent group at all.
+    expect(screen.queryByText('commandPalette.groups.recent')).toBeNull();
   });
 });


### PR DESCRIPTION
## 概要
Closes #1077 (親 #1068 / Phase C Batch1)

⌘K コマンドパレットに アイコン / StatusDot / kbd ヒント / Recents / デスクトップ導線 を追加し Raycast 級の完成度に。新設 `ui/Kbd` は #1080 コンポーザーでも再利用。

## 変更点
- `CommandPalette.tsx` 強化（アイコン・StatusDot・Recents MRU・グルーピング）
- 新規 `src/components/ui/Kbd.tsx`、`ui/index.ts` に export
- `Header.tsx` にパレット起動導線（⌘K 表示は mount 後判定でハイドレーション不整合回避）
- `locales/{en,ja}/commandPalette.json` 追加文言

## #1053 挙動契約の維持
- data-testid（command-palette / -panel / -input / -empty / -loading）保持
- 開時フォーカス→閉時復帰、入力中キー非横取り、Escape preventDefault、backdrop クローズ
- StatusDot/status-colors.ts は不変（#1078 の領域、本バッチ非対象）

## 検証
- ✅ lint / tsc / CommandPalette 30 tests pass
- ⏳ キーボード実挙動は develop 統合後の Playwright で最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)