### PR TITLE
feat(ui): ターミナルクロームを刷新（全周枠廃止・カード化・CLIセレクタDropdownMenu化）(#1079)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -72,7 +72,10 @@
     "showFiles": "Show files",
     "hideFiles": "Hide files",
     "equalizeWidths": "Equal widths",
-    "equalizeWidthsHint": "Equalize terminal widths and reset History width"
+    "equalizeWidthsHint": "Equalize terminal widths and reset History width",
+    "addSplit": "Add split",
+    "removeSplit": "Remove split",
+    "selectInstance": "Select agent instance for {split}"
   },
   "todo": {
     "addPlaceholder": "Add a todo…",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -72,7 +72,10 @@
     "showFiles": "ファイルを表示",
     "hideFiles": "ファイルを非表示",
     "equalizeWidths": "均等幅",
-    "equalizeWidthsHint": "ターミナル幅を均等にし、履歴幅を初期値に戻す"
+    "equalizeWidthsHint": "ターミナル幅を均等にし、履歴幅を初期値に戻す",
+    "addSplit": "分割を追加",
+    "removeSplit": "分割を削除",
+    "selectInstance": "{split} のエージェントインスタンスを選択"
   },
   "todo": {
     "addPlaceholder": "ToDoを追加…",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -60,12 +60,17 @@ export function TerminalComponent({
 
     // Initialize xterm.js terminal
     const term = new Terminal({
+      // Issue #1079: align the terminal chrome with the app's dark surface ladder
+      // (#1049 / #1074) instead of the floating VS Code #1e1e1e. Terminal output
+      // stays dark in both themes (#1075), so the base colors are pinned to the
+      // dark token values (--surface-2 / accent-500) and need no theme-switch
+      // update — a deliberate simplification over live getComputedStyle wiring.
       theme: {
-        background: '#1e1e1e',
-        foreground: '#d4d4d4',
-        cursor: '#d4d4d4',
-        selectionBackground: '#264f78',
-        black: '#1e1e1e',
+        background: '#0f121a', // --surface-2 (dark): recessed well
+        foreground: '#e5e7eb', // gray-200: soft foreground on the dark surface
+        cursor: '#e5e7eb',
+        selectionBackground: 'rgba(6, 182, 212, 0.3)', // accent-500 / 30%
+        black: '#0f121a',
         red: '#f48771',
         green: '#89d185',
         yellow: '#f4bf75',

--- a/src/components/worktree/ActivityBar.tsx
+++ b/src/components/worktree/ActivityBar.tsx
@@ -104,7 +104,7 @@ export const ActivityBar = memo(function ActivityBar({
   return (
     <div
       data-testid="activity-bar"
-      className={`flex flex-col items-stretch w-12 flex-shrink-0 bg-gray-100 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 ${className}`.trim()}
+      className={`flex flex-col items-stretch w-12 flex-shrink-0 bg-muted border-r border-border ${className}`.trim()}
     >
       {/* Issue #747: Sidebar (Branches) toggle. Rendered OUTSIDE the tablist so
           it is excluded from the roving-tabindex Arrow/Home/End navigation and
@@ -116,14 +116,14 @@ export const ActivityBar = memo(function ActivityBar({
           onClick={toggleSidebar}
           aria-label="Toggle sidebar"
           aria-expanded={isSidebarOpen}
-          className="flex items-center justify-center h-12 w-12 text-gray-500 dark:text-gray-400 transition-colors hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-inset"
+          className="flex items-center justify-center h-12 w-12 text-muted-foreground transition-colors hover:text-surface-foreground hover:bg-muted-foreground/10 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-inset"
         >
           <Menu size={20} aria-hidden="true" />
         </button>
       </Tooltip>
       {/* Separator between the sidebar toggle and the activity tabs */}
       <div
-        className="mx-2 my-1 border-b border-gray-200 dark:border-gray-700"
+        className="mx-2 my-1 border-b border-border"
         aria-hidden="true"
       />
       <div
@@ -151,13 +151,20 @@ export const ActivityBar = memo(function ActivityBar({
                 onClick={() => onToggle(activity.id)}
                 onKeyDown={(e) => handleKeyDown(e, index, activity.id)}
                 data-testid={`activity-bar-button-${activity.id}`}
-                className={`flex items-center justify-center h-12 w-12 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-inset ${
-                  isActive
-                    ? 'text-accent-600 dark:text-accent-400 border-l-2 border-accent-600 dark:border-accent-400 bg-white dark:bg-gray-900'
-                    : 'text-gray-500 dark:text-gray-400 border-l-2 border-transparent hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700'
-                }`}
+                className="group flex items-center justify-center h-12 w-12 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-inset"
               >
-                <Icon size={20} aria-hidden="true" />
+                {/* Issue #1079: active state is a soft accent-tinted rounded pill
+                    (bg-accent-500/10) instead of a full-cell bar + white fill. */}
+                <span
+                  aria-hidden="true"
+                  className={`flex items-center justify-center h-9 w-9 rounded-md transition-colors ${
+                    isActive
+                      ? 'bg-accent-500/10 text-accent-600 dark:text-accent-400'
+                      : 'text-muted-foreground group-hover:text-surface-foreground group-hover:bg-muted-foreground/10'
+                  }`}
+                >
+                  <Icon size={20} aria-hidden="true" />
+                </span>
               </button>
             </Tooltip>
           );

--- a/src/components/worktree/TerminalDisplay.tsx
+++ b/src/components/worktree/TerminalDisplay.tsx
@@ -8,6 +8,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState, useMemo, memo, useCallback } from 'react';
+import { ArrowUp, ArrowDown } from 'lucide-react';
 import { sanitizeTerminalOutput } from '@/lib/security/sanitize';
 import { useTerminalScroll } from '@/hooks/useTerminalScroll';
 import { useTerminalSearch } from '@/hooks/useTerminalSearch';
@@ -195,9 +196,10 @@ export const TerminalDisplay = memo(function TerminalDisplay({
         'border-gray-700',
         // Height - flex container will control actual height
         'h-full',
-        // Active state
+        // Active state — Issue #1079: the flashy full-perimeter accent border is
+        // gone (focus is now expressed subtly on the pane card). The `active`
+        // marker class is kept for behavior/tests.
         isActive ? 'active' : '',
-        isActive ? 'border-accent-500' : '',
         // Custom classes
         className,
       ]
@@ -205,6 +207,36 @@ export const TerminalDisplay = memo(function TerminalDisplay({
         .join(' '),
     [isActive, className]
   );
+
+  // Issue #1079: the scroll FAB stays subtle while idle and reveals to full
+  // opacity on scroll activity (then fades back) and on hover/focus, so it never
+  // competes with the terminal output but is always reachable.
+  const [scrollActive, setScrollActive] = useState(false);
+  const scrollActivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const revealScrollButton = useCallback(() => {
+    setScrollActive(true);
+    if (scrollActivityTimerRef.current) clearTimeout(scrollActivityTimerRef.current);
+    scrollActivityTimerRef.current = setTimeout(() => setScrollActive(false), 1500);
+  }, []);
+  useEffect(
+    () => () => {
+      if (scrollActivityTimerRef.current) clearTimeout(scrollActivityTimerRef.current);
+    },
+    []
+  );
+  const handleScrollWithReveal = useCallback(() => {
+    handleScroll();
+    revealScrollButton();
+  }, [handleScroll, revealScrollButton]);
+
+  const scrollFabClass = [
+    'absolute bottom-4 right-4 flex items-center justify-center h-9 w-9 rounded-full',
+    'bg-surface/80 backdrop-blur border border-border text-muted-foreground shadow-lg',
+    'transition-opacity hover:text-surface-foreground hover:opacity-100 focus-visible:opacity-100',
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+    // Idle stays muted (auto-fade intent) but discoverable; reveals on scroll/hover.
+    scrollActive ? 'opacity-100' : 'opacity-60',
+  ].join(' ');
 
   return (
     <div className="relative h-full flex flex-col">
@@ -230,7 +262,7 @@ export const TerminalDisplay = memo(function TerminalDisplay({
         aria-live="polite"
         aria-label="Terminal output"
         className={containerClasses}
-        onScroll={handleScroll}
+        onScroll={handleScrollWithReveal}
         onKeyDown={handleKeyDown}
         tabIndex={0}
       >
@@ -262,22 +294,25 @@ export const TerminalDisplay = memo(function TerminalDisplay({
         {isActive && isThinking && <ThinkingIndicator />}
       </div>
 
-      {/* Scroll button: shows "Scroll to top" at bottom, or "Scroll to bottom" when scrolled up */}
+      {/* Issue #1079: icon-only circular scroll FAB. Shows an up arrow at the
+          bottom (jump to top) or a down arrow when scrolled up (jump to bottom). */}
       {autoScroll ? (
         <button
+          type="button"
           onClick={scrollToTop}
-          className="absolute bottom-4 right-4 bg-accent-600 hover:bg-accent-700 text-white px-3 py-1 rounded-md text-sm shadow-lg transition-colors"
+          className={scrollFabClass}
           aria-label="Scroll to top"
         >
-          Scroll to top
+          <ArrowUp size={16} aria-hidden="true" />
         </button>
       ) : (
         <button
+          type="button"
           onClick={scrollToBottom}
-          className="absolute bottom-4 right-4 bg-accent-600 hover:bg-accent-700 text-white px-3 py-1 rounded-md text-sm shadow-lg transition-colors"
+          className={scrollFabClass}
           aria-label="Scroll to bottom"
         >
-          Scroll to bottom
+          <ArrowDown size={16} aria-hidden="true" />
         </button>
       )}
     </div>

--- a/src/components/worktree/TerminalSplitContainer.tsx
+++ b/src/components/worktree/TerminalSplitContainer.tsx
@@ -30,7 +30,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import { useTranslations } from 'next-intl';
-import { History, Files, AlignHorizontalDistributeCenter } from 'lucide-react';
+import { History, Files, AlignHorizontalDistributeCenter, Plus, Minus } from 'lucide-react';
 import { getInstanceLabel, type AgentInstance, type CLIToolType } from '@/lib/cli-tools/types';
 import type { ShowToast } from '@/types/markdown-editor';
 import { MAX_SPLITS, MIN_SPLITS } from '@/config/terminal-split-config';
@@ -279,38 +279,40 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
       className="flex flex-col h-full min-h-0"
     >
       {/* Action bar */}
-      <div className="flex items-center gap-2 px-2 py-1 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
-        <span className="text-xs text-gray-500 dark:text-gray-400">
+      <div className="flex items-center gap-1 px-2 py-1 bg-surface border-b border-border flex-shrink-0">
+        <span className="text-xs text-muted-foreground tabular-nums mr-1">
           {splits.length} / {MAX_SPLITS} splits
         </span>
 
         {/*
-          Issue #977: all action-bar buttons are left-aligned in a single
-          group, ordered +Split → -Split → Equal widths → History → Files.
-          The `ml-auto` that previously pushed +Split (and everything after)
-          to the right has been removed so the bar reads left-to-right.
+          Issue #1079: the layout-operation controls (+Split / -Split / Equal)
+          are lucide icon ghost buttons with tooltips. They form the LEFT group;
+          an `ml-auto` hairline separator pushes the History / Files panel
+          toggles to the RIGHT group ("layout ops | panel visibility").
         */}
         <button
           type="button"
           onClick={addSplit}
           disabled={!canAdd}
           aria-disabled={!canAdd}
-          aria-label="Add terminal split"
+          aria-label={t('terminal.addSplit')}
+          title={t('terminal.addSplit')}
           data-testid="add-terminal-split"
-          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-surface-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
         >
-          + Split
+          <Plus className="w-4 h-4" aria-hidden="true" />
         </button>
         <button
           type="button"
           onClick={removeSplit}
           disabled={!canRemove}
           aria-disabled={!canRemove}
-          aria-label="Remove last terminal split"
+          aria-label={t('terminal.removeSplit')}
+          title={t('terminal.removeSplit')}
           data-testid="remove-terminal-split"
-          className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-surface-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
         >
-          - Split
+          <Minus className="w-4 h-4" aria-hidden="true" />
         </button>
 
         {/*
@@ -326,14 +328,17 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
           aria-label={t('terminal.equalizeWidthsHint')}
           title={t('terminal.equalizeWidthsHint')}
           data-testid="equalize-split-widths"
-          className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-surface-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
         >
           <AlignHorizontalDistributeCenter
-            className="w-3.5 h-3.5 flex-shrink-0"
+            className="w-4 h-4 flex-shrink-0"
             aria-hidden="true"
           />
-          <span>{t('terminal.equalizeWidths')}</span>
         </button>
+
+        {/* Issue #1079: separator dividing layout ops (left) from panel toggles
+            (right). `ml-auto` pushes the History / Files group to the far right. */}
+        <div className="ml-auto h-4 w-px bg-border" aria-hidden="true" />
 
         {/*
           Issue #841 (Phase 2): History / Files visibility toggles. Always

--- a/src/components/worktree/TerminalSplitPane.tsx
+++ b/src/components/worktree/TerminalSplitPane.tsx
@@ -19,11 +19,21 @@
 'use client';
 
 import React, { memo, useCallback, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import {
   getInstanceLabel,
   type AgentInstance,
   type CLIToolType,
 } from '@/lib/cli-tools/types';
+import { StatusDot, type StatusDotStatus } from '@/components/ui/StatusDot';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu';
 
 /**
  * Issue #786 / #869: dedicated MIME so the drag payload never collides with
@@ -48,6 +58,13 @@ export interface TerminalSplitPaneProps {
   availableInstances: AgentInstance[];
   /** Called when the instance selector picks a different instance. */
   onInstanceChange: (instanceId: string) => void;
+  /**
+   * Issue #1079: this split's derived agent status, shown as a `StatusDot` in
+   * the instance-selector trigger (the session title bar). `BranchStatus` is a
+   * subset of `StatusDotStatus`, so callers can pass their derived status
+   * directly. Defaults to `idle`.
+   */
+  status?: StatusDotStatus;
   /** Called when the textarea (or any input) inside this pane gains focus. */
   onFocus: () => void;
   /** Whether tmux attach is in progress for this split. */
@@ -83,6 +100,7 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
   instance,
   availableInstances,
   onInstanceChange,
+  status = 'idle',
   onFocus,
   attaching = false,
   headerExtras,
@@ -92,6 +110,7 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
   onDropInstance,
   draggedInstanceId,
 }: TerminalSplitPaneProps) {
+  const t = useTranslations('worktree');
   // Issue #786: drag-over hover state lives LOCAL to this pane (D-3) so a hover
   // change never re-creates the parent's renderSplitPane / terminalSplitRegion
   // memo (which would re-render every split). null = no drag over this pane.
@@ -160,12 +179,13 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
         ? ' ring-2 ring-red-300 cursor-not-allowed'
         : '';
 
-  const handleSelectorChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      onInstanceChange(e.target.value);
-    },
-    [onInstanceChange],
-  );
+  // Issue #1079: the subtle focus ring and the drag-over ring share the same
+  // `ring` box-shadow. `focus-within:` is a pseudo-class (higher specificity),
+  // so it would override the more prominent 2px drag ring when a focused pane is
+  // also the drop target. Suppress the focus ring while a drag is over this pane
+  // so the drop affordance always wins.
+  const focusRingClass =
+    dragOverState === null ? ' focus-within:ring-1 focus-within:ring-accent-500/30' : '';
 
   const handleSearchClick = useCallback(() => {
     // Issue #47: dispatch terminal-wide search-open event; TerminalDisplay listens.
@@ -179,8 +199,10 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
   }, [onFocus]);
 
   const splitLabel = `Terminal split ${splitIndex + 1}`;
-  // Alias-first label for the attach skeleton (falls back to the CLI tool name).
+  // Alias-first label for the selector trigger + attach skeleton (falls back to
+  // the CLI tool name when the instance is stale/undefined).
   const attachLabel = getInstanceLabel(instance ?? { cliTool: cliToolId });
+  const selectInstanceLabel = t('terminal.selectInstance', { split: splitLabel });
 
   return (
     <div
@@ -189,7 +211,10 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
       data-testid={`terminal-split-pane-${splitIndex}`}
       data-split-index={splitIndex}
       style={style}
-      className={`flex flex-col min-w-0 h-full bg-white dark:bg-gray-900${dragRingClass}`}
+      // Issue #1079: the pane is a card (rounded, clipped, hairline border).
+      // Focus is expressed subtly via `focus-within` (a soft accent ring) instead
+      // of the old flashy full-perimeter accent border.
+      className={`flex flex-col min-w-0 h-full rounded-lg overflow-hidden border border-border bg-surface${focusRingClass}${dragRingClass}`}
       onFocusCapture={handleFocusCapture}
       onMouseDown={onFocus}
       // Issue #786: drop target handlers. Separate event system from
@@ -200,32 +225,43 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      {/* Header: instance selector + search button */}
-      <div className="px-2 py-1 flex items-center gap-2 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
-        <label className="sr-only" htmlFor={`cli-selector-${splitIndex}`}>
-          {`Select agent instance for ${splitLabel}`}
-        </label>
-        <select
-          id={`cli-selector-${splitIndex}`}
-          value={instanceId}
-          onChange={handleSelectorChange}
-          data-testid={`cli-selector-${splitIndex}`}
-          aria-label={`Select agent instance for ${splitLabel}`}
-          className="text-xs bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded px-1.5 py-0.5"
-        >
-          {availableInstances.map(inst => (
-            <option key={inst.id} value={inst.id}>
-              {getInstanceLabel(inst)}
-            </option>
-          ))}
-        </select>
+      {/* Header: session title bar — instance selector (status + alias) + search */}
+      <div className="px-2 py-1 flex items-center gap-2 bg-surface-2 border-b border-border flex-shrink-0">
+        {/* Issue #1079: native <select> → Radix DropdownMenu. The trigger reads as
+            a session title (StatusDot + alias + chevron); the radio group keeps
+            the same single-select value/onChange semantics as the old <select>. */}
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            data-testid={`cli-selector-${splitIndex}`}
+            aria-label={selectInstanceLabel}
+            className="flex items-center gap-1.5 min-w-0 max-w-[12rem] rounded px-1.5 py-0.5 text-xs border border-border bg-surface text-surface-foreground hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:ring-2 data-[state=open]:ring-ring transition-colors"
+          >
+            <StatusDot
+              status={status}
+              size="sm"
+              aria-hidden
+              data-testid={`split-status-indicator-${splitIndex}`}
+            />
+            <span className="truncate">{attachLabel}</span>
+            <ChevronDown size={14} aria-hidden="true" className="flex-shrink-0 opacity-70" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-[10rem]">
+            <DropdownMenuRadioGroup value={instanceId} onValueChange={onInstanceChange}>
+              {availableInstances.map(inst => (
+                <DropdownMenuRadioItem key={inst.id} value={inst.id}>
+                  {getInstanceLabel(inst)}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         <button
           type="button"
           onClick={handleSearchClick}
           aria-label={`Search terminal output for ${splitLabel}`}
           data-testid={`terminal-search-button-${splitIndex}`}
-          className="ml-auto flex items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+          className="ml-auto flex items-center gap-1 px-1.5 py-0.5 text-xs text-muted-foreground hover:text-surface-foreground hover:bg-muted-foreground/10 rounded transition-colors"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -251,7 +287,7 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
         {attaching ? (
           <div
             data-testid={`terminal-attach-skeleton-${splitIndex}`}
-            className="absolute inset-0 flex items-center justify-center text-xs text-gray-500 dark:text-gray-400 bg-gray-50/80 dark:bg-gray-800/80"
+            className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground bg-surface-2/80"
             role="status"
             aria-live="polite"
           >
@@ -262,7 +298,7 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
       </div>
 
       {/* Footer: navigation + prompt + message input */}
-      <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 p-2 bg-gray-50 dark:bg-gray-800">
+      <div className="flex-shrink-0 border-t border-border p-2 bg-surface-2">
         {footer}
       </div>
     </div>

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -42,7 +42,6 @@ import { useSplitMessages } from '@/hooks/useSplitMessages';
 import { useHistoryPaneState } from '@/hooks/useHistoryPaneState';
 import { buildPromptResponseBody } from '@/lib/prompt-response-body-builder';
 import { getCliToolDisplayName } from '@/lib/cli-tools/types';
-import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import type {
   TerminalSplitPaneCoreProps,
   SplitAutoYesProps,
@@ -246,29 +245,6 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
     terminal.isUnclassifiedActive &&
     !showNav &&
     !showPrompt;
-
-  // Issue #743: AI agent status indicator (dot/spinner) for the split header.
-  // Uses the same inline span markup as the Mobile canonical implementation
-  // (WorktreeDetailRefactored.tsx:1947-1974): title-only a11y (no aria-label,
-  // to avoid duplicate readout / S3-006), spinner for running/generating.
-  const statusConfig = SIDEBAR_STATUS_CONFIG[cliStatus];
-  const statusIndicator = useMemo(
-    () =>
-      statusConfig.type === 'spinner' ? (
-        <span
-          className={`w-2 h-2 rounded-full flex-shrink-0 border-2 border-t-transparent animate-spin ${statusConfig.className}`}
-          title={statusConfig.label}
-          data-testid={`split-status-indicator-${splitIndex}`}
-        />
-      ) : (
-        <span
-          className={`w-2 h-2 rounded-full flex-shrink-0 ${statusConfig.className}`}
-          title={statusConfig.label}
-          data-testid={`split-status-indicator-${splitIndex}`}
-        />
-      ),
-    [statusConfig.type, statusConfig.className, statusConfig.label, splitIndex],
-  );
 
   // Issue #744: the embedded HistoryPane for THIS split. Receives this split's
   // own messages (useSplitMessages) and the per-split highlight namespace via
@@ -515,9 +491,11 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
       instance={instance}
       availableInstances={availableInstances}
       onInstanceChange={onInstanceChange}
+      // Issue #1079: the derived agent status now renders as a StatusDot inside
+      // the selector trigger (session title bar). BranchStatus ⊂ StatusDotStatus.
+      status={cliStatus}
       onFocus={onFocus}
       attaching={terminal.attaching}
-      headerExtras={statusIndicator}
       terminal={terminalSlot}
       footer={footerSlot}
       // Issue #786 / #869: drag-drop pass-through (optional; inert when omitted).

--- a/tests/unit/components/worktree/TerminalSplitPane.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPane.test.tsx
@@ -5,13 +5,23 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import {
   TerminalSplitPane,
   AGENT_INSTANCE_DND_MIME,
 } from '@/components/worktree/TerminalSplitPane';
 import type { AgentInstance, CLIToolType } from '@/lib/cli-tools/types';
+import { installRadixJsdomPolyfills } from '@tests/helpers/radix-jsdom';
+
+// Issue #1079: the instance selector is now a Radix DropdownMenu (portalled),
+// which touches pointer-capture / scrollIntoView that jsdom does not implement.
+beforeAll(() => installRadixJsdomPolyfills());
+
+/** Open the split's instance-selector menu (keyboard-opens the Radix trigger). */
+function openSelector(splitIndex = 0) {
+  fireEvent.keyDown(screen.getByTestId(`cli-selector-${splitIndex}`), { key: 'Enter' });
+}
 
 /** Build a primary AgentInstance (id === cliTool) for tests. */
 function inst(cliTool: CLIToolType, alias?: string): AgentInstance {
@@ -63,7 +73,19 @@ describe('TerminalSplitPane', () => {
     expect(screen.getByTestId('footer-body')).toBeInTheDocument();
   });
 
-  it('renders only the available instances as selector options', () => {
+  it('shows the current instance alias and a status dot in the selector trigger', () => {
+    renderPane({
+      instanceId: 'claude',
+      instance: { id: 'claude', cliTool: 'claude', alias: 'Primary', order: 0 },
+      status: 'running',
+    });
+    const trigger = screen.getByTestId('cli-selector-0');
+    expect(trigger).toHaveTextContent('Primary');
+    // Issue #1079: the derived status renders as a StatusDot inside the trigger.
+    expect(screen.getByTestId('split-status-indicator-0')).toBeInTheDocument();
+  });
+
+  it('lists only the available instances in the selector menu', () => {
     // Issue #869: the parent already excludes instances used by other splits and
     // always includes this split's own instance, so the pane simply lists them.
     renderPane({
@@ -71,12 +93,12 @@ describe('TerminalSplitPane', () => {
       instance: inst('claude'),
       availableInstances: [inst('claude'), inst('gemini')],
     });
-    const select = screen.getByTestId('cli-selector-0') as HTMLSelectElement;
-    const values = Array.from(select.querySelectorAll('option')).map(o => o.value);
-    expect(values).toEqual(['claude', 'gemini']);
+    openSelector();
+    const items = screen.getAllByRole('menuitemradio').map(i => i.textContent);
+    expect(items).toEqual(['claude', 'gemini']);
   });
 
-  it('labels options by the instance alias', () => {
+  it('labels menu items by the instance alias', () => {
     renderPane({
       instanceId: 'claude',
       instance: { id: 'claude', cliTool: 'claude', alias: 'Primary', order: 0 },
@@ -85,16 +107,19 @@ describe('TerminalSplitPane', () => {
         { id: 'claude-2', cliTool: 'claude', alias: 'Review', order: 1 },
       ],
     });
-    const select = screen.getByTestId('cli-selector-0') as HTMLSelectElement;
-    const labels = Array.from(select.querySelectorAll('option')).map(o => o.textContent);
+    openSelector();
+    const labels = screen.getAllByRole('menuitemradio').map(i => i.textContent);
     expect(labels).toEqual(['Primary', 'Review']);
   });
 
-  it('fires onInstanceChange when selector changes', () => {
+  it('fires onInstanceChange when a different instance is picked from the menu', () => {
     const onInstanceChange = vi.fn();
-    renderPane({ onInstanceChange });
-    const select = screen.getByTestId('cli-selector-0') as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: 'codex' } });
+    renderPane({
+      onInstanceChange,
+      availableInstances: [inst('claude'), inst('codex')],
+    });
+    openSelector();
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'codex' }));
     expect(onInstanceChange).toHaveBeenCalledWith('codex');
   });
 

--- a/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
@@ -9,10 +9,14 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { TerminalSplitPaneContent } from '@/components/worktree/TerminalSplitPaneContent';
 import type { AgentInstance, CLIToolType } from '@/lib/cli-tools/types';
+import { installRadixJsdomPolyfills } from '@tests/helpers/radix-jsdom';
+
+// Issue #1079: TerminalSplitPane's instance selector is now a Radix DropdownMenu.
+beforeAll(() => installRadixJsdomPolyfills());
 
 /**
  * Issue #869: build a primary AgentInstance (id === cliTool) for tests. The
@@ -599,27 +603,29 @@ describe('TerminalSplitPaneContent', () => {
     });
   });
 
-  // Issue #743: AI agent status indicator (dot/spinner) restored in PC
-  // per-split header. Data flows in as a derived `cliStatus: BranchStatus`
-  // prop and renders via headerExtras (same shape as the Mobile canonical
-  // span at WorktreeDetailRefactored.tsx:1947-1974).
-  describe('status indicator in split header (Issue #743)', () => {
+  // Issue #743 / #1079: the derived agent status renders as a `StatusDot`
+  // inside the instance-selector trigger (the session title bar). `cliStatus:
+  // BranchStatus` is a subset of `StatusDotStatus`, so it flows straight into
+  // the `status` prop. The dot is decorative (aria-hidden) inside the labeled
+  // trigger button; running/generating animate via StatusDot's glow.
+  describe('status indicator in split header (Issue #743 / #1079)', () => {
     beforeEach(() => {
       mockFetch.mockImplementation(() =>
         okJson({ isRunning: true, fullOutput: '', thinking: false }),
       );
     });
 
-    // 1. State-specific rendering: idle/ready/waiting -> dot, running/generating -> spinner.
+    // 1. State-specific rendering via StatusDot semantics: idle→muted, ready→
+    //    success, waiting→warning; running/generating add the glow animation.
     it.each([
-      ['idle', 'dot', 'bg-gray-500'],
-      ['ready', 'dot', 'bg-green-500'],
-      ['waiting', 'dot', 'bg-yellow-500'],
-      ['running', 'spinner', 'border-info'],
-      ['generating', 'spinner', 'border-info'],
+      ['idle', 'bg-muted-foreground', false],
+      ['ready', 'bg-success', false],
+      ['waiting', 'bg-warning', false],
+      ['running', 'bg-success', true],
+      ['generating', 'bg-success', true],
     ] as const)(
-      'renders %s as a %s with class %s',
-      async (status, kind, colorClass) => {
+      'renders %s status as a StatusDot with class %s (glow=%s)',
+      async (status, colorClass, hasGlow) => {
         render(
           <TerminalSplitPaneContent
             worktreeId="w-1"
@@ -636,21 +642,21 @@ describe('TerminalSplitPaneContent', () => {
         const indicator = await screen.findByTestId('split-status-indicator-0');
         expect(indicator).toBeInTheDocument();
         expect(indicator.className).toContain(colorClass);
-        // a11y: title only (no aria-label) to avoid duplicate readout (S3-006).
+        // Decorative inside the labeled trigger button; tooltip via title.
         expect(indicator.getAttribute('title')).toBeTruthy();
-        expect(indicator.getAttribute('aria-label')).toBeNull();
+        expect(indicator.getAttribute('aria-hidden')).toBe('true');
 
-        if (kind === 'spinner') {
-          expect(indicator.className).toContain('animate-spin');
+        if (hasGlow) {
+          expect(indicator.className).toContain('animate-status-glow');
         } else {
-          expect(indicator.className).not.toContain('animate-spin');
+          expect(indicator.className).not.toContain('animate-status-glow');
         }
       },
     );
 
-    // 2. Fallback when cliStatus prop is omitted -> idle (gray dot). The existing
+    // 2. Fallback when cliStatus prop is omitted -> idle (muted dot). The existing
     //    call sites that never pass cliStatus must keep working unchanged (S3-002).
-    it('falls back to idle (gray dot) when cliStatus is omitted', async () => {
+    it('falls back to idle (muted StatusDot) when cliStatus is omitted', async () => {
       render(
         <TerminalSplitPaneContent
           worktreeId="w-1"
@@ -665,13 +671,13 @@ describe('TerminalSplitPaneContent', () => {
 
       const indicator = await screen.findByTestId('split-status-indicator-0');
       expect(indicator).toBeInTheDocument();
-      expect(indicator.className).toContain('bg-gray-500');
-      expect(indicator.className).not.toContain('animate-spin');
+      expect(indicator.className).toContain('bg-muted-foreground');
+      expect(indicator.className).not.toContain('animate-status-glow');
     });
 
-    // 3. Per-split independence: split 0 running (blue spinner), split 1 idle
-    //    (gray dot) render independently with distinct data-testids.
-    it('renders each split status independently (A=running spinner, B=idle dot)', async () => {
+    // 3. Per-split independence: split 0 running (glow), split 1 idle (muted)
+    //    render independently with distinct data-testids.
+    it('renders each split status independently (A=running glow, B=idle muted)', async () => {
       render(
         <>
           <TerminalSplitPaneContent
@@ -700,11 +706,10 @@ describe('TerminalSplitPaneContent', () => {
       const indicator0 = await screen.findByTestId('split-status-indicator-0');
       const indicator1 = await screen.findByTestId('split-status-indicator-1');
 
-      expect(indicator0.className).toContain('border-info');
-      expect(indicator0.className).toContain('animate-spin');
+      expect(indicator0.className).toContain('animate-status-glow');
 
-      expect(indicator1.className).toContain('bg-gray-500');
-      expect(indicator1.className).not.toContain('animate-spin');
+      expect(indicator1.className).toContain('bg-muted-foreground');
+      expect(indicator1.className).not.toContain('animate-status-glow');
     });
   });
 

--- a/tests/unit/components/worktree/WorktreeDetailRefactored-cli-tab-switching.test.tsx
+++ b/tests/unit/components/worktree/WorktreeDetailRefactored-cli-tab-switching.test.tsx
@@ -27,8 +27,12 @@
 
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WorktreeDetailRefactored } from '@/components/worktree/WorktreeDetailRefactored';
+import { installRadixJsdomPolyfills } from '@tests/helpers/radix-jsdom';
+
+// Issue #1079: split-0's CLI selector is now a Radix DropdownMenu (portalled).
+beforeAll(() => installRadixJsdomPolyfills());
 
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -416,10 +420,12 @@ describe('WorktreeDetailRefactored CLI tab switching (Issue #736)', () => {
     vi.restoreAllMocks();
   });
 
-  // Issue #728: Drive activeCliTab swaps through split-0's CLI selector.
+  // Issue #728 / #1079: drive activeCliTab swaps through split-0's CLI selector.
+  // The selector is now a Radix DropdownMenu: open it, then pick the target CLI's
+  // radio item (matched case-insensitively by its display-name label).
   function swapSplitZeroCliTo(value: 'copilot' | 'claude') {
-    const select = screen.getByTestId('cli-selector-0') as HTMLSelectElement;
-    fireEvent.change(select, { target: { value } });
+    fireEvent.keyDown(screen.getByTestId('cli-selector-0'), { key: 'Enter' });
+    fireEvent.click(screen.getByRole('menuitemradio', { name: new RegExp(value, 'i') }));
   }
 
   it('keeps Copilot messages when an older Claude messages response arrives later (parent stale guard)', async () => {


### PR DESCRIPTION
## 概要
Closes #1079 (親 #1068 / Phase C Batch1)。#1080 の前提の一つ。

worktree ターミナルの全周枠を廃し surface-2 カード化に統一。CLI インスタンスセレクタを native `<select>` から Radix DropdownMenu(StatusDot+alias+ChevronDown)へ置換。

## 変更点
- Terminal / ActivityBar / TerminalDisplay / TerminalSplitContainer / TerminalSplitPane(Content) を surface/border トークンへ
- `<select>` → `DropdownMenu(RadioGroup)`: `value/onValueChange` の単一選択セマンティクスと `cli-selector`/`split-status-indicator` testid を保持
- xterm theme は意図的に固定ダーク維持。`StatusDot`/`status-colors.ts` は不変（#1078 領域）

## 検証
- ✅ lint / tsc / terminal 45 tests（cli-tab-switching 含む）
- ✅ develop(#1077) 取り込み済み・コンフリクトなし
- ⏳ 端末描画・CLI切替の実挙動は develop 統合後の目視で最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)