### PR TITLE
feat(ui): データ画面コントロールの意味論を整理（Review/Repositories/More）(#1081)

### DIFF
--- a/src/components/external-apps/ExternalAppsManager.tsx
+++ b/src/components/external-apps/ExternalAppsManager.tsx
@@ -106,9 +106,9 @@ export function ExternalAppsManager() {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">External Apps</h2>
+      {/* Heading is owned by the parent page (More) — this section only
+          provides the add-app action to avoid a duplicate "External Apps" title. */}
+      <div className="flex items-center justify-end">
         <Button variant="primary" size="sm" onClick={handleAdd}>
           + Add App
         </Button>

--- a/src/components/repository/RepositoryList.tsx
+++ b/src/components/repository/RepositoryList.tsx
@@ -28,7 +28,9 @@
 'use client';
 
 import React, { memo, useCallback, useEffect, useState } from 'react';
-import { Badge, Button, Card, Input } from '@/components/ui';
+import { Pencil } from 'lucide-react';
+import { Button, Card, Input, StatusDot } from '@/components/ui';
+import { cn } from '@/lib/utils/cn';
 import {
   handleApiError,
   repositoryApi,
@@ -370,15 +372,11 @@ function RepositoryListInner({ refreshKey, onChanged }: RepositoryListProps) {
                             </p>
                           )}
                         </div>
+                      ) : repo.displayName ? (
+                        <span className="text-foreground">{repo.displayName}</span>
                       ) : (
-                        <span
-                          className={
-                            repo.displayName
-                              ? 'text-gray-900 dark:text-gray-100'
-                              : 'text-gray-400 dark:text-gray-500 italic'
-                          }
-                        >
-                          {repo.displayName ?? '(none)'}
+                        <span className="text-muted-foreground" aria-hidden="true">
+                          &mdash;
                         </span>
                       )}
                     </td>
@@ -390,18 +388,27 @@ function RepositoryListInner({ refreshKey, onChanged }: RepositoryListProps) {
                         onToggle={handleToggleVisibility}
                       />
                     </td>
-                    <td className="px-4 py-3 align-top text-xs font-mono text-gray-500 dark:text-gray-400 break-all">
-                      {repo.path}
+                    <td className="px-4 py-3 align-top">
+                      <span
+                        className="block max-w-[240px] truncate font-mono text-xs text-muted-foreground"
+                        title={repo.path}
+                      >
+                        {repo.path}
+                      </span>
                     </td>
                     <td className="px-4 py-3 align-top text-gray-700 dark:text-gray-300">
                       {repo.worktreeCount}
                     </td>
                     <td className="px-4 py-3 align-top">
-                      {repo.enabled ? (
-                        <Badge variant="success">Enabled</Badge>
-                      ) : (
-                        <Badge variant="gray">Disabled</Badge>
-                      )}
+                      <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <StatusDot
+                          status={repo.enabled ? 'ready' : 'idle'}
+                          size="sm"
+                          label={repo.enabled ? 'Enabled' : 'Disabled'}
+                          aria-hidden="true"
+                        />
+                        {repo.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
                     </td>
                     <td className="px-4 py-3 align-top">
                       {isEditing ? (
@@ -425,12 +432,13 @@ function RepositoryListInner({ refreshKey, onChanged }: RepositoryListProps) {
                         </div>
                       ) : (
                         <Button
-                          variant="secondary"
+                          variant="ghost"
                           size="sm"
+                          className="px-2"
                           onClick={() => handleStartEdit(repo)}
                           aria-label={`Edit display name for ${repo.name}`}
                         >
-                          Edit
+                          <Pencil className="h-4 w-4" aria-hidden="true" />
                         </Button>
                       )}
                     </td>
@@ -480,24 +488,19 @@ function VisibilityToggle({
       data-testid={`visibility-toggle-${repo.id}`}
       onClick={() => onToggle(repo)}
       disabled={pending}
-      className={`
-        inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium
-        border transition-colors
-        focus:outline-none focus:ring-2 focus:ring-ring
-        disabled:opacity-60 disabled:cursor-not-allowed
-        ${
-          isVisible
-            ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-300 dark:border-green-800'
-            : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-700'
-        }
-      `}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium',
+        'text-muted-foreground transition-colors',
+        'hover:bg-muted hover:text-foreground',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'disabled:opacity-60 disabled:cursor-not-allowed'
+      )}
     >
-      <span
+      <StatusDot
+        status={isVisible ? 'ready' : 'idle'}
+        size="sm"
+        label={isVisible ? 'Visible' : 'Hidden'}
         aria-hidden="true"
-        className={`
-          inline-block w-2 h-2 rounded-full
-          ${isVisible ? 'bg-green-500' : 'bg-gray-400'}
-        `}
       />
       {isVisible ? 'Visible' : 'Hidden'}
     </button>

--- a/src/components/review/ReviewTab.tsx
+++ b/src/components/review/ReviewTab.tsx
@@ -10,7 +10,8 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Link from 'next/link';
-import { Button, Card } from '@/components/ui';
+import { Card } from '@/components/ui';
+import { cn } from '@/lib/utils/cn';
 import { REVIEW_POLL_INTERVAL_MS } from '@/config/review-config';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
 import { deriveCliStatus } from '@/types/sidebar';
@@ -26,6 +27,14 @@ const FILTER_TABS: Array<{ value: ReviewFilter; label: string }> = [
   { value: 'approval', label: 'Approval' },
   { value: 'stalled', label: 'Stalled' },
 ];
+
+/** Membership predicate per filter. Shared by the visible list and the chip
+ * counts so both always agree (counts are derived, never fetched separately). */
+const FILTER_PREDICATES: Record<ReviewFilter, (wt: Worktree) => boolean> = {
+  in_review: (wt) => wt.status === 'in_review',
+  approval: (wt) => wt.isWaitingForResponse === true,
+  stalled: (wt) => wt.isStalled === true,
+};
 
 /** Small CLI status dot */
 function CliDot({ status, label }: { status: BranchStatus; label: string }) {
@@ -95,20 +104,19 @@ export default function ReviewTab() {
     };
   }, [fetchWorktrees]);
 
-  const filteredWorktrees = useMemo(() => {
-    return worktrees.filter((wt) => {
-      switch (activeFilter) {
-        case 'in_review':
-          return wt.status === 'in_review';
-        case 'approval':
-          return wt.isWaitingForResponse === true;
-        case 'stalled':
-          return wt.isStalled === true;
-        default:
-          return false;
-      }
-    });
-  }, [worktrees, activeFilter]);
+  const filteredWorktrees = useMemo(
+    () => worktrees.filter(FILTER_PREDICATES[activeFilter]),
+    [worktrees, activeFilter]
+  );
+
+  const filterCounts = useMemo<Record<ReviewFilter, number>>(
+    () => ({
+      in_review: worktrees.filter(FILTER_PREDICATES.in_review).length,
+      approval: worktrees.filter(FILTER_PREDICATES.approval).length,
+      stalled: worktrees.filter(FILTER_PREDICATES.stalled).length,
+    }),
+    [worktrees]
+  );
 
   const emptyMessage = useMemo(() => {
     switch (activeFilter) {
@@ -123,18 +131,43 @@ export default function ReviewTab() {
 
   return (
     <>
-      {/* Filter tabs */}
-      <div className="flex gap-2 mb-6" data-testid="review-filters">
-        {FILTER_TABS.map((tab) => (
-          <Button
-            key={tab.value}
-            variant={activeFilter === tab.value ? 'primary' : 'secondary'}
-            onClick={() => setActiveFilter(tab.value)}
-            data-testid={`review-filter-${tab.value}`}
-          >
-            {tab.label}
-          </Button>
-        ))}
+      {/* Filter segmented control: quiet selection (subtle accent tint), clearly
+          distinct from a solid CTA. Each chip shows its live filtered count. */}
+      <div
+        className="mb-6 inline-flex items-center gap-1 rounded-lg bg-muted p-1"
+        role="group"
+        aria-label="Review filters"
+        data-testid="review-filters"
+      >
+        {FILTER_TABS.map((tab) => {
+          const isActive = activeFilter === tab.value;
+          return (
+            <button
+              key={tab.value}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setActiveFilter(tab.value)}
+              data-testid={`review-filter-${tab.value}`}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                isActive
+                  ? 'bg-accent-500/15 text-accent-700 dark:text-accent-300'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {tab.label}
+              <span
+                className={cn(
+                  'text-xs font-semibold tabular-nums',
+                  isActive ? 'text-accent-700 dark:text-accent-300' : 'text-muted-foreground'
+                )}
+              >
+                {filterCounts[tab.value]}
+              </span>
+            </button>
+          );
+        })}
       </div>
 
       {/* Loading */}

--- a/tests/unit/app/more/page.test.tsx
+++ b/tests/unit/app/more/page.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the More page (/more)
+ * Issue #1081: Data screen control semantics — the "External Apps" heading is
+ * owned by the page; ExternalAppsManager must not render a duplicate title.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Mock AppShell to a passthrough so we don't pull in the full layout tree.
+vi.mock('@/components/layout', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'app-shell' }, children),
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) =>
+    React.createElement('a', { href, ...props }, children),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // ExternalAppsManager fetches on mount; return an empty list.
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ apps: [] }),
+  }) as unknown as typeof fetch;
+});
+
+import MorePage from '@/app/more/page';
+
+describe('More page (Issue #1081)', () => {
+  it('renders exactly one "External Apps" heading (no duplicate from the manager)', async () => {
+    render(React.createElement(MorePage));
+
+    // Wait for ExternalAppsManager to settle its initial fetch.
+    await waitFor(() => {
+      expect(screen.getByTestId('app-shell')).toBeInTheDocument();
+    });
+
+    const headings = screen.getAllByText('External Apps');
+    expect(headings).toHaveLength(1);
+    expect(headings[0].tagName).toBe('H2');
+  });
+
+  it('still exposes the add-app action inside the External Apps section', async () => {
+    render(React.createElement(MorePage));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add app/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/components/repository/RepositoryList.test.tsx
+++ b/tests/unit/components/repository/RepositoryList.test.tsx
@@ -114,7 +114,7 @@ describe('RepositoryList (Issue #644)', () => {
       expect(disabledRow.textContent).toMatch(/Disabled/);
     });
 
-    it('shows "(none)" placeholder when displayName is null', async () => {
+    it('shows a muted em-dash placeholder when displayName is null', async () => {
       vi.mocked(repositoryApi.list).mockResolvedValue({
         success: true,
         repositories: [buildRepo({ displayName: null })],
@@ -123,8 +123,25 @@ describe('RepositoryList (Issue #644)', () => {
       render(<RepositoryList refreshKey={0} />);
 
       await waitFor(() => {
-        expect(screen.getByText('(none)')).toBeInTheDocument();
+        expect(screen.getByText('—')).toBeInTheDocument();
       });
+      expect(screen.queryByText('(none)')).not.toBeInTheDocument();
+    });
+
+    it('renders the Edit control as an icon button with an aria-label', async () => {
+      vi.mocked(repositoryApi.list).mockResolvedValue({
+        success: true,
+        repositories: [buildRepo({ id: 'r1', name: 'repo-a' })],
+      });
+
+      render(<RepositoryList refreshKey={0} />);
+
+      const editButton = await screen.findByRole('button', {
+        name: /edit display name for repo-a/i,
+      });
+      // Icon-only: no visible "Edit" text label, but an SVG icon is present.
+      expect(editButton).not.toHaveTextContent(/edit/i);
+      expect(editButton.querySelector('svg')).toBeInTheDocument();
     });
 
     it('shows the displayName when it is set', async () => {

--- a/tests/unit/components/review/ReviewPage-stalled.test.tsx
+++ b/tests/unit/components/review/ReviewPage-stalled.test.tsx
@@ -122,6 +122,30 @@ describe('Review page filters', () => {
     });
   });
 
+  it('shows a count badge per filter reflecting the filtered length', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        worktrees: [
+          { id: 'a', name: 'a', repositoryName: 'r', status: 'in_review', selectedAgents: ['claude'] },
+          { id: 'b', name: 'b', repositoryName: 'r', status: 'in_review', selectedAgents: ['claude'] },
+          { id: 'c', name: 'c', repositoryName: 'r', status: 'in_progress', isWaitingForResponse: true, selectedAgents: ['claude'] },
+          // no stalled worktrees
+        ],
+      }),
+    }) as unknown as typeof fetch;
+
+    render(React.createElement(ReviewPage));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('review-filter-in_review')).toBeDefined();
+    });
+
+    expect(screen.getByTestId('review-filter-in_review').textContent).toMatch(/2/);
+    expect(screen.getByTestId('review-filter-approval').textContent).toMatch(/1/);
+    expect(screen.getByTestId('review-filter-stalled').textContent).toMatch(/0/);
+  });
+
   it('should show in_review worktrees by default', async () => {
     render(React.createElement(ReviewPage));
 


### PR DESCRIPTION
## Summary

Review / Repositories / More のデータ画面で、コントロールの視覚的意味論を整えました。**表示のみの変更**で、絞り込み・編集・削除・可視性トグルのロジックは一切変更していません。

Closes #1081

## Changes

### Review (`ReviewTab.tsx`)
- フィルタ（In Review / Approval / Stalled）を、CTA に見える primary/secondary ボタンから**件数付きの控えめなセグメンテッドコントロール**へ変更。
- 選択状態は `bg-accent-500/15` の淡いアクセント（テキストは light=`accent-700` / dark=`accent-300` で AA コントラスト）とし、ソリッドな CTA（`bg-accent-600`）と明確に区別。
- 各チップの件数は**既存のフィルタ済み配列長から算出**（新規 fetch なし。予測を list とチップで共有する述語に集約）。

### Repositories (`RepositoryList.tsx`)
- Enabled/Disabled バッジと Visibility の緑ピル2個 → **StatusDot 流の dot + muted テキスト**へ（主張を抑制）。Visibility トグルは `role="switch"` のまま操作可能。
- `(none)` → muted の em-dash（—）。
- パス → `truncate` + `font-mono` + muted + フルパスの `title` ツールチップ（折り返さない）。
- Edit → ghost な **Pencil アイコンボタン**（`aria-label` 維持）。

### More (`ExternalAppsManager.tsx`)
- 重複していた `<h2>External Apps</h2>` を削除し、ページ側の見出しに一本化。`+ Add App` アクションは維持。

### 境界・制約
- `StatusDot` / `status-colors.ts` は**未編集**（#1078 の領域）。生 gray/cyan/blue 直書きの追加なし（セマンティックトークンのみ）。

## Test Results

- **Unit**: `npm run test:unit` → 8730 passed（件数バッジ・単一見出し・em-dash・アイコンボタンの検証テストを追加）
- **Lint**: `npm run lint` → 0 errors / 0 warnings
- **Type**: `npx tsc --noEmit` → 0 errors
- **Build**: `npm run build` → success

## Checklist

- [x] Unit tests pass
- [x] Lint check passes
- [x] Type check passes
- [x] Build succeeds
- [x] No console.log in production code
- [x] StatusDot / status-colors.ts 未変更（#1078 領域）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
