### PR TITLE
feat(ui): コンポーザーをカード化しモバイルworktreeコントロールを整理 (#1080)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -5,6 +5,11 @@
     "hide": "Hide table of contents",
     "empty": "No headings"
   },
+  "composer": {
+    "placeholder": "Type your message…",
+    "commandsHint": "commands",
+    "newlineHint": "newline"
+  },
   "session": {
     "confirmKill": "End session for \"{name}\"?\n\nAll message history will be deleted. Log files will be retained.",
     "failedToKill": "Failed to end session",
@@ -75,7 +80,10 @@
     "equalizeWidthsHint": "Equalize terminal widths and reset History width",
     "addSplit": "Add split",
     "removeSplit": "Remove split",
-    "selectInstance": "Select agent instance for {split}"
+    "selectInstance": "Select agent instance for {split}",
+    "moreActions": "More actions",
+    "searchTerminal": "Search terminal",
+    "endSession": "End session"
   },
   "todo": {
     "addPlaceholder": "Add a todo…",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -5,6 +5,11 @@
     "hide": "目次を非表示",
     "empty": "見出しなし"
   },
+  "composer": {
+    "placeholder": "メッセージを入力…",
+    "commandsHint": "コマンド",
+    "newlineHint": "改行"
+  },
   "session": {
     "confirmKill": "「{name}」のセッションを終了しますか？\n\n※全てのメッセージ履歴が削除されます。ログファイルは保持されます。",
     "failedToKill": "セッションの終了に失敗しました",
@@ -75,7 +80,10 @@
     "equalizeWidthsHint": "ターミナル幅を均等にし、履歴幅を初期値に戻す",
     "addSplit": "分割を追加",
     "removeSplit": "分割を削除",
-    "selectInstance": "{split} のエージェントインスタンスを選択"
+    "selectInstance": "{split} のエージェントインスタンスを選択",
+    "moreActions": "その他の操作",
+    "searchTerminal": "ターミナル内を検索",
+    "endSession": "セッションを終了"
   },
   "todo": {
     "addPlaceholder": "ToDoを追加…",

--- a/src/components/mobile/MobileTabBar.tsx
+++ b/src/components/mobile/MobileTabBar.tsx
@@ -7,7 +7,7 @@
 'use client';
 
 import { useCallback, useMemo } from 'react';
-import { SquareTerminal, Clock, Folder, FileText, Info } from 'lucide-react';
+import { SquareTerminal, Clock, Folder, Wrench, Info } from 'lucide-react';
 import { NotificationDot } from '@/components/common/NotificationDot';
 import type { DeepLinkPane } from '@/types/ui-state';
 
@@ -65,7 +65,7 @@ const TABS: TabConfig[] = [
   { id: 'terminal', label: 'Terminal', icon: <SquareTerminal size={20} aria-hidden="true" /> },
   { id: 'history', label: 'History', icon: <Clock size={20} aria-hidden="true" /> },
   { id: 'files', label: 'Files', icon: <Folder size={20} aria-hidden="true" /> },
-  { id: 'memo', label: 'Tools', icon: <FileText size={20} aria-hidden="true" /> },
+  { id: 'memo', label: 'Tools', icon: <Wrench size={20} aria-hidden="true" /> },
   { id: 'info', label: 'Info', icon: <Info size={20} aria-hidden="true" /> },
 ];
 
@@ -90,9 +90,11 @@ export function MobileTabBar({
     (tabId: MobileTab) => {
       const isActive = tabId === activeTab;
       const baseStyles = 'flex flex-col items-center justify-center flex-1 py-2 px-1 transition-colors relative';
+      // Issue #1080: match GlobalMobileNav — no cell fill; active is expressed by
+      // accent text + a 2px top indicator bar (rendered in the button body).
       const activeStyles = isActive
-        ? 'text-accent-600 dark:text-accent-400 bg-accent-50 dark:bg-accent-900/30'
-        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800';
+        ? 'text-accent-600 dark:text-accent-400'
+        : 'text-muted-foreground hover:text-foreground';
       return `${baseStyles} ${activeStyles}`;
     },
     [activeTab]
@@ -107,14 +109,14 @@ export function MobileTabBar({
         {hasNewOutput && (
           <span
             data-testid="new-output-badge"
-            className="absolute top-1 right-1 w-2 h-2 bg-green-500 rounded-full"
+            className="absolute top-1 right-1 w-2 h-2 bg-success rounded-full"
             aria-label="New output available"
           />
         )}
         {hasPrompt && (
           <span
             data-testid="prompt-badge"
-            className="absolute top-1 right-3 w-2 h-2 bg-yellow-500 rounded-full"
+            className="absolute top-1 right-3 w-2 h-2 bg-warning rounded-full"
             aria-label="Prompt waiting"
           />
         )}
@@ -127,7 +129,7 @@ export function MobileTabBar({
       data-testid="mobile-tab-bar"
       role="tablist"
       aria-label="Mobile navigation"
-      className="fixed bottom-0 inset-x-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 flex pb-safe z-40"
+      className="fixed bottom-0 inset-x-0 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md flex pb-safe z-40"
     >
       {TABS.map((tab) => (
         <button
@@ -143,6 +145,12 @@ export function MobileTabBar({
           }}
           className={getTabStyles(tab.id)}
         >
+          {activeTab === tab.id && (
+            <span
+              aria-hidden="true"
+              className="absolute top-0 inset-x-2 h-0.5 rounded-full bg-accent-500"
+            />
+          )}
           {tab.icon}
           <span className="text-xs mt-1">{tab.label}</span>
           {tab.id === 'terminal' && renderBadges}

--- a/src/components/mobile/MobileTerminalActionsSheet.tsx
+++ b/src/components/mobile/MobileTerminalActionsSheet.tsx
@@ -1,0 +1,119 @@
+/**
+ * MobileTerminalActionsSheet (Issue #1080)
+ *
+ * Bottom sheet holding the terminal actions that previously crowded the mobile
+ * sticky control row (terminal search + End session). The sticky row is now
+ * dedicated to the agent-instance tabs; these secondary actions moved here,
+ * opened from the row's "more actions" trigger. "End session" is destructive and
+ * defers the confirmation to the caller (the existing kill-confirm dialog).
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useId } from 'react';
+import { useTranslations } from 'next-intl';
+import { Search, LogOut } from 'lucide-react';
+
+export interface MobileTerminalActionsSheetProps {
+  /** Whether the sheet is visible. */
+  open: boolean;
+  /** Dismiss the sheet (overlay tap / after an action). */
+  onClose: () => void;
+  /** Invoked when "Search terminal" is chosen. */
+  onSearch: () => void;
+  /** Invoked when "End session" is chosen (caller shows the confirm dialog). */
+  onEnd: () => void;
+  /** When true, the End action is unavailable (no running session). */
+  endDisabled?: boolean;
+}
+
+/**
+ * Bottom action sheet for mobile terminal secondary actions.
+ */
+export function MobileTerminalActionsSheet({
+  open,
+  onClose,
+  onSearch,
+  onEnd,
+  endDisabled = false,
+}: MobileTerminalActionsSheetProps) {
+  const t = useTranslations('worktree');
+  const labelId = useId();
+
+  const handleSearch = useCallback(() => {
+    onSearch();
+    onClose();
+  }, [onSearch, onClose]);
+
+  const handleEnd = useCallback(() => {
+    onEnd();
+    onClose();
+  }, [onEnd, onClose]);
+
+  // Dismiss on Escape while the sheet is open (parity with the backdrop-tap /
+  // action-button close paths for this role="dialog" aria-modal surface).
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        data-testid="terminal-actions-overlay"
+        onClick={onClose}
+        className="fixed inset-0 bg-black/50 z-50"
+        aria-hidden="true"
+      />
+
+      {/* Sheet */}
+      <div
+        data-testid="mobile-terminal-actions-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelId}
+        className="fixed bottom-0 inset-x-0 z-50 rounded-t-2xl border-t border-border bg-surface pb-safe"
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pt-3 pb-2">
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/30" aria-hidden="true" />
+        </div>
+
+        <h2 id={labelId} className="px-4 pb-2 text-sm font-medium text-muted-foreground">
+          {t('terminal.moreActions')}
+        </h2>
+
+        <div className="px-2 pb-4">
+          <button
+            type="button"
+            data-testid="actions-sheet-search"
+            onClick={handleSearch}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm text-foreground hover:bg-muted transition-colors"
+          >
+            <Search size={18} aria-hidden="true" className="text-muted-foreground" />
+            {t('terminal.searchTerminal')}
+          </button>
+          <button
+            type="button"
+            data-testid="actions-sheet-end"
+            onClick={handleEnd}
+            disabled={endDisabled}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm text-danger hover:bg-danger/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+          >
+            <LogOut size={18} aria-hidden="true" />
+            {t('terminal.endSession')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default MobileTerminalActionsSheet;

--- a/src/components/worktree/AutoYesToggle.tsx
+++ b/src/components/worktree/AutoYesToggle.tsx
@@ -11,6 +11,7 @@
 'use client';
 
 import React, { memo, useEffect, useState, useCallback } from 'react';
+import { Switch } from '@/components/ui/Switch';
 import { AutoYesConfirmDialog } from './AutoYesConfirmDialog';
 import { formatTimeRemaining, AUTO_YES_COUNTDOWN_INTERVAL_MS } from '@/config/auto-yes-config';
 import type { AutoYesDuration } from '@/config/auto-yes-config';
@@ -37,6 +38,13 @@ export interface AutoYesToggleProps {
   /** If true, render without outer container styles (for inline embedding) */
   inline?: boolean;
   /**
+   * Issue #1080: whether to show the active CLI tool name next to the label
+   * (e.g. "(Claude)"). Defaults to true (per-split PC disambiguation, #525).
+   * The mobile composer meta row sets this false since the active agent tab is
+   * already shown alongside.
+   */
+  showToolName?: boolean;
+  /**
    * Optional callback fired once when the countdown reaches 00:00 (Issue #959).
    * Lets a parent proactively disable auto-yes the instant the timer expires
    * instead of waiting for the next server poll. Optional so existing callers
@@ -52,6 +60,7 @@ export const AutoYesToggle = memo(function AutoYesToggle({
   lastAutoResponse,
   cliToolName,
   inline = false,
+  showToolName = true,
   onExpire,
 }: AutoYesToggleProps) {
   const [timeRemaining, setTimeRemaining] = useState<string>('');
@@ -137,29 +146,18 @@ export const AutoYesToggle = memo(function AutoYesToggle({
   }, []);
 
   return (
-    <div className={inline ? 'flex items-center gap-2' : 'flex items-center gap-3 px-4 py-2 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700'}>
-      {/* Toggle switch */}
-      <button
-        type="button"
-        role="switch"
-        aria-checked={displayEnabled}
-        aria-label="Auto Yes mode"
+    <div className={inline ? 'flex items-center gap-2' : 'flex items-center gap-3 px-4 py-2 bg-surface-2 border-b border-border'}>
+      {/* Toggle switch (Issue #1080: shared Radix ui/Switch) */}
+      <Switch
+        checked={displayEnabled}
+        onCheckedChange={handleToggle}
         disabled={toggling}
-        onClick={handleToggle}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 dark:focus:ring-offset-gray-800 ${
-          displayEnabled ? 'bg-accent-600' : 'bg-gray-300 dark:bg-gray-600'
-        } ${toggling ? 'opacity-50' : ''}`}
-      >
-        <span
-          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-            displayEnabled ? 'translate-x-6' : 'translate-x-1'
-          }`}
-        />
-      </button>
-      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Auto Yes</span>
+        aria-label="Auto Yes mode"
+      />
+      <span className="text-sm font-medium text-foreground">Auto Yes</span>
 
       {/* Active CLI tool indicator (Issue #525: show regardless of enabled state) */}
-      {cliToolName && (
+      {showToolName && cliToolName && (
         <span className="text-xs text-accent-600 dark:text-accent-400 font-medium" aria-label="Auto Yes target">
           ({getCliToolDisplayNameSafe(cliToolName, '')})
         </span>
@@ -167,14 +165,14 @@ export const AutoYesToggle = memo(function AutoYesToggle({
 
       {/* Countdown timer */}
       {displayEnabled && timeRemaining && (
-        <span className="text-sm text-gray-500 dark:text-gray-400" aria-label="Time remaining">
+        <span className="text-sm text-muted-foreground" aria-label="Time remaining">
           {timeRemaining}
         </span>
       )}
 
       {/* Auto-response notification */}
       {notification && (
-        <span className="text-sm text-green-600 dark:text-green-400 animate-pulse">
+        <span className="text-sm text-success animate-pulse">
           {notification}
         </span>
       )}

--- a/src/components/worktree/InterruptButton.tsx
+++ b/src/components/worktree/InterruptButton.tsx
@@ -97,7 +97,7 @@ export const InterruptButton = memo(function InterruptButton({
       type="button"
       onClick={handleInterrupt}
       disabled={disabled || isLoading}
-      className="flex-shrink-0 p-2 text-orange-600 hover:bg-orange-50 rounded-full transition-colors disabled:text-gray-300 disabled:hover:bg-transparent"
+      className="flex-shrink-0 p-2 text-danger hover:bg-danger/10 rounded-full transition-colors disabled:text-muted-foreground/40 disabled:hover:bg-transparent"
       aria-label="Stop processing"
       data-testid="interrupt-button"
     >

--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -6,8 +6,10 @@
 'use client';
 
 import React, { memo, useState, useCallback, FormEvent, useRef, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { worktreeApi, handleApiError } from '@/lib/api-client';
 import type { CLIToolType } from '@/lib/cli-tools/types';
+import { Kbd } from '@/components/ui/Kbd';
 import { SlashCommandSelector } from './SlashCommandSelector';
 import { InterruptButton } from './InterruptButton';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
@@ -56,6 +58,12 @@ export interface MessageInputProps {
    * Optional — when omitted (or when the session is idle) no toast is shown.
    */
   showToast?: ShowToast;
+  /**
+   * Issue #1080: content rendered in the composer's bottom meta row (left side),
+   * typically the per-instance Auto-Yes toggle. Sits alongside the keyboard-hint
+   * pills so Auto-Yes no longer occupies its own full-width row.
+   */
+  autoYesSlot?: React.ReactNode;
 }
 
 /**
@@ -107,7 +115,8 @@ function migrateLegacyDraftKey(worktreeId: string): void {
   }
 }
 
-export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, instanceId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast }: MessageInputProps) {
+export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, instanceId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast, autoYesSlot }: MessageInputProps) {
+  const t = useTranslations('worktree');
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -438,7 +447,9 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
         data-testid="image-file-input"
       />
 
-      <form onSubmit={handleSubmit} className={`bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2 focus-within:border-accent-500 focus-within:ring-1 focus-within:ring-accent-500 ${isMobile ? 'flex flex-col gap-1' : 'flex items-center gap-2'}`}>
+      <form onSubmit={handleSubmit} className="rounded-xl bg-surface border border-border shadow-sm px-3 py-2 focus-within:ring-2 focus-within:ring-accent-500/40 transition-shadow flex flex-col gap-1.5">
+        {/* Issue #1080: input area (action buttons + textarea + send) */}
+        <div className={isMobile ? 'flex flex-col gap-1' : 'flex items-center gap-2'}>
         {/* Mobile: Row 1 - action buttons (slash command, attach, interrupt) */}
         {isMobile && (
           <div className="flex items-center gap-1">
@@ -513,13 +524,14 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <textarea
             ref={textareaRef}
+            data-testid="message-input-textarea"
             value={message}
             onChange={handleMessageChange}
             onKeyDown={handleKeyDown}
             onCompositionStart={handleCompositionStart}
             onCompositionEnd={handleCompositionEnd}
             onFocus={onFocus}
-            placeholder={isMobile ? "Type your message..." : "Type your message... (/ for commands, Shift+Enter for line break)"}
+            placeholder={t('composer.placeholder')}
             disabled={sending}
             rows={1}
             className="flex-1 outline-none bg-transparent resize-none overflow-y-auto scrollbar-thin"
@@ -538,8 +550,14 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
 
           <button
             type="submit"
+            data-testid="send-message-button"
+            data-can-send={String((!!message.trim() || !!attachedImage) && !sending)}
             disabled={(!message.trim() && !attachedImage) || sending}
-            className="flex-shrink-0 p-2 text-accent-600 hover:bg-accent-50 dark:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors disabled:text-gray-300 dark:disabled:text-gray-600 disabled:hover:bg-transparent"
+            className={`flex-shrink-0 p-2 rounded-full transition-colors disabled:hover:bg-transparent ${
+              (!!message.trim() || !!attachedImage) && !sending
+                ? 'bg-accent-600 text-white hover:bg-accent-700 shadow-sm'
+                : 'text-muted-foreground/50'
+            }`}
             aria-label="Send message"
           >
             {sending ? (
@@ -554,6 +572,28 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             )}
           </button>
         </div>
+        </div>
+
+        {/* Issue #1080: composer meta row — Auto-Yes (left) + keyboard hints (right).
+            Renders when Auto-Yes is embedded (mobile + desktop) or on desktop for
+            the hint pills (mobile Enter inserts a newline, so no Shift+Enter hint). */}
+        {(autoYesSlot || !isMobile) && (
+          <div className="flex items-center justify-between gap-2 min-w-0" data-testid="composer-meta-row">
+            <div className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-hide">
+              {autoYesSlot}
+            </div>
+            {!isMobile && (
+              <div className="flex flex-shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground select-none">
+                <Kbd>/</Kbd>
+                <span>{t('composer.commandsHint')}</span>
+                <span aria-hidden="true" className="opacity-50">·</span>
+                <Kbd>⇧</Kbd>
+                <Kbd>↵</Kbd>
+                <span>{t('composer.newlineHint')}</span>
+              </div>
+            )}
+          </div>
+        )}
       </form>
 
       {/* Slash Command Selector */}

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -396,15 +396,6 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   const footerSlot = useMemo(
     () => (
       <div className="space-y-2">
-        {/* Issue #740: per-split Auto-Yes toggle, keyed by this split's CLI. */}
-        <AutoYesToggle
-          enabled={autoYesEnabled}
-          expiresAt={autoYesExpiresAt ?? null}
-          onToggle={onAutoYesToggle}
-          lastAutoResponse={lastAutoResponse ?? null}
-          cliToolName={cliToolId}
-          inline
-        />
         {showNav ? (
           <NavigationButtons
             worktreeId={worktreeId}
@@ -449,6 +440,18 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
           // showToast reuses the existing history toast surface.
           isProcessing={terminal.isRunning}
           showToast={showToast}
+          // Issue #1080: per-split Auto-Yes toggle now lives in the composer's
+          // bottom meta row instead of its own full-width footer row.
+          autoYesSlot={
+            <AutoYesToggle
+              enabled={autoYesEnabled}
+              expiresAt={autoYesExpiresAt ?? null}
+              onToggle={onAutoYesToggle}
+              lastAutoResponse={lastAutoResponse ?? null}
+              cliToolName={cliToolId}
+              inline
+            />
+          }
         />
       </div>
     ),

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -16,13 +16,14 @@
 
 'use client';
 
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { Loader2 } from 'lucide-react';
+import { Loader2, MoreHorizontal } from 'lucide-react';
 import { MobileHeader } from '@/components/mobile/MobileHeader';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import { MobileTabBar } from '@/components/mobile/MobileTabBar';
 import { MobilePromptSheet } from '@/components/mobile/MobilePromptSheet';
+import { MobileTerminalActionsSheet } from '@/components/mobile/MobileTerminalActionsSheet';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
 import { MessageInput } from '@/components/worktree/MessageInput';
 import { NavigationButtons } from '@/components/worktree/NavigationButtons';
@@ -223,6 +224,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     worktreeStatus,
   } = useWorktreeDetailController({ worktreeId });
 
+  // Issue #1080: mobile terminal secondary actions (search + End) moved off the
+  // sticky control row into a bottom sheet, opened from a "more actions" trigger.
+  const [showActionsSheet, setShowActionsSheet] = useState(false);
+
   // Render
   // ========================================================================
 
@@ -387,38 +392,21 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           </div>
         )}
 
-        {/* Auto Yes + CLI Tool Tabs combined row (Mobile) */}
-        <div className="sticky top-0 z-30 flex items-center gap-2 px-3 py-1.5 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-          {/* Left: Auto Yes toggle (inline mode) — fixed, does not shrink */}
-          <div className="flex-shrink-0">
-            <AutoYesToggle
-              enabled={autoYesEnabled}
-              expiresAt={autoYesExpiresAt}
-              onToggle={handleAutoYesToggle}
-              lastAutoResponse={lastAutoResponse}
-              cliToolName={activeCliTab}
-              inline
-            />
-          </div>
-          {/* Center: CLI tool tabs — horizontally scrollable so 3+ agents
-              never overflow off-screen (Issue #958). `min-w-0` is required to
-              release the flex item's default min-width:auto, otherwise the nav
-              expands past the parent instead of scrolling.
-              Issue #874: Mobile tabs are per-agent-instance (alias-aware) so
-              multiple instances of the same CLI tool are independently
-              selectable, mirroring the PC header. `displayedInstances` is the
-              per-device visible subset (localStorage); status is resolved
-              per-instance優先（PC版と整合, Issue #960）so closing one instance
-              of a duplicated CLI tool no longer leaves a sibling's status. */}
+        {/* Agent-instance tabs row (Mobile, Issue #1080) — dedicated to the
+            per-instance tabs. Auto-Yes moved into the composer meta row; terminal
+            search + End moved into the "more actions" bottom sheet. */}
+        <div className="sticky top-0 z-30 flex items-center gap-2 px-3 py-1.5 bg-surface-2 border-b border-border">
+          {/* CLI tool tabs — horizontally scrollable so 3+ agents never overflow
+              off-screen (Issue #958). `min-w-0` releases the flex item's default
+              min-width:auto so the nav scrolls instead of expanding.
+              Issue #874: per-agent-instance (alias-aware) tabs mirror the PC
+              header; `displayedInstances` is the per-device visible subset.
+              Issue #960: status resolved per-instance優先（PC版と整合）. */}
           <nav
-            className="flex gap-2 flex-1 min-w-0 overflow-x-auto scrollbar-hide"
+            className="flex gap-1 flex-1 min-w-0 overflow-x-auto scrollbar-hide"
             aria-label="Agent Instance Selection"
           >
             {displayedInstances.map((inst) => {
-              // Issue #960: resolve each instance's status from the
-              // per-instance map first so a closed instance of a duplicated
-              // CLI tool no longer inherits a running sibling's status; fall
-              // back to the per-CLI aggregate for backward compat (PC版と整合).
               const toolStatus = deriveCliStatus(
                 worktree?.sessionStatusByInstance?.[inst.id] ?? worktree?.sessionStatusByCli?.[inst.cliTool]
               );
@@ -428,10 +416,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
                 <button
                   key={inst.id}
                   onClick={() => setActiveInstanceId(inst.id)}
-                  className={`flex-shrink-0 whitespace-nowrap px-1.5 py-0.5 rounded font-medium text-xs transition-colors flex items-center gap-1 ${
+                  className={`flex-shrink-0 whitespace-nowrap px-1.5 py-1 font-medium text-xs transition-colors flex items-center gap-1 border-b-2 ${
                     isActive
-                      ? 'bg-accent-100 text-accent-700'
-                      : 'text-gray-500 hover:text-gray-700'
+                      ? 'text-accent-600 dark:text-accent-400 border-accent-500'
+                      : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 border-transparent'
                   }`}
                   aria-current={isActive ? 'page' : undefined}
                 >
@@ -451,36 +439,16 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               );
             })}
           </nav>
-          {/* Right: search + End button — pinned, always reachable regardless
-              of tab count (Issue #958) */}
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {/* [Issue #47] Terminal search button (Mobile) */}
-            <button
-              onClick={() => {
-                window.dispatchEvent(new CustomEvent('terminal-search-open'));
-              }}
-              className="flex items-center px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
-              aria-label="ターミナル内を検索"
-              data-testid="terminal-search-button-mobile"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </button>
-            <button
-              onClick={handleKillSession}
-              disabled={!activeSessionRunning}
-              className={`flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-medium rounded transition-colors ${
-                activeSessionRunning
-                  ? 'text-red-600 hover:bg-red-50'
-                  : 'invisible'
-              }`}
-              aria-label={`End ${activeCliTab} session`}
-            >
-              <span aria-hidden="true">&#x2715;</span>
-              End
-            </button>
-          </div>
+          {/* More actions (terminal search + End) — pinned, opens bottom sheet */}
+          <button
+            type="button"
+            onClick={() => setShowActionsSheet(true)}
+            className="flex-shrink-0 flex items-center justify-center min-h-[44px] min-w-[44px] rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            aria-label={tWorktree('terminal.moreActions')}
+            data-testid="mobile-more-actions-button"
+          >
+            <MoreHorizontal size={18} aria-hidden="true" />
+          </button>
         </div>
 
         <main
@@ -567,6 +535,20 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               isSessionRunning={activeSessionRunning}
               pendingInsertText={pendingInsertText}
               onInsertConsumed={handleInsertConsumedSingle}
+              // Issue #1080: Auto-Yes now lives in the composer meta row (moved off
+              // the sticky tab row). The active agent tab already names the tool, so
+              // the parenthetical tool name is suppressed here (showToolName=false).
+              autoYesSlot={
+                <AutoYesToggle
+                  enabled={autoYesEnabled}
+                  expiresAt={autoYesExpiresAt}
+                  onToggle={handleAutoYesToggle}
+                  lastAutoResponse={lastAutoResponse}
+                  cliToolName={activeCliTab}
+                  inline
+                  showToolName={false}
+                />
+              }
             />
           </div>
         </div>
@@ -589,6 +571,17 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
             cliToolName={getCliToolDisplayName(activeCliTab)}
           />
         )}
+
+        {/* Issue #1080: terminal secondary actions (search + End) bottom sheet.
+            End defers to handleKillSession, which opens the existing kill-confirm
+            dialog (destructive confirmation preserved). */}
+        <MobileTerminalActionsSheet
+          open={showActionsSheet}
+          onClose={() => setShowActionsSheet(false)}
+          onSearch={() => window.dispatchEvent(new CustomEvent('terminal-search-open'))}
+          onEnd={handleKillSession}
+          endDisabled={!activeSessionRunning}
+        />
 
         {/* File Viewer Modal (Mobile only) */}
         <FileViewer

--- a/tests/helpers/message-input-test-utils.ts
+++ b/tests/helpers/message-input-test-utils.ts
@@ -57,9 +57,14 @@ export function createDefaultProps(overrides?: {
 
 /**
  * Get the textarea element used for message input.
+ *
+ * Issue #1080: the placeholder is now i18n-driven (`worktree.composer.placeholder`),
+ * so under the key-returning next-intl test mock it is no longer the literal
+ * "Type your message". Query by the stable textarea test id instead (robust even
+ * when the slash-command selector renders its own filter input).
  */
 export function getTextarea(): HTMLTextAreaElement {
-  return screen.getByPlaceholderText(/Type your message/i) as HTMLTextAreaElement;
+  return screen.getByTestId('message-input-textarea') as HTMLTextAreaElement;
 }
 
 /**

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -25,6 +25,20 @@ vi.mock('next-intl', () => ({
 beforeAll(() => {
   // テスト開始時の初期化処理
 
+  // Polyfill ResizeObserver for jsdom (Issue #1080). Radix primitives such as
+  // ui/Switch measure their thumb via `useSize` (ResizeObserver) in a layout
+  // effect. AutoYesToggle now renders a Radix Switch, so any tree that mounts it
+  // (worktree detail, composer meta row) would otherwise throw
+  // "ResizeObserver is not defined". Global + benign (jsdom has no native impl).
+  if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
+    class ResizeObserverStub {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    (window as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+  }
+
   // Mock Element.scrollTo for jsdom (only in browser-like environments)
   if (typeof Element !== 'undefined' && typeof Element.prototype.scrollTo !== 'function') {
     Element.prototype.scrollTo = function(options?: ScrollToOptions | number) {

--- a/tests/unit/components/mobile/MobileTerminalActionsSheet.test.tsx
+++ b/tests/unit/components/mobile/MobileTerminalActionsSheet.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for MobileTerminalActionsSheet (Issue #1080)
+ *
+ * The terminal search + End actions moved off the mobile sticky row into this
+ * bottom sheet. "End session" defers confirmation to the caller.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MobileTerminalActionsSheet } from '@/components/mobile/MobileTerminalActionsSheet';
+
+describe('MobileTerminalActionsSheet', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    onSearch: vi.fn(),
+    onEnd: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when closed', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} open={false} />);
+    expect(screen.queryByTestId('mobile-terminal-actions-sheet')).not.toBeInTheDocument();
+  });
+
+  it('renders the sheet with search and end actions when open', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    expect(screen.getByTestId('mobile-terminal-actions-sheet')).toBeInTheDocument();
+    expect(screen.getByTestId('actions-sheet-search')).toBeInTheDocument();
+    expect(screen.getByTestId('actions-sheet-end')).toBeInTheDocument();
+  });
+
+  it('is a bottom sheet anchored to the bottom edge', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    const sheet = screen.getByTestId('mobile-terminal-actions-sheet');
+    expect(sheet.className).toMatch(/fixed/);
+    expect(sheet.className).toMatch(/bottom-0/);
+    expect(sheet).toHaveAttribute('role', 'dialog');
+  });
+
+  it('invokes onSearch then closes when Search is tapped', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('actions-sheet-search'));
+    expect(defaultProps.onSearch).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onEnd then closes when End session is tapped', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('actions-sheet-end'));
+    expect(defaultProps.onEnd).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables End session when endDisabled', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} endDisabled />);
+    const endBtn = screen.getByTestId('actions-sheet-end');
+    expect(endBtn).toBeDisabled();
+    fireEvent.click(endBtn);
+    expect(defaultProps.onEnd).not.toHaveBeenCalled();
+  });
+
+  it('closes when the overlay is tapped', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('terminal-actions-overlay'));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when Escape is pressed while open', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not respond to Escape when closed', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} open={false} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-Escape keys while open', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -107,6 +107,24 @@ describe('MessageInput', () => {
 
       expect(getSendButton()).not.toBeDisabled();
     });
+
+    // Issue #1080: the send button switches from a ghost affordance to a filled
+    // accent circle when the composer holds a sendable message.
+    it('should change send button class between ghost and filled on input (Issue #1080)', () => {
+      render(<MessageInput {...defaultProps} />);
+
+      const emptyBtn = getSendButton();
+      expect(emptyBtn.getAttribute('data-can-send')).toBe('false');
+      expect(emptyBtn.className).toContain('text-muted-foreground/50');
+      expect(emptyBtn.className).not.toContain('bg-accent-600');
+
+      typeMessage('Hello');
+
+      const filledBtn = getSendButton();
+      expect(filledBtn.getAttribute('data-can-send')).toBe('true');
+      expect(filledBtn.className).toContain('bg-accent-600');
+      expect(filledBtn.className).toContain('text-white');
+    });
   });
 
   // ===== Desktop behavior =====

--- a/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
@@ -49,16 +49,21 @@ vi.mock('@/components/worktree/MessageInput', () => ({
     cliToolId,
     splitIndex,
     pendingInsertText,
+    autoYesSlot,
   }: {
     cliToolId: string;
     splitIndex: number;
     pendingInsertText?: string | null;
+    // Issue #1080: Auto-Yes moved into the composer meta row (autoYesSlot).
+    autoYesSlot?: React.ReactNode;
   }) => (
     <div
       data-testid={`message-input-${splitIndex}`}
       data-cli-tool-id={cliToolId}
       data-pending-insert={pendingInsertText ?? ''}
-    />
+    >
+      {autoYesSlot}
+    </div>
   ),
 }));
 


### PR DESCRIPTION
## 概要
Closes #1080 (親 #1068 / Phase C Batch2)。#1077(ui/Kbd)+#1079(terminal) の後続。

メッセージコンポーザーをカード化し（ui/Kbd でキーヒント再利用）、モバイルの worktree コントロールを整理（新規 MobileTerminalActionsSheet に検索/End を集約、MobileTabBar/AutoYesToggle/InterruptButton 整頓）。

## 変更点
- `MessageInput.tsx`: コンポーザーのカード化 + `ui/Kbd` によるキーヒント（送信/Shift+Enter/スラッシュの挙動・testid は保持）
- 新規 `MobileTerminalActionsSheet.tsx`（role=dialog/aria-modal/backdrop-tap + **Escapeで閉じる**）
- `AutoYesToggle` を共有 Radix Switch へ、`MobileTabBar`/`WorktreeDetailRefactored` 整理
- TerminalSplitPane の #1079 DropdownMenu は温存、StatusDot/status-colors は不変（#1078 領域）

## 敵対的レビュー（touch重点）+ 仕上げ
4観点の touch/mobile 敵対レビューで **0 shippable defect**（hover-invisible/broken-composer/layout破綻なし）。指摘された a11y 仕上げ2件を反映:
- MobileTerminalActionsSheet に **Escape-to-close** 追加
- more-actions トリガーを **44px タップ領域**へ拡大

## 検証
- ✅ lint / tsc / mobile・composer 153 tests
- ✅ develop(#1081) 取り込み済み・コンフリクトなし
- ⏳ モバイル実描画は develop 統合後の Playwright(390px) で最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)