### PR TITLE
feat(ui): 稼働ステータスを StatusDot 一本化し idle ノイズを縮退 (#1078)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,4 +1,8 @@
 {
+  "sessions": {
+    "idleAgents": "{count} idle",
+    "activeAgents": "{count} active"
+  },
   "cancel": "Cancel",
   "send": "Send",
   "end": "End",

--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -1,4 +1,8 @@
 {
+  "agentStatus": {
+    "moreAgents": "{count} more agents",
+    "overflowTrigger": "More agents"
+  },
   "toc": {
     "title": "Contents",
     "show": "Show table of contents",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1,4 +1,8 @@
 {
+  "sessions": {
+    "idleAgents": "アイドル {count} 件",
+    "activeAgents": "稼働 {count} 件"
+  },
   "cancel": "キャンセル",
   "send": "送信",
   "end": "終了する",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -1,4 +1,8 @@
 {
+  "agentStatus": {
+    "moreAgents": "他 {count} 件のエージェント",
+    "overflowTrigger": "他のエージェント"
+  },
   "toc": {
     "title": "目次",
     "show": "目次を表示",

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -15,10 +15,12 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import { AppShell } from '@/components/layout';
 import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { deriveCliStatus } from '@/types/sidebar';
+import { isWorkingStatus } from '@/lib/agent-status-display';
 import { getCliToolDisplayName } from '@/lib/cli-tools/types';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
@@ -32,13 +34,9 @@ import {
   StatusDot,
 } from '@/components/ui';
 import { compareByTimestamp } from '@/lib/sidebar-utils';
-import { formatRelativeTime } from '@/lib/date-utils';
+import { formatRelativeTimeShort } from '@/lib/date-utils';
 import { STAGGER_ENTER_CLASS, staggerDelay } from '@/lib/utils/stagger';
-import {
-  MESSAGE_PREVIEW_MAX_LENGTH_PC,
-  MESSAGE_PREVIEW_MAX_LENGTH_SP,
-  sanitizePreview,
-} from '@/config/message-preview-config';
+import { sanitizePreview } from '@/config/message-preview-config';
 import type { SortKey, SortDirection } from '@/lib/sidebar-utils';
 import type { Worktree } from '@/types/models';
 import type { CLIToolType } from '@/lib/cli-tools/types';
@@ -118,6 +116,7 @@ const DEFAULT_BADGE_CLASS = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:tex
 // ============================================================================
 
 export default function SessionsPage() {
+  const tCommon = useTranslations('common');
   const { worktrees, isLoading, error } = useWorktreesCacheContext();
   // [Issue #1050] Whether we have any data to keep mounted. Based on the raw
   // (unfiltered) list so an active text filter never unmounts the list.
@@ -290,8 +289,17 @@ export default function SessionsPage() {
                   ? sanitizePreview(wt.lastUserMessage)
                   : null;
                 const relativeTime = wt.lastUserMessageAt
-                  ? formatRelativeTime(String(wt.lastUserMessageAt))
+                  ? formatRelativeTimeShort(String(wt.lastUserMessageAt))
                   : null;
+                // [Issue #1078] Only actively-working agents (running/waiting)
+                // get a labelled chip; the idle group collapses to a "+N" counter
+                // so a working session is never buried under a row of gray dots.
+                const agentStatuses = agents.map((agent) => ({
+                  agent,
+                  status: deriveCliStatus(wt.sessionStatusByCli?.[agent]),
+                }));
+                const workingAgents = agentStatuses.filter((a) => isWorkingStatus(a.status));
+                const idleCount = agentStatuses.length - workingAgents.length;
                 // [Issue #1051] Active (running) cards get an accent border +
                 // subtle glow so a working session stands out at a glance.
                 const isActive = isWorktreeActive(wt, agents);
@@ -320,19 +328,28 @@ export default function SessionsPage() {
                         </div>
                       </div>
 
-                      {/* Per-agent status dots */}
-                      <div className="flex items-center gap-2 ml-4 flex-shrink-0">
-                        {agents.map((agent) => {
-                          const agentStatus = deriveCliStatus(wt.sessionStatusByCli?.[agent]);
-                          return (
-                            <div key={agent} className="flex items-center gap-1" data-testid={`session-agent-${agent}`}>
-                              <CliDot status={agentStatus} label={getCliToolDisplayName(agent)} />
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
-                                {getCliToolDisplayName(agent)}
-                              </span>
-                            </div>
-                          );
-                        })}
+                      {/* [Issue #1078] Working agents as labelled chips; idle group collapsed */}
+                      <div className="flex items-center gap-2 ml-4 flex-shrink-0" data-testid={`session-agents-${wt.id}`}>
+                        {workingAgents.map(({ agent, status }) => (
+                          <div key={agent} className="flex items-center gap-1" data-testid={`session-agent-${agent}`}>
+                            <CliDot status={status} label={getCliToolDisplayName(agent)} />
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              {getCliToolDisplayName(agent)}
+                            </span>
+                          </div>
+                        ))}
+                        {idleCount > 0 && (
+                          <div
+                            className="flex items-center gap-1"
+                            data-testid={`session-idle-cluster-${wt.id}`}
+                            aria-label={tCommon('sessions.idleAgents', { count: idleCount })}
+                          >
+                            <StatusDot status="idle" size="sm" aria-hidden title={undefined} />
+                            <span className="text-xs text-gray-400 dark:text-gray-500 tabular-nums">
+                              +{idleCount}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
 
@@ -359,21 +376,18 @@ export default function SessionsPage() {
                     {/* Row 4: Last sent message preview + relative time [Issue #606] */}
                     {sanitizedMessage && (
                       <div className="mt-2 flex items-center gap-2" data-testid={`session-message-${wt.id}`}>
-                        <span className="text-xs text-gray-500 dark:text-gray-400 truncate min-w-0 flex-1">
-                          {/* PC preview (md and above) */}
-                          <span className="hidden md:inline" data-testid={`session-message-pc-${wt.id}`}>
-                            {sanitizedMessage.slice(0, MESSAGE_PREVIEW_MAX_LENGTH_PC)}
-                            {sanitizedMessage.length > MESSAGE_PREVIEW_MAX_LENGTH_PC ? '...' : ''}
-                          </span>
-                          {/* SP preview (below md) */}
-                          <span className="inline md:hidden" data-testid={`session-message-sp-${wt.id}`}>
-                            {sanitizedMessage.slice(0, MESSAGE_PREVIEW_MAX_LENGTH_SP)}
-                            {sanitizedMessage.length > MESSAGE_PREVIEW_MAX_LENGTH_SP ? '...' : ''}
-                          </span>
+                        {/* [Issue #1078] CSS truncate (not char-slice): byte-width is
+                            consistent across JP/EN and adapts to the container width. */}
+                        <span
+                          className="text-xs text-gray-500 dark:text-gray-400 truncate min-w-0 flex-1"
+                          data-testid={`session-message-text-${wt.id}`}
+                          title={sanitizedMessage}
+                        >
+                          {sanitizedMessage}
                         </span>
                         {relativeTime && (
                           <span
-                            className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 whitespace-nowrap"
+                            className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 whitespace-nowrap tabular-nums"
                             data-testid={`session-time-${wt.id}`}
                           >
                             {relativeTime}

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -9,8 +9,9 @@
 
 'use client';
 
-import { useMemo, memo } from 'react';
-import { MOBILE_STATUS_CONFIG, type WorktreeStatusType } from '@/config/status-colors';
+import { memo } from 'react';
+import { type WorktreeStatusType } from '@/config/status-colors';
+import { StatusDot } from '@/components/ui/StatusDot';
 import { truncateString } from '@/lib/utils';
 import type { GitStatus } from '@/types/models';
 
@@ -91,11 +92,6 @@ export function MobileHeader({
   onBackClick,
   onMenuClick,
 }: MobileHeaderProps) {
-  /**
-   * Status indicator configuration
-   */
-  const statusConfig = useMemo(() => MOBILE_STATUS_CONFIG[status], [status]);
-
   return (
     <header
       data-testid="mobile-header"
@@ -119,20 +115,13 @@ export function MobileHeader({
 
         {/* Center section: Worktree name, repository, and status */}
         <div className="flex-1 flex items-center justify-center min-w-0 px-2">
-          {/* Status indicator */}
-          {statusConfig.type === 'spinner' ? (
-            <span
-              data-testid="status-indicator"
-              aria-label={statusConfig.label}
-              className={`w-2.5 h-2.5 rounded-full mr-2 flex-shrink-0 border-2 border-t-transparent animate-spin ${statusConfig.className}`}
-            />
-          ) : (
-            <span
-              data-testid="status-indicator"
-              aria-label={statusConfig.label}
-              className={`w-2.5 h-2.5 rounded-full mr-2 flex-shrink-0 ${statusConfig.className}`}
-            />
-          )}
+          {/* Status indicator (Issue #1078: unified StatusDot visual language) */}
+          <StatusDot
+            data-testid="status-indicator"
+            status={status}
+            size="sm"
+            className="mr-2"
+          />
 
           {/* Worktree name and repository */}
           <div className="flex flex-col items-center min-w-0">

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -21,6 +21,7 @@ import dynamic from 'next/dynamic';
 import { Loader2, MoreHorizontal } from 'lucide-react';
 import { MobileHeader } from '@/components/mobile/MobileHeader';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
+import { StatusDot } from '@/components/ui/StatusDot';
 import { MobileTabBar } from '@/components/mobile/MobileTabBar';
 import { MobilePromptSheet } from '@/components/mobile/MobilePromptSheet';
 import { MobileTerminalActionsSheet } from '@/components/mobile/MobileTerminalActionsSheet';
@@ -410,7 +411,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               const toolStatus = deriveCliStatus(
                 worktree?.sessionStatusByInstance?.[inst.id] ?? worktree?.sessionStatusByCli?.[inst.cliTool]
               );
-              const statusConfig = SIDEBAR_STATUS_CONFIG[toolStatus];
+              const statusLabel = SIDEBAR_STATUS_CONFIG[toolStatus].label;
               const isActive = activeInstanceId === inst.id;
               return (
                 <button
@@ -423,17 +424,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
                   }`}
                   aria-current={isActive ? 'page' : undefined}
                 >
-                  {statusConfig.type === 'spinner' ? (
-                    <span
-                      className={`w-2 h-2 rounded-full flex-shrink-0 border-2 border-t-transparent animate-spin ${statusConfig.className}`}
-                      title={statusConfig.label}
-                    />
-                  ) : (
-                    <span
-                      className={`w-2 h-2 rounded-full flex-shrink-0 ${statusConfig.className}`}
-                      title={statusConfig.label}
-                    />
-                  )}
+                  {/* Issue #1078: unified StatusDot visual language (was blue spinner) */}
+                  <StatusDot status={toolStatus} size="sm" label={`${getInstanceLabel(inst)}: ${statusLabel}`} />
                   {getInstanceLabel(inst)}
                 </button>
               );

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -12,8 +12,18 @@
 'use client';
 
 import React, { useEffect, useCallback, useState, memo, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 import { type WorktreeStatus } from '@/components/mobile/MobileHeader';
 import { DESKTOP_STATUS_CONFIG, SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
+import { StatusDot } from '@/components/ui/StatusDot';
+import { Tooltip } from '@/components/common/Tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/DropdownMenu';
+import { classifyHeaderInstances } from '@/lib/agent-status-display';
 import { LogViewer } from '@/components/worktree/LogViewer';
 import { VersionSection } from '@/components/worktree/VersionSection';
 import { FeedbackSection } from '@/components/worktree/FeedbackSection';
@@ -489,6 +499,13 @@ const WORKTREE_STATUS_OPTIONS: Array<{ value: 'ready' | 'in_progress' | 'in_revi
 
 /** Status indicator configuration is imported from @/config/status-colors (SF1) */
 
+/**
+ * Issue #1078: max labelled agent pills kept inline in the desktop header before
+ * the rest collapse into the "+N" overflow menu. Idle/ready instances always
+ * render as narrow icon-only dots and never count against this budget.
+ */
+const MAX_HEADER_AGENT_PILLS = 4;
+
 /** Desktop header with hamburger menu, back button, worktree name, repository, status, and info button */
 export const DesktopHeader = memo(function DesktopHeader({
   worktreeName,
@@ -510,6 +527,7 @@ export const DesktopHeader = memo(function DesktopHeader({
   onAgentDragEnd,
   onKillSession,
 }: DesktopHeaderProps) {
+  const tWorktree = useTranslations('worktree');
   const statusConfig = DESKTOP_STATUS_CONFIG[status];
   // Issue #111: DRY - Use shared truncateString utility
   const DESKTOP_BRANCH_MAX_LENGTH = 30;
@@ -585,22 +603,13 @@ export const DesktopHeader = memo(function DesktopHeader({
           <span className="text-sm font-medium">Home</span>
         </button>
         <div className="w-px h-6 bg-gray-300 dark:bg-gray-600" aria-hidden="true" />
-        {/* Status indicator */}
-        {statusConfig.type === 'spinner' ? (
-          <span
-            data-testid="desktop-status-indicator"
-            title={statusConfig.label}
-            aria-label={statusConfig.label}
-            className={`w-3 h-3 rounded-full flex-shrink-0 border-2 border-t-transparent animate-spin ${statusConfig.className}`}
-          />
-        ) : (
-          <span
-            data-testid="desktop-status-indicator"
-            title={statusConfig.label}
-            aria-label={statusConfig.label}
-            className={`w-3 h-3 rounded-full flex-shrink-0 ${statusConfig.className}`}
-          />
-        )}
+        {/* Worktree-level status (Issue #1078: unified StatusDot visual language) */}
+        <StatusDot
+          data-testid="desktop-status-indicator"
+          status={status}
+          size="lg"
+          label={statusConfig.label}
+        />
         {/* Worktree name, memo, and repository */}
         <div className="flex flex-col min-w-0">
           <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate max-w-[200px] leading-tight">
@@ -642,62 +651,138 @@ export const DesktopHeader = memo(function DesktopHeader({
 
       {/* Right: Per-agent status row + Status dropdown + Info button */}
       <div className="flex items-center gap-2">
-        {/* Issue #749/#869: Per-instance session status indicators (PC only).
-            Distinct from the worktree-level dot on the left (DESKTOP_STATUS_CONFIG):
-            this row is per-agent-instance (SIDEBAR_STATUS_CONFIG) and doubles as
-            an instance-tab switcher. Each tab is labelled by its alias
-            (getInstanceLabel); status is resolved per backing CLI tool. Rendered
-            only when instances is provided (backward compat). */}
-        {instances && instances.length > 0 && (
-          <div className="flex items-center gap-2 flex-shrink-0" data-testid="desktop-agent-status-row">
-            {instances.map((inst) => {
-              // Issue #875: resolve each instance's status from the per-instance
-              // map so alias instances (instanceId !== cliToolId) show their own
-              // status; fall back to the per-CLI map for backward compat.
-              const cliStatus = deriveCliStatus(
+        {/* Issue #749/#869/#1078: Per-instance session status row (PC only).
+            Distinct from the worktree-level StatusDot on the left: this row is
+            per-agent-instance and doubles as an instance-tab switcher. Issue #1078
+            unifies the status visual on <StatusDot> and collapses idle noise —
+            active/working instances stay labelled pills, idle/ready collapse to
+            icon-only dots (label via Tooltip), and pills beyond the budget fold
+            into a "+N" overflow menu so a working session never gets buried.
+            Rendered only when instances is provided (backward compat). */}
+        {instances && instances.length > 0 && (() => {
+          // Issue #875: resolve each instance's status from the per-instance map
+          // so alias instances (instanceId !== cliToolId) show their own status;
+          // fall back to the per-CLI map for backward compat.
+          const classified = classifyHeaderInstances(
+            instances.map((inst) => ({
+              item: inst,
+              status: deriveCliStatus(
                 sessionStatusByInstance?.[inst.id] ?? sessionStatusByCli?.[inst.cliTool]
-              );
-              const agentStatusConfig = SIDEBAR_STATUS_CONFIG[cliStatus];
-              const isActive = inst.id === activeInstanceId;
-              const label = getInstanceLabel(inst);
-              return (
-                <button
-                  key={inst.id}
-                  type="button"
-                  data-testid={`desktop-agent-status-${inst.id}`}
-                  onClick={() => onActiveInstanceChange?.(inst.id)}
-                  // Issue #786: drag source. click and drag are mutually
-                  // exclusive in HTML; a plain click (no drag) still fires
-                  // onClick exactly once (S3-002 regression-guarded).
-                  draggable
-                  onDragStart={(e) => handleAgentDragStart(e, inst.id)}
-                  onDragEnd={handleAgentDragEnd}
-                  aria-label={`${label}: ${agentStatusConfig.label}`}
-                  aria-pressed={isActive}
-                  className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
-                    isActive
-                      ? 'bg-accent-100 dark:bg-accent-900/30 text-accent-900 dark:text-accent-100'
-                      : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300'
-                  }${draggingInstanceId === inst.id ? ' opacity-50 cursor-grabbing' : ''}`}
-                >
-                  {/* Issue #751: dot/spinner icon to the LEFT of the always-visible text */}
-                  {agentStatusConfig.type === 'spinner' ? (
-                    <span
-                      className={`block w-2.5 h-2.5 rounded-full border-2 border-t-transparent animate-spin ${agentStatusConfig.className}`}
-                    />
-                  ) : (
-                    <span
-                      className={`block w-2.5 h-2.5 rounded-full ${agentStatusConfig.className}`}
-                    />
-                  )}
-                  <span className="whitespace-nowrap">
-                    {label}: {agentStatusConfig.label}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        )}
+              ),
+              isActive: inst.id === activeInstanceId,
+            })),
+            MAX_HEADER_AGENT_PILLS
+          );
+          const overflow = classified.filter((c) => c.slot === 'overflow');
+          // Issue #1078: if any folded instance is actively working, surface the
+          // living glow on the "+N" trigger so a running session stays visible
+          // at a glance even when collapsed. Prefer running/generating (green
+          // glow) over waiting (amber blink); no working ones → no glow.
+          const overflowGlowStatus =
+            overflow.find((c) => c.status === 'running' || c.status === 'generating')?.status ??
+            overflow.find((c) => c.status === 'waiting')?.status ??
+            null;
+
+          return (
+            <div className="flex items-center gap-2 flex-shrink-0" data-testid="desktop-agent-status-row">
+              {classified.map((c) => {
+                if (c.slot === 'overflow') return null;
+                const inst = c.item;
+                const label = getInstanceLabel(inst);
+                const fullLabel = `${label}: ${SIDEBAR_STATUS_CONFIG[c.status].label}`;
+                const isActive = c.isActive;
+                // Issue #786: drag source. click and drag are mutually exclusive
+                // in HTML; a plain click (no drag) still fires onClick exactly
+                // once (S3-002 regression-guarded). Preserved on both pill and dot.
+                const dragProps = {
+                  draggable: true,
+                  onDragStart: (e: React.DragEvent<HTMLButtonElement>) => handleAgentDragStart(e, inst.id),
+                  onDragEnd: handleAgentDragEnd,
+                } as const;
+                const dragActive = draggingInstanceId === inst.id ? ' opacity-50 cursor-grabbing' : '';
+
+                if (c.slot === 'pill') {
+                  return (
+                    <button
+                      key={inst.id}
+                      type="button"
+                      data-testid={`desktop-agent-status-${inst.id}`}
+                      onClick={() => onActiveInstanceChange?.(inst.id)}
+                      {...dragProps}
+                      aria-label={fullLabel}
+                      aria-pressed={isActive}
+                      className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
+                        isActive
+                          ? 'bg-accent-100 dark:bg-accent-900/30 text-accent-900 dark:text-accent-100'
+                          : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300'
+                      }${dragActive}`}
+                    >
+                      {/* Issue #1078: unified StatusDot (decorative; the button carries the label) */}
+                      <StatusDot status={c.status} size="sm" aria-hidden title={undefined} />
+                      <span className="whitespace-nowrap">{fullLabel}</span>
+                    </button>
+                  );
+                }
+
+                // Idle/ready → icon-only 24px circular button; full label via Tooltip.
+                return (
+                  <Tooltip key={inst.id} content={fullLabel} placement="bottom">
+                    <button
+                      type="button"
+                      data-testid={`desktop-agent-status-${inst.id}`}
+                      onClick={() => onActiveInstanceChange?.(inst.id)}
+                      {...dragProps}
+                      aria-label={fullLabel}
+                      aria-pressed={isActive}
+                      className={`flex items-center justify-center w-6 h-6 rounded-full transition-colors ${
+                        isActive
+                          ? 'bg-accent-100 dark:bg-accent-900/30'
+                          : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                      }${dragActive}`}
+                    >
+                      <StatusDot status={c.status} size="sm" aria-hidden title={undefined} />
+                    </button>
+                  </Tooltip>
+                );
+              })}
+
+              {/* Issue #1078: width-overflow menu for surplus labelled pills. */}
+              {overflow.length > 0 && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      data-testid="desktop-agent-status-overflow"
+                      aria-label={tWorktree('agentStatus.moreAgents', { count: overflow.length })}
+                      className="flex items-center gap-1 px-2 py-1 rounded text-xs tabular-nums text-muted-foreground hover:bg-muted transition-colors"
+                    >
+                      {overflowGlowStatus && (
+                        <StatusDot status={overflowGlowStatus} size="sm" aria-hidden title={undefined} />
+                      )}
+                      +{overflow.length}
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {overflow.map((c) => {
+                      const inst = c.item;
+                      const fullLabel = `${getInstanceLabel(inst)}: ${SIDEBAR_STATUS_CONFIG[c.status].label}`;
+                      return (
+                        <DropdownMenuItem
+                          key={inst.id}
+                          data-testid={`desktop-agent-overflow-${inst.id}`}
+                          onSelect={() => onActiveInstanceChange?.(inst.id)}
+                        >
+                          <StatusDot status={c.status} size="sm" aria-hidden title={undefined} />
+                          <span className="whitespace-nowrap">{fullLabel}</span>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
+          );
+        })()}
         {/* Issue #784: Session kill button (PC only). Restored after the
             #728 (split-ification) + #755 (Desktop/Mobile split) regression that
             left the kill confirmation modal unreachable on PC. Mirrors the

--- a/src/config/status-colors.ts
+++ b/src/config/status-colors.ts
@@ -22,7 +22,11 @@ export type SidebarStatusType = BaseStatusType | 'generating';
 /** Extended status types for worktree detail (includes error) */
 export type WorktreeStatusType = BaseStatusType | 'error';
 
-/** Display type for status indicator */
+/**
+ * Display type for status indicator.
+ * @deprecated Issue #1078: `'spinner'` is being retired in favour of the unified
+ * `<StatusDot>` (running = green glow). Only `ReviewTab.tsx` still branches on it.
+ */
 export type StatusDisplayType = 'dot' | 'spinner';
 
 /** Status configuration interface */
@@ -45,7 +49,13 @@ export const STATUS_COLORS = {
   idle: 'bg-gray-500',
   /** Green for ready/active state */
   ready: 'bg-green-500',
-  /** Info (blue) border for spinner states (running/generating); kept distinct from the cyan accent */
+  /**
+   * @deprecated Issue #1078: the blue rotating-ring spinner is being unified
+   * into the single `<StatusDot>` visual language (running = green glow). Kept
+   * only because `ReviewTab.tsx` still consumes the `type: 'spinner'` branch;
+   * remove this constant and the `type: 'spinner'` configs below once that last
+   * consumer migrates to `<StatusDot>`.
+   */
   spinner: 'border-info',
   /** Yellow for waiting state (G1: distinguishes from ready) */
   waiting: 'bg-yellow-500',

--- a/src/lib/agent-status-display.ts
+++ b/src/lib/agent-status-display.ts
@@ -1,0 +1,75 @@
+/**
+ * Agent-instance status display helpers (Issue #1078).
+ *
+ * Pure logic for the worktree desktop header's per-agent status row. The row
+ * unifies the status visual on `<StatusDot>` and collapses idle noise:
+ * - active or actively-working instances render as a labelled pill,
+ * - idle / ready instances collapse to an icon-only dot (label via tooltip),
+ * - when there are more labelled pills than fit, the excess collapse into a
+ *   "+N" overflow menu so a working session never gets buried.
+ */
+
+import type { BranchStatus } from '@/types/sidebar';
+
+/** Statuses that represent an instance actively doing (or awaiting) work. */
+export function isWorkingStatus(status: BranchStatus): boolean {
+  return status === 'running' || status === 'generating' || status === 'waiting';
+}
+
+/** One instance plus the display facts the layout needs. */
+export interface HeaderInstanceItem<T> {
+  item: T;
+  status: BranchStatus;
+  isActive: boolean;
+}
+
+/**
+ * An instance renders as a labelled pill when it is the active tab or is
+ * actively working; otherwise it collapses to an icon-only dot.
+ */
+export function isLabeledInstance<T>(it: HeaderInstanceItem<T>): boolean {
+  return it.isActive || isWorkingStatus(it.status);
+}
+
+/** Where a classified instance is rendered in the header row. */
+export type HeaderInstanceSlot = 'pill' | 'dot' | 'overflow';
+
+export interface ClassifiedHeaderInstance<T> extends HeaderInstanceItem<T> {
+  slot: HeaderInstanceSlot;
+}
+
+/**
+ * Classify each instance into pill / dot / overflow, preserving the original
+ * roster order for the visible items.
+ *
+ * - `dot`: idle / ready instances — always visible (dots are narrow).
+ * - `pill`: labelled instances (active or working). At most `maxPills` stay
+ *   visible; the active tab is kept preferentially, then roster order.
+ * - `overflow`: labelled instances beyond `maxPills` — surfaced via the "+N" menu.
+ *
+ * @param items     instances in roster order
+ * @param maxPills  max labelled pills to keep inline (<=0 collapses all pills)
+ */
+export function classifyHeaderInstances<T>(
+  items: HeaderInstanceItem<T>[],
+  maxPills: number,
+): ClassifiedHeaderInstance<T>[] {
+  const labeledIndices = items
+    .map((it, index) => ({ it, index }))
+    .filter(({ it }) => isLabeledInstance(it));
+
+  const pillKeep = new Set<number>();
+  if (maxPills > 0 && labeledIndices.length > 0) {
+    const ranked = [...labeledIndices].sort(
+      (a, b) => Number(b.it.isActive) - Number(a.it.isActive) || a.index - b.index,
+    );
+    ranked.slice(0, maxPills).forEach(({ index }) => pillKeep.add(index));
+  }
+
+  return items.map((it, index) => {
+    if (!isLabeledInstance(it)) {
+      return { ...it, slot: 'dot' as const };
+    }
+    return { ...it, slot: pillKeep.has(index) ? ('pill' as const) : ('overflow' as const) };
+  });
+}

--- a/tests/unit/SessionsPage.test.tsx
+++ b/tests/unit/SessionsPage.test.tsx
@@ -46,6 +46,11 @@ vi.mock('@/lib/date-utils', () => ({
     if (!isoString) return '';
     return '2 hours ago';
   },
+  // Issue #1078: Sessions now uses the short form ("2h ago") with tabular-nums.
+  formatRelativeTimeShort: (isoString: string) => {
+    if (!isoString) return '';
+    return '2h ago';
+  },
 }));
 
 // --- WorktreesCacheProvider context mock (Issue #709) ---
@@ -126,7 +131,9 @@ describe('SessionsPage', () => {
       render(<SessionsPage />);
 
       const timeEl = screen.getByTestId('session-time-wt-time');
-      expect(timeEl.textContent).toBe('2 hours ago');
+      expect(timeEl.textContent).toBe('2h ago');
+      // Issue #1078: relative time uses tabular-nums for stable column width.
+      expect(timeEl.className).toContain('tabular-nums');
     });
 
     it('should not display message row when lastUserMessage is absent', () => {
@@ -142,7 +149,7 @@ describe('SessionsPage', () => {
       expect(screen.queryByTestId('session-message-wt-no-msg')).toBeNull();
     });
 
-    it('should truncate PC preview to 100 characters', () => {
+    it('renders the full message and truncates via CSS (no char-slice) [Issue #1078]', () => {
       const longMessage = 'A'.repeat(150);
       mockWorktrees = [
         createWorktree({
@@ -154,28 +161,15 @@ describe('SessionsPage', () => {
 
       render(<SessionsPage />);
 
-      const pcEl = screen.getByTestId('session-message-pc-wt-long');
-      // 100 chars + '...'
-      expect(pcEl.textContent).toBe('A'.repeat(100) + '...');
+      const textEl = screen.getByTestId('session-message-text-wt-long');
+      // Full text is present (CSS `truncate` clips visually, not by character count).
+      expect(textEl.textContent).toBe('A'.repeat(150));
+      expect(textEl.className).toContain('truncate');
+      // Full text also exposed via title for hover/accessibility.
+      expect(textEl.getAttribute('title')).toBe('A'.repeat(150));
     });
 
-    it('should truncate SP preview to 20 characters', () => {
-      const longMessage = 'B'.repeat(50);
-      mockWorktrees = [
-        createWorktree({
-          id: 'wt-sp',
-          lastUserMessage: longMessage,
-          lastUserMessageAt: '2026-04-01T10:00:00Z',
-        }),
-      ];
-
-      render(<SessionsPage />);
-
-      const spEl = screen.getByTestId('session-message-sp-wt-sp');
-      expect(spEl.textContent).toBe('B'.repeat(20) + '...');
-    });
-
-    it('should not add ellipsis when message is within limit', () => {
+    it('renders short messages verbatim with no ellipsis', () => {
       mockWorktrees = [
         createWorktree({
           id: 'wt-short',
@@ -186,10 +180,8 @@ describe('SessionsPage', () => {
 
       render(<SessionsPage />);
 
-      const pcEl = screen.getByTestId('session-message-pc-wt-short');
-      expect(pcEl.textContent).toBe('Short');
-      const spEl = screen.getByTestId('session-message-sp-wt-short');
-      expect(spEl.textContent).toBe('Short');
+      const textEl = screen.getByTestId('session-message-text-wt-short');
+      expect(textEl.textContent).toBe('Short');
     });
   });
 
@@ -240,7 +232,7 @@ describe('SessionsPage', () => {
 
       render(<SessionsPage />);
 
-      const pcEl = screen.getByTestId('session-message-pc-wt-ctrl');
+      const pcEl = screen.getByTestId('session-message-text-wt-ctrl');
       // Control chars and zero-width chars should be removed
       expect(pcEl.textContent).toBe('HelloWorldtest');
     });
@@ -256,7 +248,7 @@ describe('SessionsPage', () => {
 
       render(<SessionsPage />);
 
-      const pcEl = screen.getByTestId('session-message-pc-wt-newline');
+      const pcEl = screen.getByTestId('session-message-text-wt-newline');
       expect(pcEl.textContent).toBe('Line1 Line2 Line3');
     });
 
@@ -271,7 +263,7 @@ describe('SessionsPage', () => {
 
       render(<SessionsPage />);
 
-      const pcEl = screen.getByTestId('session-message-pc-wt-spaces');
+      const pcEl = screen.getByTestId('session-message-text-wt-spaces');
       expect(pcEl.textContent).toBe('Hello World Test');
     });
   });
@@ -451,6 +443,82 @@ describe('SessionsPage', () => {
       render(<SessionsPage />);
 
       expect(screen.getByTestId('sessions-empty')).toBeDefined();
+    });
+  });
+
+  // Issue #1078: only actively-working agents get a labelled chip; the idle
+  // group collapses to a "+N" counter so a working session is not buried.
+  describe('agent status display (Issue #1078)', () => {
+    const SIX_AGENTS = ['claude', 'codex', 'gemini', 'cursor', 'aider', 'qwen'];
+
+    it('running 1 + idle 5: only the running agent is a labelled chip + a "+5" idle counter', () => {
+      mockWorktrees = [
+        createWorktree({
+          id: 'wt-mix',
+          selectedAgents: SIX_AGENTS,
+          sessionStatusByCli: {
+            claude: { isRunning: true, isWaitingForResponse: false, isProcessing: true },
+          },
+        }),
+      ];
+
+      render(<SessionsPage />);
+
+      // Working agent → labelled chip.
+      expect(screen.getByTestId('session-agent-claude')).toBeDefined();
+      // Idle agents are NOT rendered as labelled chips.
+      expect(screen.queryByTestId('session-agent-codex')).toBeNull();
+      expect(screen.queryByTestId('session-agent-gemini')).toBeNull();
+      // Idle group collapses into a "+5" counter.
+      const cluster = screen.getByTestId('session-idle-cluster-wt-mix');
+      expect(cluster.textContent).toContain('+5');
+    });
+
+    it('all idle: no labelled chips, a single "+6" idle counter', () => {
+      mockWorktrees = [
+        createWorktree({ id: 'wt-idle', selectedAgents: SIX_AGENTS }),
+      ];
+
+      render(<SessionsPage />);
+
+      expect(screen.queryByTestId('session-agent-claude')).toBeNull();
+      const cluster = screen.getByTestId('session-idle-cluster-wt-idle');
+      expect(cluster.textContent).toContain('+6');
+    });
+
+    it('waiting agents also count as working (labelled chip)', () => {
+      mockWorktrees = [
+        createWorktree({
+          id: 'wt-wait',
+          selectedAgents: SIX_AGENTS,
+          sessionStatusByCli: {
+            codex: { isRunning: true, isWaitingForResponse: true, isProcessing: false },
+          },
+        }),
+      ];
+
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('session-agent-codex')).toBeDefined();
+      const cluster = screen.getByTestId('session-idle-cluster-wt-wait');
+      expect(cluster.textContent).toContain('+5');
+    });
+
+    it('all working: labelled chips for each, no idle counter', () => {
+      const running = { isRunning: true, isWaitingForResponse: false, isProcessing: true };
+      mockWorktrees = [
+        createWorktree({
+          id: 'wt-all',
+          selectedAgents: ['claude', 'codex'],
+          sessionStatusByCli: { claude: running, codex: running },
+        }),
+      ];
+
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('session-agent-claude')).toBeDefined();
+      expect(screen.getByTestId('session-agent-codex')).toBeDefined();
+      expect(screen.queryByTestId('session-idle-cluster-wt-all')).toBeNull();
     });
   });
 });

--- a/tests/unit/components/mobile/MobileHeader.test.tsx
+++ b/tests/unit/components/mobile/MobileHeader.test.tsx
@@ -67,7 +67,8 @@ describe('MobileHeader', () => {
 
       const indicator = screen.getByTestId('status-indicator');
       expect(indicator).toBeInTheDocument();
-      expect(indicator.className).toMatch(/gray|neutral/);
+      // Issue #1078: unified StatusDot uses the semantic `muted-foreground` token.
+      expect(indicator.className).toMatch(/muted|gray|neutral/);
     });
 
     it('should show running status indicator with animation', () => {
@@ -75,7 +76,9 @@ describe('MobileHeader', () => {
 
       const indicator = screen.getByTestId('status-indicator');
       expect(indicator).toBeInTheDocument();
-      expect(indicator.className).toMatch(/green|animate|pulse/);
+      // Issue #1078: StatusDot running = green glow (animate-status-glow), no spinner.
+      expect(indicator.className).toMatch(/green|success|animate/);
+      expect(indicator.className).not.toContain('animate-spin');
     });
 
     it('should show waiting status indicator', () => {
@@ -83,7 +86,8 @@ describe('MobileHeader', () => {
 
       const indicator = screen.getByTestId('status-indicator');
       expect(indicator).toBeInTheDocument();
-      expect(indicator.className).toMatch(/yellow|amber|waiting/);
+      // Issue #1078: StatusDot waiting = amber (`bg-warning`).
+      expect(indicator.className).toMatch(/warning|yellow|amber/);
     });
 
     it('should show error status indicator', () => {
@@ -91,7 +95,8 @@ describe('MobileHeader', () => {
 
       const indicator = screen.getByTestId('status-indicator');
       expect(indicator).toBeInTheDocument();
-      expect(indicator.className).toMatch(/red|error/);
+      // Issue #1078: StatusDot error = `bg-danger`.
+      expect(indicator.className).toMatch(/danger|red|error/);
     });
 
     it('should have accessible status text', () => {

--- a/tests/unit/components/worktree/WorktreeDetailSubComponents.test.tsx
+++ b/tests/unit/components/worktree/WorktreeDetailSubComponents.test.tsx
@@ -16,7 +16,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DesktopHeader } from '@/components/worktree/WorktreeDetailSubComponents';
 import { AGENT_INSTANCE_DND_MIME } from '@/components/worktree/TerminalSplitPane';
-import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import {
   getCliToolDisplayName,
   type AgentInstance,
@@ -82,21 +81,28 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
       render(<DesktopHeader {...baseProps} instances={dualClaude} />);
       expect(screen.getByTestId('desktop-agent-status-claude')).toBeDefined();
       expect(screen.getByTestId('desktop-agent-status-claude-2')).toBeDefined();
-      // Each tab is labelled by its alias (not the shared CLI display name).
-      expect(screen.getByText('Primary: Idle')).toBeDefined();
-      expect(screen.getByText('Review: Idle')).toBeDefined();
+      // Issue #1078: idle instances collapse to icon-only dots; the alias label
+      // lives on the button's aria-label (and the hover tooltip), not inline text.
+      expect(screen.getByTestId('desktop-agent-status-claude').getAttribute('aria-label')).toBe(
+        'Primary: Idle'
+      );
+      expect(screen.getByTestId('desktop-agent-status-claude-2').getAttribute('aria-label')).toBe(
+        'Review: Idle'
+      );
     });
   });
 
-  describe('status → dot/spinner class mapping', () => {
-    it('idle → gray dot (no session status entry)', () => {
+  // Issue #1078: the status visual is unified on <StatusDot> (no blue spinner).
+  // running/waiting → glow/blink (working), idle/ready → static dot. No animate-spin.
+  describe('status → StatusDot class mapping (Issue #1078)', () => {
+    it('idle → muted static dot (no session status entry)', () => {
       render(<DesktopHeader {...baseProps} instances={mkInstances(['claude'])} />);
       const span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-      expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.idle.className); // bg-gray-500
+      expect(span?.className).toContain('bg-muted-foreground');
       expect(span?.className).not.toContain('animate-spin');
     });
 
-    it('ready → green dot (isRunning only)', () => {
+    it('ready → success static dot (isRunning only)', () => {
       const sessionStatusByCli: SessionStatusMap = {
         claude: { isRunning: true, isWaitingForResponse: false, isProcessing: false },
       };
@@ -108,11 +114,11 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
         />
       );
       const span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-      expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.ready.className); // bg-green-500
+      expect(span?.className).toContain('bg-success');
       expect(span?.className).not.toContain('animate-spin');
     });
 
-    it('waiting → yellow dot (isWaitingForResponse)', () => {
+    it('waiting → warning dot with blink (isWaitingForResponse)', () => {
       const sessionStatusByCli: SessionStatusMap = {
         claude: { isRunning: true, isWaitingForResponse: true, isProcessing: false },
       };
@@ -124,11 +130,11 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
         />
       );
       const span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-      expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.waiting.className); // bg-yellow-500
+      expect(span?.className).toContain('bg-warning');
       expect(span?.className).not.toContain('animate-spin');
     });
 
-    it('running → blue spinner (isProcessing)', () => {
+    it('running → success dot with glow, NOT a spinner (isProcessing)', () => {
       const sessionStatusByCli: SessionStatusMap = {
         claude: { isRunning: true, isWaitingForResponse: false, isProcessing: true },
       };
@@ -140,8 +146,10 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
         />
       );
       const span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-      expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.running.className); // border-info
-      expect(span?.className).toContain('animate-spin');
+      expect(span?.className).toContain('bg-success');
+      expect(span?.className).toContain('animate-status-glow');
+      expect(span?.className).not.toContain('animate-spin');
+      expect(span?.className).not.toContain('border-info');
     });
   });
 
@@ -223,18 +231,18 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
       );
       const button = screen.getByTestId('desktop-agent-status-claude');
       const iconSpan = button.querySelector('span');
-      // Icon span keeps the status color class (waiting → yellow dot).
-      expect(iconSpan?.className).toContain(SIDEBAR_STATUS_CONFIG.waiting.className);
-      // Issue #751: text is now visible inline, so title is redundant and removed.
+      // Issue #1078: StatusDot waiting uses the semantic `bg-warning` token.
+      expect(iconSpan?.className).toContain('bg-warning');
+      // The decorative StatusDot carries no title/role (the button labels itself).
       expect(iconSpan?.getAttribute('title')).toBeNull();
       expect(iconSpan?.getAttribute('role')).toBeNull();
-      // The button shows the visible inline text.
+      // Working instances stay labelled pills with visible inline text.
       expect(button.textContent).toContain('Claude: Waiting for response');
     });
   });
 
-  describe('Issue #751: inline always-visible agent name + status text', () => {
-    it('renders visible text "Claude: Running" when claude is processing', () => {
+  describe('Issue #1078: working instances labelled, idle collapsed to icon dots', () => {
+    it('renders visible text "Claude: Running" for a working (pill) instance', () => {
       const sessionStatusByCli: SessionStatusMap = {
         claude: { isRunning: true, isWaitingForResponse: false, isProcessing: true },
       };
@@ -248,7 +256,7 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
       expect(screen.getByText('Claude: Running')).toBeDefined();
     });
 
-    it('renders visible text "Codex: Idle" when codex has no session', () => {
+    it('idle instance is icon-only: label on aria-label, NOT visible inline text', () => {
       const sessionStatusByCli: SessionStatusMap = {
         claude: { isRunning: true, isWaitingForResponse: false, isProcessing: true },
       };
@@ -259,18 +267,25 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
           sessionStatusByCli={sessionStatusByCli}
         />
       );
-      expect(screen.getByText('Codex: Idle')).toBeDefined();
+      // Idle codex collapses to an icon-only dot — no inline "Codex: Idle" text.
+      expect(screen.queryByText('Codex: Idle')).toBeNull();
+      expect(screen.getByTestId('desktop-agent-status-codex').getAttribute('aria-label')).toBe(
+        'Codex: Idle'
+      );
     });
 
-    it('does NOT render a Tooltip wrapper (no role="tooltip" on render)', () => {
+    it('idle instance is wrapped in a tooltip, but its content is absent until hover', () => {
       render(
         <DesktopHeader
           {...baseProps}
           instances={mkInstances(['claude', 'codex'])}
         />
       );
-      // Tooltip wrapper removed: no tooltip element should be present without hover.
+      // Idle dots use a hover tooltip for the full label; nothing with
+      // role="tooltip" is present on initial render (no accidental double label).
       expect(screen.queryByRole('tooltip')).toBeNull();
+      const codex = screen.getByTestId('desktop-agent-status-codex');
+      expect(codex.closest('[data-testid="tooltip-wrapper"]')).not.toBeNull();
     });
 
     it('row container uses gap-2 (Issue #751)', () => {
@@ -287,8 +302,8 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
         <DesktopHeader {...baseProps} instances={mkInstances(['claude'])} sessionStatusByCli={{}} />
       );
       let span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-      // idle: gray dot, not a spinner
-      expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.idle.className);
+      // idle: muted static dot, never a spinner
+      expect(span?.className).toContain('bg-muted-foreground');
       expect(span?.className).not.toContain('animate-spin');
 
       // Next poll: claude is now processing → new object identity (memo must re-render).
@@ -299,9 +314,10 @@ describe('DesktopHeader per-instance status row (Issue #749 / #869)', () => {
         <DesktopHeader {...baseProps} instances={mkInstances(['claude'])} sessionStatusByCli={updated} />
       );
       span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-      // running: blue spinner
-      expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.running.className);
-      expect(span?.className).toContain('animate-spin');
+      // running: success dot with glow (unified StatusDot), not a spinner
+      expect(span?.className).toContain('bg-success');
+      expect(span?.className).toContain('animate-status-glow');
+      expect(span?.className).not.toContain('animate-spin');
       expect(screen.getByTestId('desktop-agent-status-claude').getAttribute('aria-label')).toBe(
         'Claude: Running'
       );
@@ -467,12 +483,13 @@ describe('DesktopHeader per-instance status resolution (Issue #875)', () => {
     const primarySpan = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
     const aliasSpan = screen.getByTestId('desktop-agent-status-claude-2').querySelector('span');
 
-    // Primary → idle gray dot, no spinner.
-    expect(primarySpan?.className).toContain(SIDEBAR_STATUS_CONFIG.idle.className);
+    // Primary → idle muted dot, no spinner (Issue #1078 unified StatusDot).
+    expect(primarySpan?.className).toContain('bg-muted-foreground');
     expect(primarySpan?.className).not.toContain('animate-spin');
-    // Alias → running blue spinner.
-    expect(aliasSpan?.className).toContain(SIDEBAR_STATUS_CONFIG.running.className);
-    expect(aliasSpan?.className).toContain('animate-spin');
+    // Alias → running success dot with glow, never a spinner.
+    expect(aliasSpan?.className).toContain('bg-success');
+    expect(aliasSpan?.className).toContain('animate-status-glow');
+    expect(aliasSpan?.className).not.toContain('animate-spin');
   });
 
   it('renders the "End" button for an alias instance whose own session is running', () => {
@@ -526,7 +543,7 @@ describe('DesktopHeader per-instance status resolution (Issue #875)', () => {
     );
     // No sessionStatusByInstance → primary resolves via sessionStatusByCli.
     const span = screen.getByTestId('desktop-agent-status-claude').querySelector('span');
-    expect(span?.className).toContain(SIDEBAR_STATUS_CONFIG.ready.className);
+    expect(span?.className).toContain('bg-success');
     expect(screen.getByTestId('desktop-kill-session')).toBeDefined();
   });
 });
@@ -665,5 +682,138 @@ describe('DesktopHeader agent indicator drag source (Issue #786 / #869)', () => 
       expect(screen.getByTestId('desktop-agent-status-row')).toBeDefined();
       expect(screen.getByTestId('pc-display-size-select')).toBeDefined();
     });
+  });
+});
+
+/**
+ * Issue #1078: idle-noise collapse + "+N" overflow in the desktop agent row.
+ *
+ * - running/waiting (working) or the active instance → labelled pill,
+ * - idle/ready → icon-only dot (label via tooltip / aria-label),
+ * - labelled pills beyond the budget (4) fold into a "+N" overflow menu so a
+ *   working session never gets buried.
+ */
+describe('DesktopHeader agent-row idle collapse + overflow (Issue #1078)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function roster(n: number): AgentInstance[] {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `claude-${i}`,
+      cliTool: 'claude' as CLIToolType,
+      alias: `Agent ${i}`,
+      order: i,
+    }));
+  }
+
+  const running = { isRunning: true, isWaitingForResponse: false, isProcessing: true };
+  const waiting = { isRunning: true, isWaitingForResponse: true, isProcessing: false };
+
+  it('running 1 + idle 5: the running one is labelled, idle stay icon-only, no overflow', () => {
+    const instances = roster(6);
+    const sessionStatusByInstance = { 'claude-0': running } as NonNullable<
+      Worktree['sessionStatusByInstance']
+    >;
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={instances}
+        sessionStatusByInstance={sessionStatusByInstance}
+      />
+    );
+    // Working instance is a labelled pill (visible text).
+    expect(screen.getByText('Agent 0: Running')).toBeDefined();
+    // Idle instances are icon-only (no visible "Agent N: Idle" text), but each
+    // is still a reachable button carrying the full label on aria-label.
+    expect(screen.queryByText('Agent 1: Idle')).toBeNull();
+    expect(screen.getByTestId('desktop-agent-status-claude-5').getAttribute('aria-label')).toBe(
+      'Agent 5: Idle'
+    );
+    // Idle dots never overflow — they are narrow.
+    expect(screen.queryByTestId('desktop-agent-status-overflow')).toBeNull();
+  });
+
+  it('all idle: every instance renders as an icon-only dot, no overflow', () => {
+    render(<DesktopHeader {...baseProps} instances={roster(6)} />);
+    for (let i = 0; i < 6; i += 1) {
+      expect(screen.getByTestId(`desktop-agent-status-claude-${i}`)).toBeDefined();
+      expect(screen.queryByText(`Agent ${i}: Idle`)).toBeNull();
+    }
+    expect(screen.queryByTestId('desktop-agent-status-overflow')).toBeNull();
+  });
+
+  it('6 all working: keeps 4 pills inline and folds the remaining 2 into "+N"', () => {
+    const instances = roster(6);
+    const sessionStatusByInstance = Object.fromEntries(
+      instances.map((inst) => [inst.id, running])
+    ) as NonNullable<Worktree['sessionStatusByInstance']>;
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={instances}
+        sessionStatusByInstance={sessionStatusByInstance}
+      />
+    );
+    // First 4 remain inline as pills.
+    for (let i = 0; i < 4; i += 1) {
+      expect(screen.getByTestId(`desktop-agent-status-claude-${i}`)).toBeDefined();
+    }
+    // The rest collapse into a "+2" overflow trigger (closed menu → not inline).
+    const overflow = screen.getByTestId('desktop-agent-status-overflow');
+    expect(overflow.textContent).toContain('+2');
+    expect(screen.queryByTestId('desktop-agent-status-claude-5')).toBeNull();
+    // Issue #1078: folded working sessions still surface the living glow so a
+    // running instance stays visible at a glance even when collapsed.
+    const overflowDot = overflow.querySelector('span');
+    expect(overflowDot?.className).toContain('bg-success');
+    expect(overflowDot?.className).toContain('animate-status-glow');
+    // Token discipline: the trigger uses semantic tokens, not raw grays.
+    expect(overflow.className).toContain('text-muted-foreground');
+    expect(overflow.className).toContain('hover:bg-muted');
+    expect(overflow.className).not.toMatch(/text-gray-|bg-gray-/);
+  });
+
+  it('overflow with only waiting sessions surfaces the amber (waiting) glow', () => {
+    const instances = roster(6);
+    const sessionStatusByInstance = Object.fromEntries(
+      instances.map((inst) => [inst.id, waiting])
+    ) as NonNullable<Worktree['sessionStatusByInstance']>;
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={instances}
+        sessionStatusByInstance={sessionStatusByInstance}
+      />
+    );
+    const overflow = screen.getByTestId('desktop-agent-status-overflow');
+    const overflowDot = overflow.querySelector('span');
+    expect(overflowDot?.className).toContain('bg-warning');
+    expect(overflowDot?.className).toContain('animate-status-blink');
+  });
+
+  it('overflow prefers a running glow over a waiting one when both are folded', () => {
+    // First 4 (waiting) stay as pills; positions 4-5 (running, waiting) overflow.
+    const instances = roster(6);
+    const sessionStatusByInstance = {
+      'claude-0': waiting,
+      'claude-1': waiting,
+      'claude-2': waiting,
+      'claude-3': waiting,
+      'claude-4': running,
+      'claude-5': waiting,
+    } as NonNullable<Worktree['sessionStatusByInstance']>;
+    render(
+      <DesktopHeader
+        {...baseProps}
+        instances={instances}
+        sessionStatusByInstance={sessionStatusByInstance}
+      />
+    );
+    const overflow = screen.getByTestId('desktop-agent-status-overflow');
+    const overflowDot = overflow.querySelector('span');
+    // Running is folded → green glow wins over the folded waiting instance.
+    expect(overflowDot?.className).toContain('bg-success');
+    expect(overflowDot?.className).toContain('animate-status-glow');
   });
 });

--- a/tests/unit/lib/agent-status-display.test.ts
+++ b/tests/unit/lib/agent-status-display.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for agent-status-display (Issue #1078).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isWorkingStatus,
+  isLabeledInstance,
+  classifyHeaderInstances,
+  type HeaderInstanceItem,
+} from '@/lib/agent-status-display';
+import type { BranchStatus } from '@/types/sidebar';
+
+function mk(id: string, status: BranchStatus, isActive = false): HeaderInstanceItem<string> {
+  return { item: id, status, isActive };
+}
+
+describe('isWorkingStatus', () => {
+  it('treats running / generating / waiting as working', () => {
+    expect(isWorkingStatus('running')).toBe(true);
+    expect(isWorkingStatus('generating')).toBe(true);
+    expect(isWorkingStatus('waiting')).toBe(true);
+  });
+
+  it('treats idle / ready as not working', () => {
+    expect(isWorkingStatus('idle')).toBe(false);
+    expect(isWorkingStatus('ready')).toBe(false);
+  });
+});
+
+describe('isLabeledInstance', () => {
+  it('labels the active instance even when idle', () => {
+    expect(isLabeledInstance(mk('a', 'idle', true))).toBe(true);
+  });
+
+  it('labels working instances', () => {
+    expect(isLabeledInstance(mk('a', 'running'))).toBe(true);
+    expect(isLabeledInstance(mk('a', 'waiting'))).toBe(true);
+  });
+
+  it('collapses idle / ready non-active instances', () => {
+    expect(isLabeledInstance(mk('a', 'idle'))).toBe(false);
+    expect(isLabeledInstance(mk('a', 'ready'))).toBe(false);
+  });
+});
+
+describe('classifyHeaderInstances', () => {
+  const MAX = 4;
+
+  it('running 1 + idle 5: the running one is a pill, all idle are dots, no overflow', () => {
+    const items = [
+      mk('claude', 'running'),
+      mk('codex', 'idle'),
+      mk('gemini', 'idle'),
+      mk('cursor', 'idle'),
+      mk('aider', 'idle'),
+      mk('qwen', 'idle'),
+    ];
+    const out = classifyHeaderInstances(items, MAX);
+    expect(out.find((o) => o.item === 'claude')?.slot).toBe('pill');
+    expect(out.filter((o) => o.slot === 'dot').map((o) => o.item)).toEqual([
+      'codex',
+      'gemini',
+      'cursor',
+      'aider',
+      'qwen',
+    ]);
+    expect(out.some((o) => o.slot === 'overflow')).toBe(false);
+  });
+
+  it('all idle: every instance is an icon-only dot, no pills, no overflow', () => {
+    const items = [mk('a', 'idle'), mk('b', 'idle'), mk('c', 'idle')];
+    const out = classifyHeaderInstances(items, MAX);
+    expect(out.every((o) => o.slot === 'dot')).toBe(true);
+  });
+
+  it('6 all working: keeps maxPills pills and overflows the rest', () => {
+    const items = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) => mk(id, 'running'));
+    const out = classifyHeaderInstances(items, MAX);
+    expect(out.filter((o) => o.slot === 'pill')).toHaveLength(MAX);
+    expect(out.filter((o) => o.slot === 'overflow')).toHaveLength(2);
+    expect(out.some((o) => o.slot === 'dot')).toBe(false);
+  });
+
+  it('keeps the active instance visible even when it would otherwise overflow', () => {
+    // 5 working + an active (idle) instance last; maxPills=2. Active must win a pill slot.
+    const items = [
+      mk('a', 'running'),
+      mk('b', 'running'),
+      mk('c', 'running'),
+      mk('d', 'running'),
+      mk('active', 'idle', true),
+    ];
+    const out = classifyHeaderInstances(items, 2);
+    const active = out.find((o) => o.item === 'active');
+    expect(active?.slot).toBe('pill');
+    expect(out.filter((o) => o.slot === 'pill')).toHaveLength(2);
+    expect(out.filter((o) => o.slot === 'overflow')).toHaveLength(3);
+  });
+
+  it('preserves roster order for visible pills and dots', () => {
+    const items = [mk('a', 'running'), mk('b', 'idle'), mk('c', 'running')];
+    const out = classifyHeaderInstances(items, MAX);
+    expect(out.map((o) => o.item)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not overflow when total labelled pills are within maxPills', () => {
+    const items = [mk('a', 'running'), mk('b', 'waiting')];
+    const out = classifyHeaderInstances(items, MAX);
+    expect(out.some((o) => o.slot === 'overflow')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
Closes #1078 (親 #1068 / Phase C)。稼働ステータスの3重表現を **StatusDot 1系統**に統一し idle ノイズを縮退。

## 変更点
- `WorktreeDetailSubComponents`/`sessions/page`/`MobileHeader` を StatusDot へ統一、新規 `lib/agent-status-display.ts`
- `status-colors.ts` の spinner は @deprecated（ReviewTab が最後の消費者）
- idle 縮退（Sessions「+N idle」/ worktree ヘッダー円形+Tooltip / 「+N」DropdownMenu overflow）
- tabular-nums / CSS truncate、**DnD + タブ切替 onClick を全ボタン温存**

## 敵対的レビュー由来の仕上げ
- 「+N」overflow に稼働中があれば**集約 StatusDot グロー**（稼働セッションが埋もれない=本Issueゴール整合）
- trigger の生グレー→トークン（#1082 先取り）
- 既知の限定制約: 5個以上同時稼働時 overflow からの drag-to-split 不可（click切替維持・稀のため許容）

## 検証
✅ lint / tsc / 関連テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)