### PR TITLE
refactor(ui): 生gray/buttonのトークン移行 群D (#1061)

### DIFF
--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -63,7 +63,7 @@ export function GlobalMobileNav() {
               className={`flex flex-col items-center justify-center flex-1 h-full text-xs transition-colors ${
                 active
                   ? 'text-accent-600 dark:text-accent-400'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {tab.icon}
@@ -78,7 +78,7 @@ export function GlobalMobileNav() {
           data-testid="mobile-command-palette-trigger"
           onClick={() => setOpen(true)}
           aria-label={t('mobileTrigger')}
-          className="flex flex-col items-center justify-center flex-1 h-full text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+          className="flex flex-col items-center justify-center flex-1 h-full text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
           <Search size={20} aria-hidden="true" />
           <span className="mt-1">{t('mobileLabel')}</span>

--- a/src/components/worktree/FilePanelSplit.tsx
+++ b/src/components/worktree/FilePanelSplit.tsx
@@ -165,14 +165,14 @@ export const FilePanelSplit = memo(function FilePanelSplit({
         <div
           data-testid="file-panel-expand-bar"
           style={{ width: `${FILE_PANEL_BAR_WIDTH_PX}px` }}
-          className="flex-shrink-0 flex items-start justify-center bg-gray-100 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700"
+          className="flex-shrink-0 flex items-start justify-center bg-muted border-l border-border"
         >
           <button
             type="button"
             aria-label={t('terminal.showFiles')}
             title={t('terminal.showFiles')}
             onClick={toggleFilePanel}
-            className="flex flex-col items-center gap-2 w-full pt-2 text-gray-500 dark:text-gray-400 hover:text-accent-600 dark:hover:text-accent-400 focus:outline-none focus:ring-2 focus:ring-ring"
+            className="flex flex-col items-center gap-2 w-full pt-2 text-muted-foreground hover:text-accent-600 dark:hover:text-accent-400 focus:outline-none focus:ring-2 focus:ring-ring"
           >
             <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -220,7 +220,7 @@ export const FilePanelSplit = memo(function FilePanelSplit({
           aria-label={t('terminal.hideFiles')}
           title={t('terminal.hideFiles')}
           onClick={toggleFilePanel}
-          className="flex-shrink-0 flex items-center justify-center w-5 h-full bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500 hover:text-accent-600 dark:hover:text-accent-400 focus:outline-none focus:ring-2 focus:ring-ring"
+          className="flex-shrink-0 flex items-center justify-center w-5 h-full bg-muted border-r border-border text-muted-foreground hover:text-accent-600 dark:hover:text-accent-400 focus:outline-none focus:ring-2 focus:ring-ring"
         >
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />

--- a/src/components/worktree/FilePanelTabs.tsx
+++ b/src/components/worktree/FilePanelTabs.tsx
@@ -85,8 +85,8 @@ const TabButton = memo(function TabButton({
   );
 
   const activeClasses = isActive
-    ? 'border-accent-500 text-accent-600 dark:text-accent-400 bg-white dark:bg-gray-800'
-    : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100';
+    ? 'border-accent-500 text-accent-600 dark:text-accent-400 bg-surface'
+    : 'border-transparent text-muted-foreground hover:text-foreground';
 
   return (
     <div
@@ -109,7 +109,7 @@ const TabButton = memo(function TabButton({
       <button
         type="button"
         onClick={handleClose}
-        className="ml-1 p-0.5 rounded-sm hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+        className="ml-1 p-0.5 rounded-sm hover:bg-muted transition-colors"
         aria-label={`Close ${tab.name}`}
       >
         <X className="w-3 h-3" />
@@ -177,7 +177,7 @@ export const FilePanelTabs = memo(function FilePanelTabs({
   return (
     <div className="flex flex-col h-full">
       {/* Tab bar */}
-      <div className="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 min-w-0">
+      <div className="flex border-b border-border bg-surface dark:bg-surface-2 min-w-0">
         <div className="flex min-w-0 overflow-hidden flex-1">
           {visibleTabs.map((tab, index) => (
             <TabButton
@@ -196,20 +196,20 @@ export const FilePanelTabs = memo(function FilePanelTabs({
               type="button"
               data-testid="tab-dropdown-button"
               onClick={handleDropdownToggle}
-              className="flex items-center gap-0.5 px-2 py-2 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 border-b-2 border-transparent transition-colors"
+              className="flex items-center gap-0.5 px-2 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted border-b-2 border-transparent transition-colors"
             >
               <ChevronDown className={`w-3 h-3 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`} />
               <span>+{overflowTabs.length}</span>
             </button>
             {dropdownOpen && (
-              <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg z-50 min-w-[200px] max-h-[300px] overflow-y-auto">
+              <div className="absolute right-0 top-full mt-1 bg-surface border border-border rounded-md shadow-lg z-50 min-w-[200px] max-h-[300px] overflow-y-auto">
                 {overflowTabs.map(tab => (
                   <button
                     key={tab.path}
                     type="button"
                     data-testid={`tab-dropdown-item-${tab.path}`}
                     onClick={() => handleDropdownSelect(tab.path)}
-                    className="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 truncate"
+                    className="w-full text-left px-3 py-2 text-sm text-foreground hover:bg-muted truncate"
                     title={tab.path}
                   >
                     {tab.name}

--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -266,14 +266,14 @@ export const MobileTabBar = memo(function MobileTabBar({
   onTabChange,
 }: MobileTabBarProps) {
   return (
-    <div className="flex border-b border-gray-200 dark:border-gray-700">
+    <div className="flex border-b border-border">
       <button
         data-testid="mobile-tab-editor"
         onClick={() => onTabChange('editor')}
         className={`flex-1 py-2 text-sm font-medium ${
           mobileTab === 'editor'
             ? 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400'
-            : 'text-gray-500 dark:text-gray-400'
+            : 'text-muted-foreground'
         }`}
       >
         <FileText className="h-4 w-4 inline-block mr-1" />
@@ -285,7 +285,7 @@ export const MobileTabBar = memo(function MobileTabBar({
         className={`flex-1 py-2 text-sm font-medium ${
           mobileTab === 'preview'
             ? 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400'
-            : 'text-gray-500 dark:text-gray-400'
+            : 'text-muted-foreground'
         }`}
       >
         <Eye className="h-4 w-4 inline-block mr-1" />
@@ -308,7 +308,7 @@ export const MaximizeHint = memo(function MaximizeHint({
   return (
     <div
       data-testid="maximize-hint"
-      className="flex items-center justify-center px-4 py-1 bg-gray-800 text-gray-300 text-xs"
+      className="flex items-center justify-center px-4 py-1 bg-muted text-muted-foreground text-xs"
     >
       Press ESC to exit fullscreen {isMobile && '(or swipe down)'}
     </div>

--- a/src/components/worktree/MemoCard.tsx
+++ b/src/components/worktree/MemoCard.tsx
@@ -205,7 +205,7 @@ export const MemoCard = memo(function MemoCard({
       // Issue #787: tabIndex makes the card a focus target for search next/prev
       // scroll-to-match (focusable without entering the tab order).
       tabIndex={-1}
-      className={`bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3 focus:outline-none ${className}`}
+      className={`bg-surface dark:bg-surface-2 border border-border rounded-lg p-4 space-y-3 focus:outline-none ${className}`}
     >
       {/* Header: Title and Delete button */}
       <div className="flex items-center gap-2">
@@ -215,12 +215,12 @@ export const MemoCard = memo(function MemoCard({
           onChange={handleTitleChange}
           onBlur={handleTitleBlur}
           placeholder="Memo title"
-          className="flex-1 min-w-0 text-sm font-medium text-gray-900 dark:text-gray-100 bg-transparent border-none focus:outline-none focus:ring-0 p-0"
+          className="flex-1 min-w-0 text-sm font-medium text-foreground bg-transparent border-none focus:outline-none focus:ring-0 p-0"
         />
         {isSaving && (
           <span
             data-testid="saving-indicator"
-            className="text-xs text-gray-400 dark:text-gray-500"
+            className="text-xs text-muted-foreground"
           >
             Saving...
           </span>
@@ -235,7 +235,7 @@ export const MemoCard = memo(function MemoCard({
               disabled={!canMoveUp}
               aria-label={t('memoMoveUp')}
               title={t('memoMoveUp')}
-              className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded disabled:opacity-30 disabled:cursor-not-allowed"
+              className="flex-shrink-0 p-1 text-muted-foreground hover:text-foreground transition-colors rounded disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <ChevronUp className="w-4 h-4" aria-hidden="true" />
             </button>
@@ -246,7 +246,7 @@ export const MemoCard = memo(function MemoCard({
               disabled={!canMoveDown}
               aria-label={t('memoMoveDown')}
               title={t('memoMoveDown')}
-              className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded disabled:opacity-30 disabled:cursor-not-allowed"
+              className="flex-shrink-0 p-1 text-muted-foreground hover:text-foreground transition-colors rounded disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <ChevronDown className="w-4 h-4" aria-hidden="true" />
             </button>
@@ -259,7 +259,7 @@ export const MemoCard = memo(function MemoCard({
             data-testid="insert-memo-content"
             onClick={handleInsert}
             aria-label="Insert to message"
-            className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-accent-600 dark:hover:text-accent-400 transition-colors rounded"
+            className="flex-shrink-0 p-1 text-muted-foreground hover:text-accent-600 dark:hover:text-accent-400 transition-colors rounded"
             title="Insert to message"
           >
             <ArrowDownToLine className="w-4 h-4" aria-hidden="true" />
@@ -270,7 +270,7 @@ export const MemoCard = memo(function MemoCard({
           type="button"
           onClick={handleCopy}
           aria-label="Copy memo content"
-          className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded"
+          className="flex-shrink-0 p-1 text-muted-foreground hover:text-foreground transition-colors rounded"
         >
           {copied ? (
             <Check className="w-4 h-4 text-green-600" />
@@ -282,7 +282,7 @@ export const MemoCard = memo(function MemoCard({
           type="button"
           onClick={handleDelete}
           aria-label="Delete memo"
-          className="flex-shrink-0 p-1 text-gray-400 dark:text-gray-500 hover:text-red-500 transition-colors rounded"
+          className="flex-shrink-0 p-1 text-muted-foreground hover:text-red-500 transition-colors rounded"
         >
           <svg
             className="w-4 h-4"
@@ -308,7 +308,7 @@ export const MemoCard = memo(function MemoCard({
         onBlur={handleContentBlur}
         placeholder="Enter memo content..."
         rows={4}
-        className="w-full text-sm text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md p-2 resize-y focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+        className="w-full text-sm text-foreground bg-muted border border-border rounded-md p-2 resize-y focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
       />
 
       {/* Error message */}

--- a/src/components/worktree/MessageList.tsx
+++ b/src/components/worktree/MessageList.tsx
@@ -182,15 +182,15 @@ const MessageBubble = React.memo(function MessageBubble({
           className={`rounded-lg px-4 py-3 ${
             isUser
               ? 'bg-accent-600 text-white'
-              : 'bg-white border border-gray-200'
+              : 'bg-surface border border-border'
           }`}
         >
           {/* Header */}
           <div className="flex items-center gap-2 mb-2">
-            <span className={`text-xs font-medium ${isUser ? 'text-accent-100' : 'text-gray-500'}`}>
+            <span className={`text-xs font-medium ${isUser ? 'text-accent-100' : 'text-muted-foreground'}`}>
               {isUser ? 'You' : getCliToolDisplayNameSafe(message.cliToolId)}
             </span>
-            <span className={`text-xs ${isUser ? 'text-accent-200' : 'text-gray-400'}`}>
+            <span className={`text-xs ${isUser ? 'text-accent-200' : 'text-muted-foreground'}`}>
               {timestamp}
             </span>
           </div>
@@ -198,14 +198,14 @@ const MessageBubble = React.memo(function MessageBubble({
           {/* Content */}
           <div className={`prose prose-sm max-w-none break-words overflow-wrap-anywhere ${isUser ? 'prose-invert' : ''}`}>
             {message.summary && (
-              <div className={`text-sm font-medium mb-2 ${isUser ? 'text-accent-50' : 'text-gray-700'}`}>
+              <div className={`text-sm font-medium mb-2 ${isUser ? 'text-accent-50' : 'text-foreground'}`}>
                 {message.summary}
               </div>
             )}
-            <div className={`break-words overflow-wrap-anywhere ${isUser ? 'text-white' : 'text-gray-900'}`}>
+            <div className={`break-words overflow-wrap-anywhere ${isUser ? 'text-white' : 'text-foreground'}`}>
               {hasAnsiCodes(message.content) ? (
                 <pre
-                  className="whitespace-pre-wrap font-mono text-sm bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto"
+                  className="whitespace-pre-wrap font-mono text-sm bg-[#0d1117] text-[#c9d1d9] p-4 rounded overflow-x-auto"
                   dangerouslySetInnerHTML={{ __html: convertAnsiToHtml(message.content) }}
                 />
               ) : (
@@ -236,12 +236,12 @@ const MessageBubble = React.memo(function MessageBubble({
 
           {/* Prompt choice buttons for assistant messages */}
           {!isUser && message.promptData && onPromptRespond && (
-            <div className="mt-3 pt-3 border-t border-gray-200">
+            <div className="mt-3 pt-3 border-t border-border">
               <div className="flex items-center gap-2 mb-3">
                 <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
                   {tPrompt('awaitingSelection')}
                 </span>
-                <div className="text-sm text-gray-700 font-medium">
+                <div className="text-sm text-foreground font-medium">
                   {message.promptData.question}
                 </div>
               </div>
@@ -290,14 +290,14 @@ const MessageBubble = React.memo(function MessageBubble({
                             ? 'bg-purple-600 text-white hover:bg-purple-700 ring-2 ring-purple-400 ring-opacity-50'
                             : option.isDefault
                             ? 'bg-accent-600 text-white hover:bg-accent-700 ring-2 ring-accent-400 ring-opacity-50'
-                            : 'bg-white text-gray-700 hover:bg-gray-50 border border-gray-300'
+                            : 'bg-surface text-foreground hover:bg-muted border border-input'
                         }`}
                       >
                         <span className="inline-flex items-center gap-2">
                           <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold ${
                             selectedTextInputOption === option.number
                               ? 'bg-purple-500'
-                              : option.isDefault ? 'bg-accent-500' : 'bg-gray-200 text-gray-600'
+                              : option.isDefault ? 'bg-accent-500' : 'bg-muted text-muted-foreground'
                           }`}>
                             {option.number}
                           </span>
@@ -309,7 +309,7 @@ const MessageBubble = React.memo(function MessageBubble({
                     {/* Text input field for selected text input option */}
                     {selectedTextInputOption !== null && message.promptData?.status === 'pending' && (
                       <div className="w-full mt-3 p-4 bg-purple-50 border border-purple-200 rounded-lg">
-                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <label className="block text-sm font-medium text-foreground mb-2">
                           {tPrompt('enterCustomMessage')}:
                         </label>
                         <textarea
@@ -317,7 +317,7 @@ const MessageBubble = React.memo(function MessageBubble({
                           onChange={(e) => setTextInputValue(e.target.value)}
                           placeholder={tPrompt('enterMessageHere')}
                           rows={3}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-purple-500 focus:border-purple-500 text-sm"
+                          className="w-full px-3 py-2 border border-input rounded-md shadow-sm focus:ring-purple-500 focus:border-purple-500 text-sm"
                         />
                         <div className="flex gap-2 mt-3">
                           <button
@@ -338,7 +338,7 @@ const MessageBubble = React.memo(function MessageBubble({
                               setSelectedTextInputOption(null);
                               setTextInputValue('');
                             }}
-                            className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-all font-medium text-sm"
+                            className="px-4 py-2 bg-muted text-foreground rounded-lg hover:bg-muted/80 transition-all font-medium text-sm"
                           >
                             {tCommon('cancel')}
                           </button>
@@ -486,8 +486,8 @@ export function MessageList({
     return (
       <Card padding="lg">
         <div className="text-center py-8">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-gray-300 border-t-accent-600" />
-          <p className="mt-4 text-gray-600">Loading messages...</p>
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600" />
+          <p className="mt-4 text-muted-foreground">Loading messages...</p>
         </div>
       </Card>
     );
@@ -498,7 +498,7 @@ export function MessageList({
       <Card padding="lg">
         <div className="text-center py-8">
           <svg
-            className="mx-auto h-12 w-12 text-gray-400"
+            className="mx-auto h-12 w-12 text-muted-foreground"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -510,7 +510,7 @@ export function MessageList({
               d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
             />
           </svg>
-          <p className="mt-4 text-gray-600">No messages yet</p>
+          <p className="mt-4 text-muted-foreground">No messages yet</p>
         </div>
       </Card>
     );
@@ -547,10 +547,10 @@ export function MessageList({
         {waitingForResponse && (
           <div className="flex justify-start mb-4">
             <div className="w-full">
-              <div className="rounded-lg px-4 py-3 bg-white border border-gray-200 shadow-sm">
+              <div className="rounded-lg px-4 py-3 bg-surface border border-border shadow-sm">
                 {/* Header with status indicator */}
                 <div className="flex items-center gap-2 mb-3">
-                  <span className="text-xs font-medium text-gray-500">{getCliToolDisplayNameSafe(selectedCliTool)}</span>
+                  <span className="text-xs font-medium text-muted-foreground">{getCliToolDisplayNameSafe(selectedCliTool)}</span>
                   <div className="flex gap-1">
                     <div className="w-1.5 h-1.5 bg-green-600 rounded-full animate-pulse" />
                   </div>
@@ -558,7 +558,7 @@ export function MessageList({
                 </div>
 
                 {/* Progress indicator - fixed at top */}
-                <div className="sticky top-0 bg-white z-10 pb-2 mb-3 border-b border-gray-200">
+                <div className="sticky top-0 bg-surface z-10 pb-2 mb-3 border-b border-border">
                   {/* Thinking indicator */}
                   {isThinking && (
                     <div className="flex items-center gap-2 mb-2">
@@ -580,9 +580,9 @@ export function MessageList({
                   {/* Starting up indicator */}
                   {!isThinking && !realtimeOutput && (
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-2 h-2 rounded-full bg-gray-400 animate-pulse" />
-                      <span className="text-sm font-medium text-gray-700">{tWorktree('session.starting')}</span>
-                      <span className="text-xs text-gray-500 ml-auto">...</span>
+                      <div className="w-2 h-2 rounded-full bg-muted-foreground animate-pulse" />
+                      <span className="text-sm font-medium text-foreground">{tWorktree('session.starting')}</span>
+                      <span className="text-xs text-muted-foreground ml-auto">...</span>
                     </div>
                   )}
                 </div>
@@ -604,7 +604,7 @@ export function MessageList({
                       <div className="prose prose-sm max-w-none break-words overflow-wrap-anywhere">
                         {/\x1b\[[0-9;]*m|\[[0-9;]*m/.test(realtimeOutput) ? (
                           <pre
-                            className="whitespace-pre-wrap font-mono text-xs bg-gray-900 text-gray-300 p-3 rounded overflow-x-auto max-h-[500px] overflow-y-auto"
+                            className="whitespace-pre-wrap font-mono text-xs bg-[#0d1117] text-[#c9d1d9] p-3 rounded overflow-x-auto max-h-[500px] overflow-y-auto"
                             dangerouslySetInnerHTML={{ __html: new AnsiToHtml({
                               fg: '#d1d5db', // Default text color: gray-300
                               bg: '#1f2937', // Default background: gray-800
@@ -613,7 +613,7 @@ export function MessageList({
                             }).toHtml(realtimeOutput) }}
                           />
                         ) : (
-                          <div className="text-sm text-gray-800 whitespace-pre-wrap font-mono max-h-[500px] overflow-y-auto">
+                          <div className="text-sm text-foreground whitespace-pre-wrap font-mono max-h-[500px] overflow-y-auto">
                             {realtimeOutput}
                           </div>
                         )}
@@ -632,8 +632,8 @@ export function MessageList({
                   </div>
                 ) : (
                   <div className="text-center py-6">
-                    <div className="inline-flex items-center gap-2 text-gray-500">
-                      <div className="w-2 h-2 rounded-full bg-gray-400 animate-pulse" />
+                    <div className="inline-flex items-center gap-2 text-muted-foreground">
+                      <div className="w-2 h-2 rounded-full bg-muted-foreground animate-pulse" />
                       <p className="text-sm">{tWorktree('session.startingEllipsis')}</p>
                     </div>
                   </div>

--- a/src/components/worktree/NotesAndLogsPane.tsx
+++ b/src/components/worktree/NotesAndLogsPane.tsx
@@ -94,7 +94,7 @@ const SUB_TABS: readonly SubTabConfig[] = [
 /** CSS class for the active sub-tab button */
 const ACTIVE_TAB_CLASS = 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400 bg-accent-50 dark:bg-accent-900/30';
 /** CSS class for inactive sub-tab buttons */
-const INACTIVE_TAB_CLASS = 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800';
+const INACTIVE_TAB_CLASS = 'text-muted-foreground hover:text-foreground hover:bg-muted';
 
 // ============================================================================
 // Component
@@ -130,7 +130,7 @@ export const NotesAndLogsPane = memo(function NotesAndLogsPane({
   return (
     <div className={`flex flex-col h-full ${className}`}>
       {/* Sub-tab switcher */}
-      <div className="flex border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex-shrink-0">
+      <div className="flex border-b border-border bg-surface dark:bg-surface-2 flex-shrink-0">
         {SUB_TABS.map((tab) => (
           <button
             key={tab.id}

--- a/src/components/worktree/PaneResizer.tsx
+++ b/src/components/worktree/PaneResizer.tsx
@@ -44,7 +44,7 @@ const KEYBOARD_STEP = 10;
  * Base classes shared by all resizer states.
  *
  * VS Code-style thin divider (Issue #970): the line stays a constant 1px and
- * uses the same subtle color as fixed panel borders (`gray-200`/`gray-700`),
+ * uses the same subtle color as fixed panel borders (the `border` token),
  * so it blends in until hovered. An accent color appears on hover/focus only —
  * the line never thickens on hover. `relative` provides the positioning context
  * for the transparent `::before` hit area added per-orientation below.
@@ -52,21 +52,18 @@ const KEYBOARD_STEP = 10;
 const BASE_CLASSES = [
   'relative',
   'flex-shrink-0',
-  'bg-gray-200',
-  'dark:bg-gray-700',
+  'bg-border',
   'transition-colors',
   'duration-150',
   'hover:bg-accent-500',
-  // Explicit dark hover variant: with `darkMode: 'class'`, the base
-  // `dark:bg-gray-700` outranks a plain `hover:` accent in dark mode, so the
-  // hover accent must be re-stated under `dark:` to win (Issue #970).
+  // Explicit dark hover variant retained defensively so the accent reliably
+  // wins over the tokenized `bg-border` base in dark mode (Issue #970).
   'dark:hover:bg-accent-500',
   'focus:outline-none',
   'focus:ring-2',
   'focus:ring-ring',
   'focus:ring-offset-2',
-  'focus:ring-offset-white',
-  'dark:focus:ring-offset-gray-900',
+  'focus:ring-offset-background',
 ] as const;
 
 /**
@@ -285,7 +282,7 @@ export const PaneResizer = memo(function PaneResizer({
     const orientationClasses = isHorizontal ? HORIZONTAL_CLASSES : VERTICAL_CLASSES;
     // While dragging, accent the line and let it thicken slightly as live
     // feedback (only hover stays a constant 1px — Issue #970). `dark:bg-accent-500`
-    // is needed so the accent outranks the base `dark:bg-gray-700` in dark mode.
+    // is retained so the accent reliably outranks the tokenized base in dark mode.
     const draggingClasses = isDragging
       ? ['bg-accent-500', 'dark:bg-accent-500', 'dragging', isHorizontal ? 'w-2' : 'h-2']
       : [];

--- a/src/components/worktree/PdfPreview.tsx
+++ b/src/components/worktree/PdfPreview.tsx
@@ -95,7 +95,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
         <a
           href={dataUri}
           download={filePath.split('/').pop() || 'document.pdf'}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-input text-sm text-foreground hover:bg-muted"
           rel="noopener"
         >
           Download PDF
@@ -110,7 +110,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
         className="h-full flex items-center justify-center"
         data-testid="pdf-preview-loading"
       >
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-gray-300 dark:border-gray-600 border-t-accent-600 dark:border-t-accent-400" />
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400" />
       </div>
     );
   }
@@ -123,7 +123,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
         data-testid="pdf-preview-download"
       >
         <svg
-          className="w-16 h-16 text-gray-400 dark:text-gray-500"
+          className="w-16 h-16 text-muted-foreground"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -136,7 +136,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
             d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
           />
         </svg>
-        <p className="text-sm text-gray-700 dark:text-gray-300 break-all">
+        <p className="text-sm text-foreground break-all">
           {fileName}
         </p>
         <div className="flex flex-col gap-2 w-full max-w-xs">
@@ -151,7 +151,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
           <a
             href={blobUrl}
             download={fileName}
-            className="inline-flex items-center justify-center gap-2 px-6 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            className="inline-flex items-center justify-center gap-2 px-6 py-2 rounded-lg border border-input text-sm text-foreground hover:bg-muted transition-colors"
           >
             ダウンロード
           </a>

--- a/src/components/worktree/SearchBar.tsx
+++ b/src/components/worktree/SearchBar.tsx
@@ -47,7 +47,7 @@ export interface SearchBarProps {
 const SearchIcon = memo(function SearchIcon() {
   return (
     <svg
-      className="w-4 h-4 text-gray-400"
+      className="w-4 h-4 text-muted-foreground"
       fill="none"
       stroke="currentColor"
       viewBox="0 0 24 24"
@@ -86,7 +86,7 @@ const LoadingSpinner = memo(function LoadingSpinner() {
   return (
     <div
       data-testid="search-loading"
-      className="w-4 h-4 border-2 border-gray-300 border-t-accent-500 rounded-full animate-spin"
+      className="w-4 h-4 border-2 border-input border-t-accent-500 rounded-full animate-spin"
       aria-label="Searching..."
     />
   );
@@ -168,7 +168,7 @@ export const SearchBar = memo(function SearchBar({
   return (
     <div
       data-testid="search-bar"
-      className={`flex flex-col gap-2 p-2 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 ${className}`}
+      className={`flex flex-col gap-2 p-2 bg-surface dark:bg-surface-2 border-b border-border ${className}`}
     >
       {/* Search Input Row */}
       <div className="flex items-center gap-2">
@@ -186,7 +186,7 @@ export const SearchBar = memo(function SearchBar({
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="flex-1 min-w-0 px-2 py-1 text-sm bg-gray-50 dark:bg-gray-800 dark:text-gray-100 border border-gray-200 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-ring focus:border-accent-500"
+          className="flex-1 min-w-0 px-2 py-1 text-sm bg-muted text-foreground border border-input rounded focus:outline-none focus:ring-1 focus:ring-ring focus:border-accent-500"
           aria-label="Search files"
           aria-busy={isSearching}
         />
@@ -200,7 +200,7 @@ export const SearchBar = memo(function SearchBar({
               type="button"
               data-testid="search-clear"
               onClick={handleClear}
-              className="p-1 text-gray-400 hover:text-gray-600 rounded transition-colors"
+              className="p-1 text-muted-foreground hover:text-foreground rounded transition-colors"
               aria-label="Clear search"
             >
               <ClearIcon />
@@ -211,7 +211,7 @@ export const SearchBar = memo(function SearchBar({
 
       {/* Mode Toggle Row */}
       <div className="flex items-center gap-1">
-        <span className="text-xs text-gray-500 mr-1">Mode:</span>
+        <span className="text-xs text-muted-foreground mr-1">Mode:</span>
         <button
           type="button"
           data-testid="mode-name"
@@ -219,7 +219,7 @@ export const SearchBar = memo(function SearchBar({
           className={`px-2 py-0.5 text-xs rounded transition-colors ${
             mode === 'name'
               ? 'bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300 font-medium'
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
+              : 'bg-muted text-muted-foreground hover:bg-muted/80'
           }`}
           aria-pressed={mode === 'name'}
         >
@@ -232,7 +232,7 @@ export const SearchBar = memo(function SearchBar({
           className={`px-2 py-0.5 text-xs rounded transition-colors ${
             mode === 'content'
               ? 'bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300 font-medium'
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
+              : 'bg-muted text-muted-foreground hover:bg-muted/80'
           }`}
           aria-pressed={mode === 'content'}
         >

--- a/src/components/worktree/TodoPane.tsx
+++ b/src/components/worktree/TodoPane.tsx
@@ -30,7 +30,7 @@ import { CopyButton } from '@/components/common/CopyButton';
  * dark code-block surface. `!` wins over the component's own base color classes.
  */
 const COPY_DETAIL_BUTTON_CLASS =
-  '!border-gray-300 !bg-white !text-gray-600 hover:!bg-gray-50 dark:!border-gray-600 dark:!bg-gray-900 dark:!text-gray-300 dark:hover:!bg-gray-800';
+  '!border-input !bg-surface dark:!bg-surface-2 !text-muted-foreground hover:!bg-muted';
 
 export interface TodoPaneProps {
   /** Worktree ID to scope the todo list to. */
@@ -41,7 +41,7 @@ export interface TodoPaneProps {
 
 /** Chip styling per status (border + text/background), light and dark. */
 const STATUS_CHIP_CLASS: Record<WorktreeTodoStatus, string> = {
-  todo: 'border-gray-300 text-gray-600 dark:border-gray-600 dark:text-gray-300',
+  todo: 'border-input text-muted-foreground',
   doing:
     'border-amber-400 bg-amber-50 text-amber-700 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-300',
   done: 'border-green-500 bg-green-50 text-green-700 dark:border-green-500/60 dark:bg-green-500/10 dark:text-green-300',
@@ -247,7 +247,7 @@ export const TodoPane = React.memo(function TodoPane({
           maxLength={MAX_TODO_CONTENT_LENGTH}
           placeholder={t('todo.addPlaceholder')}
           data-testid="todo-input"
-          className="flex-1 min-w-0 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-ring"
+          className="flex-1 min-w-0 rounded-md border border-input bg-surface dark:bg-surface-2 px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
         />
         <button
           type="button"
@@ -261,7 +261,7 @@ export const TodoPane = React.memo(function TodoPane({
       </div>
 
       {/* Per-status counts */}
-      <div className="mb-2 flex justify-end gap-2 text-xs text-gray-400 dark:text-gray-500">
+      <div className="mb-2 flex justify-end gap-2 text-xs text-muted-foreground">
         <span data-testid="todo-count-todo">
           {statusLabel('todo')} {counts.todo}
         </span>
@@ -281,11 +281,11 @@ export const TodoPane = React.memo(function TodoPane({
 
       {/* Todo list */}
       {loading ? (
-        <p className="text-sm text-gray-400 dark:text-gray-500" data-testid="todo-loading">
+        <p className="text-sm text-muted-foreground" data-testid="todo-loading">
           {t('todo.loading')}
         </p>
       ) : todos.length === 0 ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="todo-empty">
+        <p className="text-sm text-muted-foreground" data-testid="todo-empty">
           {t('todo.empty')}
         </p>
       ) : (
@@ -293,7 +293,7 @@ export const TodoPane = React.memo(function TodoPane({
           {todos.map((todo, index) => (
             <li
               key={todo.id}
-              className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/40 group"
+              className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-muted group"
               data-testid="todo-item"
             >
               <button
@@ -318,8 +318,8 @@ export const TodoPane = React.memo(function TodoPane({
                 <span
                   className={`min-w-0 break-words text-sm ${
                     todo.status === 'done'
-                      ? 'line-through text-gray-400 dark:text-gray-500'
-                      : 'text-gray-800 dark:text-gray-200 group-hover/content:text-accent-700 dark:group-hover/content:text-accent-300'
+                      ? 'line-through text-muted-foreground'
+                      : 'text-foreground group-hover/content:text-accent-700 dark:group-hover/content:text-accent-300'
                   }`}
                 >
                   {todo.content}
@@ -328,7 +328,7 @@ export const TodoPane = React.memo(function TodoPane({
                   <svg
                     data-testid="todo-detail-indicator"
                     aria-label={t('todo.hasDetail')}
-                    className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500"
+                    className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -345,7 +345,7 @@ export const TodoPane = React.memo(function TodoPane({
                   disabled={index === 0}
                   aria-label={t('todo.moveUp')}
                   data-testid="todo-move-up"
-                  className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-30"
+                  className="p-1 text-muted-foreground hover:text-foreground disabled:opacity-30"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
@@ -357,7 +357,7 @@ export const TodoPane = React.memo(function TodoPane({
                   disabled={index === todos.length - 1}
                   aria-label={t('todo.moveDown')}
                   data-testid="todo-move-down"
-                  className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-30"
+                  className="p-1 text-muted-foreground hover:text-foreground disabled:opacity-30"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -368,7 +368,7 @@ export const TodoPane = React.memo(function TodoPane({
                   onClick={() => handleDelete(todo)}
                   aria-label={t('todo.delete')}
                   data-testid="todo-delete"
-                  className="inline-flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center text-gray-300 opacity-100 transition-opacity hover:text-red-500 dark:text-gray-600 dark:hover:text-red-400 sm:min-h-0 sm:min-w-0 sm:opacity-0 sm:group-hover:opacity-100"
+                  className="inline-flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center text-muted-foreground opacity-100 transition-opacity hover:text-red-500 dark:hover:text-red-400 sm:min-h-0 sm:min-w-0 sm:opacity-0 sm:group-hover:opacity-100"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -389,7 +389,7 @@ export const TodoPane = React.memo(function TodoPane({
       >
         <div className="flex flex-col gap-4">
           <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+            <span className="text-xs font-medium text-muted-foreground">
               {t('todo.contentLabel')}
             </span>
             <input
@@ -399,12 +399,12 @@ export const TodoPane = React.memo(function TodoPane({
               maxLength={MAX_TODO_CONTENT_LENGTH}
               placeholder={t('todo.contentPlaceholder')}
               data-testid="todo-edit-content"
-              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-ring"
+              className="w-full rounded-md border border-input bg-surface dark:bg-surface-2 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
             />
           </label>
           <label className="flex flex-col gap-1">
             <span className="flex items-center justify-between gap-2">
-              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+              <span className="text-xs font-medium text-muted-foreground">
                 {t('todo.detailLabel')}
               </span>
               {editDetail.trim() !== '' && (
@@ -422,7 +422,7 @@ export const TodoPane = React.memo(function TodoPane({
               rows={6}
               placeholder={t('todo.detailPlaceholder')}
               data-testid="todo-edit-detail"
-              className="w-full resize-y rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-ring"
+              className="w-full resize-y rounded-md border border-input bg-surface dark:bg-surface-2 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
             />
           </label>
           <div className="flex justify-end gap-2">
@@ -430,7 +430,7 @@ export const TodoPane = React.memo(function TodoPane({
               type="button"
               onClick={closeEditor}
               data-testid="todo-edit-cancel"
-              className="rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="rounded-md border border-input px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
             >
               {t('todo.cancel')}
             </button>

--- a/src/components/worktree/VersionSection.tsx
+++ b/src/components/worktree/VersionSection.tsx
@@ -7,7 +7,7 @@
  * MobileInfoContent (line 775-779). Both locations now use this component.
  *
  * [CONS-005] Accepts className prop to absorb style differences between
- * InfoModal (bg-gray-50) and MobileInfoContent (bg-white border).
+ * InfoModal (recessed surface) and MobileInfoContent (card + border).
  *
  * @module components/worktree/VersionSection
  */
@@ -53,13 +53,13 @@ export function VersionSection({ version, className }: VersionSectionProps) {
 
   return (
     <div className={className} data-testid="version-section">
-      <h2 className="text-sm font-medium text-gray-500 mb-1">
+      <h2 className="text-sm font-medium text-muted-foreground mb-1">
         {t('update.version')}
       </h2>
-      <p className="text-sm text-gray-700">{version}</p>
+      <p className="text-sm text-foreground">{version}</p>
 
       {loading && (
-        <p className="text-xs text-gray-400 mt-1" data-testid="version-loading">
+        <p className="text-xs text-muted-foreground mt-1" data-testid="version-loading">
           ...
         </p>
       )}

--- a/src/components/worktree/WorktreeCard.tsx
+++ b/src/components/worktree/WorktreeCard.tsx
@@ -123,7 +123,7 @@ export function WorktreeCard({ worktree, onSessionKilled }: WorktreeCardProps) {
               >
                 <svg
                   className={`w-5 h-5 ${
-                    isFavorite ? 'fill-yellow-400 text-yellow-400' : 'fill-none text-gray-400'
+                    isFavorite ? 'fill-yellow-400 text-yellow-400' : 'fill-none text-muted-foreground'
                   }`}
                   stroke="currentColor"
                   strokeWidth="2"
@@ -169,7 +169,7 @@ export function WorktreeCard({ worktree, onSessionKilled }: WorktreeCardProps) {
             {repositoryName && (
               <span
                 data-testid="worktree-card-repo-name"
-                className="text-xs text-gray-500 dark:text-gray-400"
+                className="text-xs text-muted-foreground"
               >
                 {repositoryName}
               </span>
@@ -188,15 +188,15 @@ export function WorktreeCard({ worktree, onSessionKilled }: WorktreeCardProps) {
             {/* Description */}
             {description && (
               <div>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Description</p>
-                <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-2 whitespace-pre-wrap">{description}</p>
+                <p className="text-xs text-muted-foreground mb-1">Description</p>
+                <p className="text-sm text-foreground line-clamp-2 whitespace-pre-wrap">{description}</p>
               </div>
             )}
 
             {/* Link */}
             {link && (
               <div>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Link</p>
+                <p className="text-xs text-muted-foreground mb-1">Link</p>
                 <button
                   onClick={handleLinkClick}
                   className="flex items-center gap-1 text-sm text-accent-600 dark:text-accent-400 hover:text-accent-800 dark:hover:text-accent-300 hover:underline transition-colors"
@@ -230,7 +230,7 @@ export function WorktreeCard({ worktree, onSessionKilled }: WorktreeCardProps) {
                     ? 'bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300'
                     : currentStatus === 'in_progress'
                     ? 'bg-accent-100 dark:bg-accent-900 text-accent-700 dark:text-accent-300'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                    : 'bg-muted text-muted-foreground'
                 }`}>
                   {currentStatus === 'in_progress' ? 'In Progress' : currentStatus === 'in_review' ? 'In Review' : currentStatus === 'ready' ? 'Ready' : 'Done'}
                 </span>
@@ -239,7 +239,7 @@ export function WorktreeCard({ worktree, onSessionKilled }: WorktreeCardProps) {
 
             {/* Updated At */}
             {relativeTime && (
-              <div className="flex items-center text-xs text-gray-500 dark:text-gray-400">
+              <div className="flex items-center text-xs text-muted-foreground">
                 <svg
                   className="w-4 h-4 mr-1"
                   fill="none"

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -78,7 +78,7 @@ export const MobileInfoContent = memo(function MobileInfoContent({
 
   if (!worktree) {
     return (
-      <div className="text-gray-500 text-center py-8">
+      <div className="text-muted-foreground text-center py-8">
         Loading worktree info...
       </div>
     );
@@ -89,7 +89,7 @@ export const MobileInfoContent = memo(function MobileInfoContent({
       <WorktreeInfoFields
         worktreeId={worktreeId}
         worktree={worktree}
-        cardClassName="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
+        cardClassName="bg-surface rounded-lg border border-border p-4"
         descriptionEditor={descriptionEditor}
         showLogs={showLogs}
         onToggleLogs={() => setShowLogs(!showLogs)}
@@ -293,14 +293,14 @@ export const MobileContent = memo(function MobileContent({
       return (
         <div className="h-full flex flex-col">
           {/* History sub-tab switcher: Message | Git (Issue #447) */}
-          <div className="flex border-b border-gray-200 dark:border-gray-700 shrink-0">
+          <div className="flex border-b border-border shrink-0">
             <button
               type="button"
               onClick={() => onHistorySubTabChange('message')}
               className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
                 historySubTab === 'message'
                   ? 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400 bg-accent-50 dark:bg-accent-900/30'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               Message
@@ -311,7 +311,7 @@ export const MobileContent = memo(function MobileContent({
               className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
                 historySubTab === 'git'
                   ? 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400 bg-accent-50 dark:bg-accent-900/30'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               Git

--- a/src/components/worktree/git/panels/GitChangesPanel.tsx
+++ b/src/components/worktree/git/panels/GitChangesPanel.tsx
@@ -96,20 +96,20 @@ const ChangedFileList = memo(function ChangedFileList({
   );
 
   return (
-    <div className="border-t border-gray-100 dark:border-gray-800" data-testid={testId}>
+    <div className="border-t border-border" data-testid={testId}>
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        className="w-full flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+        className="w-full flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
       >
         <span className="w-4 text-center">{open ? '▼' : '▶'}</span>
         {title} ({files.length})
       </button>
       {open && files.length === 0 && (
-        <div className="px-3 py-1.5 text-xs text-gray-400 dark:text-gray-500">None</div>
+        <div className="px-3 py-1.5 text-xs text-muted-foreground">None</div>
       )}
       {open && files.length > 0 && (
-        <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+        <ul className="divide-y divide-border">
           {files.map((file) => {
             const previewOpen = previewPath === file.path;
             return (
@@ -118,13 +118,13 @@ const ChangedFileList = memo(function ChangedFileList({
                   <span className={`inline-block w-16 shrink-0 text-xs font-medium ${STATUS_TEXT_COLOR[file.status]}`}>
                     {file.status}
                   </span>
-                  <span className="flex-1 truncate font-mono text-xs text-gray-700 dark:text-gray-300" title={file.path}>
+                  <span className="flex-1 truncate font-mono text-xs text-foreground" title={file.path}>
                     {file.path}
                   </span>
                   <button
                     type="button"
                     onClick={() => togglePreview(file.path)}
-                    className="shrink-0 w-5 text-center text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                    className="shrink-0 w-5 text-center text-xs text-muted-foreground hover:text-foreground"
                     aria-label={`Toggle diff preview for ${file.path}`}
                     aria-expanded={previewOpen}
                     data-testid="git-changes-preview-toggle"
@@ -144,7 +144,7 @@ const ChangedFileList = memo(function ChangedFileList({
                     type="button"
                     onClick={() => onToggleStage(file.path)}
                     disabled={busy}
-                    className="shrink-0 px-1.5 py-0.5 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+                    className="shrink-0 px-1.5 py-0.5 text-xs rounded border border-input text-foreground hover:bg-muted disabled:opacity-50"
                     aria-label={`${actionLabel} ${file.path}`}
                     data-testid="git-changes-toggle-button"
                   >
@@ -153,7 +153,7 @@ const ChangedFileList = memo(function ChangedFileList({
                 </div>
                 {previewOpen && (
                   <div
-                    className="px-3 pb-2 bg-gray-50/60 dark:bg-gray-800/30"
+                    className="px-3 pb-2 bg-muted/40"
                     data-testid="git-changes-inline-preview"
                   >
                     {previewLoading && (
@@ -169,7 +169,7 @@ const ChangedFileList = memo(function ChangedFileList({
                     )}
                     {!previewLoading && !previewError && previewText !== null && (
                       previewText.trim() === '' ? (
-                        <div className="py-2 text-xs text-gray-500 dark:text-gray-400">No diff available</div>
+                        <div className="py-2 text-xs text-muted-foreground">No diff available</div>
                       ) : (
                         <div className="overflow-x-auto">
                           <pre className="text-xs">
@@ -261,15 +261,15 @@ export const GitChangesPanel = memo(function GitChangesPanel({
 
   return (
     <div
-      className="flex flex-col border-b border-gray-200 dark:border-gray-700"
+      className="flex flex-col border-b border-border"
       data-testid="git-changes-section"
     >
       <div className="flex items-center justify-between px-3 py-2">
-        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Changes</span>
+        <span className="text-sm font-medium text-foreground">Changes</span>
         <button
           type="button"
           onClick={onRefresh}
-          className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded"
+          className="p-1 text-muted-foreground hover:text-foreground rounded"
           aria-label="Refresh changes"
         >
           <RefreshIcon />
@@ -333,18 +333,18 @@ export const GitChangesPanel = memo(function GitChangesPanel({
           />
 
           {/* Commit form */}
-          <div className="flex flex-col gap-2 px-3 py-2 border-t border-gray-100 dark:border-gray-800">
+          <div className="flex flex-col gap-2 px-3 py-2 border-t border-border">
             <textarea
               value={commitMessage}
               onChange={(e) => onCommitMessageChange(e.target.value)}
               placeholder="Commit message"
               rows={isMobile ? 2 : 3}
-              className="w-full resize-y rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-ring"
+              className="w-full resize-y rounded border border-input bg-surface dark:bg-surface-2 px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               data-testid="git-commit-message"
               aria-label="Commit message"
             />
             <div className="flex items-center justify-between gap-2">
-              <label className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Checkbox
                   checked={amend}
                   onCheckedChange={(checked) => onAmendChange(checked === true)}

--- a/src/components/worktree/git/panels/GitCommitHistoryPanel.tsx
+++ b/src/components/worktree/git/panels/GitCommitHistoryPanel.tsx
@@ -80,11 +80,11 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
   return (
     <>
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
         <button
           type="button"
           onClick={onToggleCommitList}
-          className="flex items-center gap-1 text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer hover:text-gray-900 dark:hover:text-gray-100"
+          className="flex items-center gap-1 text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground"
         >
           <span className="text-xs w-4 text-center">{commitListOpen ? '▼' : '▶'}</span>
           Commit History
@@ -92,7 +92,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
         <button
           type="button"
           onClick={onRefresh}
-          className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded"
+          className="p-1 text-muted-foreground hover:text-foreground rounded"
           aria-label="Refresh commit history"
         >
           <RefreshIcon />
@@ -116,7 +116,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
 
       {/* Empty state */}
       {commitListOpen && !isLoading && !commitError && commits.length === 0 && (
-        <div className="px-3 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+        <div className="px-3 py-8 text-center text-sm text-muted-foreground">
           No commits found
         </div>
       )}
@@ -127,7 +127,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
           {/* Upper: Commit list (scrollable, max 40% when open) */}
           {commitListOpen && (
             <div className={`overflow-y-auto ${selectedCommit ? 'max-h-[40%] shrink-0' : 'flex-1'}`}>
-              <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+              <ul className="divide-y divide-border">
                 {commits.map((commit) => {
                   // Issue #816 (B): inline "View diff" accordion open-state.
                   const inlineOpen = inlineDiffCommit === commit.hash;
@@ -137,7 +137,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                         <button
                           type="button"
                           onClick={() => onCommitSelect(commit.hash)}
-                          className={`flex-1 min-w-0 text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${
+                          className={`flex-1 min-w-0 text-left px-3 py-2 text-sm hover:bg-muted transition-colors ${
                             selectedCommit === commit.hash
                               ? 'bg-accent-50 dark:bg-accent-900/30'
                               : ''
@@ -147,11 +147,11 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                             <span className="font-mono text-xs text-accent-600 dark:text-accent-400 shrink-0">
                               {commit.shortHash}
                             </span>
-                            <span className="truncate text-gray-800 dark:text-gray-200">
+                            <span className="truncate text-foreground">
                               {commit.message}
                             </span>
                           </div>
-                          <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                          <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
                             <span>{commit.author}</span>
                             <span>{new Date(commit.date).toLocaleDateString()}</span>
                           </div>
@@ -161,7 +161,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                         <button
                           type="button"
                           onClick={() => onToggleInlineDiff(commit.hash)}
-                          className="shrink-0 px-2 text-xs text-accent-600 dark:text-accent-400 hover:bg-gray-50 dark:hover:bg-gray-800 hover:underline"
+                          className="shrink-0 px-2 text-xs text-accent-600 dark:text-accent-400 hover:bg-muted hover:underline"
                           aria-label={`View diff for ${commit.shortHash}`}
                           aria-expanded={inlineOpen}
                           data-testid="git-commit-view-diff-button"
@@ -173,7 +173,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                       {/* Issue #816 (B): inline accordion file list for this commit */}
                       {inlineOpen && (
                         <div
-                          className="border-t border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-gray-800/30"
+                          className="border-t border-border bg-muted/40"
                           data-testid="git-commit-inline-files"
                         >
                           {inlineFilesLoading && (
@@ -184,18 +184,18 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                           )}
                           {inlineFilesError && <InlineError message={inlineFilesError} />}
                           {!inlineFilesLoading && !inlineFilesError && inlineFiles.length === 0 && (
-                            <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                            <div className="px-3 py-2 text-xs text-muted-foreground">
                               No changed files
                             </div>
                           )}
                           {!inlineFilesLoading && inlineFiles.length > 0 && (
-                            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+                            <ul className="divide-y divide-border">
                               {inlineFiles.map((file) => (
                                 <li key={file.path}>
                                   <button
                                     type="button"
                                     onClick={() => onInlineDiffFile(commit.hash, file.path)}
-                                    className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors ${
+                                    className={`w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors ${
                                       selectedFile === file.path && selectedCommit === commit.hash
                                         ? 'bg-accent-50 dark:bg-accent-900/30'
                                         : ''
@@ -206,7 +206,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                                     <span className={`inline-block w-14 font-medium ${STATUS_TEXT_COLOR[file.status]}`}>
                                       {file.status}
                                     </span>
-                                    <span className="font-mono text-gray-700 dark:text-gray-300">
+                                    <span className="font-mono text-foreground">
                                       {file.path}
                                     </span>
                                   </button>
@@ -225,12 +225,12 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
 
           {/* Lower: Changed files + Diff (scrollable) */}
           {selectedCommit && (
-            <div className="flex-1 overflow-y-auto min-h-0 border-t border-gray-200 dark:border-gray-700">
+            <div className="flex-1 overflow-y-auto min-h-0 border-t border-border">
               {/* Changed files header */}
               <button
                 type="button"
                 onClick={() => setChangedFilesOpen((prev) => !prev)}
-                className="w-full flex items-center gap-1 px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 sticky top-0 z-10 cursor-pointer hover:text-gray-700 dark:hover:text-gray-200"
+                className="w-full flex items-center gap-1 px-3 py-2 text-xs font-medium text-muted-foreground bg-surface-2 sticky top-0 z-10 cursor-pointer hover:text-foreground"
               >
                 <span className="w-4 text-center">{changedFilesOpen ? '▼' : '▶'}</span>
                 Changed Files
@@ -248,18 +248,18 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                     </div>
                   )}
                   {!isLoadingFiles && !detailError && changedFiles.length === 0 && (
-                    <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                    <div className="px-3 py-2 text-xs text-muted-foreground">
                       No changed files
                     </div>
                   )}
                   {!isLoadingFiles && changedFiles.length > 0 && (
-                    <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+                    <ul className="divide-y divide-border">
                       {changedFiles.map((file) => (
                         <li key={file.path}>
                           <button
                             type="button"
                             onClick={() => onFileSelect(file.path)}
-                            className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${
+                            className={`w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors ${
                               selectedFile === file.path
                                 ? 'bg-accent-50 dark:bg-accent-900/30'
                                 : ''
@@ -268,7 +268,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                             <span className={`inline-block w-14 font-medium ${STATUS_TEXT_COLOR[file.status]}`}>
                               {file.status}
                             </span>
-                            <span className="font-mono text-gray-700 dark:text-gray-300">
+                            <span className="font-mono text-foreground">
                               {file.path}
                             </span>
                           </button>
@@ -281,11 +281,11 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
 
               {/* Inline diff viewer (mobile only) */}
               {isMobile && selectedFile && (
-                <div className="border-t border-gray-200 dark:border-gray-700">
+                <div className="border-t border-border">
                   <button
                     type="button"
                     onClick={() => setDiffOpen((prev) => !prev)}
-                    className="w-full flex items-center gap-1 px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 sticky top-0 z-10 cursor-pointer hover:text-gray-700 dark:hover:text-gray-200"
+                    className="w-full flex items-center gap-1 px-3 py-2 text-xs font-medium text-muted-foreground bg-surface-2 sticky top-0 z-10 cursor-pointer hover:text-foreground"
                   >
                     <span className="w-4 text-center">{diffOpen ? '▼' : '▶'}</span>
                     Diff: {selectedFile}
@@ -310,7 +310,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                         </div>
                       )}
                       {!isLoadingDiff && !diffContent && !detailError && (
-                        <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                        <div className="px-3 py-2 text-xs text-muted-foreground">
                           No diff available
                         </div>
                       )}
@@ -321,7 +321,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
 
               {/* PC: show selected file indicator */}
               {!isMobile && selectedFile && !detailError && (
-                <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700">
+                <div className="px-3 py-2 text-xs text-muted-foreground border-t border-border">
                   {isLoadingDiff ? 'Loading diff...' : `Diff displayed in file panel: ${selectedFile}`}
                 </div>
               )}

--- a/src/components/worktree/git/panels/GitStashPanel.tsx
+++ b/src/components/worktree/git/panels/GitStashPanel.tsx
@@ -54,17 +54,17 @@ export const GitStashPanel = memo(function GitStashPanel({
 
   return (
     <div
-      className="border-b border-gray-200 dark:border-gray-700"
+      className="border-b border-border"
       data-testid="git-stash-section"
     >
       <div className="flex items-center justify-between px-3 py-2">
         <button
           type="button"
           onClick={() => setOpen((prev) => !prev)}
-          className="flex items-center gap-1 text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer hover:text-gray-900 dark:hover:text-gray-100"
+          className="flex items-center gap-1 text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground"
         >
           <span className="text-xs w-4 text-center">{open ? '▼' : '▶'}</span>
-          Stash {stashes.length > 0 && <span className="text-xs text-gray-400">({stashes.length})</span>}
+          Stash {stashes.length > 0 && <span className="text-xs text-muted-foreground">({stashes.length})</span>}
         </button>
         <div className="flex items-center gap-1">
           {open && onAskAi && stashes.length > 0 && (
@@ -76,7 +76,7 @@ export const GitStashPanel = memo(function GitStashPanel({
           <button
             type="button"
             onClick={onRefresh}
-            className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded"
+            className="p-1 text-muted-foreground hover:text-foreground rounded"
             aria-label="Refresh stash list"
           >
             <RefreshIcon />
@@ -118,11 +118,11 @@ export const GitStashPanel = memo(function GitStashPanel({
               value={pushMessage}
               onChange={(e) => setPushMessage(e.target.value)}
               placeholder="Stash message (optional)"
-              className="w-full px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+              className="w-full px-2 py-1 text-xs border border-input rounded bg-surface dark:bg-surface-2 text-foreground"
               data-testid="git-stash-push-message"
             />
             <div className="flex items-center justify-between gap-2">
-              <label className="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
+              <label className="flex items-center gap-1 text-xs text-muted-foreground">
                 <Checkbox
                   checked={includeUntracked}
                   onCheckedChange={(checked) => setIncludeUntracked(checked === true)}
@@ -148,13 +148,13 @@ export const GitStashPanel = memo(function GitStashPanel({
 
           {/* Stash list */}
           {loading ? (
-            <div className="py-3 text-center text-xs text-gray-500 dark:text-gray-400" role="status">
+            <div className="py-3 text-center text-xs text-muted-foreground" role="status">
               Loading stashes...
             </div>
           ) : stashes.length === 0 ? (
-            <div className="py-3 text-center text-xs text-gray-500 dark:text-gray-400">No stashes</div>
+            <div className="py-3 text-center text-xs text-muted-foreground">No stashes</div>
           ) : (
-            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+            <ul className="divide-y divide-border">
               {stashes.map((stash) => (
                 <li key={stash.index} className="py-1.5" data-testid="git-stash-row">
                   <div className="flex items-center justify-between gap-2">
@@ -162,7 +162,7 @@ export const GitStashPanel = memo(function GitStashPanel({
                       <span className="font-mono text-xs text-accent-600 dark:text-accent-400">
                         stash@{'{'}{stash.index}{'}'}
                       </span>
-                      <span className="ml-2 text-xs text-gray-700 dark:text-gray-300 truncate">
+                      <span className="ml-2 text-xs text-foreground truncate">
                         {stash.message}
                       </span>
                     </div>
@@ -171,7 +171,7 @@ export const GitStashPanel = memo(function GitStashPanel({
                         type="button"
                         disabled={busy}
                         onClick={() => onApply(stash.index)}
-                        className="px-1.5 py-0.5 text-xs rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+                        className="px-1.5 py-0.5 text-xs rounded border border-input hover:bg-muted disabled:opacity-50"
                         data-testid="stash-apply-button"
                       >
                         Apply
@@ -180,7 +180,7 @@ export const GitStashPanel = memo(function GitStashPanel({
                         type="button"
                         disabled={busy}
                         onClick={() => onPop(stash.index)}
-                        className="px-1.5 py-0.5 text-xs rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+                        className="px-1.5 py-0.5 text-xs rounded border border-input hover:bg-muted disabled:opacity-50"
                         data-testid="stash-pop-button"
                       >
                         Pop
@@ -237,7 +237,7 @@ export const GitStashPanel = memo(function GitStashPanel({
             <button
               type="button"
               onClick={() => setDropConfirm(null)}
-              className="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+              className="px-2 py-1 text-xs rounded border border-input hover:bg-muted"
             >
               Cancel
             </button>

--- a/src/components/worktree/timers/TimerEditDialog.tsx
+++ b/src/components/worktree/timers/TimerEditDialog.tsx
@@ -50,7 +50,7 @@ export interface TimerEditDialogProps {
 }
 
 const INPUT_CLASS =
-  'w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-ring';
+  'w-full px-3 py-2 text-sm border border-input rounded-md bg-surface dark:bg-surface-2 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring';
 
 // =============================================================================
 // Component
@@ -157,7 +157,7 @@ export function TimerEditDialog({
     <div className="flex flex-col gap-3">
       {/* Agent instance selector (Issue #942) */}
       <div>
-        <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1" htmlFor="timer-instance-select">
+        <label className="block text-xs font-semibold text-foreground mb-1" htmlFor="timer-instance-select">
           {t('timer.agent')}
         </label>
         <select
@@ -177,7 +177,7 @@ export function TimerEditDialog({
 
       {/* Message input */}
       <div>
-        <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1" htmlFor="timer-message-input">
+        <label className="block text-xs font-semibold text-foreground mb-1" htmlFor="timer-message-input">
           {t('timer.message')}
         </label>
         <textarea
@@ -194,7 +194,7 @@ export function TimerEditDialog({
 
       {/* Delay selector */}
       <div>
-        <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1" htmlFor="timer-delay-select">
+        <label className="block text-xs font-semibold text-foreground mb-1" htmlFor="timer-delay-select">
           {t('timer.delay')}
         </label>
         <select
@@ -229,7 +229,7 @@ export function TimerEditDialog({
       <button
         type="button"
         onClick={onClose}
-        className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+        className="px-4 py-2 text-sm font-medium text-foreground hover:bg-muted rounded-md transition-colors"
       >
         {t('timer.close')}
       </button>
@@ -261,7 +261,7 @@ export function TimerEditDialog({
     <Modal isOpen={isOpen} onClose={onClose} title={title} size="md">
       <div className="flex flex-col gap-4">
         {body}
-        <div className="pt-2 border-t border-gray-200 dark:border-gray-700">{footerButtons}</div>
+        <div className="pt-2 border-t border-border">{footerButtons}</div>
       </div>
     </Modal>
   );

--- a/tests/unit/components/PaneResizer.test.tsx
+++ b/tests/unit/components/PaneResizer.test.tsx
@@ -228,11 +228,11 @@ describe('PaneResizer', () => {
     it('should use subtle panel-border color matching fixed borders (light/dark)', () => {
       render(<PaneResizer onResize={mockOnResize} />);
       const separator = screen.getByRole('separator');
-      // Same color family as fixed panel borders (gray-200 / dark gray-700),
-      // not the heavy bg-gray-700 used before.
-      expect(separator.className).toContain('bg-gray-200');
-      expect(separator.className).toContain('dark:bg-gray-700');
-      expect(separator.className).not.toMatch(/(^|\s)bg-gray-700(\s|$)/);
+      // [#1061] Divider uses the `border` token (same value as the fixed panel
+      // borders gray-200 / gray-700) and theme-follows via CSS var — it must not
+      // reintroduce a raw gray bg utility.
+      expect(separator.className).toContain('bg-border');
+      expect(separator.className).not.toMatch(/bg-gray-\d/);
     });
 
     it('should keep a constant 1px line at rest (no hover thickening)', () => {
@@ -254,8 +254,8 @@ describe('PaneResizer', () => {
       render(<PaneResizer onResize={mockOnResize} />);
       const separator = screen.getByRole('separator');
       expect(separator.className).toContain('hover:bg-accent-500');
-      // dark:class strategy requires an explicit dark hover variant to beat the
-      // base dark:bg-gray-700.
+      // A dark hover variant is retained defensively so the accent reliably wins
+      // over the tokenized `bg-border` base in dark mode (#1061).
       expect(separator.className).toContain('dark:hover:bg-accent-500');
     });
 


### PR DESCRIPTION
#1061 分割並列 **群D (4/4)**。21ファイルの生gray→トークン / button→ui/Button。ターミナル出力面はダーク維持(意図的除外)。挙動不変。lint/tsc pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)