### PR TITLE
refactor(ui): 生gray/buttonのトークン移行 群B (#1061)

### DIFF
--- a/src/components/external-apps/ExternalAppCard.tsx
+++ b/src/components/external-apps/ExternalAppCard.tsx
@@ -80,10 +80,10 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">
-          <h4 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
+          <h4 className="text-base font-semibold text-foreground truncate">
             {app.displayName}
           </h4>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 font-mono truncate">
+          <p className="text-xs text-muted-foreground mt-0.5 font-mono truncate">
             {app.name}
           </p>
         </div>
@@ -95,22 +95,22 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Info */}
       <div className="space-y-2 mb-4">
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600 dark:text-gray-300">Status</span>
+          <span className="text-sm text-muted-foreground">Status</span>
           <ExternalAppStatus appId={app.id} pollInterval={30000} />
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600 dark:text-gray-300">Port</span>
-          <span className="text-sm font-mono text-gray-900 dark:text-gray-100">:{app.targetPort}</span>
+          <span className="text-sm text-muted-foreground">Port</span>
+          <span className="text-sm font-mono text-foreground">:{app.targetPort}</span>
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600 dark:text-gray-300">Path</span>
-          <span className="text-sm font-mono text-gray-900 dark:text-gray-100 truncate max-w-[150px]">
+          <span className="text-sm text-muted-foreground">Path</span>
+          <span className="text-sm font-mono text-foreground truncate max-w-[150px]">
             /proxy/{app.pathPrefix}/
           </span>
         </div>
         {app.websocketEnabled && (
           <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-600 dark:text-gray-300">WebSocket</span>
+            <span className="text-sm text-muted-foreground">WebSocket</span>
             <Badge variant="info">Enabled</Badge>
           </div>
         )}
@@ -124,7 +124,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Actions */}
       {showDeleteConfirm ? (
         <div className="space-y-2">
-          <p className="text-sm text-gray-600 dark:text-gray-300">
+          <p className="text-sm text-muted-foreground">
             Delete &quot;{app.displayName}&quot;?
           </p>
           <div className="flex gap-2">

--- a/src/components/external-apps/ExternalAppsManager.tsx
+++ b/src/components/external-apps/ExternalAppsManager.tsx
@@ -119,7 +119,7 @@ export function ExternalAppsManager() {
         <Card padding="lg">
           <div className="flex items-center justify-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent-600" />
-            <span className="ml-3 text-gray-600 dark:text-gray-300">Loading apps...</span>
+            <span className="ml-3 text-muted-foreground">Loading apps...</span>
           </div>
         </Card>
       ) : error ? (
@@ -134,10 +134,10 @@ export function ExternalAppsManager() {
       ) : apps.length === 0 ? (
         <Card padding="lg">
           <div className="text-center py-8">
-            <p className="text-gray-500 dark:text-gray-400 mb-4">
+            <p className="text-muted-foreground mb-4">
               No external apps registered yet.
             </p>
-            <p className="text-sm text-gray-400 dark:text-gray-500 mb-4">
+            <p className="text-sm text-muted-foreground mb-4">
               Add an external app to proxy requests to other frontend
               applications.
             </p>

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -11,6 +11,7 @@
 
 import { memo } from 'react';
 import { type WorktreeStatusType } from '@/config/status-colors';
+import { Button } from '@/components/ui';
 import { StatusDot } from '@/components/ui/StatusDot';
 import { truncateString } from '@/lib/utils';
 import type { GitStatus } from '@/types/models';
@@ -96,20 +97,21 @@ export function MobileHeader({
     <header
       data-testid="mobile-header"
       role="banner"
-      className="sticky top-0 inset-x-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm pt-safe z-40"
+      className="sticky top-0 inset-x-0 bg-surface border-b border-border shadow-sm pt-safe z-40"
     >
       <div className="flex items-center justify-between h-14 px-4">
         {/* Left section: Back button or spacer */}
         <div className="w-10 flex-shrink-0">
           {onBackClick && (
-            <button
+            <Button
+              variant="ghost"
               type="button"
               onClick={onBackClick}
               aria-label="Back"
-              className="p-2 -ml-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors dark:text-gray-300"
+              className="p-2 -ml-2 rounded-full hover:bg-muted transition-colors dark:text-foreground"
             >
               <Icon path={ICON_PATHS.back} />
-            </button>
+            </Button>
           )}
         </div>
 
@@ -129,11 +131,11 @@ export function MobileHeader({
               role="heading"
               data-testid="worktree-name"
               title={worktreeName}
-              className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate text-center leading-tight"
+              className="text-sm font-medium text-foreground truncate text-center leading-tight"
             >
               {worktreeName}
             </h1>
-            <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
               {repositoryName && (
                 <span className="truncate max-w-[100px] text-center">
                   {repositoryName}
@@ -141,7 +143,7 @@ export function MobileHeader({
               )}
               {gitStatus && gitStatus.currentBranch !== '(unknown)' && (
                 <>
-                  {repositoryName && <span className="text-gray-300 dark:text-gray-600">/</span>}
+                  {repositoryName && <span className="text-muted-foreground/50">/</span>}
                   <span
                     className="truncate max-w-[80px] font-mono"
                     title={gitStatus.currentBranch}
@@ -161,14 +163,15 @@ export function MobileHeader({
         {/* Right section: Menu button or spacer */}
         <div className="w-10 flex-shrink-0 flex justify-end">
           {onMenuClick && (
-            <button
+            <Button
+              variant="ghost"
               type="button"
               onClick={onMenuClick}
               aria-label="Menu"
-              className="p-2 -mr-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors dark:text-gray-300"
+              className="p-2 -mr-2 rounded-full hover:bg-muted transition-colors dark:text-foreground"
             >
               <Icon path={ICON_PATHS.menu} />
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/src/components/worktree/ExecutionLogPane.tsx
+++ b/src/components/worktree/ExecutionLogPane.tsx
@@ -19,6 +19,7 @@ import { formatTimestamp } from '@/components/worktree/schedules/format';
 import { parseCmateContent } from '@/lib/cmate-validator';
 import { parseCliToolColumn } from '@/lib/cmate-cli-tool-parser';
 import type { AgentInstance } from '@/lib/cli-tools/types';
+import { Button } from '@/components/ui';
 
 // ============================================================================
 // Types
@@ -256,8 +257,8 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
     return (
       <div className={`flex items-center justify-center h-full p-4 ${className}`}>
         <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-4 border-gray-200 dark:border-gray-700 border-t-accent-500 rounded-full animate-spin" />
-          <span className="text-sm text-gray-500 dark:text-gray-400">{t('loading')}</span>
+          <div className="w-8 h-8 border-4 border-border border-t-accent-500 rounded-full animate-spin" />
+          <span className="text-sm text-muted-foreground">{t('loading')}</span>
         </div>
       </div>
     );
@@ -268,13 +269,14 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
       <div className={`flex items-center justify-center h-full p-4 ${className}`}>
         <div className="text-center">
           <span className="text-sm text-red-600 dark:text-red-400">{error}</span>
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={() => void fetchData()}
             className="ml-2 px-3 py-1 text-sm text-white bg-accent-500 rounded hover:bg-accent-600"
           >
             {t('retry')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -283,7 +285,8 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
   return (
     <div className={`flex flex-col h-full ${className}`}>
       {/* Tab bar (Issue #826): separate "Schedules" view from "Logs" view */}
-      <div className="flex shrink-0 border-b border-gray-200 dark:border-gray-700 px-4 pt-3">
+      <div className="flex shrink-0 border-b border-border px-4 pt-3">
+        {/* Issue #1061: role=tab aria-selected セグメントタブ — 残置 */}
         <button
           type="button"
           data-testid="schedule-tab-schedules"
@@ -293,11 +296,12 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
           className={`-mb-px px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
             activeTab === 'schedules'
               ? 'border-accent-500 text-accent-700 dark:text-accent-300'
-              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
           }`}
         >
           {t('tabs.schedules')} ({schedules.length})
         </button>
+        {/* Issue #1061: role=tab aria-selected セグメントタブ — 残置 */}
         <button
           type="button"
           data-testid="schedule-tab-logs"
@@ -307,7 +311,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
           className={`-mb-px px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
             activeTab === 'logs'
               ? 'border-accent-500 text-accent-700 dark:text-accent-300'
-              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
           }`}
         >
           {t('tabs.logs')} ({logs.length})
@@ -332,9 +336,9 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
               ) : (
                 <div className="space-y-2">
                   {activeSchedules.map((schedule) => (
-                    <div key={schedule.scheduleId} className="rounded border border-accent-200/80 bg-white/80 p-3 dark:border-accent-900/40 dark:bg-gray-900/60">
+                    <div key={schedule.scheduleId} className="rounded border border-accent-200/80 bg-white/80 p-3 dark:border-accent-900/40 dark:bg-surface/60">
                       <div className="flex items-center justify-between gap-2">
-                        <span className="font-medium text-sm text-gray-900 dark:text-gray-100">{schedule.name}</span>
+                        <span className="font-medium text-sm text-foreground">{schedule.name}</span>
                         <div className="flex items-center gap-2">
                           <span className={`text-xs px-2 py-0.5 rounded ${schedule.isCronActive ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'}`}>
                             {schedule.isCronActive ? t('activeState.active') : t('activeState.inactive')}
@@ -346,7 +350,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                           )}
                         </div>
                       </div>
-                      <div className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                      <div className="mt-1 text-xs text-muted-foreground">
                         <span>{t('cron')}: {schedule.cronExpression || 'N/A'}</span>
                         <span className="ml-3">{t('agentLabel')}: {schedule.cliToolId}</span>
                         {schedule.model && (
@@ -371,9 +375,10 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5V12l3 2" />
                   </svg>
                 </div>
-                <p className="font-semibold text-gray-700 dark:text-gray-200 mb-1">{t('emptyState.title')}</p>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-xs">{t('emptyState.description')}</p>
-                <button
+                <p className="font-semibold text-foreground mb-1">{t('emptyState.title')}</p>
+                <p className="text-sm text-muted-foreground mb-5 max-w-xs">{t('emptyState.description')}</p>
+                <Button
+                  variant="ghost"
                   type="button"
                   data-testid="schedule-empty-cta"
                   onClick={handleNewSchedule}
@@ -383,7 +388,8 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                     <path d="M10 4a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V5a1 1 0 011-1z" />
                   </svg>
                   {t('emptyState.createButton')}
-                </button>
+                </Button>
+                {/* Issue #1061: パディングなしテキストリンク（Button の余白/lift が外観を変える）— 残置 */}
                 <button
                   type="button"
                   data-testid="schedule-manual-toggle"
@@ -396,7 +402,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                 {manualStepsOpen && (
                   <ol
                     data-testid="schedule-manual-steps"
-                    className="mt-3 text-xs text-left inline-block space-y-1.5 list-decimal list-inside text-gray-500 dark:text-gray-400"
+                    className="mt-3 text-xs text-left inline-block space-y-1.5 list-decimal list-inside text-muted-foreground"
                   >
                     <li>{t('noSchedulesStep1')}</li>
                     <li>{t('noSchedulesStep2')}</li>
@@ -408,7 +414,8 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
             ) : (
               <div>
                 <div className="mb-2 flex items-center justify-end">
-                  <button
+                  <Button
+                    variant="ghost"
                     type="button"
                     data-testid="schedule-new-button"
                     onClick={handleNewSchedule}
@@ -418,17 +425,18 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                       <path d="M10 4a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V5a1 1 0 011-1z" />
                     </svg>
                     {t('edit.newSchedule')}
-                  </button>
+                  </Button>
                 </div>
                 <div className="space-y-2">
                   {schedules.map((schedule) => {
                     const isEnabled = schedule.enabled === 1;
                     return (
-                      <div key={schedule.id} className="border border-gray-200 dark:border-gray-700 rounded p-3 bg-white dark:bg-gray-900">
+                      <div key={schedule.id} className="border border-border rounded p-3 bg-white dark:bg-surface">
                         <div className="flex items-center justify-between gap-2">
                           <span className="font-medium text-sm truncate">{schedule.name}</span>
                           <div className="flex items-center gap-1">
                             {/* Inline enabled toggle (1-click, no modal) */}
+                            {/* Issue #1061: role=switch aria-checked トグルトラック（knob 描画）— 残置 */}
                             <button
                               type="button"
                               role="switch"
@@ -438,7 +446,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                               data-testid={`schedule-toggle-${schedule.name}`}
                               onClick={() => void handleToggleSchedule(schedule)}
                               className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-                                isEnabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
+                                isEnabled ? 'bg-green-500' : 'bg-input'
                               }`}
                             >
                               <span
@@ -447,29 +455,31 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
                                 }`}
                               />
                             </button>
-                            <button
+                            <Button
+                              variant="ghost"
                               type="button"
                               data-testid={`schedule-edit-${schedule.name}`}
                               aria-label={t('edit.edit')}
                               title={t('edit.edit')}
                               onClick={() => void handleEditSchedule(schedule)}
-                              className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-accent-600 dark:hover:text-accent-400 hover:bg-accent-50 dark:hover:bg-accent-900/20 rounded transition-colors"
+                              className="p-1.5 text-muted-foreground hover:text-accent-600 dark:hover:text-accent-400 hover:bg-accent-50 dark:hover:bg-accent-900/20 rounded transition-colors"
                             >
                               <EditIcon />
-                            </button>
-                            <button
+                            </Button>
+                            <Button
+                              variant="ghost"
                               type="button"
                               data-testid={`schedule-delete-${schedule.name}`}
                               aria-label={t('edit.delete')}
                               title={t('edit.delete')}
                               onClick={() => void handleDeleteSchedule(schedule.name)}
-                              className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded transition-colors"
+                              className="p-1.5 text-muted-foreground hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded transition-colors"
                             >
                               <DeleteIcon />
-                            </button>
+                            </Button>
                           </div>
                         </div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <div className="text-xs text-muted-foreground mt-1">
                           <span>{t('cron')}: {schedule.cron_expression || 'N/A'}</span>
                           {schedule.last_executed_at && (
                             <span className="ml-3">{t('lastRun')}: {formatTimestamp(schedule.last_executed_at)}</span>

--- a/src/components/worktree/FeedbackSection.tsx
+++ b/src/components/worktree/FeedbackSection.tsx
@@ -26,7 +26,7 @@ import {
 /**
  * Props for FeedbackSection.
  * [CONS-005] className allows parent to specify container styling
- * (InfoModal: bg-gray-50, MobileInfoContent: bg-white border).
+ * (InfoModal: bg-muted, MobileInfoContent: bg-surface border).
  */
 export interface FeedbackSectionProps {
   className?: string;
@@ -48,7 +48,7 @@ export function FeedbackSection({ className }: FeedbackSectionProps) {
 
   return (
     <div className={className} data-testid="feedback-section">
-      <h2 className="text-sm font-medium text-gray-500 mb-2">
+      <h2 className="text-sm font-medium text-muted-foreground mb-2">
         {t('feedback.title')}
       </h2>
       <div className="flex flex-col gap-1">

--- a/src/components/worktree/FileSearchBar.tsx
+++ b/src/components/worktree/FileSearchBar.tsx
@@ -12,6 +12,7 @@
 
 import React, { memo } from 'react';
 import { X } from 'lucide-react';
+import { Button } from '@/components/ui';
 
 export interface FileSearchBarProps {
   /** Ref for the search input element */
@@ -51,7 +52,7 @@ export const FileSearchBar = memo(function FileSearchBar({
   onClose,
 }: FileSearchBarProps) {
   return (
-    <div className="flex items-center gap-1 px-2 py-1 bg-gray-200 dark:bg-gray-700 border-b border-gray-300 dark:border-gray-600 flex-shrink-0">
+    <div className="flex items-center gap-1 px-2 py-1 bg-muted border-b border-input flex-shrink-0">
       <input
         ref={inputRef}
         type="text"
@@ -62,18 +63,18 @@ export const FileSearchBar = memo(function FileSearchBar({
           if (e.key === 'Enter') { if (e.shiftKey) { onPrevMatch(); } else { onNextMatch(); } }
         }}
         placeholder="検索..."
-        className="flex-1 min-w-0 px-2 py-0.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-100 border border-gray-300 dark:border-gray-600 rounded outline-none focus:ring-1 focus:ring-ring"
+        className="flex-1 min-w-0 px-2 py-0.5 text-sm bg-surface dark:text-foreground border border-input rounded outline-none focus:ring-1 focus:ring-ring"
         autoComplete="off"
         autoCorrect="off"
         autoCapitalize="off"
         spellCheck={false}
       />
-      <span className="text-xs text-gray-500 min-w-[3rem] text-right">
+      <span className="text-xs text-muted-foreground min-w-[3rem] text-right">
         {matchCount > 0 ? `${currentIdx + 1}/${matchCount}` : '0/0'}
       </span>
-      <button type="button" onClick={onPrevMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white disabled:text-gray-300 dark:disabled:text-gray-600" aria-label="前の結果">▲</button>
-      <button type="button" onClick={onNextMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white disabled:text-gray-300 dark:disabled:text-gray-600" aria-label="次の結果">▼</button>
-      <button type="button" onClick={onClose} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-gray-400 hover:text-gray-800 dark:hover:text-white" aria-label="検索を閉じる"><X className="w-4 h-4" /></button>
+      <Button variant="ghost" type="button" onClick={onPrevMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50" aria-label="前の結果">▲</Button>
+      <Button variant="ghost" type="button" onClick={onNextMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50" aria-label="次の結果">▼</Button>
+      <Button variant="ghost" type="button" onClick={onClose} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white" aria-label="検索を閉じる"><X className="w-4 h-4" /></Button>
     </div>
   );
 });

--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -30,6 +30,7 @@ import { useFileMetadataDisplay } from '@/hooks/useFileMetadataDisplay';
 import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import { useLocale } from 'next-intl';
 import { FilePlus, FolderPlus, AlertCircle, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui';
 
 // ============================================================================
 // Types
@@ -492,8 +493,8 @@ export const FileTreeView = memo(function FileTreeView({
         data-testid="file-tree-loading"
         className={`flex items-center justify-center p-4 ${className}`}
       >
-        <span className="w-5 h-5 border-2 border-gray-300 dark:border-gray-600 border-t-cyan-500 rounded-full animate-spin" />
-        <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">Loading files...</span>
+        <span className="w-5 h-5 border-2 border-input border-t-cyan-500 rounded-full animate-spin" />
+        <span className="ml-2 text-sm text-muted-foreground">Loading files...</span>
       </div>
     );
   }
@@ -522,31 +523,33 @@ export const FileTreeView = memo(function FileTreeView({
     return (
       <div
         data-testid="file-tree-empty"
-        className={`p-4 text-center text-gray-500 dark:text-gray-400 ${className}`}
+        className={`p-4 text-center text-muted-foreground ${className}`}
       >
         <p className="text-sm">No files found</p>
         {/* Action buttons for empty state - only show when callbacks are provided */}
         {(onNewFile || onNewDirectory) && (
           <div className="flex flex-col gap-2 mt-4">
             {onNewFile && (
-              <button
+              <Button
+                variant="ghost"
                 data-testid="empty-new-file-button"
                 onClick={() => onNewFile('')}
-                className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-foreground bg-surface border border-input rounded-md hover:bg-muted transition-colors"
               >
                 <FilePlus className="w-4 h-4" aria-hidden="true" />
                 <span>New File</span>
-              </button>
+              </Button>
             )}
             {onNewDirectory && (
-              <button
+              <Button
+                variant="ghost"
                 data-testid="empty-new-directory-button"
                 onClick={() => onNewDirectory('')}
-                className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-foreground bg-surface border border-input rounded-md hover:bg-muted transition-colors"
               >
                 <FolderPlus className="w-4 h-4" aria-hidden="true" />
                 <span>New Directory</span>
-              </button>
+              </Button>
             )}
           </div>
         )}
@@ -559,7 +562,7 @@ export const FileTreeView = memo(function FileTreeView({
     return (
       <div
         data-testid="file-tree-no-results"
-        className={`p-4 text-center text-gray-500 dark:text-gray-400 ${className}`}
+        className={`p-4 text-center text-muted-foreground ${className}`}
       >
         <p className="text-sm">
           No {searchMode === 'content' ? 'files containing' : 'files matching'} &quot;{searchQuery}&quot;
@@ -573,30 +576,32 @@ export const FileTreeView = memo(function FileTreeView({
       data-testid="file-tree-view"
       role="tree"
       aria-label="File tree"
-      className={`overflow-auto bg-white dark:bg-gray-900 ${className}`}
+      className={`overflow-auto bg-surface ${className}`}
     >
       {/* [Issue #300/#888] Toolbar: root-level create actions + manual refresh.
           Always rendered so the manual refresh button (Issue #888) is available
           even when no create callbacks are wired in. */}
       <div
         data-testid="file-tree-toolbar"
-        className="flex items-center gap-1 p-1 border-b border-gray-200 dark:border-gray-700"
+        className="flex items-center gap-1 p-1 border-b border-border"
       >
         {onNewFile && (
+          /* Issue #1061: dense toolbar control — base padding/hover-lift would change the dense feel — 残置 */
           <button
             data-testid="toolbar-new-file-button"
             onClick={() => onNewFile('')}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors"
           >
             <FilePlus className="w-4 h-4" aria-hidden="true" />
             <span>New File</span>
           </button>
         )}
         {onNewDirectory && (
+          /* Issue #1061: dense toolbar control — base padding/hover-lift would change the dense feel — 残置 */
           <button
             data-testid="toolbar-new-directory-button"
             onClick={() => onNewDirectory('')}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors"
           >
             <FolderPlus className="w-4 h-4" aria-hidden="true" />
             <span>New Directory</span>
@@ -613,17 +618,18 @@ export const FileTreeView = memo(function FileTreeView({
               data-testid="file-tree-refetch-indicator"
               role="status"
               aria-live="polite"
-              className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+              className="flex items-center gap-1 text-xs text-muted-foreground"
             >
               <span
                 aria-hidden="true"
-                className="w-3 h-3 border-2 border-gray-300 dark:border-gray-600 border-t-cyan-500 rounded-full animate-spin"
+                className="w-3 h-3 border-2 border-input border-t-cyan-500 rounded-full animate-spin"
               />
               <span className="sr-only">Refreshing files</span>
             </div>
           )}
           {/* [Issue #888] Manual refresh: re-fetch the root + all expanded
               directories on demand (preserves scroll/selection/expansion). */}
+          {/* Issue #1061: dense toolbar icon control — base padding/hover-lift would change the dense feel — 残置 */}
           <button
             data-testid="file-tree-refresh-button"
             type="button"
@@ -633,7 +639,7 @@ export const FileTreeView = memo(function FileTreeView({
             disabled={isRefetching}
             aria-label="Refresh file tree"
             title="更新"
-            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <RefreshCw
               className={`w-4 h-4 ${isRefetching ? 'animate-spin' : ''}`}
@@ -653,7 +659,8 @@ export const FileTreeView = memo(function FileTreeView({
         >
           <AlertCircle className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
           <span className="flex-1 truncate">{error}</span>
-          <button
+          <Button
+            variant="ghost"
             data-testid="file-tree-refetch-retry-button"
             onClick={() => {
               void reloadTreeWithExpandedDirs();
@@ -661,7 +668,7 @@ export const FileTreeView = memo(function FileTreeView({
             className="px-2 py-0.5 text-xs rounded border border-red-300 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
           >
             再試行
-          </button>
+          </Button>
         </div>
       )}
       {filteredRootItems.map((item) => (

--- a/src/components/worktree/GitPane.tsx
+++ b/src/components/worktree/GitPane.tsx
@@ -36,6 +36,7 @@ import { useBranches } from '@/hooks/useBranches';
 import { useStash } from '@/hooks/useStash';
 import { useDangerZone } from '@/hooks/useDangerZone';
 import { GIT_STATUS_POLL_INTERVAL_MS } from '@/config/git-status-config';
+import { Button } from '@/components/ui';
 import { BranchCheckoutDropdown } from '@/components/worktree/git/BranchCheckoutDropdown';
 import { AdvancedSection } from '@/components/worktree/git/AdvancedSection';
 import {
@@ -401,20 +402,21 @@ export const GitPane = memo(function GitPane({
     <AdvancedSection open={advancedOpen} onToggle={toggleAdvanced}>
       {/* Fetch (Issue #783 op, decoupled from Pull/Push per Issue #815) */}
       <div
-        className="flex flex-col gap-1.5 px-3 py-2 border-b border-gray-200 dark:border-gray-700"
+        className="flex flex-col gap-1.5 px-3 py-2 border-b border-border"
         data-testid="git-advanced-fetch"
       >
-        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Remote</span>
+        <span className="text-xs font-medium text-muted-foreground">Remote</span>
         <div>
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={() => runNetworkFetch({})}
             disabled={networkProgressState === 'running'}
-            className="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+            className="px-2 py-1 text-xs rounded border border-input text-foreground hover:bg-muted disabled:opacity-50"
             data-testid="git-fetch-button"
           >
             Fetch
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/components/worktree/ImageViewer.tsx
+++ b/src/components/worktree/ImageViewer.tsx
@@ -49,7 +49,7 @@ export function ImageViewer({ src, alt, onError }: ImageViewerProps) {
 
   if (hasError) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
         <svg
           className="w-16 h-16 mb-4"
           fill="none"
@@ -64,7 +64,7 @@ export function ImageViewer({ src, alt, onError }: ImageViewerProps) {
           />
         </svg>
         <p className="text-sm">Failed to load image</p>
-        <p className="text-xs text-gray-400 mt-1">{alt}</p>
+        <p className="text-xs text-muted-foreground mt-1">{alt}</p>
       </div>
     );
   }

--- a/src/components/worktree/MarkdownToolbar.tsx
+++ b/src/components/worktree/MarkdownToolbar.tsx
@@ -27,6 +27,7 @@ import {
   Check,
 } from 'lucide-react';
 import type { ViewMode } from '@/types/markdown-editor';
+import { Button } from '@/components/ui';
 
 // ============================================================================
 // Types
@@ -90,11 +91,11 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
   hideViewModeToggle,
 }: MarkdownToolbarProps) {
   return (
-    <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+    <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-muted">
       {/* File path and dirty indicator */}
       <div className="flex items-center gap-2 min-w-0 flex-shrink">
-        <FileText className="h-4 w-4 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-        <span className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">{filePath}</span>
+        <FileText className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        <span className="text-sm font-medium text-foreground truncate">{filePath}</span>
         {isDirty && (
           <span
             data-testid="dirty-indicator"
@@ -109,41 +110,44 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
       <div className="flex items-center gap-2 flex-shrink-0">
         {/* View mode buttons - hide on mobile portrait with split mode, or in text-only mode */}
         {!showMobileTabs && !hideViewModeToggle && (
-          <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
+          <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+            {/* Issue #1061: セグメントコントロールのトグル（アクティブ thumb 表現）— 残置 */}
             <button
               data-testid="view-mode-split"
               aria-pressed={viewMode === 'split'}
               onClick={() => onViewModeChange('split')}
               className={`p-1.5 rounded ${
                 viewMode === 'split'
-                  ? 'bg-white dark:bg-gray-600 shadow-sm text-accent-600 dark:text-accent-400'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                  ? 'bg-white dark:bg-input shadow-sm text-accent-600 dark:text-accent-400'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
               title="Split view"
             >
               <Columns className="h-4 w-4" />
             </button>
+            {/* Issue #1061: セグメントコントロールのトグル（アクティブ thumb 表現）— 残置 */}
             <button
               data-testid="view-mode-editor"
               aria-pressed={viewMode === 'editor'}
               onClick={() => onViewModeChange('editor')}
               className={`p-1.5 rounded ${
                 viewMode === 'editor'
-                  ? 'bg-white dark:bg-gray-600 shadow-sm text-accent-600 dark:text-accent-400'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                  ? 'bg-white dark:bg-input shadow-sm text-accent-600 dark:text-accent-400'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
               title="Editor only"
             >
               <FileText className="h-4 w-4" />
             </button>
+            {/* Issue #1061: セグメントコントロールのトグル（アクティブ thumb 表現）— 残置 */}
             <button
               data-testid="view-mode-preview"
               aria-pressed={viewMode === 'preview'}
               onClick={() => onViewModeChange('preview')}
               className={`p-1.5 rounded ${
                 viewMode === 'preview'
-                  ? 'bg-white dark:bg-gray-600 shadow-sm text-accent-600 dark:text-accent-400'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                  ? 'bg-white dark:bg-input shadow-sm text-accent-600 dark:text-accent-400'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
               title="Preview only"
             >
@@ -153,11 +157,12 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
         )}
 
         {/* Copy content button */}
-        <button
+        <Button
+          variant="ghost"
           data-testid="copy-content-button"
           onClick={onCopy}
-          className={`p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded ${
-            copied ? 'text-green-500' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+          className={`p-1.5 hover:bg-muted rounded ${
+            copied ? 'text-green-500' : 'text-muted-foreground hover:text-foreground'
           }`}
           title="Copy content"
         >
@@ -166,13 +171,14 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
           ) : (
             <Copy className="h-4 w-4" />
           )}
-        </button>
+        </Button>
 
         {/* Maximize button */}
-        <button
+        <Button
+          variant="ghost"
           data-testid="maximize-button"
           onClick={onToggleFullscreen}
-          className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+          className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
           title={isMaximized ? 'Exit fullscreen (ESC)' : 'Enter fullscreen (Ctrl+Shift+F)'}
           aria-pressed={isMaximized}
         >
@@ -181,18 +187,19 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
           ) : (
             <Maximize2 className="h-4 w-4" />
           )}
-        </button>
+        </Button>
 
         {/* Auto-save toggle */}
         <div className="flex items-center gap-1.5">
-          <span className="text-xs text-gray-500 dark:text-gray-400">Auto</span>
+          <span className="text-xs text-muted-foreground">Auto</span>
+          {/* Issue #1061: role=switch aria-checked トグルトラック（knob 描画）— 残置 */}
           <button
             data-testid="auto-save-toggle"
             role="switch"
             aria-checked={isAutoSaveEnabled}
             onClick={() => onAutoSaveToggle(!isAutoSaveEnabled)}
             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-              isAutoSaveEnabled ? 'bg-accent-600' : 'bg-gray-300 dark:bg-gray-600'
+              isAutoSaveEnabled ? 'bg-accent-600' : 'bg-input'
             }`}
           >
             <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
@@ -203,35 +210,37 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
 
         {/* Save button OR auto-save indicator */}
         {isAutoSaveEnabled ? (
-          <span data-testid="auto-save-indicator" className="text-sm text-gray-500 dark:text-gray-400">
+          <span data-testid="auto-save-indicator" className="text-sm text-muted-foreground">
             {isAutoSaving ? 'Saving...' : isDirty ? '' : 'Saved'}
           </span>
         ) : (
-          <button
+          <Button
+            variant="ghost"
             data-testid="save-button"
             onClick={onSave}
             disabled={!isDirty || isSaving}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
               isDirty && !isSaving
                 ? 'bg-accent-600 text-white hover:bg-accent-700'
-                : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+                : 'bg-muted text-muted-foreground cursor-not-allowed'
             }`}
           >
             <Save className="h-4 w-4" />
             {isSaving ? 'Saving...' : 'Save'}
-          </button>
+          </Button>
         )}
 
         {/* Close button */}
         {onClose && (
-          <button
+          <Button
+            variant="ghost"
             data-testid="close-button"
             onClick={onClose}
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
             title="Close"
           >
             <X className="h-4 w-4" />
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/components/worktree/MemoSearchBar.tsx
+++ b/src/components/worktree/MemoSearchBar.tsx
@@ -12,6 +12,7 @@
 'use client';
 
 import React, { useRef, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui';
 
 export interface MemoSearchBarProps {
   /** Current search query */
@@ -75,7 +76,7 @@ export function MemoSearchBar({
 
   return (
     <div
-      className="flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded"
+      className="flex items-center gap-1 px-2 py-1 bg-muted border border-input rounded"
       role="search"
       aria-label="Memo search"
     >
@@ -88,7 +89,7 @@ export function MemoSearchBar({
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}
         placeholder="Search..."
-        className="flex-1 min-w-0 bg-transparent text-gray-800 dark:text-gray-200 text-sm outline-none placeholder-gray-400 dark:placeholder-gray-500"
+        className="flex-1 min-w-0 bg-transparent text-foreground text-sm outline-none placeholder-muted-foreground"
         aria-label="Search memos"
         autoComplete="off"
         autoCorrect="off"
@@ -100,39 +101,42 @@ export function MemoSearchBar({
         role="status"
         aria-live="polite"
         aria-atomic="true"
-        className="text-gray-500 dark:text-gray-400 text-xs min-w-[3rem] text-right"
+        className="text-muted-foreground text-xs min-w-[3rem] text-right"
       >
         {countDisplay}
       </span>
 
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={onPrev}
         disabled={matchCount === 0}
         aria-label="Previous match (prev)"
-        className="text-gray-500 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white disabled:text-gray-300 dark:disabled:text-gray-600 min-w-[36px] min-h-[36px] flex items-center justify-center text-base"
+        className="text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50 min-w-[36px] min-h-[36px] flex items-center justify-center text-base"
       >
         ▲
-      </button>
+      </Button>
 
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={onNext}
         disabled={matchCount === 0}
         aria-label="Next match (next)"
-        className="text-gray-500 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white disabled:text-gray-300 dark:disabled:text-gray-600 min-w-[36px] min-h-[36px] flex items-center justify-center text-base"
+        className="text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50 min-w-[36px] min-h-[36px] flex items-center justify-center text-base"
       >
         ▼
-      </button>
+      </Button>
 
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={onClose}
         aria-label="Close search (close)"
-        className="text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-white min-w-[36px] min-h-[36px] flex items-center justify-center text-base ml-1"
+        className="text-muted-foreground hover:text-foreground dark:hover:text-white min-w-[36px] min-h-[36px] flex items-center justify-center text-base ml-1"
       >
         ✕
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -25,7 +25,7 @@ const MermaidDiagram = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="mermaid-loading flex items-center gap-2 text-gray-500 p-4">
+      <div className="mermaid-loading flex items-center gap-2 text-muted-foreground p-4">
         <Loader2 className="animate-spin h-4 w-4" />
         <span>Loading diagram...</span>
       </div>

--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from 'next-intl';
 import { worktreeApi, handleApiError } from '@/lib/api-client';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import { Kbd } from '@/components/ui/Kbd';
+import { Button } from '@/components/ui';
 import { SlashCommandSelector } from './SlashCommandSelector';
 import { InterruptButton } from './InterruptButton';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
@@ -423,6 +424,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
           <span className="truncate text-accent-800 dark:text-accent-300">{attachedImage.file.name}</span>
+          {/* Issue #1061: dense p-0.5 icon action in the attachment pill (hover-lift would disturb the compact pill) — 残置 */}
           <button
             type="button"
             onClick={removeAttachment}
@@ -453,7 +455,8 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
         {/* Mobile: Row 1 - action buttons (slash command, attach, interrupt) */}
         {isMobile && (
           <div className="flex items-center gap-1">
-            <button
+            <Button
+              variant="ghost"
               type="button"
               onClick={() => {
                 if (isFreeInputMode) {
@@ -461,19 +464,20 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
                 }
                 setShowCommandSelector(true);
               }}
-              className="flex-shrink-0 p-2 text-gray-500 hover:text-accent-600 hover:bg-accent-50 dark:text-gray-400 dark:hover:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors"
+              className="flex-shrink-0 p-2 text-muted-foreground hover:text-accent-600 hover:bg-accent-50 dark:hover:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors"
               aria-label="Show slash commands"
               data-testid="mobile-command-button"
             >
               <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
               </svg>
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
               type="button"
               onClick={openFileDialog}
               disabled={isUploading || sending}
-              className="flex-shrink-0 p-2 text-gray-500 hover:text-accent-600 hover:bg-accent-50 dark:text-gray-400 dark:hover:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors disabled:text-gray-300 dark:disabled:text-gray-600 disabled:hover:bg-transparent"
+              className="flex-shrink-0 p-2 text-muted-foreground hover:text-accent-600 hover:bg-accent-50 dark:hover:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors disabled:text-muted-foreground/50 disabled:hover:bg-transparent"
               aria-label="Attach image"
               data-testid="attach-image-button"
             >
@@ -487,7 +491,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
                 </svg>
               )}
-            </button>
+            </Button>
             <InterruptButton
               worktreeId={worktreeId}
               cliToolId={cliToolId || 'claude'}
@@ -499,11 +503,12 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
 
         {/* Desktop: Image attach button (inline) */}
         {!isMobile && (
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={openFileDialog}
             disabled={isUploading || sending}
-            className="flex-shrink-0 p-2 text-gray-500 hover:text-accent-600 hover:bg-accent-50 dark:text-gray-400 dark:hover:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors disabled:text-gray-300 dark:disabled:text-gray-600 disabled:hover:bg-transparent"
+            className="flex-shrink-0 p-2 text-muted-foreground hover:text-accent-600 hover:bg-accent-50 dark:hover:text-accent-400 dark:hover:bg-accent-900/30 rounded-full transition-colors disabled:text-muted-foreground/50 disabled:hover:bg-transparent"
             aria-label="Attach image"
             data-testid="attach-image-button"
           >
@@ -517,7 +522,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
               </svg>
             )}
-          </button>
+          </Button>
         )}
 
         {/* Row 2 (mobile) / inline (desktop): message input + send */}
@@ -548,7 +553,8 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             />
           )}
 
-          <button
+          <Button
+            variant="ghost"
             type="submit"
             data-testid="send-message-button"
             data-can-send={String((!!message.trim() || !!attachedImage) && !sending)}
@@ -570,7 +576,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
               </svg>
             )}
-          </button>
+          </Button>
         </div>
         </div>
 

--- a/src/components/worktree/MoveDialog.tsx
+++ b/src/components/worktree/MoveDialog.tsx
@@ -14,6 +14,7 @@
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { Modal } from '@/components/ui/Modal';
+import { Button } from '@/components/ui';
 import { useTranslations } from 'next-intl';
 import type { TreeItem } from '@/types/models';
 import { ChevronRight, Folder, FolderOpen, Loader2 } from 'lucide-react';
@@ -199,7 +200,7 @@ export const MoveDialog = memo(function MoveDialog({
       <div key={node.path}>
         <div
           className={`flex items-center gap-1 py-1.5 px-2 cursor-pointer rounded text-sm transition-colors ${
-            isSelected ? 'bg-accent-100 text-accent-800' : 'hover:bg-gray-100 text-gray-700'
+            isSelected ? 'bg-accent-100 text-accent-800' : 'hover:bg-muted text-foreground'
           } ${!isValid ? 'opacity-40 cursor-not-allowed' : ''}`}
           style={{ paddingLeft: `${0.5 + depth * 1.25}rem` }}
           onClick={() => {
@@ -208,6 +209,7 @@ export const MoveDialog = memo(function MoveDialog({
             }
           }}
         >
+          {/* Issue #1061: tiny icon toggle in a dense tree row (base padding/lift would break the layout) — 残置 */}
           <button
             className="w-4 h-4 flex items-center justify-center flex-shrink-0"
             onClick={(e) => {
@@ -216,10 +218,10 @@ export const MoveDialog = memo(function MoveDialog({
             }}
           >
             {isLoading ? (
-              <Loader2 className="w-3 h-3 animate-spin text-gray-400" />
+              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
             ) : (
               <ChevronRight
-                className={`w-3 h-3 text-gray-400 transition-transform ${
+                className={`w-3 h-3 text-muted-foreground transition-transform ${
                   isExpanded ? 'rotate-90' : ''
                 }`}
               />
@@ -247,16 +249,16 @@ export const MoveDialog = memo(function MoveDialog({
     <Modal isOpen={isOpen} onClose={onClose} title={t('fileTree.moveDialogTitle')} size="md">
       <div className="flex flex-col gap-4">
         {/* Source info */}
-        <div className="text-sm text-gray-600">
-          {t('fileTree.moveTo')}: <span className="font-mono text-gray-800">{sourcePath}</span>
+        <div className="text-sm text-muted-foreground">
+          {t('fileTree.moveTo')}: <span className="font-mono text-foreground">{sourcePath}</span>
         </div>
 
         {/* Directory tree */}
-        <div className="border border-gray-200 rounded-lg max-h-64 overflow-y-auto p-2">
+        <div className="border border-border rounded-lg max-h-64 overflow-y-auto p-2">
           {/* Root directory option */}
           <div
             className={`flex items-center gap-1 py-1.5 px-2 cursor-pointer rounded text-sm transition-colors ${
-              selectedPath === '' ? 'bg-accent-100 text-accent-800' : 'hover:bg-gray-100 text-gray-700'
+              selectedPath === '' ? 'bg-accent-100 text-accent-800' : 'hover:bg-muted text-foreground'
             } ${!isValidDestination('') ? 'opacity-40 cursor-not-allowed' : ''}`}
             onClick={() => {
               if (isValidDestination('')) {
@@ -271,7 +273,7 @@ export const MoveDialog = memo(function MoveDialog({
 
           {rootLoading ? (
             <div className="flex items-center justify-center py-4">
-              <Loader2 className="w-5 h-5 animate-spin text-gray-400" />
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
             </div>
           ) : (
             directoryTree.map((node) => renderDirectoryNode(node, 1))
@@ -280,19 +282,21 @@ export const MoveDialog = memo(function MoveDialog({
 
         {/* Action buttons */}
         <div className="flex justify-end gap-2">
-          <button
+          <Button
+            variant="ghost"
             onClick={onClose}
-            className="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            className="px-4 py-2 text-sm text-foreground bg-white border border-border rounded-md hover:bg-muted transition-colors"
           >
             {tCommon('cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
             onClick={() => onConfirm(selectedPath)}
             disabled={!canConfirm}
             className="px-4 py-2 text-sm text-white bg-accent-600 rounded-md hover:bg-accent-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {t('fileTree.moveConfirm')}
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>

--- a/src/components/worktree/PromptMessage.tsx
+++ b/src/components/worktree/PromptMessage.tsx
@@ -13,6 +13,7 @@ import type { ChatMessage } from '@/types/models';
 import { format } from 'date-fns';
 import { getDateFnsLocale } from '@/lib/date-locale';
 import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
+import { Button } from '@/components/ui';
 
 export interface PromptMessageProps {
   message: ChatMessage;
@@ -58,8 +59,8 @@ const BUTTON_BASE_CLASSES = 'rounded-lg font-medium transition-all disabled:opac
 function SendingIndicator({ className = '' }: { className?: string }) {
   const t = useTranslations('prompt');
   return (
-    <div className={`flex items-center gap-2 text-sm text-gray-500 ${className}`.trim()}>
-      <div className="animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-accent-600" />
+    <div className={`flex items-center gap-2 text-sm text-muted-foreground ${className}`.trim()}>
+      <div className="animate-spin rounded-full h-4 w-4 border-2 border-input border-t-accent-600" />
       <span>{t('sending')}</span>
     </div>
   );
@@ -90,26 +91,26 @@ export function PromptMessage({ message, onRespond }: PromptMessageProps) {
 
   return (
     <div className="mb-4">
-      <div className="bg-yellow-50 border-2 border-yellow-300 rounded-lg p-4 shadow-sm">
+      <div className="bg-yellow-50 dark:bg-muted border-2 border-yellow-300 dark:border-yellow-600 rounded-lg p-4 shadow-sm">
         {/* Header */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <TriangleAlert className="w-6 h-6 text-yellow-600" aria-hidden="true" />
-            <span className="font-bold text-yellow-800">{t('confirmationFrom', { toolName: getCliToolDisplayNameSafe(message.cliToolId, 'Claude') })}</span>
+            <TriangleAlert className="w-6 h-6 text-yellow-600 dark:text-yellow-400" aria-hidden="true" />
+            <span className="font-bold text-yellow-800 dark:text-yellow-300">{t('confirmationFrom', { toolName: getCliToolDisplayNameSafe(message.cliToolId, 'Claude') })}</span>
           </div>
-          <span className="text-xs text-yellow-600">{timestamp}</span>
+          <span className="text-xs text-yellow-600 dark:text-yellow-400">{timestamp}</span>
         </div>
 
         {/* Instruction text (Issue #235: rawContent display) [SF-S2-004] */}
         {displayContent && (
-          <div className="text-sm text-gray-700 whitespace-pre-wrap mb-2">
+          <div className="text-sm text-foreground whitespace-pre-wrap mb-2">
             {displayContent}
           </div>
         )}
 
         {/* Question */}
         <div className="mb-4">
-          <p className="text-base text-gray-800 leading-relaxed">
+          <p className="text-base text-foreground leading-relaxed">
             {prompt.question}
           </p>
         </div>
@@ -120,20 +121,22 @@ export function PromptMessage({ message, onRespond }: PromptMessageProps) {
             {/* Yes/No buttons for yes_no prompts */}
             {prompt.type === 'yes_no' && (
               <div className="flex items-center gap-3">
-                <button
+                <Button
+                  variant="ghost"
                   onClick={() => handleRespond('yes')}
                   disabled={responding}
                   className={`px-6 py-2 ${BUTTON_BASE_CLASSES} bg-accent-600 text-white hover:bg-accent-700 focus:ring-ring`}
                 >
                   {t('yes')}
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="ghost"
                   onClick={() => handleRespond('no')}
                   disabled={responding}
-                  className={`px-6 py-2 ${BUTTON_BASE_CLASSES} bg-white border-2 border-gray-300 hover:bg-gray-50 focus:ring-gray-500`}
+                  className={`px-6 py-2 ${BUTTON_BASE_CLASSES} bg-surface border-2 border-input hover:bg-muted focus:ring-ring`}
                 >
                   {t('no')}
-                </button>
+                </Button>
                 {responding && <SendingIndicator />}
               </div>
             )}
@@ -142,6 +145,7 @@ export function PromptMessage({ message, onRespond }: PromptMessageProps) {
             {prompt.type === 'multiple_choice' && (
               <div className="space-y-2">
                 {prompt.options.map((option) => (
+                  /* Issue #1061: full-width left-aligned choice row (w-full text-left) — base centering/hover-lift would break the row layout — 残置 */
                   <button
                     key={option.number}
                     onClick={() => handleRespond(option.number.toString())}
@@ -150,7 +154,7 @@ export function PromptMessage({ message, onRespond }: PromptMessageProps) {
                       w-full text-left px-4 py-3 ${BUTTON_BASE_CLASSES}
                       ${option.isDefault
                         ? 'bg-accent-600 text-white hover:bg-accent-700 border-2 border-accent-600'
-                        : 'bg-white border-2 border-gray-300 hover:bg-gray-50 text-gray-900'
+                        : 'bg-surface border-2 border-input hover:bg-muted text-foreground'
                       }
                       focus:ring-ring
                     `}
@@ -171,9 +175,9 @@ export function PromptMessage({ message, onRespond }: PromptMessageProps) {
             )}
           </div>
         ) : (
-          <div className="bg-white border border-gray-300 rounded-lg px-4 py-2 inline-block">
-            <span className="text-sm text-gray-600">
-              <CircleCheck size={16} className="inline align-[-3px] mr-1 text-green-600" aria-hidden="true" />{t('answered')}: <strong className="text-gray-900">{prompt.answer}</strong>
+          <div className="bg-surface border border-input rounded-lg px-4 py-2 inline-block">
+            <span className="text-sm text-muted-foreground">
+              <CircleCheck size={16} className="inline align-[-3px] mr-1 text-green-600" aria-hidden="true" />{t('answered')}: <strong className="text-foreground">{prompt.answer}</strong>
             </span>
           </div>
         )}

--- a/src/components/worktree/PromptPanel.tsx
+++ b/src/components/worktree/PromptPanel.tsx
@@ -12,7 +12,7 @@ import { memo, useState, useCallback, useId, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import type { PromptData, YesNoPromptData, MultipleChoicePromptData } from '@/types/models';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
-import { RadioGroup, RadioGroupItem } from '@/components/ui';
+import { RadioGroup, RadioGroupItem, Button } from '@/components/ui';
 import { usePromptAnimation } from '@/hooks/usePromptAnimation';
 
 /** Animation duration for prompt panel transitions */
@@ -29,7 +29,7 @@ const BUTTON_BASE_STYLES = `
 const BUTTON_PRIMARY_STYLES = 'bg-accent-600 text-white hover:bg-accent-700 focus:ring-ring';
 
 /** Secondary button styles */
-const BUTTON_SECONDARY_STYLES = 'bg-white dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 focus:ring-gray-500';
+const BUTTON_SECONDARY_STYLES = 'bg-surface border-2 border-input hover:bg-muted text-foreground focus:ring-ring';
 
 /**
  * Props for PromptPanel component
@@ -136,33 +136,34 @@ function PromptPanelContent({
           {cliToolName ? t('confirmationFrom', { toolName: cliToolName }) : t('confirmationFromClaude')}
         </h3>
         {onDismiss && (
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={onDismiss}
             aria-label="close"
-            className="p-1 rounded hover:bg-yellow-200 dark:hover:bg-gray-700 transition-colors"
+            className="p-1 rounded hover:bg-yellow-200 dark:hover:bg-muted transition-colors"
           >
             <svg className="w-5 h-5 text-yellow-700 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
-          </button>
+          </Button>
         )}
       </div>
 
       {/* Instruction Text (context preceding the prompt) */}
       {promptData.instructionText && (
-        <div className="max-h-40 overflow-y-auto whitespace-pre-wrap text-sm text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded p-2 border border-gray-200 dark:border-gray-700">
+        <div className="max-h-40 overflow-y-auto whitespace-pre-wrap text-sm text-muted-foreground bg-muted rounded p-2 border border-border">
           {promptData.instructionText}
         </div>
       )}
 
       {/* Question */}
-      <p className="text-gray-800 dark:text-gray-200 leading-relaxed">{promptData.question}</p>
+      <p className="text-foreground leading-relaxed">{promptData.question}</p>
 
       {/* Answering indicator */}
       {isDisabled && (
-        <div data-testid="answering-indicator" className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400" role="status" aria-live="polite">
-          <div className="animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-accent-600" aria-hidden="true" />
+        <div data-testid="answering-indicator" className="flex items-center gap-2 text-sm text-muted-foreground" role="status" aria-live="polite">
+          <div className="animate-spin rounded-full h-4 w-4 border-2 border-input border-t-accent-600" aria-hidden="true" />
           <span>{t('sending')}</span>
         </div>
       )}
@@ -216,26 +217,28 @@ function YesNoPromptActions({
   const isNoDefault = promptData.defaultOption === 'no';
 
   const yesButtonClasses = `${BUTTON_BASE_STYLES} ${BUTTON_PRIMARY_STYLES} ${isYesDefault ? 'primary default highlighted' : ''}`;
-  const noButtonClasses = `${BUTTON_BASE_STYLES} ${isNoDefault ? 'bg-gray-600 text-white hover:bg-gray-700 primary default highlighted' : BUTTON_SECONDARY_STYLES}`;
+  const noButtonClasses = `${BUTTON_BASE_STYLES} ${isNoDefault ? 'bg-foreground text-background hover:bg-foreground/90 primary default highlighted' : BUTTON_SECONDARY_STYLES}`;
 
   return (
     <div className="flex items-center gap-3" role="group" aria-label="Yes or No options">
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={onYes}
         disabled={disabled}
         className={yesButtonClasses}
       >
         {t('yes')}
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="ghost"
         type="button"
         onClick={onNo}
         disabled={disabled}
         className={noButtonClasses}
       >
         {t('no')}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -273,7 +276,7 @@ function MultipleChoicePromptActions({
     const baseClasses = 'flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-all';
     const selectionClasses = isSelected
       ? 'bg-accent-50 dark:bg-accent-900/30 border-2 border-accent-500'
-      : 'bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600';
+      : 'bg-surface border-2 border-border hover:border-input';
     const disabledClasses = disabled ? 'opacity-50 cursor-not-allowed' : '';
     return `${baseClasses} ${selectionClasses} ${disabledClasses}`;
   }, [selectedOption, disabled]);
@@ -323,12 +326,13 @@ function MultipleChoicePromptActions({
             onChange={(e) => onTextInputChange(e.target.value)}
             disabled={disabled}
             placeholder={t('enterValuePlaceholder')}
-            className="w-full px-4 py-2 border-2 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-lg focus:outline-none focus:border-accent-500 disabled:opacity-50"
+            className="w-full px-4 py-2 border-2 border-input dark:bg-muted dark:text-foreground rounded-lg focus:outline-none focus:border-accent-500 disabled:opacity-50"
           />
         </div>
       )}
 
       {/* Submit button */}
+      {/* Issue #1061: full-width (w-full) without justify-center — base centering/hover-lift would alter layout — 残置 */}
       <button
         type="button"
         onClick={onSubmit}
@@ -345,7 +349,7 @@ function MultipleChoicePromptActions({
  * Generates container class names based on animation state
  */
 function getContainerClasses(animationClass: string): string {
-  const baseClasses = 'bg-yellow-50 dark:bg-gray-800 border-2 border-yellow-300 dark:border-yellow-600 rounded-lg p-4 shadow-lg transition-all duration-200 ease-in-out';
+  const baseClasses = 'bg-yellow-50 dark:bg-muted border-2 border-yellow-300 dark:border-yellow-600 rounded-lg p-4 shadow-lg transition-all duration-200 ease-in-out';
 
   let animationStyles = 'opacity-100';
   if (animationClass === 'animate-fade-in') {

--- a/src/components/worktree/SlashCommandList.tsx
+++ b/src/components/worktree/SlashCommandList.tsx
@@ -46,7 +46,7 @@ export function SlashCommandList({
 
   if (groups.length === 0) {
     return (
-      <div className={`text-sm text-gray-500 p-4 text-center ${className}`}>
+      <div className={`text-sm text-muted-foreground p-4 text-center ${className}`}>
         No commands available
       </div>
     );
@@ -57,7 +57,7 @@ export function SlashCommandList({
       {groups.map((group) => (
         <div key={group.category} className="mb-2">
           {/* Category label */}
-          <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider bg-gray-50 dark:bg-gray-800">
+          <div className="px-3 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider bg-muted">
             {group.label}
           </div>
 
@@ -69,6 +69,7 @@ export function SlashCommandList({
               const isHighlighted = currentIndex === highlightedIndex;
 
               return (
+                /* Issue #1061: full-width text-left menu row — 残置 */
                 <button
                   key={command.name}
                   type="button"
@@ -87,7 +88,7 @@ export function SlashCommandList({
                       Codex
                     </span>
                   )}
-                  <span className="text-gray-600 dark:text-gray-300 text-sm truncate">
+                  <span className="text-muted-foreground text-sm truncate">
                     {command.description}
                   </span>
                 </button>

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -28,6 +28,7 @@ import { LogViewer } from '@/components/worktree/LogViewer';
 import { VersionSection } from '@/components/worktree/VersionSection';
 import { FeedbackSection } from '@/components/worktree/FeedbackSection';
 import { Modal } from '@/components/ui/Modal';
+import { Button } from '@/components/ui';
 import { worktreeApi } from '@/lib/api-client';
 import { truncateString } from '@/lib/utils';
 import { ClipboardCopy, Check } from 'lucide-react';
@@ -240,18 +241,19 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
     <>
       {/* Worktree Name */}
       <div className={cardClassName}>
-        <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Worktree</h2>
-        <p className="text-lg font-semibold text-gray-900 dark:text-gray-100">{worktree.name}</p>
+        <h2 className="text-sm font-medium text-muted-foreground mb-1">Worktree</h2>
+        <p className="text-lg font-semibold text-foreground">{worktree.name}</p>
       </div>
 
       {/* Repository Info */}
       <div className={cardClassName}>
         <div className="flex items-center gap-1.5 mb-1">
-          <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400">Repository</h2>
-          <button
+          <h2 className="text-sm font-medium text-muted-foreground">Repository</h2>
+          <Button
+            variant="ghost"
             type="button"
             onClick={handleCopyRepoPath}
-            className="flex-shrink-0 p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
             aria-label="Copy repository path"
             title={repoPathCopied ? 'Copied!' : 'Copy repository path'}
           >
@@ -260,20 +262,21 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
             ) : (
               <ClipboardCopy className="w-3.5 h-3.5" />
             )}
-          </button>
+          </Button>
         </div>
-        <p className="text-base text-gray-900 dark:text-gray-100">{worktree.repositoryDisplayName ?? worktree.repositoryName}</p>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 break-all">{worktree.repositoryPath}</p>
+        <p className="text-base text-foreground">{worktree.repositoryDisplayName ?? worktree.repositoryName}</p>
+        <p className="text-xs text-muted-foreground mt-1 break-all">{worktree.repositoryPath}</p>
       </div>
 
       {/* Path */}
       <div className={cardClassName}>
         <div className="flex items-center gap-1.5 mb-1">
-          <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400">Path</h2>
-          <button
+          <h2 className="text-sm font-medium text-muted-foreground">Path</h2>
+          <Button
+            variant="ghost"
             type="button"
             onClick={handleCopyPath}
-            className="flex-shrink-0 p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
             aria-label="Copy worktree path"
             title={pathCopied ? 'Copied!' : 'Copy path'}
           >
@@ -282,14 +285,14 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
             ) : (
               <ClipboardCopy className="w-3.5 h-3.5" />
             )}
-          </button>
+          </Button>
         </div>
-        <p className="text-sm text-gray-700 dark:text-gray-300 break-all font-mono">{worktree.path}</p>
+        <p className="text-sm text-foreground break-all font-mono">{worktree.path}</p>
       </div>
 
       {/* Status - dropdown for mobile */}
       <div className={cardClassName}>
-        <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Status</h2>
+        <h2 className="text-sm font-medium text-muted-foreground mb-1">Status</h2>
         <select
           value={worktree.status ?? ''}
           onChange={async (e) => {
@@ -309,7 +312,7 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
               // Silently handle
             }
           }}
-          className="text-sm px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-ring focus:border-transparent w-full"
+          className="text-sm px-3 py-1.5 rounded-lg border border-input bg-surface text-foreground focus:ring-2 focus:ring-ring focus:border-transparent w-full"
           data-testid="mobile-status-dropdown"
           aria-label="Worktree status"
         >
@@ -324,8 +327,9 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
       {/* Description - Editable */}
       <div className={cardClassName}>
         <div className="flex items-center justify-between mb-2">
-          <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400">Description</h2>
+          <h2 className="text-sm font-medium text-muted-foreground">Description</h2>
           {!isEditing && (
+            /* Issue #1061: borderless text-link — Button base padding/hover-lift would distort the inline link — 残置 */
             <button
               type="button"
               onClick={startEditing}
@@ -341,34 +345,36 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
               value={text}
               onChange={(e) => setText(e.target.value)}
               placeholder="Add notes about this branch..."
-              className="w-full min-h-[150px] p-3 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+              className="w-full min-h-[150px] p-3 border border-input dark:bg-surface dark:text-foreground rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
               autoFocus
             />
             <div className="flex gap-2">
-              <button
+              <Button
+                variant="ghost"
                 type="button"
                 onClick={handleSave}
                 disabled={isSaving}
                 className="px-4 py-2 bg-accent-600 text-white rounded-lg hover:bg-accent-700 disabled:opacity-50 text-sm font-medium"
               >
                 {isSaving ? 'Saving...' : 'Save'}
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="ghost"
                 type="button"
                 onClick={handleCancel}
                 disabled={isSaving}
-                className="px-4 py-2 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 rounded-lg hover:bg-gray-300 disabled:opacity-50 text-sm font-medium"
+                className="px-4 py-2 bg-muted text-foreground rounded-lg hover:bg-border disabled:opacity-50 text-sm font-medium"
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </div>
         ) : (
           <div className="min-h-[50px]">
             {worktree.description ? (
-              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{worktree.description}</p>
+              <p className="text-sm text-foreground whitespace-pre-wrap">{worktree.description}</p>
             ) : (
-              <p className="text-sm text-gray-400 italic">No description added yet</p>
+              <p className="text-sm text-muted-foreground italic">No description added yet</p>
             )}
           </div>
         )}
@@ -377,7 +383,7 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
       {/* Link */}
       {worktree.link && (
         <div className={cardClassName}>
-          <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Link</h2>
+          <h2 className="text-sm font-medium text-muted-foreground mb-1">Link</h2>
           <a
             href={worktree.link}
             target="_blank"
@@ -392,8 +398,8 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
       {/* Last Updated */}
       {worktree.updatedAt && (
         <div className={cardClassName}>
-          <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Last Updated</h2>
-          <p className="text-sm text-gray-700 dark:text-gray-300">
+          <h2 className="text-sm font-medium text-muted-foreground mb-1">Last Updated</h2>
+          <p className="text-sm text-foreground">
             {new Date(worktree.updatedAt).toLocaleString()}
           </p>
         </div>
@@ -408,7 +414,8 @@ export const WorktreeInfoFields = memo(function WorktreeInfoFields({
       {/* Logs */}
       <div className={cardClassName}>
         <div className="flex items-center justify-between mb-2">
-          <h2 className="text-sm font-medium text-gray-500">Logs</h2>
+          <h2 className="text-sm font-medium text-muted-foreground">Logs</h2>
+          {/* Issue #1061: borderless text-link — Button base padding/hover-lift would distort the inline link — 残置 */}
           <button
             type="button"
             onClick={onToggleLogs}
@@ -577,13 +584,14 @@ export const DesktopHeader = memo(function DesktopHeader({
     : null;
 
   return (
-    <div className="flex items-center justify-between px-4 py-3 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+    <div className="flex items-center justify-between px-4 py-3 bg-surface border-b border-border">
       {/* Left: Back button and title (Issue #747: hamburger moved to ActivityBar) */}
       <div className="flex items-center gap-3">
+        {/* Issue #1061: paddingless nav link — Button base px-4 py-2 would enlarge/misalign the header back control — 残置 */}
         <button
           type="button"
           onClick={onBackClick}
-          className="flex items-center gap-1 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors"
+          className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
           aria-label="Go back to worktree list"
         >
           <svg
@@ -602,7 +610,7 @@ export const DesktopHeader = memo(function DesktopHeader({
           </svg>
           <span className="text-sm font-medium">Home</span>
         </button>
-        <div className="w-px h-6 bg-gray-300 dark:bg-gray-600" aria-hidden="true" />
+        <div className="w-px h-6 bg-border" aria-hidden="true" />
         {/* Worktree-level status (Issue #1078: unified StatusDot visual language) */}
         <StatusDot
           data-testid="desktop-status-indicator"
@@ -612,16 +620,16 @@ export const DesktopHeader = memo(function DesktopHeader({
         />
         {/* Worktree name, memo, and repository */}
         <div className="flex flex-col min-w-0">
-          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate max-w-[200px] leading-tight">
+          <h1 className="text-lg font-semibold text-foreground truncate max-w-[200px] leading-tight">
             {worktreeName}
           </h1>
-          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <span className="truncate max-w-[200px]">
               {repositoryName}
             </span>
             {gitStatus && gitStatus.currentBranch !== '(unknown)' && (
               <>
-                <span className="text-gray-300 dark:text-gray-600">/</span>
+                <span className="text-muted-foreground">/</span>
                 <span
                   className="truncate max-w-[150px] font-mono"
                   title={gitStatus.currentBranch}
@@ -636,9 +644,9 @@ export const DesktopHeader = memo(function DesktopHeader({
             )}
             {truncatedDescription && (
               <>
-                <span className="text-gray-300 dark:text-gray-600">—</span>
+                <span className="text-muted-foreground">—</span>
                 <span
-                  className="truncate max-w-[300px] text-gray-400 dark:text-gray-500"
+                  className="truncate max-w-[300px] text-muted-foreground"
                   title={worktreeDescription}
                 >
                   {truncatedDescription}
@@ -703,6 +711,7 @@ export const DesktopHeader = memo(function DesktopHeader({
 
                 if (c.slot === 'pill') {
                   return (
+                    /* Issue #1061: draggable instance-tab switcher (aria-pressed) with typed drag handlers — 残置 */
                     <button
                       key={inst.id}
                       type="button"
@@ -714,7 +723,7 @@ export const DesktopHeader = memo(function DesktopHeader({
                       className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
                         isActive
                           ? 'bg-accent-100 dark:bg-accent-900/30 text-accent-900 dark:text-accent-100'
-                          : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300'
+                          : 'hover:bg-muted text-foreground'
                       }${dragActive}`}
                     >
                       {/* Issue #1078: unified StatusDot (decorative; the button carries the label) */}
@@ -727,6 +736,7 @@ export const DesktopHeader = memo(function DesktopHeader({
                 // Idle/ready → icon-only 24px circular button; full label via Tooltip.
                 return (
                   <Tooltip key={inst.id} content={fullLabel} placement="bottom">
+                    {/* Issue #1061: draggable instance-tab switcher (aria-pressed) — 残置 */}
                     <button
                       type="button"
                       data-testid={`desktop-agent-status-${inst.id}`}
@@ -737,7 +747,7 @@ export const DesktopHeader = memo(function DesktopHeader({
                       className={`flex items-center justify-center w-6 h-6 rounded-full transition-colors ${
                         isActive
                           ? 'bg-accent-100 dark:bg-accent-900/30'
-                          : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                          : 'hover:bg-muted'
                       }${dragActive}`}
                     >
                       <StatusDot status={c.status} size="sm" aria-hidden title={undefined} />
@@ -750,6 +760,7 @@ export const DesktopHeader = memo(function DesktopHeader({
               {overflow.length > 0 && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
+                    {/* Issue #1061: DropdownMenuTrigger asChild requires ref forwarding; Button forwards no ref — 残置 */}
                     <button
                       type="button"
                       data-testid="desktop-agent-status-overflow"
@@ -790,7 +801,8 @@ export const DesktopHeader = memo(function DesktopHeader({
             only when a kill handler is wired AND the active CLI session is
             running; click opens the existing confirmation modal. */}
         {onKillSession && activeInstanceRunning && (
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={onKillSession}
             className="flex items-center gap-1 px-2 py-1.5 text-xs font-medium rounded-lg text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors flex-shrink-0"
@@ -799,7 +811,7 @@ export const DesktopHeader = memo(function DesktopHeader({
           >
             <span aria-hidden="true">&#x2715;</span>
             End
-          </button>
+          </Button>
         )}
         {/* Worktree status dropdown */}
         {onWorktreeStatusChange && (
@@ -810,7 +822,7 @@ export const DesktopHeader = memo(function DesktopHeader({
               onWorktreeStatusChange(val === '' ? null : val as 'ready' | 'in_progress' | 'in_review' | 'done');
             }}
             onClick={(e) => e.stopPropagation()}
-            className="text-xs px-2 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-ring focus:border-transparent cursor-pointer"
+            className="text-xs px-2 py-1.5 rounded-lg border border-input bg-surface text-foreground focus:ring-2 focus:ring-ring focus:border-transparent cursor-pointer"
             data-testid="desktop-status-dropdown"
             aria-label="Worktree status"
           >
@@ -826,10 +838,11 @@ export const DesktopHeader = memo(function DesktopHeader({
             showGlobalNav:false), so it is surfaced here too. PC only — the
             selector returns null on mobile. */}
         <PcDisplaySizeSelector />
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={onInfoClick}
-        className="relative flex items-center gap-1.5 px-3 py-1.5 text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+        className="relative flex items-center gap-1.5 px-3 py-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"
         aria-label="View worktree information"
       >
         <svg
@@ -854,7 +867,7 @@ export const DesktopHeader = memo(function DesktopHeader({
             aria-label="Update available"
           />
         )}
-      </button>
+      </Button>
       </div>
     </div>
   );
@@ -904,7 +917,7 @@ export const InfoModal = memo(function InfoModal({
         <WorktreeInfoFields
           worktreeId={worktreeId}
           worktree={worktree}
-          cardClassName="bg-gray-50 dark:bg-gray-800 rounded-lg p-4"
+          cardClassName="bg-muted rounded-lg p-4"
           descriptionEditor={descriptionEditor}
           showLogs={showLogs}
           onToggleLogs={() => setShowLogs(!showLogs)}
@@ -925,10 +938,10 @@ export const LoadingIndicator = memo(function LoadingIndicator() {
     >
       <div className="flex flex-col items-center gap-3">
         <div
-          className="animate-spin rounded-full h-8 w-8 border-4 border-gray-300 dark:border-gray-600 border-t-accent-600 dark:border-t-accent-400"
+          className="animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400"
           aria-hidden="true"
         />
-        <p className="text-gray-600 dark:text-gray-400">Loading worktree...</p>
+        <p className="text-muted-foreground">Loading worktree...</p>
       </div>
     </div>
   );
@@ -969,13 +982,14 @@ export const ErrorDisplay = memo(function ErrorDisplay({
         <p className="text-red-600 font-medium">Error loading worktree</p>
         <p className="text-red-500 text-sm mt-2">{message}</p>
         {onRetry && (
-          <button
+          <Button
+            variant="ghost"
             type="button"
             onClick={onRetry}
             className="mt-4 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
           >
             Retry
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/components/worktree/git/BranchCheckoutDropdown.tsx
+++ b/src/components/worktree/git/BranchCheckoutDropdown.tsx
@@ -17,7 +17,7 @@ import {
   CHECKOUT_HISTORY_LOSS_WARNING,
   CHECKOUT_RUNNING_SESSION_WARNING,
 } from '@/config/git-status-config';
-import { Checkbox } from '@/components/ui';
+import { Button, Checkbox } from '@/components/ui';
 
 interface BranchCheckoutDropdownProps {
   branches: BranchInfo[];
@@ -65,11 +65,12 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
 
   return (
     <div className="relative" data-testid="branch-checkout-dropdown">
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={() => setMenuOpen((prev) => !prev)}
         disabled={busy || options.length === 0}
-        className="flex items-center gap-1 px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-accent-700 dark:text-accent-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex items-center gap-1 px-2 py-1 text-xs rounded border border-input text-accent-700 dark:text-accent-300 hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
         data-testid="branch-checkout-dropdown-toggle"
         aria-haspopup="menu"
         aria-expanded={menuOpen}
@@ -77,28 +78,29 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
       >
         Checkout
         <span aria-hidden="true" className="text-[10px]">▾</span>
-      </button>
+      </Button>
 
       {menuOpen && (
         <div
-          className="absolute left-0 top-full z-20 mt-1 min-w-[12rem] max-h-64 overflow-y-auto rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
+          className="absolute left-0 top-full z-20 mt-1 min-w-[12rem] max-h-64 overflow-y-auto rounded border border-border bg-surface shadow-lg"
           role="menu"
           data-testid="branch-checkout-menu"
         >
           {options.length === 0 ? (
-            <div className="px-3 py-1.5 text-xs text-gray-400 dark:text-gray-500">No branches</div>
+            <div className="px-3 py-1.5 text-xs text-muted-foreground">No branches</div>
           ) : (
-            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+            <ul className="divide-y divide-border">
               {options.map((branch) => {
                 const checkedOutElsewhere = branch.checkedOutWorktreePath !== null;
                 return (
                   <li key={`${branch.isRemote ? 'r' : 'l'}:${branch.name}`}>
+                    {/* Issue #1061: full-width left-aligned menu row — 残置 */}
                     <button
                       type="button"
                       role="menuitem"
                       onClick={() => openCheckout(branch)}
                       disabled={busy || checkedOutElsewhere}
-                      className="w-full text-left px-3 py-1.5 font-mono text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full text-left px-3 py-1.5 font-mono text-xs text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
                       aria-label={`Checkout ${branch.name}`}
                       title={
                         checkedOutElsewhere
@@ -108,7 +110,7 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
                     >
                       {branch.name}
                       {branch.isDefault && (
-                        <span className="ml-1.5 text-[10px] text-gray-400 dark:text-gray-500">default</span>
+                        <span className="ml-1.5 text-[10px] text-muted-foreground">default</span>
                       )}
                     </button>
                   </li>
@@ -137,8 +139,8 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
           aria-modal="true"
           data-testid="branch-checkout-confirm"
         >
-          <div className="w-full max-w-md rounded-lg bg-white dark:bg-gray-800 p-4 shadow-xl flex flex-col gap-3">
-            <h3 className="text-sm font-medium text-gray-800 dark:text-gray-200">
+          <div className="w-full max-w-md rounded-lg bg-surface p-4 shadow-xl flex flex-col gap-3">
+            <h3 className="text-sm font-medium text-foreground">
               Checkout <span className="font-mono">{checkoutTarget.name}</span>?
             </h3>
 
@@ -162,7 +164,7 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
               </div>
             )}
 
-            <label className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <Checkbox
                 checked={checkoutForce}
                 onCheckedChange={(checked) => setCheckoutForce(checked === true)}
@@ -172,14 +174,16 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
             </label>
 
             <div className={`flex items-center justify-end gap-2 ${isMobile ? 'flex-wrap' : ''}`}>
-              <button
+              <Button
+                variant="ghost"
                 type="button"
                 onClick={() => setCheckoutTarget(null)}
-                className="px-3 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+                className="px-3 py-1 text-xs rounded border border-input text-foreground hover:bg-muted"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="ghost"
                 type="button"
                 onClick={confirmCheckout}
                 disabled={busy}
@@ -187,7 +191,7 @@ export const BranchCheckoutDropdown = memo(function BranchCheckoutDropdown({
                 data-testid="branch-checkout-confirm-button"
               >
                 Checkout
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/components/worktree/git/GitPaneMobileTabs.tsx
+++ b/src/components/worktree/git/GitPaneMobileTabs.tsx
@@ -76,11 +76,12 @@ export const GitPaneMobileTabs = memo(function GitPaneMobileTabs({
       role="tablist"
       aria-label="Git pane sections"
       data-testid="git-pane-mobile-tabs"
-      className="flex shrink-0 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 sticky top-0 z-30"
+      className="flex shrink-0 border-b border-border bg-surface sticky top-0 z-30"
     >
       {GIT_PANE_TABS.map((tab) => {
         const isActive = tab === activeTab;
         return (
+          // Issue #1061: segmented tab (role=tab/aria-selected) — 残置
           <button
             key={tab}
             type="button"
@@ -92,7 +93,7 @@ export const GitPaneMobileTabs = memo(function GitPaneMobileTabs({
             className={`flex flex-1 flex-col items-center justify-center gap-1 py-2 px-1 text-xs transition-colors border-b-2 ${
               isActive
                 ? 'text-accent-600 dark:text-accent-400 border-accent-500 bg-accent-50 dark:bg-accent-900/30'
-                : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted'
             }`}
           >
             <TabIcon path={ICON_PATHS[tab]} />


### PR DESCRIPTION
#1061 分割並列 **群B (2/4)**。21ファイルの生gray→トークン / button→ui/Button。ターミナル出力面はダーク維持。挙動不変。lint/tsc pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)