### PR TITLE
fix(external-apps): 重複nameで500ではなく409を返す (#1104)

### DIFF
--- a/src/app/api/external-apps/route.ts
+++ b/src/app/api/external-apps/route.ts
@@ -14,6 +14,7 @@ import {
   getAllExternalApps,
   createExternalApp,
   getExternalAppByPathPrefix,
+  ExternalAppDbError,
 } from '@/lib/external-apps/db';
 import { getExternalAppCache } from '@/lib/external-apps/cache';
 import { validateCreateInput } from '@/lib/external-apps/validation';
@@ -99,8 +100,10 @@ export async function POST(request: Request) {
 
       return NextResponse.json({ app }, { status: 201 });
     } catch (dbError) {
-      // Check for unique constraint violation (duplicate name)
-      if (dbError instanceof Error && dbError.message.includes('UNIQUE constraint')) {
+      // Check for unique constraint violation (duplicate name or pathPrefix).
+      // createExternalApp wraps the raw SQLite error into an ExternalAppDbError
+      // with code 'DUPLICATE', so inspect the typed error rather than its message.
+      if (dbError instanceof ExternalAppDbError && dbError.code === 'DUPLICATE') {
         return NextResponse.json(
           { error: `An app with name "${input.name}" or pathPrefix "${input.pathPrefix}" already exists` },
           { status: 409 }

--- a/tests/integration/external-apps-api.test.ts
+++ b/tests/integration/external-apps-api.test.ts
@@ -221,17 +221,9 @@ describe('External Apps API', () => {
       expect(data.error).toContain('pathPrefix');
     });
 
-    // QUARANTINED (Issue #1102): this asserts correct behavior but catches a REAL
-    // product bug, not test drift. lib/external-apps/db.ts re-wraps the SQLite
-    // "UNIQUE constraint" error into an ExternalAppDbError (code: 'DUPLICATE') whose
-    // message no longer contains "UNIQUE constraint", so the route's
-    // `dbError.message.includes('UNIQUE constraint')` check (external-apps/route.ts)
-    // no longer matches → a duplicate name returns 500 instead of 409. The route
-    // should check `err instanceof ExternalAppDbError && err.code === 'DUPLICATE'`.
-    // Fixing that is a production change, out of this test-drift issue's scope.
-    // Duplicate pathPrefix still returns 409 (handled by a pre-check), so that
-    // sibling test remains active. Un-skip once the route is fixed.
-    it.skip('should return 409 for duplicate name', async () => {
+    // Fixed in #1104: route now checks ExternalAppDbError.code === 'DUPLICATE'
+    // (was quarantined in #1102 because the route returned 500 for a duplicate name).
+    it('should return 409 for duplicate name', async () => {
       // Create initial app
       createExternalApp(db, {
         name: 'existing-app',


### PR DESCRIPTION
Closes #1104。

## 修正
- `route.ts`: catch の重複判定を `message.includes('UNIQUE constraint')`(ラップ後に外れ 500 化)から **`dbError instanceof ExternalAppDbError && dbError.code === 'DUPLICATE'`** の型/コード判定へ。`ExternalAppDbError` を import。
- #1102 で quarantine した `should return 409 for duplicate name` を **un-skip**（#1104 で修正済み）。

## 検証
- ✅ 重複 name → **409**（duplicate pathPrefix も 409 のまま回帰なし）
- ✅ **test:integration 644 passed / 0 failed / 0 skipped**（最後の quarantine 解消）
- ✅ test:unit 8761 / lint / tsc 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)