### PR TITLE
feat(timer): Timer履歴の詳細モーダル表示と失敗理由の記録 (#1107)

### DIFF
--- a/locales/en/schedule.json
+++ b/locales/en/schedule.json
@@ -159,6 +159,12 @@
     "loadMore": "Load more",
     "clearHistory": "Clear history",
     "clearConfirm": "Delete all sent, failed, and cancelled timer history?",
-    "cleared": "History cleared ({count} items)"
+    "cleared": "History cleared ({count} items)",
+    "detailTitle": "Timer Details",
+    "statusLabel": "Status",
+    "scheduledTime": "Scheduled Send",
+    "createdTime": "Created",
+    "sentTime": "Sent",
+    "failureReason": "Failure Reason"
   }
 }

--- a/locales/ja/schedule.json
+++ b/locales/ja/schedule.json
@@ -159,6 +159,12 @@
     "loadMore": "もっと見る",
     "clearHistory": "履歴クリア",
     "clearConfirm": "送信済み・失敗・キャンセル済みのタイマー履歴をすべて削除しますか？",
-    "cleared": "履歴を削除しました（{count}件）"
+    "cleared": "履歴を削除しました（{count}件）",
+    "detailTitle": "タイマー詳細",
+    "statusLabel": "ステータス",
+    "scheduledTime": "予定送信時刻",
+    "createdTime": "作成時刻",
+    "sentTime": "送信時刻",
+    "failureReason": "失敗理由"
   }
 }

--- a/src/app/api/worktrees/[id]/timers/route.ts
+++ b/src/app/api/worktrees/[id]/timers/route.ts
@@ -214,6 +214,7 @@ export async function GET(
         status: t.status,
         createdAt: t.createdAt,
         sentAt: t.sentAt,
+        error: t.error,
       })),
       hasMore,
     });

--- a/src/components/worktree/TimerPane.tsx
+++ b/src/components/worktree/TimerPane.tsx
@@ -28,6 +28,7 @@ import type { CLIToolType, AgentInstance } from '@/lib/cli-tools/types';
 import { CLI_TOOL_IDS, agentInstancesFromSelectedAgents } from '@/lib/cli-tools/types';
 import { formatDelayLabel } from './timers/timer-format';
 import { TimerEditDialog } from './timers/TimerEditDialog';
+import { TimerDetailModal, type TimerItem } from './timers/TimerDetailModal';
 
 // =============================================================================
 // Types
@@ -45,18 +46,7 @@ interface TimerPaneProps {
   selectedAgents?: CLIToolType[];
 }
 
-interface TimerItem {
-  id: string;
-  cliToolId: string;
-  /** Target agent instance (Issue #942). Legacy rows fall back to cliToolId. */
-  instanceId: string;
-  message: string;
-  delayMs: number;
-  scheduledSendTime: number;
-  status: string;
-  createdAt: number;
-  sentAt: number | null;
-}
+// TimerItem is shared with TimerDetailModal (includes the Issue #1107 `error`).
 
 // =============================================================================
 // Helpers
@@ -94,6 +84,7 @@ export const TimerPane = memo(function TimerPane({ worktreeId, instances }: Time
   const [timers, setTimers] = useState<TimerItem[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedTimer, setSelectedTimer] = useState<TimerItem | null>(null);
   const [, setTick] = useState(0); // Force re-render for countdown
 
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -276,7 +267,17 @@ export const TimerPane = memo(function TimerPane({ worktreeId, instances }: Time
           {timers.map((timer) => (
             <div
               key={timer.id}
-              className="flex items-center gap-2 p-2 rounded-lg border border-border bg-surface"
+              role="button"
+              tabIndex={0}
+              data-testid="timer-row"
+              onClick={() => setSelectedTimer(timer)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setSelectedTimer(timer);
+                }
+              }}
+              className="flex items-center gap-2 p-2 rounded-lg border border-border bg-surface text-left cursor-pointer hover:bg-muted transition-colors"
             >
               <div className="flex-1 min-w-0">
                 <div className="text-sm text-foreground truncate">
@@ -303,7 +304,11 @@ export const TimerPane = memo(function TimerPane({ worktreeId, instances }: Time
               {timer.status === 'pending' && (
                 <button
                   type="button"
-                  onClick={() => handleCancel(timer.id)}
+                  onClick={(e) => {
+                    // Row click opens the detail modal; keep cancel isolated.
+                    e.stopPropagation();
+                    void handleCancel(timer.id);
+                  }}
                   className="px-2 py-1 text-xs text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded transition-colors"
                 >
                   {t('timer.cancel')}
@@ -342,6 +347,12 @@ export const TimerPane = memo(function TimerPane({ worktreeId, instances }: Time
         instances={instances}
         onClose={() => setDialogOpen(false)}
         onSaved={() => { void fetchTimers(); }}
+      />
+
+      <TimerDetailModal
+        timer={selectedTimer}
+        instances={resolvedInstances}
+        onClose={() => setSelectedTimer(null)}
       />
     </div>
   );

--- a/src/components/worktree/timers/TimerDetailModal.tsx
+++ b/src/components/worktree/timers/TimerDetailModal.tsx
@@ -1,0 +1,172 @@
+/**
+ * TimerDetailModal Component
+ * Issue #1107: Timer履歴の詳細モーダル表示と失敗理由の記録
+ *
+ * Opened by clicking a history row in TimerPane. Shows the full instruction
+ * message (no 60-char truncation), the target instance, delay / scheduled time,
+ * created / sent timestamps, status, and — for `failed` timers — the persisted
+ * failure reason (`error`). Mirrors ExecutionLogsView's failure detail on the
+ * Schedule side; the `error` string is shown verbatim.
+ *
+ * PC = `@/components/ui/Modal`, mobile = `FullScreenModal` (via `useIsMobile()`),
+ * matching TimerEditDialog so the history detail has no mobile regression.
+ */
+
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { Modal } from '@/components/ui/Modal';
+import { FullScreenModal } from '@/components/common/FullScreenModal';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import type { AgentInstance } from '@/lib/cli-tools/types';
+import { formatDelayLabel } from './timer-format';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Timer row shape shared with TimerPane's list (Issue #1107 adds `error`). */
+export interface TimerItem {
+  id: string;
+  cliToolId: string;
+  /** Target agent instance (Issue #942). Legacy rows fall back to cliToolId. */
+  instanceId: string;
+  message: string;
+  delayMs: number;
+  scheduledSendTime: number;
+  status: string;
+  createdAt: number;
+  sentAt: number | null;
+  /** Failure reason for `failed` timers (Issue #1107). NULL otherwise. */
+  error: string | null;
+}
+
+export interface TimerDetailModalProps {
+  /** Selected timer to show; when null the modal is closed. */
+  timer: TimerItem | null;
+  /** Resolved agent roster, used to render the instance alias. */
+  instances: AgentInstance[];
+  onClose: () => void;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case 'pending': return 'text-info';
+    case 'sending': return 'text-yellow-600 dark:text-yellow-400';
+    case 'sent': return 'text-green-600 dark:text-green-400';
+    case 'failed': return 'text-red-600 dark:text-red-400';
+    case 'cancelled': return 'text-muted-foreground';
+    case 'no_session': return 'text-orange-600 dark:text-orange-400';
+    default: return 'text-muted-foreground';
+  }
+}
+
+/** Format a unix-millis timestamp using the viewer's locale. */
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function TimerDetailModal({ timer, instances, onClose }: TimerDetailModalProps) {
+  const t = useTranslations('schedule');
+  const isMobile = useIsMobile();
+
+  if (!timer) return null;
+
+  const instanceLabel =
+    instances.find((inst) => inst.id === timer.instanceId)?.alias ?? timer.cliToolId;
+
+  const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+      <div className="text-xs font-semibold text-muted-foreground mb-0.5">{label}</div>
+      <div className="text-sm text-foreground break-words">{children}</div>
+    </div>
+  );
+
+  const body = (
+    <div className="flex flex-col gap-3" data-testid="timer-detail-body">
+      {/* Full instruction message (no truncation) */}
+      <div>
+        <div className="text-xs font-semibold text-muted-foreground mb-1">{t('timer.message')}</div>
+        <pre
+          data-testid="timer-detail-message"
+          className="text-sm whitespace-pre-wrap break-words font-mono text-foreground bg-muted rounded p-2 max-h-60 overflow-y-auto"
+        >
+          {timer.message}
+        </pre>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label={t('timer.agent')}>
+          <span className="text-accent-600 dark:text-accent-400 font-medium">{instanceLabel}</span>
+        </Field>
+        <Field label={t('timer.statusLabel')}>
+          <span className={getStatusColor(timer.status)}>{t(`timer.status.${timer.status}`)}</span>
+        </Field>
+        <Field label={t('timer.delay')}>{formatDelayLabel(timer.delayMs)}</Field>
+        <Field label={t('timer.scheduledTime')}>{formatTimestamp(timer.scheduledSendTime)}</Field>
+        <Field label={t('timer.createdTime')}>{formatTimestamp(timer.createdAt)}</Field>
+        {timer.sentAt !== null && (
+          <Field label={t('timer.sentTime')}>{formatTimestamp(timer.sentAt)}</Field>
+        )}
+      </div>
+
+      {/* Failure reason: only for failed timers that recorded one. */}
+      {timer.status === 'failed' && timer.error && (
+        <div>
+          <div className="text-xs font-semibold text-red-600 dark:text-red-400 mb-1">
+            {t('timer.failureReason')}
+          </div>
+          <pre
+            data-testid="timer-detail-error"
+            className="text-xs whitespace-pre-wrap break-words font-mono text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded p-2 max-h-40 overflow-y-auto"
+          >
+            {timer.error}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+
+  const footer = (
+    <div className="flex items-center justify-end">
+      <button
+        type="button"
+        data-testid="timer-detail-close"
+        onClick={onClose}
+        className="px-4 py-2 text-sm font-medium text-foreground hover:bg-muted rounded-md transition-colors"
+      >
+        {t('timer.close')}
+      </button>
+    </div>
+  );
+
+  const title = t('timer.detailTitle');
+
+  if (isMobile) {
+    return (
+      <FullScreenModal isOpen title={title} onClose={onClose} footer={footer}>
+        {body}
+      </FullScreenModal>
+    );
+  }
+
+  return (
+    <Modal isOpen title={title} onClose={onClose} size="md">
+      <div className="flex flex-col gap-4">
+        {body}
+        <div className="pt-2 border-t border-border">{footer}</div>
+      </div>
+    </Modal>
+  );
+}
+
+export default TimerDetailModal;

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -22,6 +22,7 @@ import { v36_migrations } from './v36-worktree-branch';
 import { v37_migrations } from './v37-worktree-todos';
 import { v38_migrations } from './v38-worktree-todo-status';
 import { v39_migrations } from './v39-worktree-todo-detail';
+import { v40_migrations } from './v40-timer-error';
 
 /**
  * Complete ordered list of all migrations.
@@ -49,4 +50,5 @@ export const migrations: Migration[] = [
   ...v37_migrations,
   ...v38_migrations,
   ...v39_migrations,
+  ...v40_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 39;
+export const CURRENT_SCHEMA_VERSION = 40;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v40-timer-error.ts
+++ b/src/lib/db/migrations/v40-timer-error.ts
@@ -1,0 +1,32 @@
+/** Migration v40: Add error column to timer_messages (Issue #1107).
+ *
+ * Timer (Issue #534) records a one-shot delayed send. On failure it only flips
+ * `status` to 'failed' and logs the real reason server-side, so the UI can show
+ * nothing but a red "Failed" label. Mirroring the Schedule side's
+ * `execution_logs.result` (Issue #481), we add a nullable `error` column so the
+ * failure reason is persisted, returned by the API, and shown in the detail modal.
+ *
+ * Backward compatibility: the column is nullable with no backfill — existing
+ * rows keep `error = NULL`, which the UI treats as "no reason recorded".
+ */
+
+import type { Migration } from './runner';
+
+export const v40_migrations: Migration[] = [
+  {
+    version: 40,
+    name: 'add-error-to-timer-messages',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE timer_messages ADD COLUMN error TEXT;
+      `);
+
+      console.log('Added error column to timer_messages table');
+    },
+    down: () => {
+      // SQLite cannot drop a column without a table rebuild; no-op rollback
+      // (mirrors the v35 instance_id migration).
+      console.log('No rollback for error column (SQLite limitation)');
+    },
+  },
+];

--- a/src/lib/db/timer-db.ts
+++ b/src/lib/db/timer-db.ts
@@ -31,6 +31,11 @@ export interface TimerMessage {
   status: TimerStatus;
   createdAt: number;
   sentAt: number | null;
+  /**
+   * Failure reason for `failed` timers (Issue #1107). NULL for every other
+   * status and for rows created before the v40 migration.
+   */
+  error: string | null;
 }
 
 /** Parameters for creating a new timer */
@@ -68,6 +73,8 @@ interface TimerMessageRow {
   status: string;
   created_at: number;
   sent_at: number | null;
+  /** Nullable failure reason (Issue #1107). NULL for pre-v40 rows. */
+  error: string | null;
 }
 
 // =============================================================================
@@ -75,7 +82,16 @@ interface TimerMessageRow {
 // =============================================================================
 
 /** SELECT column list for timer_messages queries */
-const TIMER_COLUMNS = 'id, worktree_id, cli_tool_id, instance_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at';
+const TIMER_COLUMNS = 'id, worktree_id, cli_tool_id, instance_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at, error';
+
+/**
+ * Fixed reason stored on timers recovered from a stuck 'sending' state after a
+ * server restart (Issue #1107). The original failure reason is unknowable at
+ * recovery time, so a stable English marker is used (shown verbatim in the UI,
+ * mirroring the Schedule side's raw `result`).
+ */
+export const STUCK_SENDING_RECOVERY_ERROR =
+  "Recovered from a stuck 'sending' state after a server restart.";
 
 // =============================================================================
 // Row Mapping
@@ -96,6 +112,7 @@ function mapRow(row: TimerMessageRow): TimerMessage {
     status: row.status as TimerStatus,
     createdAt: row.created_at,
     sentAt: row.sent_at,
+    error: row.error ?? null,
   };
 }
 
@@ -144,6 +161,8 @@ export function createTimer(
     status: 'pending',
     createdAt: now,
     sentAt: null,
+    // error column defaults to NULL (not listed in the INSERT above).
+    error: null,
   };
 }
 
@@ -210,23 +229,33 @@ export function getPendingTimers(
 }
 
 /**
- * Update timer status. Optionally set sentAt timestamp.
+ * Update timer status. Optionally set sentAt timestamp and/or a failure reason.
+ *
+ * Issue #1107: `error` is a trailing optional argument so existing 3-arg
+ * (status-only) and 4-arg (status + sentAt) call sites are unchanged. Only the
+ * `failed` transition passes a reason; it is written to the `error` column.
  */
 export function updateTimerStatus(
   db: Database.Database,
   id: string,
   status: TimerStatus,
-  sentAt?: number
+  sentAt?: number,
+  error?: string
 ): void {
+  const sets: string[] = ['status = ?'];
+  const params: (string | number)[] = [status];
+
   if (sentAt !== undefined) {
-    db.prepare(`
-      UPDATE timer_messages SET status = ?, sent_at = ? WHERE id = ?
-    `).run(status, sentAt, id);
-  } else {
-    db.prepare(`
-      UPDATE timer_messages SET status = ? WHERE id = ?
-    `).run(status, id);
+    sets.push('sent_at = ?');
+    params.push(sentAt);
   }
+  if (error !== undefined) {
+    sets.push('error = ?');
+    params.push(error);
+  }
+
+  params.push(id);
+  db.prepare(`UPDATE timer_messages SET ${sets.join(', ')} WHERE id = ?`).run(...params);
 }
 
 /**
@@ -321,9 +350,11 @@ export function clearTimerHistory(
 export function recoverStuckSendingTimers(
   db: Database.Database
 ): number {
+  // Issue #1107: record a stable recovery reason so the failure is explainable
+  // in the detail modal (the true cause is lost across the restart).
   const result = db.prepare(`
-    UPDATE timer_messages SET status = 'failed' WHERE status = 'sending'
-  `).run();
+    UPDATE timer_messages SET status = 'failed', error = ? WHERE status = 'sending'
+  `).run(STUCK_SENDING_RECOVERY_ERROR);
 
   return result.changes;
 }

--- a/src/lib/timer-manager.ts
+++ b/src/lib/timer-manager.ts
@@ -109,7 +109,10 @@ async function executeTimer(timerId: string): Promise<void> {
     });
 
     if (!result.ok) {
-      updateTimerStatus(db, timerId, 'failed');
+      // [Issue #1107] Persist the failure reason so the detail modal can show
+      // it (previously logged server-side only).
+      const reason = `[${result.stage}] ${result.error}`;
+      updateTimerStatus(db, timerId, 'failed', undefined, reason);
       logger.error('timer:send-failed', { timerId, stage: result.stage, error: result.error });
       return;
     }
@@ -120,7 +123,8 @@ async function executeTimer(timerId: string): Promise<void> {
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     try {
-      updateTimerStatus(db, timerId, 'failed');
+      // [Issue #1107] Persist the thrown error message as the failure reason.
+      updateTimerStatus(db, timerId, 'failed', undefined, msg);
     } catch {
       // DB update failure is non-fatal
     }

--- a/tests/unit/components/worktree/TimerPane.test.tsx
+++ b/tests/unit/components/worktree/TimerPane.test.tsx
@@ -24,6 +24,7 @@ interface FakeTimer {
   status: string;
   createdAt: number;
   sentAt: number | null;
+  error: string | null;
 }
 
 function makeTimer(overrides: Partial<FakeTimer> = {}): FakeTimer {
@@ -37,6 +38,7 @@ function makeTimer(overrides: Partial<FakeTimer> = {}): FakeTimer {
     status: 'pending',
     createdAt: 1_700_000_000_000,
     sentAt: null,
+    error: null,
     ...overrides,
   };
 }
@@ -109,5 +111,62 @@ describe('TimerPane (Issue #945)', () => {
     await waitFor(() => expect(screen.getByTestId('timer-new-button')).toBeDefined());
     expect((screen.getByTestId('timer-new-button') as HTMLButtonElement).disabled).toBe(true);
     expect(screen.getByText('schedule.timer.maxReached')).toBeDefined();
+  });
+});
+
+describe('TimerPane detail modal (Issue #1107)', () => {
+  const longMessage = 'x'.repeat(80); // > 60 chars so the list row truncates
+
+  it('opens the detail modal with the full message when a row is clicked', async () => {
+    stubTimers([makeTimer({ status: 'sent', sentAt: 1_700_000_100_000, message: longMessage })]);
+    render(<TimerPane worktreeId="wt-1" />);
+    await waitFor(() => expect(screen.getByTestId('timer-row')).toBeDefined());
+
+    // Modal is closed initially.
+    expect(screen.queryByTestId('timer-detail-message')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('timer-row'));
+
+    const detail = screen.getByTestId('timer-detail-message');
+    expect(detail.textContent).toBe(longMessage); // full, not truncated
+  });
+
+  it('shows the failure reason for a failed timer', async () => {
+    stubTimers([
+      makeTimer({ status: 'failed', error: '[send] tmux session not found' }),
+    ]);
+    render(<TimerPane worktreeId="wt-1" />);
+    await waitFor(() => expect(screen.getByTestId('timer-row')).toBeDefined());
+
+    fireEvent.click(screen.getByTestId('timer-row'));
+
+    expect(screen.getByText('schedule.timer.failureReason')).toBeDefined();
+    expect(screen.getByTestId('timer-detail-error').textContent).toBe('[send] tmux session not found');
+  });
+
+  it('does not show a failure reason section for non-failed timers', async () => {
+    stubTimers([makeTimer({ status: 'sent', sentAt: 1_700_000_100_000 })]);
+    render(<TimerPane worktreeId="wt-1" />);
+    await waitFor(() => expect(screen.getByTestId('timer-row')).toBeDefined());
+
+    fireEvent.click(screen.getByTestId('timer-row'));
+
+    expect(screen.queryByTestId('timer-detail-error')).toBeNull();
+  });
+
+  it('does not open the modal when the pending cancel button is clicked', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ timers: [makeTimer({ status: 'pending' })], hasMore: false }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    render(<TimerPane worktreeId="wt-1" />);
+    await waitFor(() => expect(screen.getByTestId('timer-row')).toBeDefined());
+
+    // Click the cancel button nested inside the clickable row.
+    fireEvent.click(screen.getByText('schedule.timer.cancel'));
+
+    // stopPropagation prevents the row's onClick → modal stays closed.
+    expect(screen.queryByTestId('timer-detail-message')).toBeNull();
   });
 });

--- a/tests/unit/db/migration-v40-timer-error.test.ts
+++ b/tests/unit/db/migration-v40-timer-error.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for migration v40 (timer_messages.error, Issue #1107).
+ *
+ * Three angles:
+ *  1. Fresh DB end state — the full migration chain adds a nullable `error`
+ *     column to timer_messages.
+ *  2. Harmless migration — applying v40.up() over a v35-shaped table leaves
+ *     existing rows with error = NULL (no data loss).
+ *  3. Idempotency — re-running the migration chain is a no-op (runner-level).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations, CURRENT_SCHEMA_VERSION, getCurrentVersion } from '@/lib/db/db-migrations';
+import { v40_migrations } from '@/lib/db/migrations/v40-timer-error';
+
+interface ColumnInfo { name: string; notnull: number; dflt_value: string | null }
+
+function columns(db: Database.Database, table: string): ColumnInfo[] {
+  return db.pragma(`table_info(${table})`) as ColumnInfo[];
+}
+
+describe('migration v40: fresh DB end state', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('brings the schema to v40', () => {
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(40);
+  });
+
+  it('adds a nullable error column (TEXT, not NOT NULL)', () => {
+    const errorCol = columns(db, 'timer_messages').find((c) => c.name === 'error');
+    expect(errorCol).toBeDefined();
+    expect(errorCol!.notnull).toBe(0);
+  });
+
+  it('keeps the existing timer columns alongside error', () => {
+    const names = columns(db, 'timer_messages').map((c) => c.name);
+    expect(names).toContain('message');
+    expect(names).toContain('status');
+    expect(names).toContain('instance_id');
+    expect(names).toContain('error');
+  });
+});
+
+describe('migration v40: harmless migration over existing rows', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    // Reconstruct a v35-shaped table (no error column) to exercise up().
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE timer_messages (
+        id TEXT PRIMARY KEY,
+        worktree_id TEXT NOT NULL,
+        cli_tool_id TEXT NOT NULL,
+        instance_id TEXT,
+        message TEXT NOT NULL,
+        delay_ms INTEGER NOT NULL,
+        scheduled_send_time INTEGER NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at INTEGER NOT NULL,
+        sent_at INTEGER
+      );
+    `);
+    db.prepare(`
+      INSERT INTO timer_messages (id, worktree_id, cli_tool_id, instance_id, message, delay_ms, scheduled_send_time, status, created_at, sent_at)
+      VALUES ('existing', 'wt-1', 'claude', 'claude', 'legacy', 300000, 9999999999999, 'failed', 1, NULL)
+    `).run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('backfills existing rows with error = NULL (no data loss)', () => {
+    v40_migrations[0].up(db);
+
+    const row = db
+      .prepare('SELECT id, message, status, error FROM timer_messages WHERE id = ?')
+      .get('existing') as { id: string; message: string; status: string; error: string | null };
+
+    expect(row.message).toBe('legacy');
+    expect(row.status).toBe('failed');
+    expect(row.error).toBeNull();
+  });
+});
+
+describe('migration v40: idempotency via runner', () => {
+  it('re-running runMigrations is a no-op', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    expect(() => runMigrations(db)).not.toThrow();
+    const names = columns(db, 'timer_messages').map((c) => c.name);
+    expect(names).toContain('error');
+    db.close();
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 39 after Migration #39 (worktree todo detail)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(39);
+    it('should be 40 after Migration #40 (timer error column)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(40);
     });
   });
 

--- a/tests/unit/lib/db/timer-db.test.ts
+++ b/tests/unit/lib/db/timer-db.test.ts
@@ -37,7 +37,7 @@ function setupTestDb(): Database.Database {
     );
   `);
 
-  // Create timer_messages table (v23 migration + v35 instance_id, Issue #942)
+  // Create timer_messages table (v23 migration + v35 instance_id + v40 error)
   testDb.exec(`
     CREATE TABLE timer_messages (
       id TEXT PRIMARY KEY,
@@ -50,6 +50,7 @@ function setupTestDb(): Database.Database {
       status TEXT NOT NULL DEFAULT 'pending',
       created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
       sent_at INTEGER,
+      error TEXT,
       FOREIGN KEY (worktree_id) REFERENCES worktrees(id) ON DELETE CASCADE
     );
 
@@ -243,6 +244,62 @@ describe('timer-db', () => {
 
       const updated = getTimerById(db, timer.id);
       expect(updated!.status).toBe('failed');
+    });
+  });
+
+  // ==========================================================================
+  // Issue #1107: error column (failure reason persistence)
+  // ==========================================================================
+
+  describe('error column (Issue #1107)', () => {
+    it('should default error to null on createTimer', () => {
+      const timer = createTimer(db, { worktreeId: 'wt-1', cliToolId: 'claude', message: 'Test', delayMs: 300000 });
+
+      expect(timer.error).toBeNull();
+      const fetched = getTimerById(db, timer.id);
+      expect(fetched!.error).toBeNull();
+    });
+
+    it('should persist error when updateTimerStatus is called with a reason', () => {
+      const timer = createTimer(db, { worktreeId: 'wt-1', cliToolId: 'claude', message: 'Test', delayMs: 300000 });
+
+      updateTimerStatus(db, timer.id, 'failed', undefined, '[send] tmux session not found');
+
+      const updated = getTimerById(db, timer.id);
+      expect(updated!.status).toBe('failed');
+      expect(updated!.error).toBe('[send] tmux session not found');
+    });
+
+    it('should leave error null for non-failed transitions (backward compatible calls)', () => {
+      const timer = createTimer(db, { worktreeId: 'wt-1', cliToolId: 'claude', message: 'Test', delayMs: 300000 });
+
+      // 3-arg and 4-arg calls (sending/sent) never touch error.
+      updateTimerStatus(db, timer.id, 'sending');
+      updateTimerStatus(db, timer.id, 'sent', Date.now());
+
+      const updated = getTimerById(db, timer.id);
+      expect(updated!.status).toBe('sent');
+      expect(updated!.error).toBeNull();
+    });
+
+    it('should expose the error column through getTimersByWorktree', () => {
+      const timer = createTimer(db, { worktreeId: 'wt-1', cliToolId: 'claude', message: 'Test', delayMs: 300000 });
+      updateTimerStatus(db, timer.id, 'failed', undefined, 'boom');
+
+      const [row] = getTimersByWorktree(db, 'wt-1');
+      expect(row.error).toBe('boom');
+    });
+
+    it('should set a recovery reason when recovering stuck sending timers', () => {
+      const timer = createTimer(db, { worktreeId: 'wt-1', cliToolId: 'claude', message: 'Test', delayMs: 300000 });
+      updateTimerStatus(db, timer.id, 'sending');
+
+      recoverStuckSendingTimers(db);
+
+      const updated = getTimerById(db, timer.id);
+      expect(updated!.status).toBe('failed');
+      expect(updated!.error).toBeTruthy();
+      expect(typeof updated!.error).toBe('string');
     });
   });
 

--- a/tests/unit/lib/timer-manager.test.ts
+++ b/tests/unit/lib/timer-manager.test.ts
@@ -405,10 +405,14 @@ describe('timer-manager', () => {
 
       await vi.advanceTimersByTimeAsync(200);
 
+      // [Issue #1107] failed transition now persists the reason as the 5th arg
+      // (sentAt=undefined, error="[stage] message").
       expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
         expect.anything(),
         timerId,
-        'failed'
+        'failed',
+        undefined,
+        '[send] tmux session not found'
       );
       // Must NOT mark as sent when the send failed
       expect(mockUpdateTimerStatus).not.toHaveBeenCalledWith(
@@ -448,10 +452,13 @@ describe('timer-manager', () => {
 
       await vi.advanceTimersByTimeAsync(200);
 
+      // [Issue #1107] thrown error message is persisted as the failure reason.
       expect(mockUpdateTimerStatus).toHaveBeenCalledWith(
         expect.anything(),
         timerId,
-        'failed'
+        'failed',
+        undefined,
+        'createMessage failed'
       );
     });
   });


### PR DESCRIPTION
## 概要
Issue #1107 の実装。Schedule 側の `execution_logs`（result/exit_code を ExecutionLogsView で表示）方式を Timer へ横展開し、履歴の追跡性を改善する。

## 変更内容
- **DB**: migration `v40-timer-error.ts` で `timer_messages` に `error`(TEXT, nullable) 列を追加、schema 39→40
- **timer-db**: `error` 列の read/write 貫通、`updateTimerStatus` に optional `error` 引数（既存呼び出しは不変）、`recoverStuckSendingTimers` に固定リカバリ理由
- **timer-manager**: 送信失敗(stage/error)・例外(error.message)を `error` 列へ永続化（no_session は保存せず）
- **API**: GET timers レスポンスに `error` を追加
- **UI**: `TimerDetailModal` 新設。履歴行クリックで指示全文＋メタ＋失敗理由を表示（PC=Modal / mobile=FullScreenModal）。pending のキャンセルボタンは stopPropagation でモーダルを開かない
- **i18n**: `schedule.json` の timer ブロックに en/ja lockstep でラベル追加

## 決定事項の反映
- 失敗タイマーの30日自動削除は現状維持（対象から外さない）
- 指示全文の見せ方は詳細モーダル

## 品質ゲート（worker報告＋orchestrator独立検証）
- tsc --noEmit: ✅ 0 errors（独立再検証済み）
- lint: ✅ 0 warnings/errors（独立再検証済み）
- test:unit: ✅ 8775 passed（worker）
- i18n parity: ✅ 52 passed（worker）
- build: ✅ 成功（worker）

Refs #1107