### PR TITLE
feat(files): Filesツリー展開状態のworktree単位永続化と表示リセット (#1108)

### DIFF
--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -28,8 +28,9 @@ import { computeMatchedPaths } from '@/lib/utils';
 import { useFilePolling } from '@/hooks/useFilePolling';
 import { useFileMetadataDisplay } from '@/hooks/useFileMetadataDisplay';
 import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
+import { useFileTreeExpandedState } from '@/hooks/useFileTreeExpandedState';
 import { useLocale } from 'next-intl';
-import { FilePlus, FolderPlus, AlertCircle, RefreshCw } from 'lucide-react';
+import { FilePlus, FolderPlus, AlertCircle, RefreshCw, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui';
 
 // ============================================================================
@@ -73,6 +74,13 @@ export interface FileTreeViewProps {
   searchResults?: SearchResultItem[];
   /** [Issue #21] Callback when a search result is selected (optional) */
   onSearchResultSelect?: (filePath: string) => void;
+  /**
+   * [Issue #1108] Called by the toolbar reset button after the tree clears its
+   * own view state (expansion / cache / scroll). The parent uses it to reset
+   * the controller-owned parts of a full reset: clear search, close open file
+   * tabs / viewer. Optional so the tree still renders without it.
+   */
+  onResetView?: () => void;
 }
 
 /** Maximum number of concurrent directory fetches during tree reload */
@@ -113,6 +121,7 @@ export const FileTreeView = memo(function FileTreeView({
   searchMode,
   searchResults,
   onSearchResultSelect,
+  onResetView,
 }: FileTreeViewProps) {
   // [Issue #162] Get locale for date formatting
   const locale = useLocale();
@@ -123,8 +132,15 @@ export const FileTreeView = memo(function FileTreeView({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rootItems, setRootItems] = useState<TreeItem[]>([]);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // [Issue #1108] Expansion set is persisted per worktree in localStorage so
+  // open folders survive activity switches / reloads / worktree round-trips.
+  const { expanded, setExpanded, resetExpanded } =
+    useFileTreeExpandedState(worktreeId);
   const [cache, setCache] = useState<Map<string, TreeItem[]>>(() => new Map());
+
+  // [Issue #1108] Ref to the scrollable tree container so the reset button can
+  // return the scroll position to the top.
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // [Issue #164] Ref to access current expanded state without adding to useEffect dependencies
   const expandedRef = useRef(expanded);
@@ -246,7 +262,7 @@ export const FileTreeView = memo(function FileTreeView({
         setLoading(false);
       }
     }
-  }, [fetchDirectory]);
+  }, [fetchDirectory, setExpanded]);
 
   useEffect(() => {
     void reloadTreeWithExpandedDirs();
@@ -390,7 +406,20 @@ export const FileTreeView = memo(function FileTreeView({
       }
       return next;
     });
-  }, []);
+  }, [setExpanded]);
+
+  /**
+   * [Issue #1108] Full view reset: return the Files view to its initial state.
+   * Resets the tree-owned parts here (expansion + persisted key, cached
+   * children, scroll position) and delegates the controller-owned parts
+   * (search, open file tabs / viewer) to `onResetView`.
+   */
+  const handleResetView = useCallback(() => {
+    resetExpanded();
+    setCache(new Map());
+    scrollContainerRef.current?.scrollTo({ top: 0 });
+    onResetView?.();
+  }, [resetExpanded, onResetView]);
 
   /**
    * [Issue #21] Compute matched paths for content search
@@ -422,7 +451,7 @@ export const FileTreeView = memo(function FileTreeView({
         return next;
       });
     }
-  }, [matchedPaths, cache, searchResults]);
+  }, [matchedPaths, cache, searchResults, setExpanded]);
 
   /**
    * [Issue #21] Filter root items based on search
@@ -573,6 +602,7 @@ export const FileTreeView = memo(function FileTreeView({
 
   return (
     <div
+      ref={scrollContainerRef}
       data-testid="file-tree-view"
       role="tree"
       aria-label="File tree"
@@ -645,6 +675,22 @@ export const FileTreeView = memo(function FileTreeView({
               className={`w-4 h-4 ${isRefetching ? 'animate-spin' : ''}`}
               aria-hidden="true"
             />
+          </button>
+          {/* [Issue #1108] Reset the Files view to its initial state: collapse
+              all folders (and drop the persisted key), clear the cache, scroll
+              to top, and clear search / open file tabs / viewer via onResetView.
+              Distinct from "更新" (refresh), which preserves expansion. Lives in
+              the always-visible toolbar so it stays reachable on touch devices. */}
+          {/* Issue #1061: dense toolbar icon control — base padding/hover-lift would change the dense feel — 残置 */}
+          <button
+            data-testid="file-tree-reset-button"
+            type="button"
+            onClick={handleResetView}
+            aria-label="Reset file tree view"
+            title="表示をリセット"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors"
+          >
+            <RotateCcw className="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -137,6 +137,8 @@ export interface WorktreeDetailDesktopProps {
   onDelete: (path: string) => void;
   onUpload: (targetDir: string) => void;
   onMove: (path: string, type: 'file' | 'directory') => void;
+  /** [Issue #1108] Reset the controller-owned Files view state (search + tabs/viewer). */
+  onFileTreeReset: () => void;
 
   // Git activity
   onDiffSelect: (diff: string, filePath: string) => void;
@@ -242,6 +244,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
   onDelete,
   onUpload,
   onMove,
+  onFileTreeReset,
   onDiffSelect,
   onAgentInstancesChange,
   vibeLocalModel,
@@ -539,6 +542,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
             onDelete={onDelete}
             onUpload={onUpload}
             onMove={onMove}
+            onResetView={onFileTreeReset}
             refreshTrigger={fileTreeRefresh}
             pollingEnabled={activeActivity === 'files'}
             searchQuery={fileSearch.query}
@@ -610,6 +614,7 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       onDelete,
       onUpload,
       onMove,
+      onFileTreeReset,
       fileTreeRefresh,
       onDiffSelect,
       handleInsertToMessage,

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -131,6 +131,8 @@ interface MobileContentProps {
   onUpload: (targetDir: string) => void;
   /** [Issue #162] Move callback */
   onMove?: (path: string, type: 'file' | 'directory') => void;
+  /** [Issue #1108] Reset the controller-owned Files view state (search + mobile viewer/editor). */
+  onFileTreeReset?: () => void;
   refreshTrigger: number;
   /** [Issue #21] File search hook return object */
   fileSearch: UseFileSearchReturn;
@@ -248,6 +250,7 @@ export const MobileContent = memo(function MobileContent({
   onDelete,
   onUpload,
   onMove,
+  onFileTreeReset,
   refreshTrigger,
   fileSearch,
   showToast,
@@ -371,6 +374,7 @@ export const MobileContent = memo(function MobileContent({
               onDelete={onDelete}
               onUpload={onUpload}
               onMove={onMove}
+              onResetView={onFileTreeReset}
               refreshTrigger={refreshTrigger}
               pollingEnabled={activeTab === 'files'}
               searchQuery={fileSearch.query}

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -215,6 +215,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     tWorktree,
     tabsActions,
     tabsState,
+    resetFileTreeView,
     toasts,
     toggleInstanceVisible,
     vibeLocalContextWindow,
@@ -313,6 +314,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           onDelete={handleDelete}
           onUpload={handleUpload}
           onMove={handleMove}
+          onFileTreeReset={resetFileTreeView}
           onDiffSelect={handleDiffSelect}
           onAgentInstancesChange={handleAgentInstancesChange}
           vibeLocalModel={vibeLocalModel}
@@ -465,6 +467,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
             onDelete={handleDelete}
             onUpload={handleUpload}
             onMove={handleMove}
+            onFileTreeReset={resetFileTreeView}
             refreshTrigger={fileTreeRefresh}
             fileSearch={fileSearch}
             showToast={showToast}

--- a/src/hooks/useFileTabs.ts
+++ b/src/hooks/useFileTabs.ts
@@ -68,7 +68,8 @@ export type FileTabsAction =
   | { type: 'DELETE_FILE'; path: string }
   | { type: 'RESTORE'; paths: string[]; activePath: string | null }
   | { type: 'SET_DIRTY'; path: string; isDirty: boolean }
-  | { type: 'MOVE_TO_FRONT'; path: string };
+  | { type: 'MOVE_TO_FRONT'; path: string }
+  | { type: 'CLOSE_ALL' };
 
 // ============================================================================
 // Helper Functions
@@ -256,6 +257,13 @@ export function fileTabsReducer(state: FileTabsState, action: FileTabsAction): F
       return { tabs: newTabs, activeIndex: 0 };
     }
 
+    case 'CLOSE_ALL': {
+      // [Issue #1108] Full view reset closes every open tab. Short-circuit when
+      // already empty so upstream useReducer skips a needless re-render.
+      if (state.tabs.length === 0) return state;
+      return initialState;
+    }
+
     default:
       return state;
   }
@@ -275,6 +283,8 @@ export interface FileTabsActions {
   onFileDeleted: (path: string) => void;
   /** Move a tab to the front (index 0) [DR1-003, DR2-007] */
   moveToFront: (path: string) => void;
+  /** Close every open tab (Issue #1108 full view reset). */
+  closeAllTabs: () => void;
 }
 
 /** Read persisted tab data from localStorage */
@@ -385,9 +395,13 @@ export function useFileTabs(worktreeId: string): readonly [FileTabsState, FileTa
     dispatch({ type: 'MOVE_TO_FRONT', path });
   }, []);
 
+  const closeAllTabs = useCallback(() => {
+    dispatch({ type: 'CLOSE_ALL' });
+  }, []);
+
   const actions = useMemo<FileTabsActions>(
-    () => ({ dispatch, openFile, closeTab, activateTab, onFileRenamed, onFileDeleted, moveToFront }),
-    [dispatch, openFile, closeTab, activateTab, onFileRenamed, onFileDeleted, moveToFront],
+    () => ({ dispatch, openFile, closeTab, activateTab, onFileRenamed, onFileDeleted, moveToFront, closeAllTabs }),
+    [dispatch, openFile, closeTab, activateTab, onFileRenamed, onFileDeleted, moveToFront, closeAllTabs],
   );
 
   return [state, actions] as const;

--- a/src/hooks/useFileTreeExpandedState.ts
+++ b/src/hooks/useFileTreeExpandedState.ts
@@ -1,0 +1,122 @@
+/**
+ * useFileTreeExpandedState Hook (Issue #1108)
+ *
+ * Persists the FileTreeView directory-expansion set (`Set<string>`) per worktree
+ * in localStorage so expanded folders survive activity switches, panel
+ * open/close, page reloads and worktree round-trips. Mirrors the per-worktree
+ * localStorage pattern of `useFileTabs` / `useActivityBarState`.
+ *
+ * Persistence:
+ *   - `commandmate:file-tree-expanded:<worktreeId>` — JSON array of paths.
+ *
+ * Design notes:
+ *   - The set is restored via a *lazy* useState initializer (not an effect) so
+ *     it is available synchronously on the first render. FileTreeView's mount
+ *     reload reads the expanded set through a ref and must see the persisted
+ *     dirs in order to re-fetch their children (Issue #1108 S3-001). This is
+ *     safe from a hydration standpoint because FileTreeView renders a loading
+ *     placeholder until `rootItems` are fetched client-side, so the expanded
+ *     set never affects the SSR/first-paint DOM.
+ *   - `setExpanded` is a raw `Dispatch<SetStateAction<Set<string>>>` so the
+ *     existing functional-update call sites (stale removal, handleToggle,
+ *     content-search auto-expand) keep working unchanged.
+ *   - An empty set removes the key rather than storing `"[]"`, keeping storage
+ *     clean and satisfying the reset contract (the key is deleted, not just
+ *     emptied).
+ *   - Persisting keys off the worktree that `expanded` was hydrated for
+ *     (tracked in `lastWorktreeIdRef`) so a worktree switch never leaks one
+ *     branch's expansion into another's key.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const FILE_TREE_EXPANDED_STORAGE_KEY_PREFIX =
+  'commandmate:file-tree-expanded:';
+
+export function getFileTreeExpandedStorageKey(worktreeId: string): string {
+  return FILE_TREE_EXPANDED_STORAGE_KEY_PREFIX + worktreeId;
+}
+
+export interface UseFileTreeExpandedStateReturn {
+  /** Currently expanded directory paths. */
+  expanded: Set<string>;
+  /** Raw state setter (value or updater), persisted via effect. */
+  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>;
+  /** Collapse everything and delete the persisted key. */
+  resetExpanded: () => void;
+}
+
+function readStoredExpanded(worktreeId: string): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(
+      getFileTreeExpandedStorageKey(worktreeId),
+    );
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((p) => typeof p === 'string')) {
+      return new Set(parsed as string[]);
+    }
+  } catch {
+    /* malformed / unavailable */
+  }
+  return new Set();
+}
+
+function writeStoredExpanded(worktreeId: string, expanded: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const key = getFileTreeExpandedStorageKey(worktreeId);
+    if (expanded.size === 0) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+    window.localStorage.setItem(key, JSON.stringify(Array.from(expanded)));
+  } catch {
+    /* quota exceeded / unavailable */
+  }
+}
+
+/**
+ * Manage the FileTreeView expansion set with per-worktree localStorage
+ * persistence.
+ *
+ * @param worktreeId - worktree whose expansion set to persist/restore.
+ */
+export function useFileTreeExpandedState(
+  worktreeId: string,
+): UseFileTreeExpandedStateReturn {
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    readStoredExpanded(worktreeId),
+  );
+
+  // Tracks the worktree that the current `expanded` value belongs to. Updated
+  // synchronously on a worktree switch (before the re-render that carries the
+  // rehydrated set) so the persist effect never writes to the wrong key.
+  const lastWorktreeIdRef = useRef(worktreeId);
+
+  // Re-hydrate when the worktree changes in place (without a remount).
+  useEffect(() => {
+    if (lastWorktreeIdRef.current === worktreeId) return;
+    lastWorktreeIdRef.current = worktreeId;
+    setExpanded(readStoredExpanded(worktreeId));
+  }, [worktreeId]);
+
+  // Persist whenever the set changes. Keyed on `expanded` only: on a worktree
+  // switch the set reference is unchanged in that render (the rehydrate setter
+  // schedules a later render), so this does not fire until `expanded` actually
+  // reflects the new worktree — and it always writes under lastWorktreeIdRef.
+  useEffect(() => {
+    writeStoredExpanded(lastWorktreeIdRef.current, expanded);
+  }, [expanded]);
+
+  const resetExpanded = useCallback(() => {
+    setExpanded(new Set());
+  }, []);
+
+  return { expanded, setExpanded, resetExpanded };
+}
+
+export default useFileTreeExpandedState;

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -804,6 +804,19 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     setEditorFilePath(null);
   }, []);
 
+  /**
+   * [Issue #1108] Controller-owned part of the Files full view reset. The
+   * FileTreeView toolbar button resets its own view state (expansion / cache /
+   * scroll) and then calls this to clear search and close open file surfaces:
+   * desktop tabs plus the mobile file viewer / editor (mobile has no tabs).
+   */
+  const resetFileTreeView = useCallback(() => {
+    fileSearch.clearSearch();
+    tabsActions.closeAllTabs();
+    setMobileFileViewerPath(null);
+    setEditorFilePath(null);
+  }, [fileSearch, tabsActions]);
+
   /** Handle file save in editor - refresh tree to reflect changes (savedPath accepted for callback interface compatibility) */
   const handleEditorSave = useCallback((_savedPath: string) => {
     setFileTreeRefresh(prev => prev + 1);
@@ -1460,6 +1473,7 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     handleMobileFileViewerClose,
     handleMobileTabChange,
     handleMove,
+    resetFileTreeView,
     handleMoveCancel,
     handleMoveConfirm,
     handleNewDirectory,

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { FileTreeView } from '@/components/worktree/FileTreeView';
 import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
+import { getFileTreeExpandedStorageKey } from '@/hooks/useFileTreeExpandedState';
 import type { TreeResponse } from '@/types/models';
 
 // Mock fetch globally
@@ -39,6 +40,9 @@ describe('FileTreeView', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // [Issue #1108] Expansion is now persisted per worktree in localStorage;
+    // clear it between tests so state does not leak across cases.
+    window.localStorage.clear();
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/tree/src')) {
         return Promise.resolve({
@@ -58,6 +62,7 @@ describe('FileTreeView', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    window.localStorage.clear();
   });
 
   describe('Basic rendering', () => {
@@ -1956,6 +1961,90 @@ describe('FileTreeView', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  // [Issue #1108] Per-worktree expansion persistence + full view reset.
+  describe('Expansion persistence + view reset (Issue #1108)', () => {
+    const WT = 'test-worktree';
+    const KEY = getFileTreeExpandedStorageKey(WT);
+
+    it('persists expanded directories to localStorage per worktree', async () => {
+      render(<FileTreeView worktreeId={WT} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('tree-item-src'));
+
+      await waitFor(() => {
+        expect(screen.getByText('components')).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        const raw = window.localStorage.getItem(KEY);
+        expect(raw).not.toBeNull();
+        expect(JSON.parse(raw as string)).toContain('src');
+      });
+    });
+
+    it('restores persisted expansion on mount (re-fetches expanded dir)', async () => {
+      // Seed a previously-persisted expansion for this worktree.
+      window.localStorage.setItem(KEY, JSON.stringify(['src']));
+
+      render(<FileTreeView worktreeId={WT} />);
+
+      // 'components' (a child of src) appears without any click because the
+      // restored expansion drives the mount re-fetch (Issue #1108 S3-001).
+      await waitFor(() => {
+        expect(screen.getByText('components')).toBeInTheDocument();
+        expect(screen.getByText('index.ts')).toBeInTheDocument();
+      });
+    });
+
+    it('renders a reset button distinct from the refresh button', async () => {
+      render(<FileTreeView worktreeId={WT} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-reset-button')).toBeInTheDocument();
+        expect(screen.getByTestId('file-tree-refresh-button')).toBeInTheDocument();
+      });
+    });
+
+    it('reset collapses all folders and deletes the persisted key', async () => {
+      render(<FileTreeView worktreeId={WT} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('src')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('tree-item-src'));
+      await waitFor(() => {
+        expect(screen.getByText('components')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(window.localStorage.getItem(KEY)).not.toBeNull();
+      });
+
+      fireEvent.click(screen.getByTestId('file-tree-reset-button'));
+
+      await waitFor(() => {
+        // Expanded children are gone (collapsed to initial state).
+        expect(screen.queryByText('components')).not.toBeInTheDocument();
+        // Persisted key is removed, not just emptied.
+        expect(window.localStorage.getItem(KEY)).toBeNull();
+      });
+    });
+
+    it('reset invokes onResetView so the parent can clear search / tabs', async () => {
+      const onResetView = vi.fn();
+      render(<FileTreeView worktreeId={WT} onResetView={onResetView} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('file-tree-reset-button')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('file-tree-reset-button'));
+      expect(onResetView).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/hooks/useFileTabs.test.ts
+++ b/tests/unit/hooks/useFileTabs.test.ts
@@ -334,6 +334,29 @@ describe('fileTabsReducer', () => {
     });
   });
 
+  describe('CLOSE_ALL', () => {
+    it('should clear all tabs and reset activeIndex to null', () => {
+      const stateWithTabs: FileTabsState = {
+        tabs: [
+          { path: 'a.ts', name: 'a.ts', content: null, loading: false, error: null, isDirty: false },
+          { path: 'b.ts', name: 'b.ts', content: null, loading: false, error: null, isDirty: false },
+        ],
+        activeIndex: 1,
+      };
+      const result = fileTabsReducer(stateWithTabs, { type: 'CLOSE_ALL' });
+
+      expect(result.tabs).toEqual([]);
+      expect(result.activeIndex).toBeNull();
+    });
+
+    it('should return the same reference when already empty (no-op)', () => {
+      const emptyState: FileTabsState = { tabs: [], activeIndex: null };
+      const result = fileTabsReducer(emptyState, { type: 'CLOSE_ALL' });
+
+      expect(result).toBe(emptyState);
+    });
+  });
+
   // ============================================================================
   // MAX_FILE_TABS regression guard (Issue #505) [DR3-002]
   // ============================================================================
@@ -641,6 +664,37 @@ describe('useFileTabs', () => {
 
       expect(result.current[0].tabs).toHaveLength(1);
       expect(result.current[0].tabs[0].path).toBe('b.ts');
+    });
+  });
+
+  describe('closeAllTabs', () => {
+    it('should close every open tab and clear the persisted key', () => {
+      const { result } = renderHook(() => useFileTabs('test-wt'));
+
+      act(() => {
+        result.current[1].openFile('a.ts');
+        result.current[1].openFile('b.ts');
+        result.current[1].openFile('c.ts');
+      });
+      expect(result.current[0].tabs).toHaveLength(3);
+
+      act(() => {
+        result.current[1].closeAllTabs();
+      });
+
+      expect(result.current[0].tabs).toHaveLength(0);
+      expect(result.current[0].activeIndex).toBeNull();
+      // Persisted empty state should not restore any tabs.
+      const raw = window.localStorage.getItem('commandmate:file-tabs:test-wt');
+      const parsed = raw ? JSON.parse(raw) : { paths: [] };
+      expect(parsed.paths).toEqual([]);
+    });
+
+    it('closeAllTabs identity is stable across renders', () => {
+      const { result, rerender } = renderHook(() => useFileTabs('test-wt'));
+      const fn1 = result.current[1].closeAllTabs;
+      rerender();
+      expect(Object.is(fn1, result.current[1].closeAllTabs)).toBe(true);
     });
   });
 

--- a/tests/unit/hooks/useFileTreeExpandedState.test.ts
+++ b/tests/unit/hooks/useFileTreeExpandedState.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for useFileTreeExpandedState (Issue #1108)
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useFileTreeExpandedState,
+  getFileTreeExpandedStorageKey,
+  FILE_TREE_EXPANDED_STORAGE_KEY_PREFIX,
+} from '@/hooks/useFileTreeExpandedState';
+
+const WT = 'wt-1';
+const KEY = getFileTreeExpandedStorageKey(WT);
+
+function readKey(worktreeId: string): string[] | null {
+  const raw = window.localStorage.getItem(
+    getFileTreeExpandedStorageKey(worktreeId),
+  );
+  return raw ? (JSON.parse(raw) as string[]) : null;
+}
+
+describe('useFileTreeExpandedState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('uses the colon-scoped per-worktree storage key', () => {
+    expect(KEY).toBe(`${FILE_TREE_EXPANDED_STORAGE_KEY_PREFIX}${WT}`);
+    expect(KEY).toBe('commandmate:file-tree-expanded:wt-1');
+  });
+
+  it('defaults to an empty set for an unvisited worktree', () => {
+    const { result } = renderHook(() => useFileTreeExpandedState(WT));
+    expect(result.current.expanded.size).toBe(0);
+  });
+
+  it('restores the persisted set synchronously on mount (lazy init)', () => {
+    window.localStorage.setItem(KEY, JSON.stringify(['src', 'src/hooks']));
+    const { result } = renderHook(() => useFileTreeExpandedState(WT));
+    // Available on the very first render (no act/effect needed).
+    expect(result.current.expanded.has('src')).toBe(true);
+    expect(result.current.expanded.has('src/hooks')).toBe(true);
+    expect(result.current.expanded.size).toBe(2);
+  });
+
+  it('persists on change (functional updater supported)', () => {
+    const { result } = renderHook(() => useFileTreeExpandedState(WT));
+    act(() => {
+      result.current.setExpanded((prev) => new Set(prev).add('src'));
+    });
+    expect(readKey(WT)).toEqual(['src']);
+    act(() => {
+      result.current.setExpanded((prev) => new Set(prev).add('docs'));
+    });
+    expect(new Set(readKey(WT))).toEqual(new Set(['src', 'docs']));
+  });
+
+  it('removes the key (does not store "[]") when the set becomes empty', () => {
+    window.localStorage.setItem(KEY, JSON.stringify(['src']));
+    const { result } = renderHook(() => useFileTreeExpandedState(WT));
+    act(() => {
+      result.current.setExpanded(new Set());
+    });
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('resetExpanded() collapses everything and deletes the persisted key', () => {
+    window.localStorage.setItem(KEY, JSON.stringify(['src', 'docs']));
+    const { result } = renderHook(() => useFileTreeExpandedState(WT));
+    act(() => {
+      result.current.resetExpanded();
+    });
+    expect(result.current.expanded.size).toBe(0);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('re-hydrates when worktreeId changes without leaking across worktrees', () => {
+    window.localStorage.setItem(
+      getFileTreeExpandedStorageKey('wt-a'),
+      JSON.stringify(['a-dir']),
+    );
+    window.localStorage.setItem(
+      getFileTreeExpandedStorageKey('wt-b'),
+      JSON.stringify(['b-dir']),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useFileTreeExpandedState(id),
+      { initialProps: { id: 'wt-a' } },
+    );
+    expect(result.current.expanded.has('a-dir')).toBe(true);
+
+    rerender({ id: 'wt-b' });
+
+    // Now shows wt-b's set, not wt-a's.
+    expect(result.current.expanded.has('b-dir')).toBe(true);
+    expect(result.current.expanded.has('a-dir')).toBe(false);
+    // wt-a's key is untouched (no cross-worktree leakage).
+    expect(readKey('wt-a')).toEqual(['a-dir']);
+    expect(readKey('wt-b')).toEqual(['b-dir']);
+  });
+
+  it('does not write another worktree\'s expansion into the new key on switch', () => {
+    window.localStorage.setItem(
+      getFileTreeExpandedStorageKey('wt-a'),
+      JSON.stringify(['a-dir']),
+    );
+    // wt-b starts unvisited (no key).
+    const { rerender } = renderHook(
+      ({ id }) => useFileTreeExpandedState(id),
+      { initialProps: { id: 'wt-a' } },
+    );
+    rerender({ id: 'wt-b' });
+    // wt-b remains unvisited/empty — 'a-dir' must not have leaked in.
+    expect(window.localStorage.getItem(getFileTreeExpandedStorageKey('wt-b'))).toBeNull();
+  });
+
+  it('resetExpanded identity is stable across renders', () => {
+    const { result, rerender } = renderHook(() => useFileTreeExpandedState(WT));
+    const reset1 = result.current.resetExpanded;
+    rerender();
+    expect(Object.is(reset1, result.current.resetExpanded)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1108 の実装。`useFileTabs` / `useFilePanelState` の worktree 単位 localStorage パターンを踏襲し、Files ツリーの展開状態を永続化。あわせて「初期表示に戻す」フルリセット機能を追加する。

## 変更内容
- **新規 `useFileTreeExpandedState`**: 展開集合を worktree 単位 localStorage（キー `commandmate:file-tree-expanded:<worktreeId>`）に永続化。lazy-init 復元をマウント再フェッチに乗せ、空集合はキー削除、worktree 間の漏洩なし
- **`useFileTabs`**: `CLOSE_ALL` / `closeAllTabs()` を追加
- **`FileTreeView`**: フック統合＋ツールバーに「表示をリセット」ボタン（更新ボタンの隣・常時可視）＋ `onResetView` prop
- **Controller / Desktop / Mobile / Refactored**: `resetFileTreeView`（検索クリア・全タブ閉じ・モバイルビューア閉）を配線し、初期表示に戻すフルリセットを実現

## 決定事項の反映
- 永続化とリセットをセットで実装
- リセット範囲は「初期表示に戻す」フルリセット（展開状態＋検索＋開いているタブ）

## 品質ゲート（worker報告＋orchestrator独立検証）
- tsc --noEmit: ✅ 0 errors（統合後に独立再検証済み）
- lint: ✅ 0 warnings/errors（統合後に独立再検証済み）
- test:unit: ✅ 8779 passed（worker）
- build: ✅ 成功（worker）

## 備考
- ブランチは #1107 マージ後の origin/develop を merge 済み（Files/Timer は非重複でクリーンマージ、Timer 反転なしを確認）

Refs #1108