### PR TITLE
fix(mobile): viewportFit:'cover' を追加しiOS safe-area対応を有効化 (#1131)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,11 +17,14 @@ export const metadata: Metadata = {
 
 // [Issue #1082] themeColor follows the light/dark --background token so the
 // browser chrome (mobile address bar / PWA) matches the active theme.
+// [Issue #1131] viewportFit: 'cover' is required for iOS to expose non-zero
+// env(safe-area-inset-*) values; without it every pt-safe/pb-safe is a no-op.
 export const viewport: Viewport = {
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#fafafb' },
     { media: '(prefers-color-scheme: dark)', color: '#0a0c12' },
   ],
+  viewportFit: 'cover',
 };
 
 export default async function RootLayout({

--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -51,7 +51,7 @@ export function GlobalMobileNav() {
   return (
     <nav
       data-testid="global-mobile-nav"
-      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md safe-area-bottom"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md pb-safe"
     >
       <div className="flex items-center justify-around h-14">
         {MOBILE_NAV_TABS.map((tab) => {

--- a/tests/unit/app/layout-viewport.test.ts
+++ b/tests/unit/app/layout-viewport.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Unit tests for the root layout viewport export.
+ * Issue #1131: viewportFit: 'cover' must be set so iOS exposes non-zero
+ * env(safe-area-inset-*) values — without it every pt-safe/pb-safe utility
+ * (mobile headers, bottom navs, message composer offsets) is a no-op.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the layout module's runtime dependencies — we only assert on the
+// static `viewport` / `metadata` exports, not on rendering.
+vi.mock('next-intl/server', () => ({
+  getLocale: vi.fn(),
+  getMessages: vi.fn(),
+  getTimeZone: vi.fn(),
+}));
+vi.mock('geist/font/sans', () => ({ GeistSans: { variable: 'font-sans' } }));
+vi.mock('geist/font/mono', () => ({ GeistMono: { variable: 'font-mono' } }));
+vi.mock('@/components/providers/AppProviders', () => ({ AppProviders: () => null }));
+
+import { viewport } from '@/app/layout';
+
+describe('root layout viewport (Issue #1131)', () => {
+  it('sets viewportFit to "cover" so iOS safe-area insets are non-zero', () => {
+    expect(viewport.viewportFit).toBe('cover');
+  });
+
+  it('keeps the theme-following themeColor entries (Issue #1082)', () => {
+    expect(viewport.themeColor).toEqual([
+      { media: '(prefers-color-scheme: light)', color: '#fafafb' },
+      { media: '(prefers-color-scheme: dark)', color: '#0a0c12' },
+    ]);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1131 の対応。viewport 設定に `viewportFit: 'cover'` が無く、iOSで `env(safe-area-inset-*)` が常に0となり既存のsafe-area対応が全て無効化されていた問題を修正。

## 変更内容
- `src/app/layout.tsx`: viewport エクスポートに `viewportFit: 'cover'` を追加
- `GlobalMobileNav.tsx`: 未定義クラス `safe-area-bottom` → 定義済みの `pb-safe` に修正（関連潜在バグ）
- viewport エクスポート値のユニットテスト追加

## 品質ゲート
lint / tsc / test:unit / build 全てPASS（ワーカー実行＋オーケストレーター再検証）

Refs #1131（親: #1110 UI/UX最先端化 Phase 1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)