### PR TITLE
feat(ui): ヘッダーナビのアクティブインジケータ実装と角丸スケール規約の導入 (#1119)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -344,6 +344,24 @@ import { Skeleton } from '@/components/ui';
 
 ---
 
+## 角丸スケール (Border Radius, Issue #1119)
+
+角丸は用途ごとに以下のスケールから選ぶ（Tailwind v3: `sm`=2px / `md`=6px / `lg`=8px）。
+
+| 用途 | クラス | 対象例 |
+|------|--------|--------|
+| コントロール | `rounded-md` | Button / Input / Select / Textarea / アイコンボタン |
+| コンテナ | `rounded-lg` | Card / Modal / Panel |
+| ポップアップ面 | `rounded-md` | DropdownMenu / Select content / Tooltip |
+| チップ・円形要素 | `rounded-full` | Badge / Switch / StatusDot / RadioGroup / ピル |
+| 小型インライン要素 | `rounded-sm` | Checkbox / Kbd / メニュー項目（高さ ~20px 以下） |
+
+- 裸の `rounded`（4px）は**原則禁止**。新規コードでは上記スケールから選択する
+- `src/components/ui/` と `src/components/layout/` は本規約に準拠済み。feature 配下に残る
+  裸 `rounded` は一括置換せず、該当ファイルを変更する際に随時規約へ寄せる
+
+---
+
 ## モーション (Motion, Issue #1050)
 
 マイクロインタラクションは **[`tailwindcss-animate`](https://github.com/jamiebuilds/tailwindcss-animate)**

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -80,10 +80,11 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
                 <Link
                   key={item.href}
                   href={item.href}
-                  className={`text-sm font-medium transition-colors ${
+                  aria-current={active ? 'page' : undefined}
+                  className={`relative py-1 text-sm font-medium transition-colors after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:rounded-full after:bg-accent-600 dark:after:bg-accent-400 after:origin-center motion-safe:after:transition-transform after:duration-200 after:ease-[var(--motion-ease-out)] ${
                     active
-                      ? 'text-accent-600 dark:text-accent-400'
-                      : 'text-muted-foreground hover:text-foreground'
+                      ? 'text-accent-600 dark:text-accent-400 after:scale-x-100'
+                      : 'text-muted-foreground hover:text-foreground after:scale-x-0'
                   }`}
                 >
                   {item.label}
@@ -96,7 +97,7 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
               data-testid="header-command-palette-trigger"
               onClick={() => setOpen(true)}
               aria-label={t('mobileTrigger')}
-              className="hidden md:inline-flex items-center gap-2 rounded-lg border border-border bg-surface px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-surface-2 transition-colors"
+              className="hidden md:inline-flex items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-surface-2 transition-colors"
             >
               <Search size={16} strokeWidth={2} aria-hidden="true" className="shrink-0" />
               <span>{t('searchAction')}</span>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -451,7 +451,7 @@ export const Sidebar = memo(function Sidebar() {
               <Link
                 href="/repositories"
                 aria-label="Repositories"
-                className="p-1 rounded text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover
+                className="p-1 rounded-md text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover
                   focus:outline-none focus:ring-2 focus:ring-ring
                   transition-colors inline-flex items-center"
               >
@@ -724,7 +724,7 @@ function ViewModeToggle({
         onClick={handleClick}
         aria-label={viewMode === 'grouped' ? 'Switch to flat view' : 'Switch to grouped view'}
         className="
-          p-1 rounded text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover
+          p-1 rounded-md text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover
           focus:outline-none focus:ring-2 focus:ring-ring
           transition-colors
         "
@@ -870,7 +870,7 @@ const SyncButton = memo(function SyncButton({
           onClick={handleSync}
           disabled={isSyncing}
           aria-label={t('syncButtonLabel')}
-          className="p-1 rounded text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover
+          className="p-1 rounded-md text-sidebar-muted hover:text-sidebar-foreground hover:bg-sidebar-hover
             focus:outline-none focus:ring-2 focus:ring-ring
             disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -27,7 +27,7 @@ export const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer inline-flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded border border-input bg-surface text-surface-foreground shadow-sm transition-colors',
+      'peer inline-flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-input bg-surface text-surface-foreground shadow-sm transition-colors',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-[state=checked]:border-accent-600 data-[state=checked]:bg-accent-600 data-[state=checked]:text-white',

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -25,7 +25,7 @@ export function Kbd({ className, children, ...rest }: KbdProps) {
   return (
     <kbd
       className={cn(
-        'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-border bg-surface px-1',
+        'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-sm border border-border bg-surface px-1',
         'font-mono text-[10px] font-medium leading-none text-muted-foreground',
         className
       )}

--- a/tests/unit/components/layout/Header.test.tsx
+++ b/tests/unit/components/layout/Header.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tests for Header navigation active indicator (Issue #1119)
+ *
+ * Verifies aria-current="page" assignment and the sliding underline
+ * indicator classes for each route.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Header } from '@/components/layout/Header';
+
+const usePathnameMock = vi.fn<() => string>(() => '/');
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => usePathnameMock(),
+}));
+
+vi.mock('@/contexts/CommandPaletteContext', () => ({
+  useCommandPalette: () => ({ setOpen: vi.fn() }),
+}));
+
+vi.mock('@/components/common/ThemeToggle', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
+
+vi.mock('@/components/layout/PcDisplaySizeSelector', () => ({
+  PcDisplaySizeSelector: () => <div data-testid="pc-display-size-selector" />,
+}));
+
+const NAV_LABELS = ['Home', 'Chat', 'Sessions', 'Repos', 'Review/Report', 'More'] as const;
+
+const ROUTE_CASES: Array<{ pathname: string; activeLabel: (typeof NAV_LABELS)[number] }> = [
+  { pathname: '/', activeLabel: 'Home' },
+  { pathname: '/chat', activeLabel: 'Chat' },
+  { pathname: '/sessions', activeLabel: 'Sessions' },
+  { pathname: '/sessions/abc123', activeLabel: 'Sessions' },
+  { pathname: '/repositories', activeLabel: 'Repos' },
+  { pathname: '/review', activeLabel: 'Review/Report' },
+  { pathname: '/more', activeLabel: 'More' },
+];
+
+function getNavLink(label: string): HTMLElement {
+  return screen.getByRole('link', { name: label });
+}
+
+describe('Header navigation active indicator', () => {
+  beforeEach(() => {
+    usePathnameMock.mockReturnValue('/');
+  });
+
+  describe.each(ROUTE_CASES)('pathname: $pathname', ({ pathname, activeLabel }) => {
+    it(`marks only "${activeLabel}" with aria-current="page"`, () => {
+      usePathnameMock.mockReturnValue(pathname);
+      render(<Header />);
+
+      for (const label of NAV_LABELS) {
+        const link = getNavLink(label);
+        if (label === activeLabel) {
+          expect(link).toHaveAttribute('aria-current', 'page');
+        } else {
+          expect(link).not.toHaveAttribute('aria-current');
+        }
+      }
+    });
+  });
+
+  it('renders the underline indicator expanded only on the active item', () => {
+    usePathnameMock.mockReturnValue('/sessions');
+    render(<Header />);
+
+    expect(getNavLink('Sessions').className).toContain('after:scale-x-100');
+    expect(getNavLink('Home').className).toContain('after:scale-x-0');
+  });
+
+  it('does not mark Home as active on non-root routes', () => {
+    usePathnameMock.mockReturnValue('/chat');
+    render(<Header />);
+
+    expect(getNavLink('Home')).not.toHaveAttribute('aria-current');
+    expect(getNavLink('Chat')).toHaveAttribute('aria-current', 'page');
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1119 の対応。ヘッダーナビのアクティブ表示を「文字色のみ」からアニメーション付き下線インジケータへ引き上げ、角丸スケール規約を導入。

## 変更内容
- Header ナビ: CSS-only 下線インジケータ（::after scale-x、モーショントークン準拠、motion-safe ガード）＋ `aria-current="page"`
- `docs/design-system.md`: 角丸スケール規約を独立セクションで追記（control=md / container=lg / chip=full / 小型インライン=sm、裸 rounded 原則禁止）
- 角丸統一（明確な逸脱のみ）: ui/Kbd・ui/Checkbox（→sm）、Sidebarアイコンボタン（→md）、Headerパレットトリガー（lg→md）
- Header アクティブ状態の全6ルートテスト追加

## 品質ゲート
lint / tsc / test:unit / build 全てPASS（ワーカー実行＋オーケストレーター再検証）

Refs #1119（親: #1110 UI/UX最先端化 Phase 2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)