### PR TITLE
feat(ui): スケルトンローディング展開とSpinner統一・loading.tsx整備 (#1118)

### DIFF
--- a/src/app/chat/loading.tsx
+++ b/src/app/chat/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/more/loading.tsx
+++ b/src/app/more/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,10 @@ import { TodoWidget } from '@/components/home/TodoWidget';
 import { HomeQuickActions } from '@/components/home/HomeQuickActions';
 
 export default function Home() {
-  const { worktrees } = useWorktreesCacheContext();
+  const { worktrees, isLoading } = useWorktreesCacheContext();
+  // [Issue #1118] Skeletons only on the very first load; once the cache has
+  // data, poll re-fetches keep the rendered content (non-blocking pattern).
+  const isFirstLoad = isLoading && worktrees.length === 0;
 
   return (
     <AppShell>
@@ -40,7 +43,7 @@ export default function Home() {
         <div className="grid grid-cols-1 gap-4 md:grid-cols-12" data-testid="home-bento-grid">
           {/* Session Overview + Recent sessions — large tile */}
           <div className="md:col-span-8">
-            <SessionOverviewTile worktrees={worktrees} />
+            <SessionOverviewTile worktrees={worktrees} isLoading={isFirstLoad} />
           </div>
 
           {/* ToDo — medium tile */}

--- a/src/app/repositories/loading.tsx
+++ b/src/app/repositories/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/review/loading.tsx
+++ b/src/app/review/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/sessions/loading.tsx
+++ b/src/app/sessions/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -31,6 +31,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Skeleton,
   StatusDot,
 } from '@/components/ui';
 import { compareByTimestamp } from '@/lib/sidebar-utils';
@@ -405,8 +406,33 @@ export default function SessionsPage() {
           <>
             {/* No data yet: loading / blocking error / empty are mutually exclusive. */}
             {isLoading && (
-              <div className="text-muted-foreground" data-testid="sessions-loading">
-                Loading sessions...
+              // [Issue #1118] First-load only (hasWorktrees keeps the list on
+              // re-fetch). Skeleton cards mirror the session card layout:
+              // name/branch lines + agent chip, then a message/time footer.
+              <div
+                className="space-y-2"
+                data-testid="sessions-loading"
+                role="status"
+                aria-label="Loading sessions"
+              >
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="block bg-surface rounded-lg p-4 border border-border shadow-sm"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0 flex-1 space-y-1.5">
+                        <Skeleton className="h-4 w-40 max-w-full" />
+                        <Skeleton className="h-3 w-56 max-w-full" />
+                      </div>
+                      <Skeleton className="ml-4 h-3 w-16 flex-shrink-0" />
+                    </div>
+                    <div className="mt-3 flex items-center gap-2">
+                      <Skeleton className="h-3 min-w-0 flex-1" />
+                      <Skeleton className="h-3 w-10 flex-shrink-0" />
+                    </div>
+                  </div>
+                ))}
               </div>
             )}
             {!isLoading && error && (

--- a/src/app/worktrees/[id]/files/[...path]/page.tsx
+++ b/src/app/worktrees/[id]/files/[...path]/page.tsx
@@ -9,7 +9,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { List, BookOpen } from 'lucide-react';
-import { Card } from '@/components/ui';
+import { Card, Spinner } from '@/components/ui';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
@@ -159,7 +159,7 @@ export default function FileViewerPage() {
         {loading && (
           <Card padding="lg">
             <div className="flex items-center justify-center py-12">
-              <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-gray-300 border-t-accent-600" />
+              <Spinner size="xl" variant="accent" />
               <p className="ml-3 text-gray-600">Loading file...</p>
             </div>
           </Card>

--- a/src/app/worktrees/[id]/loading.tsx
+++ b/src/app/worktrees/[id]/loading.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route-segment Suspense fallback (Issue #1118).
+ * Thin by design — see RouteLoading for rationale.
+ */
+
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/src/app/worktrees/[id]/terminal/page.tsx
+++ b/src/app/worktrees/[id]/terminal/page.tsx
@@ -8,7 +8,8 @@
 import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import { ArrowLeft, Terminal, Monitor, Code, Loader2, Bot, Zap, Sparkles, SquareTerminal } from 'lucide-react';
+import { ArrowLeft, Terminal, Monitor, Code, Bot, Zap, Sparkles, SquareTerminal } from 'lucide-react';
+import { Spinner } from '@/components/ui/Spinner';
 import { isTmuxControlModeEnabledForClient } from '@/lib/tmux/tmux-control-mode-flags';
 import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
 import { getTerminalFontSize } from '@/hooks/usePcDisplaySize';
@@ -27,7 +28,7 @@ const TerminalComponent = dynamic(
     ssr: false,
     loading: () => (
       <div className="flex items-center justify-center h-full bg-gray-900 text-gray-400">
-        <Loader2 className="animate-spin h-6 w-6 mr-2" />
+        <Spinner size="lg" className="mr-2" />
         <span>Loading terminal...</span>
       </div>
     ),

--- a/src/components/common/RouteLoading.tsx
+++ b/src/components/common/RouteLoading.tsx
@@ -1,0 +1,29 @@
+/**
+ * RouteLoading Component
+ * Shared route-level Suspense fallback for App Router loading.tsx files
+ * (Issue #1118).
+ *
+ * Deliberately thin: every screen is a `'use client'` page that fetches on
+ * mount, so the real loading UX lives in per-component skeletons. This
+ * fallback only covers the route-segment (chunk / RSC) load and sketches a
+ * generic page outline: a heading line and two content cards.
+ */
+
+import { Skeleton } from '@/components/ui/Skeleton';
+
+export function RouteLoading() {
+  return (
+    <div
+      className="container-custom py-8"
+      role="status"
+      aria-label="Loading page"
+      data-testid="route-loading"
+    >
+      <Skeleton className="mb-6 h-8 w-48 max-w-full" />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Skeleton className="h-40 rounded-lg" />
+        <Skeleton className="h-40 rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/external-apps/ExternalAppsManager.tsx
+++ b/src/components/external-apps/ExternalAppsManager.tsx
@@ -7,7 +7,7 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { Button, Card } from '@/components/ui';
+import { Button, Card, Spinner } from '@/components/ui';
 import { ExternalAppCard } from './ExternalAppCard';
 import { ExternalAppForm } from './ExternalAppForm';
 import type { ExternalApp } from '@/types/external-apps';
@@ -118,7 +118,7 @@ export function ExternalAppsManager() {
       {isLoading ? (
         <Card padding="lg">
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent-600" />
+            <Spinner size="xl" variant="accent" />
             <span className="ml-3 text-muted-foreground">Loading apps...</span>
           </div>
         </Card>

--- a/src/components/home/AssistantChatPanel.tsx
+++ b/src/components/home/AssistantChatPanel.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { Trash2 } from 'lucide-react';
-import { Button, Card } from '@/components/ui';
+import { Button, Card, Skeleton } from '@/components/ui';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
 import { AssistantMessageInput } from './AssistantMessageInput';
 import { AssistantMessageList } from './AssistantMessageList';
@@ -48,6 +48,15 @@ export function AssistantChatPanel() {
   const [starting, setStarting] = useState(false);
   const [stopping, setStopping] = useState(false);
   const [clearing, setClearing] = useState(false);
+  // [Issue #1118] History skeleton state, derived (not effect-toggled) so the
+  // empty state never flashes for a frame before the skeleton appears:
+  // loading until the repo list has answered, and, once a repo is selected,
+  // until the conversation for the current repo+tool key has been fetched.
+  const [reposLoaded, setReposLoaded] = useState(false);
+  const [loadedConversationKey, setLoadedConversationKey] = useState<string | null>(null);
+  const conversationKey = `${selectedRepoId}:${selectedTool}`;
+  const conversationLoading =
+    !reposLoaded || (selectedRepoId !== '' && loadedConversationKey !== conversationKey);
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const conversationActive = conversation?.status === 'ready' || conversation?.status === 'running';
@@ -113,6 +122,8 @@ export function AssistantChatPanel() {
         }
       } catch {
         // Silent fetch failure
+      } finally {
+        setReposLoaded(true);
       }
     }
 
@@ -160,6 +171,10 @@ export function AssistantChatPanel() {
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to load conversation');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadedConversationKey(`${selectedRepoId}:${selectedTool}`);
         }
       }
     })();
@@ -441,14 +456,31 @@ export function AssistantChatPanel() {
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden">
-              <AssistantMessageList
-                messages={messages}
-                assistantLabel={assistantLabel}
-                sessionActive={conversationActive}
-                waitingForResponse={executionRunning}
-                canEdit={canSend}
-                onEditMessage={handleEditMessage}
-              />
+              {conversationLoading && messages.length === 0 ? (
+                // [Issue #1118] First-load skeleton mirroring the message list
+                // container and its chat bubbles (user right, assistant left).
+                <div
+                  className="h-full min-h-0 overflow-hidden rounded-xl border border-border bg-surface-2 p-3"
+                  data-testid="assistant-chat-loading"
+                  role="status"
+                  aria-label="Loading conversation"
+                >
+                  <div className="space-y-3">
+                    <Skeleton className="ml-auto h-10 w-3/5 rounded-2xl" />
+                    <Skeleton className="mr-auto h-16 w-4/5 rounded-2xl" />
+                    <Skeleton className="ml-auto h-10 w-2/5 rounded-2xl" />
+                  </div>
+                </div>
+              ) : (
+                <AssistantMessageList
+                  messages={messages}
+                  assistantLabel={assistantLabel}
+                  sessionActive={conversationActive}
+                  waitingForResponse={executionRunning}
+                  canEdit={canSend}
+                  onEditMessage={handleEditMessage}
+                />
+              )}
             </div>
 
             <div className="shrink-0">

--- a/src/components/home/AssistantMessageInput.tsx
+++ b/src/components/home/AssistantMessageInput.tsx
@@ -14,7 +14,7 @@
 'use client';
 
 import React, { memo, useState, useCallback, useRef, useEffect } from 'react';
-import { Button } from '@/components/ui';
+import { Button, Spinner } from '@/components/ui';
 
 export interface AssistantMessageInputProps {
   /** Called when the user sends a message */
@@ -152,26 +152,7 @@ export const AssistantMessageInput = memo(function AssistantMessageInput({
         data-testid="assistant-send-button"
       >
         {sending ? (
-          <svg
-            className="animate-spin h-4 w-4"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <Spinner size="sm" />
         ) : (
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path

--- a/src/components/home/AssistantMessageList.tsx
+++ b/src/components/home/AssistantMessageList.tsx
@@ -8,6 +8,7 @@ import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import type { AssistantMessage } from '@/lib/db/assistant-conversation-db';
 import { CopyButton } from '@/components/common/CopyButton';
+import { Spinner } from '@/components/ui/Spinner';
 
 interface AssistantMessageListProps {
   messages: AssistantMessage[];
@@ -280,26 +281,7 @@ export function AssistantMessageList({
               data-testid="assistant-waiting-indicator"
               aria-live="polite"
             >
-              <svg
-                className="h-4 w-4 animate-spin text-accent-600 dark:text-accent-400"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <Spinner size="sm" variant="accent" />
               <span className="text-sm text-foreground">
                 {assistantLabel} is thinking...
               </span>

--- a/src/components/home/HomeSessionSummary.tsx
+++ b/src/components/home/HomeSessionSummary.tsx
@@ -14,19 +14,21 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { StatusDot } from '@/components/ui';
+import { Skeleton, StatusDot } from '@/components/ui';
 import { cn } from '@/lib/utils/cn';
 import type { Worktree } from '@/types/models';
 
 export interface HomeSessionSummaryProps {
   /** Worktrees to aggregate counts from */
   worktrees: Worktree[];
+  /** [Issue #1118] First-load skeleton (shapes match the loaded stat boxes) */
+  isLoading?: boolean;
 }
 
 /**
  * Displays Running and Waiting session counts as compact inline stats.
  */
-export function HomeSessionSummary({ worktrees }: HomeSessionSummaryProps) {
+export function HomeSessionSummary({ worktrees, isLoading = false }: HomeSessionSummaryProps) {
   const { runningCount, waitingCount } = useMemo(() => {
     let running = 0;
     let waiting = 0;
@@ -40,6 +42,30 @@ export function HomeSessionSummary({ worktrees }: HomeSessionSummaryProps) {
     }
     return { runningCount: running, waitingCount: waiting };
   }, [worktrees]);
+
+  if (isLoading) {
+    // Same box chrome as the loaded stats; label (text-xs ≈ h-4) and count
+    // (text-3xl ≈ h-9) skeletons keep the tile height stable on swap.
+    return (
+      <div
+        className="grid grid-cols-2 gap-3"
+        data-testid="home-session-summary-loading"
+        role="status"
+        aria-label="Loading session summary"
+      >
+        {[0, 1].map((i) => (
+          <div key={i} className="rounded-lg border border-border bg-surface-2 px-3 py-2">
+            <div className="flex h-4 items-center">
+              <Skeleton className="h-3 w-16" />
+            </div>
+            <div className="flex h-9 items-center">
+              <Skeleton className="h-7 w-10" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-2 gap-3" data-testid="home-session-summary">

--- a/src/components/home/RecentSessionsList.tsx
+++ b/src/components/home/RecentSessionsList.tsx
@@ -11,6 +11,7 @@
 
 import React, { useMemo } from 'react';
 import Link from 'next/link';
+import { Skeleton } from '@/components/ui';
 import { compareByTimestamp } from '@/lib/sidebar-utils';
 import { formatRelativeTimeShort } from '@/lib/date-utils';
 import type { Worktree } from '@/types/models';
@@ -20,6 +21,8 @@ export interface RecentSessionsListProps {
   worktrees: Worktree[];
   /** Max number of sessions to show (default 5) */
   limit?: number;
+  /** [Issue #1118] First-load skeleton (rows match the loaded list rows) */
+  isLoading?: boolean;
 }
 
 /** Recency signal for a worktree: last user message, falling back to update time. */
@@ -38,12 +41,36 @@ function statusDotClass(wt: Worktree): string {
   return 'bg-muted-foreground';
 }
 
-export function RecentSessionsList({ worktrees, limit = 5 }: RecentSessionsListProps) {
+export function RecentSessionsList({ worktrees, limit = 5, isLoading = false }: RecentSessionsListProps) {
   const recent = useMemo(() => {
     return [...worktrees]
       .sort((a, b) => compareByTimestamp(recencyOf(a), recencyOf(b)))
       .slice(0, limit);
   }, [worktrees, limit]);
+
+  if (isLoading) {
+    // Rows mirror the loaded link rows (dot + two text lines + time) so the
+    // list height does not jump when real sessions replace the skeleton.
+    return (
+      <ul
+        className="space-y-1"
+        data-testid="recent-sessions-loading"
+        role="status"
+        aria-label="Loading recent sessions"
+      >
+        {Array.from({ length: limit }, (_, i) => (
+          <li key={i} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+            <Skeleton className="h-2 w-2 shrink-0 rounded-full" />
+            <span className="min-w-0 flex-1 space-y-1">
+              <Skeleton className="h-4 w-2/5" />
+              <Skeleton className="h-3 w-3/5" />
+            </span>
+            <Skeleton className="h-3 w-8 shrink-0" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
 
   if (recent.length === 0) {
     return (

--- a/src/components/home/SessionOverviewTile.tsx
+++ b/src/components/home/SessionOverviewTile.tsx
@@ -18,16 +18,23 @@ import type { Worktree } from '@/types/models';
 export interface SessionOverviewTileProps {
   /** Worktrees to render counts and recent sessions from */
   worktrees: Worktree[];
+  /**
+   * [Issue #1118] First-load skeleton: headings stay, stats and the recent
+   * list render as placeholders. Callers should gate this to the initial load
+   * (e.g. `isLoading && worktrees.length === 0`) so poll re-fetches never
+   * flip the tile back to skeletons.
+   */
+  isLoading?: boolean;
 }
 
-export function SessionOverviewTile({ worktrees }: SessionOverviewTileProps) {
+export function SessionOverviewTile({ worktrees, isLoading = false }: SessionOverviewTileProps) {
   return (
     <Card variant="elevated" className="h-full" data-testid="session-overview-tile">
       <h2 className="mb-3 text-lg font-semibold text-foreground">
         Session Overview
       </h2>
 
-      <HomeSessionSummary worktrees={worktrees} />
+      <HomeSessionSummary worktrees={worktrees} isLoading={isLoading} />
 
       <div className="mt-4 flex items-center justify-between">
         <h3 className="text-sm font-semibold text-foreground">
@@ -42,7 +49,7 @@ export function SessionOverviewTile({ worktrees }: SessionOverviewTileProps) {
         </Link>
       </div>
       <div className="mt-2">
-        <RecentSessionsList worktrees={worktrees} />
+        <RecentSessionsList worktrees={worktrees} isLoading={isLoading} />
       </div>
     </Card>
   );

--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -15,7 +15,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Card, Checkbox, Input } from '@/components/ui';
+import { Button, Card, Checkbox, Input, Skeleton } from '@/components/ui';
 import { todoApi, type TodoItem } from '@/lib/api/todo-api';
 import { MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
 
@@ -260,8 +260,23 @@ export function TodoWidget() {
           )}
 
           {/* Todo list */}
-          {loading ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+          {loading && todos.length === 0 ? (
+            // [Issue #1118] First-load only skeleton (re-fetches after
+            // add/toggle keep the current list): rows mirror a todo item
+            // (checkbox + text).
+            <ul
+              className="space-y-1"
+              data-testid="todo-loading"
+              role="status"
+              aria-label="Loading todos"
+            >
+              {[0, 1, 2].map((i) => (
+                <li key={i} className="flex items-center gap-2 rounded-md px-1 py-1">
+                  <Skeleton className="h-4 w-4 shrink-0 rounded" />
+                  <Skeleton className={`h-4 ${i === 1 ? 'w-2/3' : 'w-5/6'}`} />
+                </li>
+              ))}
+            </ul>
           ) : todos.length === 0 ? (
             <p className="text-sm text-muted-foreground" data-testid="todo-empty">
               No todos yet.

--- a/src/components/mobile/MobilePromptSheet.tsx
+++ b/src/components/mobile/MobilePromptSheet.tsx
@@ -10,7 +10,7 @@ import { useState, useCallback, useId, useMemo, useRef, useEffect, memo } from '
 import { useTranslations } from 'next-intl';
 import type { PromptData, YesNoPromptData, MultipleChoicePromptData } from '@/types/models';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
-import { RadioGroup, RadioGroupItem } from '@/components/ui';
+import { RadioGroup, RadioGroupItem, Spinner } from '@/components/ui';
 import { usePromptAnimation } from '@/hooks/usePromptAnimation';
 
 /** Animation duration for sheet transitions */
@@ -281,7 +281,7 @@ function PromptContent({
       {/* Answering indicator */}
       {isDisabled && (
         <div data-testid="answering-indicator" className="flex items-center gap-2 text-sm text-muted-foreground" role="status" aria-live="polite">
-          <div className="animate-spin rounded-full h-4 w-4 border-2 border-input border-t-accent-600" aria-hidden="true" />
+          <Spinner size="sm" variant="accent" />
           <span>{t('sending')}</span>
         </div>
       )}

--- a/src/components/repository/RepositoryList.tsx
+++ b/src/components/repository/RepositoryList.tsx
@@ -29,7 +29,7 @@
 
 import React, { memo, useCallback, useEffect, useState } from 'react';
 import { Pencil } from 'lucide-react';
-import { Button, Card, Input, StatusDot } from '@/components/ui';
+import { Button, Card, Input, Skeleton, StatusDot } from '@/components/ui';
 import { cn } from '@/lib/utils/cn';
 import {
   handleApiError,
@@ -78,6 +78,38 @@ const INITIAL_EDIT: EditState = {
  * />
  * ```
  */
+/** Shared by the loaded table and the loading skeleton (Issue #1118). */
+function RepositoryTableHead() {
+  return (
+    <thead className="bg-muted border-b border-border">
+      <tr>
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Name
+        </th>
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Display name
+        </th>
+        {/* Issue #690: Visibility column placed before Path so it is always reachable on narrow screens */}
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Visibility
+        </th>
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Path
+        </th>
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Worktrees
+        </th>
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Status
+        </th>
+        <th className="px-4 py-2 text-left font-medium text-foreground">
+          Actions
+        </th>
+      </tr>
+    </thead>
+  );
+}
+
 function RepositoryListInner({ refreshKey, onChanged }: RepositoryListProps) {
   const [repositories, setRepositories] = useState<RepositoryListItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -264,11 +296,33 @@ function RepositoryListInner({ refreshKey, onChanged }: RepositoryListProps) {
   );
 
   if (loading && repositories.length === 0) {
+    // [Issue #1118] First-load skeleton: real table header + placeholder rows
+    // so the loaded table appears without a layout shift.
     return (
-      <Card padding="lg">
-        <p className="text-sm text-muted-foreground">
-          Loading repositories...
-        </p>
+      <Card padding="none">
+        <div
+          className="overflow-x-auto"
+          data-testid="repository-list-loading"
+          role="status"
+          aria-label="Loading repositories"
+        >
+          <table className="min-w-full text-sm">
+            <RepositoryTableHead />
+            <tbody>
+              {[0, 1, 2].map((i) => (
+                <tr key={i} className="border-b border-border">
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-24" /></td>
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-20" /></td>
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-16" /></td>
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-48" /></td>
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-10" /></td>
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-14" /></td>
+                  <td className="px-4 py-3 align-top"><Skeleton className="h-4 w-20" /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </Card>
     );
   }
@@ -306,32 +360,7 @@ function RepositoryListInner({ refreshKey, onChanged }: RepositoryListProps) {
       <Card padding="none">
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
-            <thead className="bg-muted border-b border-border">
-              <tr>
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Name
-                </th>
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Display name
-                </th>
-                {/* Issue #690: Visibility column placed before Path so it is always reachable on narrow screens */}
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Visibility
-                </th>
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Path
-                </th>
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Worktrees
-                </th>
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Status
-                </th>
-                <th className="px-4 py-2 text-left font-medium text-foreground">
-                  Actions
-                </th>
-              </tr>
-            </thead>
+            <RepositoryTableHead />
             <tbody>
               {repositories.length === 0 && (
                 <tr>

--- a/src/components/review/ReportTab.tsx
+++ b/src/components/review/ReportTab.tsx
@@ -11,7 +11,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import ReportDatePicker from './ReportDatePicker';
-import { Button, Card, Input, RadioGroup, RadioGroupItem, Textarea } from '@/components/ui';
+import { Button, Card, Input, RadioGroup, RadioGroupItem, Skeleton, Spinner, Textarea } from '@/components/ui';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
 import { SUMMARY_ALLOWED_TOOLS, MAX_USER_INSTRUCTION_LENGTH } from '@/config/review-config';
 import { useReportGeneration } from '@/hooks/useReportGeneration';
@@ -259,7 +259,13 @@ export default function ReportTab() {
             Select Template
           </label>
           {isLoadingTemplates ? (
-            <div className="text-sm text-muted-foreground">Loading templates...</div>
+            <Skeleton
+              className="h-9 w-full"
+              data-testid="report-template-loading"
+              role="status"
+              aria-label="Loading templates"
+              aria-hidden={undefined}
+            />
           ) : templates.length === 0 ? (
             <div className="text-sm text-muted-foreground">No templates available. Create one in the Template tab.</div>
           ) : (
@@ -315,7 +321,7 @@ export default function ReportTab() {
       {/* Message count */}
       <div className="mb-4 text-sm text-muted-foreground" data-testid="message-count">
         {isLoading ? (
-          'Loading...'
+          <Skeleton className="h-4 w-48" />
         ) : messageCount === 0 ? (
           'No messages for this date.'
         ) : (
@@ -333,7 +339,7 @@ export default function ReportTab() {
       {/* Loading spinner for generation (local or remote) */}
       {(isGenerating || isRemoteGenerating) && (
         <div className="flex items-center gap-2 mb-4 text-sm text-muted-foreground" data-testid="generating-spinner">
-          <div className="w-4 h-4 border-2 border-accent-600 border-t-transparent rounded-full animate-spin" />
+          <Spinner size="sm" variant="muted" />
           {isRemoteGenerating && remoteStatus.tool
             ? `Generating report... (tool: ${remoteStatus.tool}${remoteStatus.startedAt ? `, started: ${Math.round((Date.now() - new Date(remoteStatus.startedAt).getTime()) / 1000)}s ago` : ''})`
             : 'Generating summary...'}

--- a/src/components/review/ReviewTab.tsx
+++ b/src/components/review/ReviewTab.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Link from 'next/link';
-import { Card } from '@/components/ui';
+import { Card, Skeleton } from '@/components/ui';
 import { cn } from '@/lib/utils/cn';
 import { REVIEW_POLL_INTERVAL_MS } from '@/config/review-config';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
@@ -170,10 +170,25 @@ export default function ReviewTab() {
         })}
       </div>
 
-      {/* Loading */}
+      {/* Loading — card-shaped skeletons mirroring review list items (Issue #1118) */}
       {isLoading && (
-        <div className="text-muted-foreground" data-testid="review-loading">
-          Loading...
+        <div
+          className="space-y-2"
+          data-testid="review-loading"
+          role="status"
+          aria-label="Loading reviews"
+        >
+          {[0, 1, 2].map((i) => (
+            <Card key={i} padding="md">
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-40 max-w-full" />
+                  <Skeleton className="h-3 w-24 max-w-full" />
+                </div>
+                <Skeleton className="ml-4 h-5 w-16 flex-shrink-0" />
+              </div>
+            </Card>
+          ))}
         </div>
       )}
 

--- a/src/components/review/TemplateTab.tsx
+++ b/src/components/review/TemplateTab.tsx
@@ -9,7 +9,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { Button, Card, Input, Textarea } from '@/components/ui';
+import { Button, Card, Input, Skeleton, Textarea } from '@/components/ui';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
 import {
   MAX_TEMPLATES,
@@ -165,7 +165,23 @@ export default function TemplateTab() {
         </h2>
 
         {isLoading ? (
-          <div className="text-sm text-muted-foreground" data-testid="template-loading">Loading...</div>
+          // [Issue #1118] Card-shaped skeletons instead of naked loading text
+          <div
+            className="space-y-3"
+            data-testid="template-loading"
+            role="status"
+            aria-label="Loading templates"
+          >
+            {[0, 1].map((i) => (
+              <Card key={i} padding="md">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-full" />
+                  <Skeleton className="h-3 w-2/3" />
+                </div>
+              </Card>
+            ))}
+          </div>
         ) : templates.length === 0 ? (
           <div className="text-sm text-muted-foreground" data-testid="template-empty">No templates yet.</div>
         ) : (

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils/cn';
+import { Spinner } from './Spinner';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
 export type ButtonSize = 'sm' | 'md' | 'lg';
@@ -93,28 +94,7 @@ export function Button({
       disabled={isDisabled}
       {...props}
     >
-      {loading && (
-        <svg
-          className="animate-spin -ml-1 mr-2 h-4 w-4"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
-      )}
+      {loading && <Spinner size="sm" className="-ml-1 mr-2" />}
       {children}
     </button>
   );

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,78 @@
+/**
+ * Spinner Component
+ * Rotating loading indicator (Issue #1118).
+ *
+ * Consolidates the hand-written inline SVG / border-trick spinners that were
+ * duplicated across screens. Use Skeleton for content-shaped placeholders and
+ * Spinner for inline/button "busy" states where a skeleton does not fit.
+ */
+
+import React from 'react';
+import { cn } from '@/lib/utils/cn';
+
+export type SpinnerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type SpinnerVariant = 'current' | 'accent' | 'muted';
+
+const sizeClasses: Record<SpinnerSize, string> = {
+  xs: 'h-3 w-3',
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+  xl: 'h-8 w-8',
+};
+
+const variantClasses: Record<SpinnerVariant, string> = {
+  // Follows the parent's text color (e.g. white inside a primary Button)
+  current: '',
+  accent: 'text-accent-600 dark:text-accent-400',
+  muted: 'text-muted-foreground',
+};
+
+export interface SpinnerProps extends React.SVGAttributes<SVGSVGElement> {
+  size?: SpinnerSize;
+  variant?: SpinnerVariant;
+}
+
+/**
+ * Spinner loading indicator
+ *
+ * Decorative by default (aria-hidden). When the spinner is the only loading
+ * cue, pass `role="status"` and an `aria-label` (and reset aria-hidden).
+ *
+ * @example
+ * ```tsx
+ * <Spinner size="sm" className="mr-2" />
+ * <Spinner size="xl" variant="accent" />
+ * ```
+ */
+export function Spinner({
+  size = 'md',
+  variant = 'current',
+  className,
+  ...props
+}: SpinnerProps) {
+  return (
+    <svg
+      className={cn('animate-spin', sizeClasses[size], variantClasses[variant], className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -31,6 +31,9 @@ export type { TextareaProps } from './Textarea';
 export { Skeleton } from './Skeleton';
 export type { SkeletonProps } from './Skeleton';
 
+export { Spinner } from './Spinner';
+export type { SpinnerProps, SpinnerSize, SpinnerVariant } from './Spinner';
+
 export { Switch } from './Switch';
 export type { SwitchProps } from './Switch';
 

--- a/src/components/worktree/AgentInstancesPane.tsx
+++ b/src/components/worktree/AgentInstancesPane.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/lib/cli-tools/types';
 import { MIN_AGENT_INSTANCES } from '@/lib/agent-instances-validator';
 import { VibeLocalSettings } from '@/components/worktree/VibeLocalSettings';
+import { Spinner } from '@/components/ui/Spinner';
 
 // ============================================================================
 // Types
@@ -332,7 +333,7 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
           data-testid="agent-instances-loading"
           className="mt-3 flex items-center gap-2 text-xs text-muted-foreground"
         >
-          <span className="w-3 h-3 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
+          <Spinner size="xs" variant="muted" />
           {t('loading')}
         </div>
       )}

--- a/src/components/worktree/AgentSettingsPane.tsx
+++ b/src/components/worktree/AgentSettingsPane.tsx
@@ -19,7 +19,7 @@ import {
   type CLIToolType,
 } from '@/lib/cli-tools/types';
 import { VibeLocalSettings } from '@/components/worktree/VibeLocalSettings';
-import { Checkbox } from '@/components/ui';
+import { Checkbox, Spinner } from '@/components/ui';
 
 // ============================================================================
 // Types
@@ -211,7 +211,7 @@ export const AgentSettingsPane = memo(function AgentSettingsPane({
           data-testid="agent-settings-loading"
           className="mt-3 flex items-center gap-2 text-xs text-muted-foreground"
         >
-          <span className="w-3 h-3 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
+          <Spinner size="xs" variant="muted" />
           {t('loading')}
         </div>
       )}

--- a/src/components/worktree/ExecutionLogPane.tsx
+++ b/src/components/worktree/ExecutionLogPane.tsx
@@ -19,7 +19,7 @@ import { formatTimestamp } from '@/components/worktree/schedules/format';
 import { parseCmateContent } from '@/lib/cmate-validator';
 import { parseCliToolColumn } from '@/lib/cmate-cli-tool-parser';
 import type { AgentInstance } from '@/lib/cli-tools/types';
-import { Button } from '@/components/ui';
+import { Button, Spinner } from '@/components/ui';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
 
 // ============================================================================
@@ -259,7 +259,7 @@ export const ExecutionLogPane = memo(function ExecutionLogPane({
     return (
       <div className={`flex items-center justify-center h-full p-4 ${className}`}>
         <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-4 border-border border-t-accent-500 rounded-full animate-spin" />
+          <Spinner size="xl" variant="accent" />
           <span className="text-sm text-muted-foreground">{t('loading')}</span>
         </div>
       </div>

--- a/src/components/worktree/FilePanelContent.tsx
+++ b/src/components/worktree/FilePanelContent.tsx
@@ -29,6 +29,8 @@ import hljs from 'highlight.js';
 import 'highlight.js/styles/github-dark.css';
 import { Z_INDEX } from '@/config/z-index';
 import { COPY_FEEDBACK_RESET_MS } from '@/config/ui-feedback-config';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { Spinner } from '@/components/ui/Spinner';
 
 /** Fixed row height for the virtualized CodeViewer (px). Monospace + leading-6. */
 const CODE_VIEWER_ROW_HEIGHT_PX = 24;
@@ -37,7 +39,7 @@ const CODE_VIEWER_ROW_HEIGHT_PX = 24;
 function DynamicImportSpinner() {
   return (
     <div className="flex items-center justify-center py-12 bg-surface">
-      <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400" />
+      <Spinner size="xl" variant="accent" />
     </div>
   );
 }
@@ -119,7 +121,7 @@ const MARP_FRONTMATTER_REGEX = /^---\s*\nmarp:\s*true/;
 function LoadingSpinner() {
   return (
     <div className="flex items-center justify-center py-12">
-      <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400" />
+      <Spinner size="xl" variant="accent" />
       <p className="ml-3 text-muted-foreground">Loading file...</p>
     </div>
   );
@@ -476,7 +478,7 @@ function CodeViewer({
                     dangerouslySetInnerHTML={{ __html: html }}
                   />
                 ) : (
-                  <span className="text-muted-foreground italic">Loading…</span>
+                  <Skeleton className="h-4 w-3/4" />
                 )}
               </div>
             </div>

--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -31,7 +31,7 @@ import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import { useFileTreeExpandedState } from '@/hooks/useFileTreeExpandedState';
 import { useLocale } from 'next-intl';
 import { FilePlus, FolderPlus, AlertCircle, RefreshCw, RotateCcw } from 'lucide-react';
-import { Button } from '@/components/ui';
+import { Button, Skeleton } from '@/components/ui';
 
 // ============================================================================
 // Types
@@ -517,13 +517,26 @@ export const FileTreeView = memo(function FileTreeView({
   // rendered in the toolbar area instead (see below).
   const isInitialLoading = loading && rootItems.length === 0;
   if (isInitialLoading) {
+    // [Issue #1118] Skeleton rows shaped like tree nodes (chevron/icon +
+    // name at staggered indents) instead of a centered spinner, so the real
+    // tree replaces them without a layout jump.
     return (
       <div
         data-testid="file-tree-loading"
-        className={`flex items-center justify-center p-4 ${className}`}
+        className={`p-2 ${className}`}
+        role="status"
+        aria-label="Loading files"
       >
-        <span className="w-5 h-5 border-2 border-input border-t-cyan-500 rounded-full animate-spin" />
-        <span className="ml-2 text-sm text-muted-foreground">Loading files...</span>
+        {[0, 8, 16, 8, 0, 8].map((indent, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-2 py-1.5 pr-2"
+            style={{ paddingLeft: `${8 + indent}px` }}
+          >
+            <Skeleton className="h-4 w-4 shrink-0 rounded" />
+            <Skeleton className={`h-4 ${i % 3 === 0 ? 'w-32' : i % 3 === 1 ? 'w-24' : 'w-40'} max-w-full`} />
+          </div>
+        ))}
       </div>
     );
   }

--- a/src/components/worktree/FileViewer.tsx
+++ b/src/components/worktree/FileViewer.tsx
@@ -20,7 +20,7 @@
 
 import React, { memo, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslations } from 'next-intl';
-import { Modal } from '@/components/ui';
+import { Modal, Spinner } from '@/components/ui';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
 import { FileContent } from '@/types/models';
 import { ImageViewer } from './ImageViewer';
@@ -723,7 +723,7 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
       <div className="max-h-[60vh] sm:max-h-[70vh] flex flex-col">
         {loading && (
           <div className="flex items-center justify-center py-12">
-            <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-muted border-t-accent-600 dark:border-t-accent-400" />
+            <Spinner size="xl" variant="accent" />
             <p className="ml-3 text-muted-foreground">Loading file...</p>
           </div>
         )}

--- a/src/components/worktree/HistoryPane.tsx
+++ b/src/components/worktree/HistoryPane.tsx
@@ -13,7 +13,7 @@
 import React, { useMemo, useCallback, memo, useRef, useLayoutEffect, useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { Search, User, UserCheck, ChevronRight } from 'lucide-react';
-import { Checkbox } from '@/components/ui';
+import { Checkbox, Skeleton } from '@/components/ui';
 import type { ChatMessage } from '@/types/models';
 import { useConversationHistory } from '@/hooks/useConversationHistory';
 import { useHistorySearch } from '@/hooks/useHistorySearch';
@@ -122,20 +122,35 @@ export interface HistoryPaneProps {
 // Sub-components
 // ============================================================================
 
+/**
+ * Issue #1118: Card-shaped skeleton mirroring the ConversationPairCard outline
+ * (rounded-lg border, mb-4 rhythm) so the loading state matches the loaded
+ * layout instead of popping in. Kept generic on purpose — the real card is
+ * being restructured by Issue #1117, so only the outer shape is mimicked.
+ */
 function LoadingIndicator() {
   return (
     <div
       data-testid="loading-indicator"
-      className="flex items-center justify-center py-4"
       role="status"
       aria-label="Loading messages"
     >
-      <div className="flex gap-1" aria-hidden="true">
-        <span className="w-2 h-2 bg-muted-foreground rounded-full animate-pulse" />
-        <span className="w-2 h-2 bg-muted-foreground rounded-full animate-pulse delay-100" />
-        <span className="w-2 h-2 bg-muted-foreground rounded-full animate-pulse delay-200" />
-      </div>
-      <span className="ml-2 text-sm text-muted-foreground">Loading...</span>
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="mb-4 overflow-hidden rounded-lg border border-border"
+        >
+          <div className="flex items-center gap-2 p-3">
+            <Skeleton className="h-4 w-4 rounded-full" />
+            <Skeleton className="h-4 w-1/3" />
+          </div>
+          <div className="space-y-2 px-3 pb-3">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-5/6" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/worktree/InterruptButton.tsx
+++ b/src/components/worktree/InterruptButton.tsx
@@ -9,6 +9,7 @@
 
 import React, { memo, useState, useCallback, useRef } from 'react';
 import type { CLIToolType } from '@/lib/cli-tools/types';
+import { Spinner } from '@/components/ui/Spinner';
 
 export interface InterruptButtonProps {
   worktreeId: string;
@@ -102,26 +103,7 @@ export const InterruptButton = memo(function InterruptButton({
       data-testid="interrupt-button"
     >
       {isLoading ? (
-        <svg
-          className="animate-spin h-5 w-5"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
+        <Spinner size="md" />
       ) : (
         <StopIcon />
       )}

--- a/src/components/worktree/LogViewer.tsx
+++ b/src/components/worktree/LogViewer.tsx
@@ -7,7 +7,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Input } from '@/components/ui';
+import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Input, Spinner } from '@/components/ui';
 import { ToastContainer, useToast } from '@/components/common/Toast';
 import { worktreeApi, handleApiError } from '@/lib/api-client';
 import { copyToClipboard } from '@/lib/clipboard-utils';
@@ -266,7 +266,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
         <CardContent>
           {loading && logFiles.length === 0 && (
             <div className="text-center py-4">
-              <div className="inline-block animate-spin rounded-full h-6 w-6 border-4 border-input border-t-accent-600" />
+              <Spinner size="lg" variant="accent" className="inline-block" />
             </div>
           )}
 
@@ -381,7 +381,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
           <CardContent>
             {loading && (
               <div className="text-center py-8">
-                <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600" />
+                <Spinner size="xl" variant="accent" className="inline-block" />
               </div>
             )}
 

--- a/src/components/worktree/MarkdownEditor.tsx
+++ b/src/components/worktree/MarkdownEditor.tsx
@@ -36,6 +36,7 @@ import { debounce } from '@/lib/utils';
 import { copyToClipboard } from '@/lib/clipboard-utils';
 import { ToastContainer, useToast } from '@/components/common/Toast';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
+import { Spinner } from '@/components/ui/Spinner';
 import { PaneResizer } from '@/components/worktree/PaneResizer';
 import { MarkdownToolbar } from '@/components/worktree/MarkdownToolbar';
 import {
@@ -803,7 +804,7 @@ export const MarkdownEditor = memo(function MarkdownEditor({
         className="flex items-center justify-center h-full bg-surface"
       >
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400" />
+          <Spinner size="xl" variant="accent" className="inline-block" />
           <p className="mt-4 text-muted-foreground">Loading...</p>
         </div>
       </div>

--- a/src/components/worktree/MemoAddButton.tsx
+++ b/src/components/worktree/MemoAddButton.tsx
@@ -12,6 +12,7 @@
 'use client';
 
 import React, { memo } from 'react';
+import { Spinner } from '@/components/ui/Spinner';
 
 // ============================================================================
 // Types
@@ -86,10 +87,7 @@ export const MemoAddButton = memo(function MemoAddButton({
         `}
       >
         {isLoading ? (
-          <span
-            data-testid="loading-indicator"
-            className="w-5 h-5 border-2 border-muted border-t-accent-500 rounded-full animate-spin"
-          />
+          <Spinner data-testid="loading-indicator" size="md" variant="accent" />
         ) : (
           <svg
             className="w-5 h-5"

--- a/src/components/worktree/MemoPane.tsx
+++ b/src/components/worktree/MemoPane.tsx
@@ -20,6 +20,7 @@ import type { WorktreeMemo } from '@/types/models';
 import { MemoCard } from './MemoCard';
 import { MemoAddButton } from './MemoAddButton';
 import { MemoSearchBar } from './MemoSearchBar';
+import { Spinner } from '@/components/ui/Spinner';
 
 // ============================================================================
 // Types
@@ -229,7 +230,7 @@ export const MemoPane = memo(function MemoPane({
           data-testid="memo-loading"
           className="flex flex-col items-center gap-3"
         >
-          <div className="w-8 h-8 border-4 border-border border-t-accent-500 rounded-full animate-spin" />
+          <Spinner size="xl" variant="accent" />
           <span className="text-sm text-muted-foreground">Loading memos...</span>
         </div>
       </div>

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -11,11 +11,11 @@
 
 import React from 'react';
 import dynamic from 'next/dynamic';
-import { Loader2 } from 'lucide-react';
+import { Spinner } from '@/components/ui/Spinner';
 
 /**
  * Dynamic import of MermaidDiagram with SSR disabled
- * [SF2-004] Uses existing Loader2 spinner for consistent loading UI
+ * [SF2-004] Uses the shared Spinner primitive for consistent loading UI
  */
 const MermaidDiagram = dynamic(
   () =>
@@ -26,7 +26,7 @@ const MermaidDiagram = dynamic(
     ssr: false,
     loading: () => (
       <div className="mermaid-loading flex items-center gap-2 text-muted-foreground p-4">
-        <Loader2 className="animate-spin h-4 w-4" />
+        <Spinner size="sm" />
         <span>Loading diagram...</span>
       </div>
     ),

--- a/src/components/worktree/MermaidDiagram.tsx
+++ b/src/components/worktree/MermaidDiagram.tsx
@@ -15,6 +15,7 @@
 import React, { useState, useEffect, useRef, useId } from 'react';
 import mermaid from 'mermaid';
 import { MERMAID_CONFIG } from '@/config/mermaid-config';
+import { Spinner } from '@/components/ui/Spinner';
 
 /**
  * Props for MermaidDiagram component
@@ -138,7 +139,7 @@ export function MermaidDiagram({
         className="flex items-center justify-center p-4 text-muted-foreground"
       >
         <div className="flex items-center gap-2">
-          <div className="inline-block animate-spin rounded-full h-4 w-4 border-2 border-muted border-t-accent-600" />
+          <Spinner size="sm" variant="accent" />
           <span>Rendering diagram...</span>
         </div>
       </div>

--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -10,7 +10,7 @@ import { useTranslations } from 'next-intl';
 import { worktreeApi, handleApiError } from '@/lib/api-client';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import { Kbd } from '@/components/ui/Kbd';
-import { Button } from '@/components/ui';
+import { Button, Spinner } from '@/components/ui';
 import { SlashCommandSelector } from './SlashCommandSelector';
 import { InterruptButton } from './InterruptButton';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
@@ -482,10 +482,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
               data-testid="attach-image-button"
             >
               {isUploading ? (
-                <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
+                <Spinner size="md" />
               ) : (
                 <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
@@ -513,10 +510,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             data-testid="attach-image-button"
           >
             {isUploading ? (
-              <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
+              <Spinner size="md" />
             ) : (
               <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
@@ -567,10 +561,7 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             aria-label="Send message"
           >
             {sending ? (
-              <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
+              <Spinner size="md" />
             ) : (
               <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />

--- a/src/components/worktree/MoveDialog.tsx
+++ b/src/components/worktree/MoveDialog.tsx
@@ -14,10 +14,10 @@
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
 import { Modal } from '@/components/ui/Modal';
-import { Button } from '@/components/ui';
+import { Button, Spinner } from '@/components/ui';
 import { useTranslations } from 'next-intl';
 import type { TreeItem } from '@/types/models';
-import { ChevronRight, Folder, FolderOpen, Loader2 } from 'lucide-react';
+import { ChevronRight, Folder, FolderOpen } from 'lucide-react';
 
 /**
  * Recursively update a directory tree node's children.
@@ -218,7 +218,7 @@ export const MoveDialog = memo(function MoveDialog({
             }}
           >
             {isLoading ? (
-              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+              <Spinner size="xs" variant="muted" />
             ) : (
               <ChevronRight
                 className={`w-3 h-3 text-muted-foreground transition-transform ${
@@ -273,7 +273,7 @@ export const MoveDialog = memo(function MoveDialog({
 
           {rootLoading ? (
             <div className="flex items-center justify-center py-4">
-              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+              <Spinner size="md" variant="muted" />
             </div>
           ) : (
             directoryTree.map((node) => renderDirectoryNode(node, 1))

--- a/src/components/worktree/PdfPreview.tsx
+++ b/src/components/worktree/PdfPreview.tsx
@@ -28,6 +28,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { PDF_IFRAME_SANDBOX } from '@/config/pdf-extensions';
+import { Spinner } from '@/components/ui/Spinner';
 
 export type PdfPreviewVariant = 'iframe' | 'download';
 
@@ -110,7 +111,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
         className="h-full flex items-center justify-center"
         data-testid="pdf-preview-loading"
       >
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400" />
+        <Spinner size="xl" variant="accent" />
       </div>
     );
   }

--- a/src/components/worktree/PromptMessage.tsx
+++ b/src/components/worktree/PromptMessage.tsx
@@ -13,7 +13,7 @@ import type { ChatMessage } from '@/types/models';
 import { format } from 'date-fns';
 import { getDateFnsLocale } from '@/lib/date-locale';
 import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
-import { Button } from '@/components/ui';
+import { Button, Spinner } from '@/components/ui';
 
 export interface PromptMessageProps {
   message: ChatMessage;
@@ -60,7 +60,7 @@ function SendingIndicator({ className = '' }: { className?: string }) {
   const t = useTranslations('prompt');
   return (
     <div className={`flex items-center gap-2 text-sm text-muted-foreground ${className}`.trim()}>
-      <div className="animate-spin rounded-full h-4 w-4 border-2 border-input border-t-accent-600" />
+      <Spinner size="sm" variant="accent" />
       <span>{t('sending')}</span>
     </div>
   );

--- a/src/components/worktree/PromptPanel.tsx
+++ b/src/components/worktree/PromptPanel.tsx
@@ -12,7 +12,7 @@ import { memo, useState, useCallback, useId, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import type { PromptData, YesNoPromptData, MultipleChoicePromptData } from '@/types/models';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
-import { RadioGroup, RadioGroupItem, Button } from '@/components/ui';
+import { RadioGroup, RadioGroupItem, Button, Spinner } from '@/components/ui';
 import { usePromptAnimation } from '@/hooks/usePromptAnimation';
 
 /** Animation duration for prompt panel transitions */
@@ -163,7 +163,7 @@ function PromptPanelContent({
       {/* Answering indicator */}
       {isDisabled && (
         <div data-testid="answering-indicator" className="flex items-center gap-2 text-sm text-muted-foreground" role="status" aria-live="polite">
-          <div className="animate-spin rounded-full h-4 w-4 border-2 border-input border-t-accent-600" aria-hidden="true" />
+          <Spinner size="sm" variant="accent" />
           <span>{t('sending')}</span>
         </div>
       )}

--- a/src/components/worktree/SearchBar.tsx
+++ b/src/components/worktree/SearchBar.tsx
@@ -14,6 +14,7 @@
 import React, { memo, useCallback, useRef, useEffect } from 'react';
 import { MOBILE_BREAKPOINT } from '@/hooks/useIsMobile';
 import type { SearchMode } from '@/types/models';
+import { Spinner } from '@/components/ui/Spinner';
 
 // ============================================================================
 // Types
@@ -84,9 +85,12 @@ const ClearIcon = memo(function ClearIcon() {
 
 const LoadingSpinner = memo(function LoadingSpinner() {
   return (
-    <div
+    <Spinner
+      size="sm"
+      variant="accent"
       data-testid="search-loading"
-      className="w-4 h-4 border-2 border-input border-t-accent-500 rounded-full animate-spin"
+      role="status"
+      aria-hidden={false}
       aria-label="Searching..."
     />
   );

--- a/src/components/worktree/TreeNode.tsx
+++ b/src/components/worktree/TreeNode.tsx
@@ -27,6 +27,7 @@ import {
   DEFAULT_FILE_METADATA_DISPLAY,
   type FileMetadataDisplaySettings,
 } from '@/hooks/useFileMetadataDisplay';
+import { Spinner } from '@/components/ui/Spinner';
 
 // ============================================================================
 // Types
@@ -395,7 +396,7 @@ export const TreeNode = memo(function TreeNode({
         {isDirectory ? (
           <span className="w-4 h-4 flex items-center justify-center">
             {loading ? (
-              <span className="w-3 h-3 border-2 border-input border-t-accent-500 rounded-full animate-spin" />
+              <Spinner size="xs" variant="accent" />
             ) : (
               <ChevronIcon expanded={isExpanded} />
             )}

--- a/src/components/worktree/VibeLocalSettings.tsx
+++ b/src/components/worktree/VibeLocalSettings.tsx
@@ -20,6 +20,7 @@ import {
   VIBE_LOCAL_CONTEXT_WINDOW_MIN,
   VIBE_LOCAL_CONTEXT_WINDOW_MAX,
 } from '@/lib/cli-tools/types';
+import { Spinner } from '@/components/ui/Spinner';
 
 // ============================================================================
 // Types
@@ -177,7 +178,7 @@ export const VibeLocalSettings = memo(function VibeLocalSettings({
 
       {loadingModels ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <span className="w-3 h-3 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
+          <Spinner size="xs" variant="muted" />
           {t('loading')}
         </div>
       ) : ollamaError && ollamaModels.length === 0 ? (

--- a/src/components/worktree/VideoViewer.tsx
+++ b/src/components/worktree/VideoViewer.tsx
@@ -18,6 +18,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { Spinner } from '@/components/ui/Spinner';
 
 export interface VideoViewerProps {
   /** Video source (Base64 data URI) */
@@ -79,7 +80,7 @@ export function VideoViewer({ src, onError }: VideoViewerProps) {
     <div className="flex flex-col items-center justify-center p-4">
       {isLoading && (
         <div className="flex items-center justify-center py-8">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600" />
+          <Spinner size="xl" variant="accent" />
           <p className="ml-3 text-muted-foreground">Loading video...</p>
         </div>
       )}

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -18,7 +18,8 @@
 
 import React, { memo, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { Loader2, MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal } from 'lucide-react';
+import { Spinner } from '@/components/ui/Spinner';
 import { MobileHeader } from '@/components/mobile/MobileHeader';
 import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import { StatusDot } from '@/components/ui/StatusDot';
@@ -45,7 +46,7 @@ const MarkdownEditor = dynamic(
     ssr: false,
     loading: () => (
       <div className="flex items-center justify-center h-full bg-surface text-muted-foreground">
-        <Loader2 className="animate-spin h-6 w-6 mr-2" />
+        <Spinner size="lg" className="mr-2" />
         <span>Loading editor...</span>
       </div>
     ),

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -28,7 +28,7 @@ import { LogViewer } from '@/components/worktree/LogViewer';
 import { VersionSection } from '@/components/worktree/VersionSection';
 import { FeedbackSection } from '@/components/worktree/FeedbackSection';
 import { Modal } from '@/components/ui/Modal';
-import { Button } from '@/components/ui';
+import { Button, Spinner } from '@/components/ui';
 import { worktreeApi } from '@/lib/api-client';
 import { truncateString } from '@/lib/utils';
 import { ClipboardCopy, Check } from 'lucide-react';
@@ -937,10 +937,7 @@ export const LoadingIndicator = memo(function LoadingIndicator() {
       aria-live="polite"
     >
       <div className="flex flex-col items-center gap-3">
-        <div
-          className="animate-spin rounded-full h-8 w-8 border-4 border-input border-t-accent-600 dark:border-t-accent-400"
-          aria-hidden="true"
-        />
+        <Spinner size="xl" variant="accent" />
         <p className="text-muted-foreground">Loading worktree...</p>
       </div>
     </div>

--- a/src/components/worktree/git/panels/GitBranchPanel.tsx
+++ b/src/components/worktree/git/panels/GitBranchPanel.tsx
@@ -15,7 +15,7 @@ import type { BranchInfo, BranchInclude } from '@/types/git';
 import { branchCreatePrompt, branchDeletePrompt } from '@/lib/git-ai-prompt-templates';
 import { AskAiButton, RefreshIcon } from '@/components/worktree/git/gitPaneShared';
 import { useGitPaneContext } from '@/components/worktree/git/GitPaneContext';
-import { Checkbox } from '@/components/ui';
+import { Checkbox, Spinner } from '@/components/ui';
 
 export interface GitBranchPanelProps {
   branches: BranchInfo[];
@@ -124,7 +124,7 @@ export const GitBranchPanel = memo(function GitBranchPanel({
 
           {loading && branches.length === 0 && (
             <div className="flex items-center gap-2 px-3 pb-2" role="status">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" />
+              <Spinner size="sm" variant="accent" />
               <span className="sr-only">Loading branches...</span>
             </div>
           )}

--- a/src/components/worktree/git/panels/GitChangesPanel.tsx
+++ b/src/components/worktree/git/panels/GitChangesPanel.tsx
@@ -18,7 +18,7 @@ import {
   type ChangesDiffMode,
 } from '@/components/worktree/git/gitPaneShared';
 import { useGitPaneContext } from '@/components/worktree/git/GitPaneContext';
-import { Checkbox } from '@/components/ui';
+import { Checkbox, Spinner } from '@/components/ui';
 
 interface ChangedFileListProps {
   title: string;
@@ -158,7 +158,7 @@ const ChangedFileList = memo(function ChangedFileList({
                   >
                     {previewLoading && (
                       <div className="flex items-center gap-2 py-2" role="status">
-                        <div className="animate-spin rounded-full h-3.5 w-3.5 border-b-2 border-accent-500" />
+                        <Spinner size="xs" variant="accent" />
                         <span className="sr-only">Loading diff preview...</span>
                       </div>
                     )}
@@ -278,7 +278,7 @@ export const GitChangesPanel = memo(function GitChangesPanel({
 
       {loading && !staged && (
         <div className="flex items-center gap-2 px-3 pb-2" role="status">
-          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" />
+          <Spinner size="sm" variant="accent" />
           <span className="sr-only">Loading changes...</span>
         </div>
       )}

--- a/src/components/worktree/git/panels/GitCommitHistoryPanel.tsx
+++ b/src/components/worktree/git/panels/GitCommitHistoryPanel.tsx
@@ -19,6 +19,7 @@ import {
   RefreshIcon,
 } from '@/components/worktree/git/gitPaneShared';
 import { useGitPaneContext } from '@/components/worktree/git/GitPaneContext';
+import { Spinner } from '@/components/ui/Spinner';
 
 export interface GitCommitHistoryPanelProps {
   commits: CommitInfo[];
@@ -102,7 +103,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
       {/* Loading state */}
       {commitListOpen && isLoading && (
         <div className="flex items-center justify-center py-8" role="status">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-accent-500" />
+          <Spinner size="lg" variant="accent" />
           <span className="sr-only">Loading commit history...</span>
         </div>
       )}
@@ -178,7 +179,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                         >
                           {inlineFilesLoading && (
                             <div className="flex items-center justify-center py-3" role="status">
-                              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" />
+                              <Spinner size="sm" variant="accent" />
                               <span className="sr-only">Loading changed files...</span>
                             </div>
                           )}
@@ -243,7 +244,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
 
                   {isLoadingFiles && (
                     <div className="flex items-center justify-center py-4" role="status">
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" />
+                      <Spinner size="sm" variant="accent" />
                       <span className="sr-only">Loading changed files...</span>
                     </div>
                   )}
@@ -294,7 +295,7 @@ export const GitCommitHistoryPanel = memo(function GitCommitHistoryPanel({
                     <>
                       {isLoadingDiff && (
                         <div className="flex items-center justify-center py-4" role="status">
-                          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" />
+                          <Spinner size="sm" variant="accent" />
                           <span className="sr-only">Loading diff...</span>
                         </div>
                       )}

--- a/src/components/worktree/git/panels/GitCurrentStatusBar.tsx
+++ b/src/components/worktree/git/panels/GitCurrentStatusBar.tsx
@@ -14,6 +14,7 @@ import { memo } from 'react';
 import type { GitStatus } from '@/types/models';
 import { RefreshIcon } from '@/components/worktree/git/gitPaneShared';
 import { useGitPaneContext } from '@/components/worktree/git/GitPaneContext';
+import { Spinner } from '@/components/ui/Spinner';
 
 export interface GitCurrentStatusBarProps {
   gitStatus: GitStatus | null;
@@ -51,7 +52,7 @@ export const GitCurrentStatusBar = memo(function GitCurrentStatusBar({
       {/* Loading: only show the spinner before the first successful load */}
       {statusLoading && !gitStatus && (
         <div className="flex items-center gap-2 py-1" role="status">
-          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" />
+          <Spinner size="sm" variant="accent" />
           <span className="sr-only">Loading git status...</span>
         </div>
       )}

--- a/src/components/worktree/git/panels/GitNetworkOperationsBar.tsx
+++ b/src/components/worktree/git/panels/GitNetworkOperationsBar.tsx
@@ -21,6 +21,7 @@
 import React, { memo, useEffect, useState } from 'react';
 import type { GitNetworkOperation } from '@/types/git';
 import { useGitPaneContext } from '@/components/worktree/git/GitPaneContext';
+import { Spinner } from '@/components/ui/Spinner';
 
 export interface GitNetworkOperationsBarProps {
   /** 3-value progress state from useGitPaneNetworkOps. */
@@ -135,7 +136,7 @@ export const GitNetworkOperationsBar = memo(function GitNetworkOperationsBar({
           data-testid="git-network-progress-bar"
         >
           <span className="flex items-center gap-2" role="status" data-testid="git-network-operation-spinner">
-            <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-500" aria-hidden="true" />
+            <Spinner size="sm" variant="accent" />
             <span>
               {operation === 'push' ? 'Pushing' : operation === 'pull' ? 'Pulling' : 'Fetching'}… {elapsed}s
             </span>

--- a/tests/unit/AssistantChatPanel.test.tsx
+++ b/tests/unit/AssistantChatPanel.test.tsx
@@ -84,4 +84,26 @@ describe('AssistantChatPanel', () => {
       await screen.findByText('Select a repository and click Start to open an assistant session.'),
     ).toBeInTheDocument();
   });
+
+  it('shows a history skeleton while the conversation loads, then the message list (Issue #1118)', async () => {
+    let resolveConversation!: (value: null) => void;
+    vi.mocked(assistantApi.getConversation).mockReturnValue(
+      new Promise((resolve) => {
+        resolveConversation = resolve;
+      }) as ReturnType<typeof assistantApi.getConversation>,
+    );
+
+    render(<AssistantChatPanel />);
+
+    // Pending conversation fetch → bubble-shaped skeleton in the history area
+    const loading = await screen.findByTestId('assistant-chat-loading');
+    expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+
+    resolveConversation(null);
+
+    expect(
+      await screen.findByText('Select a repository and click Start to open an assistant session.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-chat-loading')).toBeNull();
+  });
 });

--- a/tests/unit/HomeSessionSummary.test.tsx
+++ b/tests/unit/HomeSessionSummary.test.tsx
@@ -74,4 +74,18 @@ describe('HomeSessionSummary', () => {
     expect(screen.getByTestId('running-count').className).toContain('text-foreground');
     expect(screen.getByTestId('waiting-count').className).toContain('text-muted-foreground');
   });
+
+  it('renders two skeleton stat boxes instead of counts while loading (Issue #1118)', () => {
+    render(<HomeSessionSummary worktrees={[]} isLoading />);
+    const loading = screen.getByTestId('home-session-summary-loading');
+    expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('running-count')).toBeNull();
+    expect(screen.queryByTestId('waiting-count')).toBeNull();
+  });
+
+  it('shows real counts once isLoading is false (Issue #1118)', () => {
+    render(<HomeSessionSummary worktrees={[]} isLoading={false} />);
+    expect(screen.queryByTestId('home-session-summary-loading')).toBeNull();
+    expect(screen.getByTestId('running-count').textContent).toBe('0');
+  });
 });

--- a/tests/unit/SessionsPage.test.tsx
+++ b/tests/unit/SessionsPage.test.tsx
@@ -429,6 +429,16 @@ describe('SessionsPage', () => {
       expect(screen.getByTestId('sessions-loading')).toBeDefined();
     });
 
+    it('should render skeleton session cards without naked loading text (Issue #1118)', () => {
+      mockIsLoading = true;
+
+      render(<SessionsPage />);
+
+      const loading = screen.getByTestId('sessions-loading');
+      expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+      expect(loading.textContent).not.toContain('Loading sessions');
+    });
+
     it('should show error state', () => {
       mockError = new Error('Network error');
 

--- a/tests/unit/components/HistoryPane.test.tsx
+++ b/tests/unit/components/HistoryPane.test.tsx
@@ -267,6 +267,21 @@ describe('HistoryPane', () => {
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     });
 
+    it('should render card-shaped skeletons without naked loading text (Issue #1118)', () => {
+      render(
+        <HistoryPane
+          messages={[]}
+          worktreeId={defaultWorktreeId}
+          onFilePathClick={mockOnFilePathClick}
+          isLoading={true}
+        />
+      );
+
+      const indicator = screen.getByTestId('loading-indicator');
+      expect(indicator.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+      expect(indicator.textContent).not.toContain('Loading');
+    });
+
     it('should not show loading indicator when isLoading is false', () => {
       render(
         <HistoryPane

--- a/tests/unit/components/common/RouteLoading.test.tsx
+++ b/tests/unit/components/common/RouteLoading.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Tests for RouteLoading (Issue #1118: route-level loading.tsx fallback)
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RouteLoading } from '@/components/common/RouteLoading';
+
+describe('RouteLoading', () => {
+  it('renders a page-outline skeleton announced as status', () => {
+    render(<RouteLoading />);
+    const root = screen.getByTestId('route-loading');
+    expect(root.getAttribute('role')).toBe('status');
+    expect(root.getAttribute('aria-label')).toBe('Loading page');
+    expect(root.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('contains no naked loading text', () => {
+    render(<RouteLoading />);
+    expect(screen.getByTestId('route-loading').textContent).toBe('');
+  });
+});

--- a/tests/unit/components/dynamic-import-patterns.test.ts
+++ b/tests/unit/components/dynamic-import-patterns.test.ts
@@ -57,9 +57,9 @@ describe('Dynamic Import Patterns', () => {
       expect(content).toContain('loading');
     });
 
-    it('should import Loader2 from lucide-react', () => {
-      expect(content).toContain('Loader2');
-      expect(content).toContain('lucide-react');
+    it('should render the shared Spinner in the loading placeholder (Issue #1118)', () => {
+      expect(content).toContain('Spinner');
+      expect(content).not.toContain('Loader2');
     });
   });
 
@@ -95,9 +95,9 @@ describe('Dynamic Import Patterns', () => {
       expect(content).toContain('loading');
     });
 
-    it('should import Loader2 from lucide-react', () => {
-      expect(content).toContain('Loader2');
-      expect(content).toContain('lucide-react');
+    it('should render the shared Spinner in the loading placeholder (Issue #1118)', () => {
+      expect(content).toContain('Spinner');
+      expect(content).not.toContain('Loader2');
     });
   });
 

--- a/tests/unit/components/home/RecentSessionsList.test.tsx
+++ b/tests/unit/components/home/RecentSessionsList.test.tsx
@@ -76,4 +76,19 @@ describe('RecentSessionsList', () => {
     render(<RecentSessionsList worktrees={worktrees} />);
     expect(screen.getAllByTestId(/^recent-session-/)).toHaveLength(5);
   });
+
+  it('renders limit-many skeleton rows instead of the empty state while loading (Issue #1118)', () => {
+    render(<RecentSessionsList worktrees={[]} isLoading />);
+    const loading = screen.getByTestId('recent-sessions-loading');
+    expect(loading.querySelectorAll('li')).toHaveLength(5);
+    expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('recent-sessions-empty')).toBeNull();
+  });
+
+  it('swaps skeletons for real rows once loaded (Issue #1118)', () => {
+    const worktrees = [createMockWorktree({ id: 'wt-1' })];
+    render(<RecentSessionsList worktrees={worktrees} isLoading={false} />);
+    expect(screen.queryByTestId('recent-sessions-loading')).toBeNull();
+    expect(screen.getByTestId('recent-session-wt-1')).toBeDefined();
+  });
 });

--- a/tests/unit/components/home/SessionOverviewTile.test.tsx
+++ b/tests/unit/components/home/SessionOverviewTile.test.tsx
@@ -56,4 +56,15 @@ describe('SessionOverviewTile', () => {
     render(<SessionOverviewTile worktrees={[]} />);
     expect(screen.getByTestId('session-overview-view-all').getAttribute('href')).toBe('/sessions');
   });
+
+  it('renders stat/list skeletons with headings intact while loading (Issue #1118)', () => {
+    render(<SessionOverviewTile worktrees={[]} isLoading />);
+    expect(screen.getByTestId('home-session-summary-loading')).toBeDefined();
+    expect(screen.getByTestId('recent-sessions-loading')).toBeDefined();
+    // Chrome (headings, View all link) stays visible during loading
+    expect(screen.getByText('Session Overview')).toBeDefined();
+    expect(screen.getByTestId('session-overview-view-all')).toBeDefined();
+    expect(screen.queryByTestId('running-count')).toBeNull();
+    expect(screen.queryByTestId('recent-sessions-empty')).toBeNull();
+  });
 });

--- a/tests/unit/components/home/TodoWidget.test.tsx
+++ b/tests/unit/components/home/TodoWidget.test.tsx
@@ -228,4 +228,25 @@ describe('TodoWidget mobile layout (Issue #909)', () => {
       expect(mockedApi.remove).toHaveBeenCalledWith('repo-a', 't1'),
     );
   });
+
+  it('shows skeleton rows while loading, then the loaded list (Issue #1118)', async () => {
+    let resolveList!: (todos: TodoItem[]) => void;
+    mockedApi.listAll.mockReturnValue(
+      new Promise<TodoItem[]>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    render(<TodoWidget />);
+
+    // While listAll is pending: pulse skeleton rows, no naked "Loading…" text
+    const loading = await screen.findByTestId('todo-loading');
+    expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Loading…')).toBeNull();
+
+    resolveList(TODOS);
+
+    expect(await screen.findByText('alpha task')).toBeInTheDocument();
+    expect(screen.queryByTestId('todo-loading')).toBeNull();
+  });
 });

--- a/tests/unit/components/repository/RepositoryList.test.tsx
+++ b/tests/unit/components/repository/RepositoryList.test.tsx
@@ -577,4 +577,32 @@ describe('RepositoryList (Issue #644)', () => {
       expect(disabledRow.textContent).toMatch(/Disabled/);
     });
   });
+
+  describe('Loading skeleton (Issue #1118)', () => {
+    it('shows table-shaped skeleton rows while loading, then the loaded rows', async () => {
+      let resolveList!: (value: { success: boolean; repositories: RepositoryListItem[] }) => void;
+      vi.mocked(repositoryApi.list).mockReturnValue(
+        new Promise((resolve) => {
+          resolveList = resolve;
+        }) as ReturnType<typeof repositoryApi.list>,
+      );
+
+      render(<RepositoryList refreshKey={0} />);
+
+      // While pending: skeleton (real table header + pulse rows), no naked text
+      const loading = screen.getByTestId('repository-list-loading');
+      expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+      expect(loading.textContent).toContain('Name');
+      expect(screen.queryByText('Loading repositories...')).toBeNull();
+
+      await act(async () => {
+        resolveList({ success: true, repositories: [buildRepo({ id: 'r1', name: 'repo-a' })] });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('repository-row-r1')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('repository-list-loading')).toBeNull();
+    });
+  });
 });

--- a/tests/unit/components/ui/Spinner.test.tsx
+++ b/tests/unit/components/ui/Spinner.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for Spinner primitive (Issue #1118: consolidate hand-written spinners)
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Spinner } from '@/components/ui/Spinner';
+
+function renderSpinner(ui: React.ReactElement): SVGSVGElement {
+  const { container } = render(ui);
+  const svg = container.querySelector('svg');
+  expect(svg).not.toBeNull();
+  return svg as SVGSVGElement;
+}
+
+describe('Spinner', () => {
+  it('renders an svg with the animate-spin class (selector compat with legacy tests)', () => {
+    const svg = renderSpinner(<Spinner />);
+    expect(svg.classList.contains('animate-spin')).toBe(true);
+    // Tailwind-doc style track + arc: both follow currentColor
+    expect(svg.querySelector('circle')).not.toBeNull();
+    expect(svg.querySelector('path')).not.toBeNull();
+  });
+
+  it('defaults to the md size (h-5 w-5)', () => {
+    const svg = renderSpinner(<Spinner />);
+    expect(svg.classList.contains('h-5')).toBe(true);
+    expect(svg.classList.contains('w-5')).toBe(true);
+  });
+
+  it.each([
+    ['xs', 'h-3', 'w-3'],
+    ['sm', 'h-4', 'w-4'],
+    ['md', 'h-5', 'w-5'],
+    ['lg', 'h-6', 'w-6'],
+    ['xl', 'h-8', 'w-8'],
+  ] as const)('applies the %s size classes', (size, h, w) => {
+    const svg = renderSpinner(<Spinner size={size} />);
+    expect(svg.classList.contains(h)).toBe(true);
+    expect(svg.classList.contains(w)).toBe(true);
+  });
+
+  it('inherits currentColor by default (no text- color class)', () => {
+    const svg = renderSpinner(<Spinner />);
+    const classes = Array.from(svg.classList);
+    expect(classes.some((c) => c.startsWith('text-'))).toBe(false);
+  });
+
+  it('applies the accent variant colors for both themes', () => {
+    const svg = renderSpinner(<Spinner variant="accent" />);
+    expect(svg.classList.contains('text-accent-600')).toBe(true);
+    expect(svg.classList.contains('dark:text-accent-400')).toBe(true);
+  });
+
+  it('applies the muted variant color', () => {
+    const svg = renderSpinner(<Spinner variant="muted" />);
+    expect(svg.classList.contains('text-muted-foreground')).toBe(true);
+  });
+
+  it('is aria-hidden by default (decorative)', () => {
+    const svg = renderSpinner(<Spinner />);
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('allows overriding aria attributes for standalone use', () => {
+    const svg = renderSpinner(
+      <Spinner aria-hidden={undefined} role="status" aria-label="Loading" />
+    );
+    expect(svg.getAttribute('role')).toBe('status');
+    expect(svg.getAttribute('aria-label')).toBe('Loading');
+  });
+
+  it('merges a custom className with last-wins for size conflicts', () => {
+    const svg = renderSpinner(<Spinner size="sm" className="h-10 w-10" />);
+    expect(svg.classList.contains('h-10')).toBe(true);
+    expect(svg.classList.contains('h-4')).toBe(false);
+  });
+});

--- a/tests/unit/components/worktree/FileTreeView.test.tsx
+++ b/tests/unit/components/worktree/FileTreeView.test.tsx
@@ -71,6 +71,13 @@ describe('FileTreeView', () => {
       expect(screen.getByTestId('file-tree-loading')).toBeInTheDocument();
     });
 
+    it('should render tree-row skeletons without naked loading text (Issue #1118)', () => {
+      render(<FileTreeView worktreeId="test-worktree" />);
+      const loading = screen.getByTestId('file-tree-loading');
+      expect(loading.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+      expect(loading.textContent).not.toContain('Loading files');
+    });
+
     it('should render tree items after loading', async () => {
       render(<FileTreeView worktreeId="test-worktree" />);
 


### PR DESCRIPTION
## 概要
Issue #1118 の対応。ローディング表示を「スピナー/裸テキスト」からレイアウト整合スケルトンへ引き上げ、コンテンツのポップインを解消。

## 変更内容
- `ui/Spinner.tsx` 新設: 手書きインラインSVG/borderスピナー43箇所を共通プリミティブへ置換
- 主要画面にレイアウト整合スケルトン（Home Session Overview/ToDo、Sessions一覧、Repositories一覧、HistoryPane（汎用Card型・loading分岐のみ）、ファイルツリー、AssistantChatPanel、Reviewタブ群）
- 裸テキストローディングをスケルトンへ置換（MessageList.tsxは#1117衝突回避のため対象外）
- 初回ロードのみスケルトン表示（再fetch時は既存コンテンツ維持の非ブロッキングパターン）
- 主要7ルートに loading.tsx（薄いRouteLoadingフォールバック）追加

## 品質ゲート
lint / tsc / test:unit (8818 passed) / build 全てPASS（ワーカー実行＋オーケストレーター再検証）

Refs #1118（親: #1110 UI/UX最先端化 Phase 2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)