### PR TITLE
fix(mobile): useIsMobileを描画前レイアウトエフェクトで解決し初回デスクトップ描画フリップを解消 (#1126)

### DIFF
--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -5,11 +5,30 @@
  * breakpoint is evaluated against the CSS viewport — exactly like Tailwind's
  * `md:` — rather than the layout width, which can diverge from the CSS viewport
  * under zoom, WebView, and device-emulation environments (Issue #1069).
+ *
+ * SSR-flip flash fix (Issue #1126): the seed stays `false` so the server render
+ * and the first client render agree (no hydration mismatch), but the correction
+ * runs in a *layout* effect. `useLayoutEffect` fires after commit yet BEFORE the
+ * browser paints, so the state update it schedules is flushed in the same frame
+ * — the accurate `isMobile` value is applied before the first paint. On a mobile
+ * viewport the desktop tree is therefore replaced before it is ever painted,
+ * eliminating the desktop→mobile flip flash without any UA sniffing or
+ * double-mounting of the heavy `WorktreeDetail` tree (the discarded branch is
+ * torn down within the same commit, so its passive polling effects never run).
  */
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` is a no-op on the server and React warns when it is called
+ * during server rendering. Fall back to `useEffect` there to keep SSR
+ * warning-free, while preserving the pre-paint timing on the client where the
+ * flash-elimination actually matters.
+ */
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * Default mobile breakpoint (768px - matches Tailwind's md breakpoint)
@@ -52,16 +71,17 @@ export interface UseIsMobileOptions {
 export function useIsMobile(options: UseIsMobileOptions = {}): boolean {
   const { breakpoint = MOBILE_BREAKPOINT } = options;
 
-  // IMPORTANT: Always start with false to match SSR and avoid hydration mismatch
-  // The actual mobile detection happens in useEffect after hydration
+  // IMPORTANT: Always start with false to match SSR and avoid hydration mismatch.
+  // The actual mobile detection happens in the layout effect below, which is
+  // flushed before the first browser paint (Issue #1126).
   const [isMobile, setIsMobile] = useState<boolean>(false);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // `max-width: breakpoint - 1` is the exact complement of Tailwind's `md:`
     // (`min-width: breakpoint`); for the default 768 this is `max-width: 767px`.
     const mediaQuery = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
 
-    // Sync state on mount (after hydration is complete)
+    // Sync state on mount, before paint, so the correct tree is the first frame.
     setIsMobile(mediaQuery.matches);
 
     const handleChange = (event: MediaQueryListEvent) => {

--- a/tests/unit/hooks/useIsMobile-hydration.test.tsx
+++ b/tests/unit/hooks/useIsMobile-hydration.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Hydration behavior tests for useIsMobile (Issue #1126)
+ *
+ * The SSR-flip flash fix keeps the SSR/first-client render deterministically
+ * `false` (desktop) so hydration matches the server HTML — no mismatch warning
+ * — and then corrects to the real viewport value in a layout effect that is
+ * flushed before the browser paints. These tests exercise a real
+ * `hydrateRoot()` against pre-rendered "desktop" HTML on a mobile viewport and
+ * assert:
+ *   1. React logs no hydration-mismatch warning.
+ *   2. The client resolves to the mobile value after hydration.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { act } from '@testing-library/react';
+import { hydrateRoot } from 'react-dom/client';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+/** Minimal probe that renders the string form of the detected mode. */
+function Probe() {
+  const isMobile = useIsMobile();
+  return <div data-testid="probe">{isMobile ? 'mobile' : 'desktop'}</div>;
+}
+
+/** Install a `matchMedia` stub that reports the given match result. */
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+/** Collect console.error calls whose message looks like a hydration warning. */
+function hydrationWarnings(spy: ReturnType<typeof vi.spyOn>): unknown[][] {
+  return (spy.mock.calls as unknown[][]).filter((args: unknown[]) =>
+    /hydrat|did not match|server (?:rendered )?html|text content does not match/i.test(
+      String(args[0])
+    )
+  );
+}
+
+describe('useIsMobile hydration (Issue #1126)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('hydrates desktop SSR HTML on a mobile viewport without a mismatch warning', async () => {
+    stubMatchMedia(true); // viewport is mobile at hydration time
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Server rendered the SSR-safe `false` branch → "desktop".
+    const container = document.createElement('div');
+    container.innerHTML = '<div data-testid="probe">desktop</div>';
+    document.body.appendChild(container);
+
+    await act(async () => {
+      hydrateRoot(container, <Probe />);
+    });
+
+    // No hydration mismatch: the first client render matched the server HTML.
+    expect(hydrationWarnings(errorSpy)).toEqual([]);
+    // The layout effect then corrected the value to the real (mobile) viewport.
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('mobile');
+  });
+
+  it('keeps desktop HTML stable when hydrating on a desktop viewport', async () => {
+    stubMatchMedia(false); // viewport is desktop at hydration time
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const container = document.createElement('div');
+    container.innerHTML = '<div data-testid="probe">desktop</div>';
+    document.body.appendChild(container);
+
+    await act(async () => {
+      hydrateRoot(container, <Probe />);
+    });
+
+    expect(hydrationWarnings(errorSpy)).toEqual([]);
+    // No regression on desktop: the value stays false, no flip occurs.
+    expect(container.querySelector('[data-testid="probe"]')?.textContent).toBe('desktop');
+  });
+});

--- a/tests/unit/hooks/useIsMobile.test.ts
+++ b/tests/unit/hooks/useIsMobile.test.ts
@@ -91,7 +91,8 @@ describe('useIsMobile', () => {
     it('seeds state with false on the first render even on a mobile viewport', () => {
       // The SSR-safe invariant: the useState seed is false so the server render
       // and the first client render agree (no hydration mismatch). Detection
-      // happens in useEffect, which only runs on the client after hydration.
+      // happens in a layout effect (Issue #1126), which only runs on the client
+      // — flushed before the first paint so the correct tree is the first frame.
       setViewportWidth(390);
       const renders: boolean[] = [];
       renderHook(() => {
@@ -103,7 +104,7 @@ describe('useIsMobile', () => {
       expect(renders[renders.length - 1]).toBe(true);
     });
 
-    it('does not call matchMedia during the initial render (only in effect)', () => {
+    it('does not call matchMedia during the initial render (only in the layout effect)', () => {
       // Server-side there is no matchMedia; the hook must not touch it during
       // render. renderHook flushes effects, so by the end it has been called,
       // but never before the first render committed.


### PR DESCRIPTION
## 概要
Issue #1126 の対応。useIsMobileが初期値falseでSSR→hydration後にフリップし、モバイル実機でデスクトップUIが一瞬描画される問題を解消。

## 対策（案C採用）
- 案A（CSS両ツリー出し分け）: 重いWorktreeDetailが二重マウントし両分岐のterminalペインが同時ポーリング開始→不採用
- 案B（UAヒント+cookie）: viewport幅基準とUAのmobileが不一致（狭幅デスクトップ/タブレット）でhydration mismatch再導入→不採用
- **案C（採用）**: SSR/初回クライアントは決定的にfalse（デスクトップ）を返しSSR HTMLと一致（mismatch警告なし）。検出をisomorphic useLayoutEffectで行い、commit後・描画前にflushされるため補正後のisMobile値が最初のフレームに反映。モバイルではデスクトップツリーが描画前に差し替わる

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1126（親: #1110 UI/UX最先端化 Phase 4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)