### PR TITLE
fix(mobile): モバイルA11y改善（focus trap・44pxタップターゲット・tablistキーボード） (#1127)

### DIFF
--- a/src/components/mobile/MobilePromptSheet.tsx
+++ b/src/components/mobile/MobilePromptSheet.tsx
@@ -6,12 +6,13 @@
 
 'use client';
 
-import { useState, useCallback, useId, useMemo, useRef, useEffect, memo } from 'react';
+import { useState, useCallback, useId, useMemo, useEffect, memo } from 'react';
 import { useTranslations } from 'next-intl';
 import type { PromptData, YesNoPromptData, MultipleChoicePromptData } from '@/types/models';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
 import { RadioGroup, RadioGroupItem, Spinner } from '@/components/ui';
 import { usePromptAnimation } from '@/hooks/usePromptAnimation';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 /** Animation duration for sheet transitions */
 const ANIMATION_DURATION_MS = 300;
@@ -22,7 +23,7 @@ const SWIPE_DISMISS_THRESHOLD = 100;
 /** Button style constants */
 const BUTTON_STYLES = {
   /** Common button base styles */
-  base: 'px-6 py-3 rounded-lg font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2',
+  base: 'px-6 py-3 rounded-lg font-medium transition-all touch-manipulation disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2',
   /** Primary button styles */
   primary: 'bg-accent-600 text-white hover:bg-accent-700 focus:ring-ring',
   /** Secondary button styles */
@@ -69,10 +70,16 @@ export const MobilePromptSheet = memo(function MobilePromptSheet({
   });
   const labelId = useId();
 
+  // [Issue #1127] Trap keyboard focus within the sheet while it is the active
+  // modal surface (Tab cycling + focus restore); shares the single useFocusTrap
+  // implementation with ui/Modal. The ref doubles as the sheet element ref.
+  const sheetRef = useFocusTrap<HTMLDivElement>({
+    active: visible && promptData !== null,
+  });
+
   // Swipe handling state
   const [touchStartY, setTouchStartY] = useState<number | null>(null);
   const [translateY, setTranslateY] = useState(0);
-  const sheetRef = useRef<HTMLDivElement>(null);
 
   // Reset translate when visibility changes
   useEffect(() => {

--- a/src/components/mobile/MobileTabBar.tsx
+++ b/src/components/mobile/MobileTabBar.tsx
@@ -6,7 +6,7 @@
 
 'use client';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { SquareTerminal, Clock, Folder, Wrench, Info } from 'lucide-react';
 import { NotificationDot } from '@/components/common/NotificationDot';
 import type { DeepLinkPane } from '@/types/ui-state';
@@ -83,13 +83,19 @@ export function MobileTabBar({
   hasUpdate = false,
   onSearchParamsChange,
 }: MobileTabBarProps) {
+  // [Issue #1127] Button refs for the ARIA tabs roving-tabindex pattern: arrow
+  // keys move focus (and selection) to the neighbouring tab element directly.
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
   /**
    * Get tab styles based on active state
    */
   const getTabStyles = useCallback(
     (tabId: MobileTab) => {
       const isActive = tabId === activeTab;
-      const baseStyles = 'flex flex-col items-center justify-center flex-1 py-2 px-1 transition-colors relative';
+      // [Issue #1127] min-h-[44px] + touch-manipulation: guarantee a ≥44px tap
+      // target and suppress the double-tap zoom delay on touch devices.
+      const baseStyles = 'flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 px-1 transition-colors relative touch-manipulation';
       // Issue #1080: match GlobalMobileNav — no cell fill; active is expressed by
       // accent text + a 2px top indicator bar (rendered in the button body).
       const activeStyles = isActive
@@ -98,6 +104,50 @@ export function MobileTabBar({
       return `${baseStyles} ${activeStyles}`;
     },
     [activeTab]
+  );
+
+  /**
+   * Activate a tab by index: notify the parent and mirror to searchParams.
+   */
+  const activateTab = useCallback(
+    (tab: MobileTab) => {
+      onTabChange(tab);
+      onSearchParamsChange?.(toDeepLinkPane(tab));
+    },
+    [onTabChange, onSearchParamsChange]
+  );
+
+  /**
+   * ARIA tabs keyboard model (Issue #1127): Arrow keys move between tabs with
+   * wraparound, Home/End jump to the ends. Selection follows focus (automatic
+   * activation), matching a bottom tab bar's tap semantics.
+   */
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      let nextIndex: number | null = null;
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = (index + 1) % TABS.length;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex = (index - 1 + TABS.length) % TABS.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = TABS.length - 1;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      tabRefs.current[nextIndex]?.focus();
+      activateTab(TABS[nextIndex].id);
+    },
+    [activateTab]
   );
 
   /**
@@ -131,18 +181,22 @@ export function MobileTabBar({
       aria-label="Mobile navigation"
       className="fixed bottom-0 inset-x-0 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md flex pb-safe z-40"
     >
-      {TABS.map((tab) => (
+      {TABS.map((tab, index) => (
         <button
           key={tab.id}
+          ref={(el) => {
+            tabRefs.current[index] = el;
+          }}
           type="button"
           data-testid={`mobile-tab-${tab.id}`}
           role="tab"
           aria-selected={activeTab === tab.id}
           aria-label={tab.label}
-          onClick={() => {
-            onTabChange(tab.id);
-            onSearchParamsChange?.(toDeepLinkPane(tab.id));
-          }}
+          // Roving tabindex: only the active tab is in the page tab order; the
+          // rest are reached with the arrow keys (Issue #1127).
+          tabIndex={activeTab === tab.id ? 0 : -1}
+          onClick={() => activateTab(tab.id)}
+          onKeyDown={(e) => handleKeyDown(e, index)}
           className={getTabStyles(tab.id)}
         >
           {activeTab === tab.id && (

--- a/src/components/mobile/MobileTerminalActionsSheet.tsx
+++ b/src/components/mobile/MobileTerminalActionsSheet.tsx
@@ -13,6 +13,7 @@
 import React, { useCallback, useEffect, useId } from 'react';
 import { useTranslations } from 'next-intl';
 import { Search, LogOut } from 'lucide-react';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 export interface MobileTerminalActionsSheetProps {
   /** Whether the sheet is visible. */
@@ -39,6 +40,10 @@ export function MobileTerminalActionsSheet({
 }: MobileTerminalActionsSheetProps) {
   const t = useTranslations('worktree');
   const labelId = useId();
+
+  // [Issue #1127] Keep keyboard focus inside the sheet while open (shared
+  // useFocusTrap); pairs with the existing Escape/backdrop dismiss paths.
+  const sheetRef = useFocusTrap<HTMLDivElement>({ active: open });
 
   const handleSearch = useCallback(() => {
     onSearch();
@@ -75,10 +80,12 @@ export function MobileTerminalActionsSheet({
 
       {/* Sheet */}
       <div
+        ref={sheetRef}
         data-testid="mobile-terminal-actions-sheet"
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelId}
+        tabIndex={-1}
         className="fixed bottom-0 inset-x-0 z-50 rounded-t-2xl border-t border-border bg-surface pb-safe"
       >
         {/* Drag handle */}
@@ -95,7 +102,7 @@ export function MobileTerminalActionsSheet({
             type="button"
             data-testid="actions-sheet-search"
             onClick={handleSearch}
-            className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm text-foreground hover:bg-muted transition-colors"
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm text-foreground hover:bg-muted transition-colors touch-manipulation"
           >
             <Search size={18} aria-hidden="true" className="text-muted-foreground" />
             {t('terminal.searchTerminal')}
@@ -105,7 +112,7 @@ export function MobileTerminalActionsSheet({
             data-testid="actions-sheet-end"
             onClick={handleEnd}
             disabled={endDisabled}
-            className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm text-danger hover:bg-danger/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm text-danger hover:bg-danger/10 transition-colors touch-manipulation disabled:opacity-40 disabled:hover:bg-transparent"
           >
             <LogOut size={18} aria-hidden="true" />
             {t('terminal.endSession')}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -17,7 +17,9 @@ const buttonVariants = cva(
   // focus-visible + ring-offset-background: keyboard-only ring, and the offset
   // color is tied to the page background so dark mode no longer paints the
   // default white halo (Tabs/Switch are the reference).
-  'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background',
+  // [Issue #1127] touch-manipulation: opt every Button out of the browser's
+  // double-tap-to-zoom delay on touch devices (no visual change).
+  'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-all duration-200 touch-manipulation focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background',
   {
     variants: {
       variant: {

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -5,12 +5,13 @@
 
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { cva } from 'class-variance-authority';
 import { Z_INDEX } from '@/config/z-index';
 import { EXIT_ANIMATION_DURATION_MS } from '@/config/ui-feedback-config';
 import { useExitAnimation } from '@/hooks/useExitAnimation';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 import { cn } from '@/lib/utils/cn';
 
 const modalSizeVariants = cva('', {
@@ -62,7 +63,13 @@ export function Modal({
   showCloseButton = true,
   disableClose = false,
 }: ModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+
+  // [Issue #1127] Trap keyboard focus inside the dialog while it is open (Tab
+  // cycling, initial focus, focus restore on close). Engaged on `isOpen` — not
+  // `shouldRender` — so focus returns to the opener the moment closing begins,
+  // even while the exit animation keeps the panel mounted.
+  const modalRef = useFocusTrap<HTMLDivElement>({ active: isOpen });
 
   // [Issue #1114] Keep the modal mounted for the exit window so the
   // data-[state=closed] fade/zoom-out animation can play before unmount.
@@ -118,6 +125,10 @@ export function Modal({
           ref={modalRef}
           data-state={dataState}
           data-testid="modal-panel"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={title ? titleId : undefined}
+          tabIndex={-1}
           className={cn(
             'relative w-full',
             modalSizeVariants({ size }),
@@ -135,11 +146,12 @@ export function Modal({
           {/* Header */}
           {(title || showCloseButton) && (
             <div className="flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 border-b border-border flex-shrink-0">
-              <h3 className="text-base sm:text-lg font-semibold text-foreground truncate pr-2">{title}</h3>
+              <h3 id={titleId} className="text-base sm:text-lg font-semibold text-foreground truncate pr-2">{title}</h3>
               {showCloseButton && (
                 <button
                   onClick={onClose}
-                  className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+                  aria-label="Close"
+                  className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 touch-manipulation"
                 >
                   <svg
                     className="w-5 h-5 sm:w-6 sm:h-6"

--- a/src/components/worktree/WorktreeCard.tsx
+++ b/src/components/worktree/WorktreeCard.tsx
@@ -120,7 +120,11 @@ export function WorktreeCard({ worktree, onSessionKilled }: WorktreeCardProps) {
               <button
                 onClick={handleToggleFavorite}
                 disabled={isTogglingFavorite}
-                className="flex-shrink-0 transition-colors hover:scale-110"
+                className="flex-shrink-0 transition-colors hover:scale-110 touch-manipulation"
+                // Issue #1127: this control is icon-only, so its `title` tooltip
+                // is invisible on touch/SR. aria-label gives it a real
+                // accessible name reachable without hover.
+                aria-label={isFavorite ? t('common.favorites.remove') : t('common.favorites.add')}
                 title={isFavorite ? t('common.favorites.remove') : t('common.favorites.add')}
               >
                 <svg

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -300,7 +300,9 @@ export const MobileContent = memo(function MobileContent({
             <button
               type="button"
               onClick={() => onHistorySubTabChange('message')}
-              className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
+              // Issue #1127: min-h-[44px] + touch-manipulation — ≥44px tap
+              // target (text stays text-xs) and no double-tap zoom delay.
+              className={`flex-1 min-h-[44px] px-3 py-1.5 text-xs font-medium transition-colors touch-manipulation ${
                 historySubTab === 'message'
                   ? 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400 bg-accent-50 dark:bg-accent-900/30'
                   : 'text-muted-foreground hover:text-foreground'
@@ -311,7 +313,9 @@ export const MobileContent = memo(function MobileContent({
             <button
               type="button"
               onClick={() => onHistorySubTabChange('git')}
-              className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors ${
+              // Issue #1127: min-h-[44px] + touch-manipulation — ≥44px tap
+              // target (text stays text-xs) and no double-tap zoom delay.
+              className={`flex-1 min-h-[44px] px-3 py-1.5 text-xs font-medium transition-colors touch-manipulation ${
                 historySubTab === 'git'
                   ? 'text-accent-600 dark:text-accent-400 border-b-2 border-accent-600 dark:border-accent-400 bg-accent-50 dark:bg-accent-900/30'
                   : 'text-muted-foreground hover:text-foreground'

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -427,7 +427,11 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
                 <button
                   key={inst.id}
                   onClick={() => setActiveInstanceId(inst.id)}
-                  className={`flex-shrink-0 whitespace-nowrap px-1.5 py-1 font-medium text-xs transition-colors flex items-center gap-1 border-b-2 ${
+                  // Issue #1127: min-h-[44px] + touch-manipulation give these
+                  // densely-packed instance tabs a ≥44px tap target (text stays
+                  // text-xs; only the hit area grows) and kill the double-tap
+                  // zoom delay on touch devices.
+                  className={`flex-shrink-0 whitespace-nowrap min-h-[44px] px-1.5 py-1 font-medium text-xs transition-colors flex items-center gap-1 border-b-2 touch-manipulation ${
                     isActive
                       ? 'text-accent-600 dark:text-accent-400 border-accent-500'
                       : 'text-muted-foreground hover:text-foreground border-transparent'
@@ -445,7 +449,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           <button
             type="button"
             onClick={() => setShowActionsSheet(true)}
-            className="flex-shrink-0 flex items-center justify-center min-h-[44px] min-w-[44px] rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            className="flex-shrink-0 flex items-center justify-center min-h-[44px] min-w-[44px] rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors touch-manipulation"
             aria-label={tWorktree('terminal.moreActions')}
             data-testid="mobile-more-actions-button"
           >

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,157 @@
+/**
+ * useFocusTrap (Issue #1127)
+ *
+ * Confines keyboard focus to a container while it is active — the missing piece
+ * for our modal/bottom-sheet surfaces (`ui/Modal`, `MobilePromptSheet`,
+ * `MobileTerminalActionsSheet`) which previously let Tab escape to the page
+ * behind the overlay.
+ *
+ * Why a hook instead of Radix Dialog: those surfaces are bespoke (custom portal,
+ * enter/exit animation via useExitAnimation/usePromptAnimation, and swipe-to-
+ * dismiss). Swapping in `@radix-ui/react-dialog` — not currently a dependency —
+ * would force a rewrite of all three and their tests. A single shared hook adds
+ * the trap without disturbing that machinery, and keeps the implementation in
+ * one place per the issue's "focus trap は1実装に集約" directive.
+ *
+ * Behaviour while `active`:
+ * - moves focus into the container on activation (initial focus),
+ * - cycles Tab / Shift+Tab within the container's focusable elements,
+ * - restores focus to the previously focused element on deactivation/unmount.
+ */
+
+'use client';
+
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Elements that can receive keyboard focus. Visibility is intentionally not part
+ * of the filter: layout metrics (offsetParent / getClientRects) are unavailable
+ * under jsdom, so we exclude disabled controls and tabindex="-1" up front and
+ * drop `hidden` / `aria-hidden` nodes below instead.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export interface UseFocusTrapOptions {
+  /** Whether the trap is engaged. Defaults to true. */
+  active?: boolean;
+  /** Move focus into the container when the trap engages. Defaults to true. */
+  initialFocus?: boolean;
+  /** Restore focus to the previously focused element on release. Defaults to true. */
+  restoreFocus?: boolean;
+}
+
+/**
+ * Returns a ref to attach to the trap container. Attach it to the dialog/sheet
+ * panel; the panel is made programmatically focusable (tabindex="-1") if it is
+ * not already, so initial focus can land on the dialog itself.
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>(
+  options: UseFocusTrapOptions = {}
+): RefObject<T> {
+  const { active = true, initialFocus = true, restoreFocus = true } = options;
+  const containerRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    // Whether focus already sat inside the container when the trap engaged.
+    // React applies `autoFocus` during commit (before this effect), so a
+    // consumer that autofocuses one of its own controls lands here as "inside".
+    // In that case the consumer owns focus: we neither steal initial focus nor
+    // hijack focus restoration from it (e.g. ConfirmDialog / ConfirmProvider).
+    const previouslyInside =
+      previouslyFocused !== null && container.contains(previouslyFocused);
+
+    const getFocusable = (): HTMLElement[] =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter(
+        (el) =>
+          !el.hasAttribute('hidden') && el.getAttribute('aria-hidden') !== 'true'
+      );
+
+    if (initialFocus && !previouslyInside) {
+      if (!container.hasAttribute('tabindex')) {
+        container.setAttribute('tabindex', '-1');
+      }
+      container.focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Tab') return;
+
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        // Nothing focusable inside — keep focus pinned to the container.
+        event.preventDefault();
+        container.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      const onContainer = activeEl === container;
+
+      // Focus sits outside the trap entirely — pull it back to the edge.
+      if (!activeEl || !container.contains(activeEl)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (event.shiftKey) {
+        // Wrap backwards from the first element (or the container itself).
+        if (activeEl === first || onContainer) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (activeEl === last || onContainer) {
+        // Wrap forwards from the last element (or the container itself).
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // Only restore focus the trap itself moved in from outside; if focus
+      // started inside (consumer-managed), leave restoration to the consumer.
+      if (
+        restoreFocus &&
+        !previouslyInside &&
+        previouslyFocused &&
+        document.contains(previouslyFocused)
+      ) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [active, initialFocus, restoreFocus]);
+
+  return containerRef;
+}
+
+export default useFocusTrap;

--- a/tests/unit/components/mobile-tap-targets.test.ts
+++ b/tests/unit/components/mobile-tap-targets.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Mobile tap-target guard (Issue #1127)
+ *
+ * The two densely-packed tab rows called out in the issue — the mobile
+ * agent-instance tabs (WorktreeDetailRefactored) and the History sub-tabs
+ * (WorktreeDetailMobile) — live inside heavy containers that are impractical to
+ * render in isolation, so their ≥44px hit-area styling is asserted at the source
+ * level (same approach as motion-foundation.test.ts). MobileTabBar's equivalent
+ * styling is covered by a render test in MobileTabBar.test.tsx.
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const root = process.cwd();
+
+function read(relative: string): string {
+  return readFileSync(path.join(root, relative), 'utf8');
+}
+
+describe('Mobile tap targets ≥44px (Issue #1127)', () => {
+  it('agent-instance tabs guarantee a ≥44px tap target', () => {
+    const src = read('src/components/worktree/WorktreeDetailRefactored.tsx');
+    // The instance tab keeps its text-xs visual but gains a 44px hit area.
+    expect(src).toContain('whitespace-nowrap min-h-[44px] px-1.5 py-1 font-medium text-xs');
+    expect(src).toContain('touch-manipulation');
+  });
+
+  it('History sub-tabs guarantee a ≥44px tap target', () => {
+    const src = read('src/components/worktree/WorktreeDetailMobile.tsx');
+    // Both Message and Git sub-tabs share the same 44px hit-area styling.
+    const matches = src.match(
+      /flex-1 min-h-\[44px\] px-3 py-1\.5 text-xs font-medium transition-colors touch-manipulation/g
+    );
+    expect(matches).not.toBeNull();
+    expect(matches?.length).toBe(2);
+  });
+});

--- a/tests/unit/components/mobile/MobilePromptSheet.test.tsx
+++ b/tests/unit/components/mobile/MobilePromptSheet.test.tsx
@@ -421,6 +421,8 @@ describe('MobilePromptSheet', () => {
     });
 
     it('should trap focus within the sheet', () => {
+      // Issue #1127: Tab / Shift+Tab cycle within the sheet instead of escaping
+      // to the page behind the overlay.
       render(
         <MobilePromptSheet
           {...defaultProps}
@@ -429,8 +431,22 @@ describe('MobilePromptSheet', () => {
         />
       );
 
-      const buttons = screen.getAllByRole('button');
+      const sheet = screen.getByTestId('mobile-prompt-sheet');
+      // Initial focus lands on the sheet dialog itself.
+      expect(document.activeElement).toBe(sheet);
+
+      const buttons = Array.from(sheet.querySelectorAll('button'));
       expect(buttons.length).toBeGreaterThan(0);
+      const first = buttons[0];
+      const last = buttons[buttons.length - 1];
+
+      last.focus();
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(document.activeElement).toBe(first);
+
+      first.focus();
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(last);
     });
   });
 

--- a/tests/unit/components/mobile/MobileTabBar.test.tsx
+++ b/tests/unit/components/mobile/MobileTabBar.test.tsx
@@ -407,4 +407,110 @@ describe('MobileTabBar', () => {
       expect(badge).toHaveAttribute('aria-label', 'Update available');
     });
   });
+
+  // Issue #1127: ARIA tabs pattern — roving tabindex + arrow-key navigation.
+  describe('Roving tabindex (Issue #1127)', () => {
+    it('puts only the active tab in the page tab order', () => {
+      render(<MobileTabBar {...defaultProps} activeTab="history" />);
+
+      expect(screen.getByRole('tab', { name: /history/i })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('tab', { name: /terminal/i })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('tab', { name: /files/i })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('tab', { name: /tools/i })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('tab', { name: /info/i })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('moves the roving tabindex when the active tab changes', () => {
+      const { rerender } = render(<MobileTabBar {...defaultProps} activeTab="terminal" />);
+      expect(screen.getByRole('tab', { name: /terminal/i })).toHaveAttribute('tabindex', '0');
+
+      rerender(<MobileTabBar {...defaultProps} activeTab="files" />);
+      expect(screen.getByRole('tab', { name: /files/i })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('tab', { name: /terminal/i })).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('Arrow-key navigation (Issue #1127)', () => {
+    it('ArrowRight focuses and selects the next tab', () => {
+      const onTabChange = vi.fn();
+      render(<MobileTabBar {...defaultProps} activeTab="terminal" onTabChange={onTabChange} />);
+
+      const terminalTab = screen.getByRole('tab', { name: /terminal/i });
+      terminalTab.focus();
+      fireEvent.keyDown(terminalTab, { key: 'ArrowRight' });
+
+      expect(onTabChange).toHaveBeenCalledWith('history');
+      expect(document.activeElement).toBe(screen.getByRole('tab', { name: /history/i }));
+    });
+
+    it('ArrowLeft wraps from the first tab to the last', () => {
+      const onTabChange = vi.fn();
+      render(<MobileTabBar {...defaultProps} activeTab="terminal" onTabChange={onTabChange} />);
+
+      const terminalTab = screen.getByRole('tab', { name: /terminal/i });
+      fireEvent.keyDown(terminalTab, { key: 'ArrowLeft' });
+
+      expect(onTabChange).toHaveBeenCalledWith('info');
+      expect(document.activeElement).toBe(screen.getByRole('tab', { name: /info/i }));
+    });
+
+    it('ArrowRight wraps from the last tab to the first', () => {
+      const onTabChange = vi.fn();
+      render(<MobileTabBar {...defaultProps} activeTab="info" onTabChange={onTabChange} />);
+
+      const infoTab = screen.getByRole('tab', { name: /info/i });
+      fireEvent.keyDown(infoTab, { key: 'ArrowRight' });
+
+      expect(onTabChange).toHaveBeenCalledWith('terminal');
+      expect(document.activeElement).toBe(screen.getByRole('tab', { name: /terminal/i }));
+    });
+
+    it('Home jumps to the first tab and End to the last', () => {
+      const onTabChange = vi.fn();
+      render(<MobileTabBar {...defaultProps} activeTab="files" onTabChange={onTabChange} />);
+
+      const filesTab = screen.getByRole('tab', { name: /files/i });
+
+      fireEvent.keyDown(filesTab, { key: 'Home' });
+      expect(onTabChange).toHaveBeenCalledWith('terminal');
+      expect(document.activeElement).toBe(screen.getByRole('tab', { name: /terminal/i }));
+
+      fireEvent.keyDown(screen.getByRole('tab', { name: /terminal/i }), { key: 'End' });
+      expect(onTabChange).toHaveBeenCalledWith('info');
+      expect(document.activeElement).toBe(screen.getByRole('tab', { name: /info/i }));
+    });
+
+    it('also mirrors arrow navigation to searchParams when provided', () => {
+      const onSearchParamsChange = vi.fn();
+      render(
+        <MobileTabBar
+          {...defaultProps}
+          activeTab="terminal"
+          onSearchParamsChange={onSearchParamsChange}
+        />
+      );
+
+      fireEvent.keyDown(screen.getByRole('tab', { name: /terminal/i }), { key: 'ArrowRight' });
+      expect(onSearchParamsChange).toHaveBeenCalledWith('history');
+    });
+
+    it('ignores unrelated keys', () => {
+      const onTabChange = vi.fn();
+      render(<MobileTabBar {...defaultProps} activeTab="terminal" onTabChange={onTabChange} />);
+
+      fireEvent.keyDown(screen.getByRole('tab', { name: /terminal/i }), { key: 'a' });
+      expect(onTabChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Tap targets (Issue #1127)', () => {
+    it('gives every tab a ≥44px hit area and touch-manipulation', () => {
+      render(<MobileTabBar {...defaultProps} />);
+
+      screen.getAllByRole('tab').forEach((tab) => {
+        expect(tab.className).toContain('min-h-[44px]');
+        expect(tab.className).toContain('touch-manipulation');
+      });
+    });
+  });
 });

--- a/tests/unit/components/mobile/MobileTerminalActionsSheet.test.tsx
+++ b/tests/unit/components/mobile/MobileTerminalActionsSheet.test.tsx
@@ -87,4 +87,23 @@ describe('MobileTerminalActionsSheet', () => {
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(defaultProps.onClose).not.toHaveBeenCalled();
   });
+
+  // Issue #1127: focus trap parity with ui/Modal.
+  it('moves initial focus to the sheet and traps Tab within it', () => {
+    render(<MobileTerminalActionsSheet {...defaultProps} />);
+    const sheet = screen.getByTestId('mobile-terminal-actions-sheet');
+    expect(document.activeElement).toBe(sheet);
+
+    const buttons = Array.from(sheet.querySelectorAll('button'));
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+
+    last.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
 });

--- a/tests/unit/components/ui/Modal.test.tsx
+++ b/tests/unit/components/ui/Modal.test.tsx
@@ -184,3 +184,53 @@ describe('Modal', () => {
     expect(screen.queryByRole('button')).toBeNull();
   });
 });
+
+// [Issue #1127] Focus management: dialog semantics + focus trap.
+describe('Modal focus trap (Issue #1127)', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = 'unset';
+  });
+
+  it('exposes dialog semantics on the panel', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="A11y">
+        <p>content</p>
+      </Modal>
+    );
+    const panel = screen.getByTestId('modal-panel');
+    expect(panel).toHaveAttribute('role', 'dialog');
+    expect(panel).toHaveAttribute('aria-modal', 'true');
+    expect(panel).toHaveAttribute('aria-labelledby');
+  });
+
+  it('moves initial focus to the dialog when opened', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Focus">
+        <button data-testid="a">A</button>
+      </Modal>
+    );
+    expect(document.activeElement).toBe(screen.getByTestId('modal-panel'));
+  });
+
+  it('cycles Tab and Shift+Tab within the dialog', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Trap">
+        <button data-testid="a">A</button>
+        <button data-testid="b">B</button>
+      </Modal>
+    );
+    const panel = screen.getByTestId('modal-panel');
+    const focusables = Array.from(panel.querySelectorAll('button'));
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    last.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/tests/unit/hooks/useFocusTrap.test.tsx
+++ b/tests/unit/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for useFocusTrap (Issue #1127)
+ *
+ * Verifies the focus-trap contract used by ui/Modal and the mobile sheets:
+ * initial focus into the container, Tab / Shift+Tab cycling, and focus restore
+ * to the opener on release.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React, { useState } from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+function Trap({
+  active = true,
+  restoreFocus = true,
+  initialFocus = true,
+}: {
+  active?: boolean;
+  restoreFocus?: boolean;
+  initialFocus?: boolean;
+}) {
+  const ref = useFocusTrap<HTMLDivElement>({ active, restoreFocus, initialFocus });
+  return (
+    <div ref={ref} data-testid="trap">
+      <button data-testid="first">First</button>
+      <button data-testid="middle">Middle</button>
+      <button data-testid="last">Last</button>
+    </div>
+  );
+}
+
+function ToggleHarness() {
+  const [active, setActive] = useState(false);
+  return (
+    <div>
+      <button data-testid="outside" onClick={() => setActive(true)}>
+        Open
+      </button>
+      {active && (
+        <>
+          <Trap active />
+          <button data-testid="close" onClick={() => setActive(false)}>
+            Close
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+describe('useFocusTrap', () => {
+  afterEach(() => cleanup());
+
+  it('moves initial focus to the container when engaged', () => {
+    render(<Trap />);
+    expect(document.activeElement).toBe(screen.getByTestId('trap'));
+  });
+
+  it('makes the container programmatically focusable (tabindex=-1)', () => {
+    render(<Trap />);
+    expect(screen.getByTestId('trap')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not steal focus when initialFocus is false', () => {
+    render(<Trap initialFocus={false} />);
+    expect(document.activeElement).not.toBe(screen.getByTestId('trap'));
+  });
+
+  it('wraps focus from the last element to the first on Tab', () => {
+    render(<Trap />);
+    const first = screen.getByTestId('first');
+    const last = screen.getByTestId('last');
+
+    last.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('wraps focus from the first element to the last on Shift+Tab', () => {
+    render(<Trap />);
+    const first = screen.getByTestId('first');
+    const last = screen.getByTestId('last');
+
+    first.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('pulls focus back inside when Tab is pressed from the container', () => {
+    render(<Trap />);
+    const container = screen.getByTestId('trap');
+    const first = screen.getByTestId('first');
+
+    container.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('does not intercept non-Tab keys', () => {
+    render(<Trap />);
+    const middle = screen.getByTestId('middle');
+    middle.focus();
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(middle);
+  });
+
+  it('is inert when active is false', () => {
+    render(<Trap active={false} />);
+    expect(document.activeElement).not.toBe(screen.getByTestId('trap'));
+  });
+
+  it('restores focus to the opener when released', () => {
+    render(<ToggleHarness />);
+    const outside = screen.getByTestId('outside');
+
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    // Open: focus moves into the trap.
+    fireEvent.click(outside);
+    expect(document.activeElement).toBe(screen.getByTestId('trap'));
+
+    // Close: trap unmounts and focus returns to the opener.
+    fireEvent.click(screen.getByTestId('close'));
+    expect(document.activeElement).toBe(outside);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1127 の対応。モバイルのアクセシビリティ/エルゴノミクスの穴を塞ぐ（focus trap欠如、44px未満タップターゲット、ARIA tabsパターン未完、touch-manipulation未使用）。

## focus trap（useFocusTrap共通フックに1実装集約）
- 選定理由: Modal/シート類は独自ポータル＋enter/exitアニメ＋スワイプdismissのbespoke実装。Radix Dialogは未導入で置換すると3面＋テスト全書き直し。共通フックなら既存機構を壊さずtrapのみ追加でき「1実装に集約」要件に合致
- 挙動: 初期フォーカス移動／Tab・Shift+Tab循環／閉時に呼び出し元へ復帰。**autoFoc/自前restoreで消費側がフォーカス管理する場合（ConfirmDialog）は初期奪取・復帰をスキップ**
- 適用: ui/Modal（role=dialog/aria-modal/aria-labelledby付与）・MobilePromptSheet・MobileTerminalActionsSheet

## その他
- 44pxタップターゲット（視覚サイズ不変、ヒットエリアのみ拡大）: エージェントタブ、Historyサブタブ、MobileTabBar
- MobileTabBar ARIA tabsパターン: 矢印/Home/End移動＋ラップアラウンド＋roving tabindex
- touch-manipulationをButton系＋モバイル操作面へ付与

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1127（親: #1110 UI/UX最先端化 Phase 4）
Blocks: #1128（ジェスチャー、MobilePromptSheet/MobileTabBar共有のため後発）

🤖 Generated with [Claude Code](https://claude.com/claude-code)