### PR TITLE
feat(mobile): ジェスチャー強化（スワイプタブ切替・pull-to-refresh・キーボード追従） (#1128)

### DIFF
--- a/src/app/repositories/page.tsx
+++ b/src/app/repositories/page.tsx
@@ -16,18 +16,35 @@
 
 import { useCallback, useState } from 'react';
 import { AppShell } from '@/components/layout';
+import { PullToRefresh } from '@/components/common/PullToRefresh';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { RepositoryList, RepositoryManager } from '@/components/repository';
 
+/** Issue #1128: minimum spinner hold so a pull reads as a real refresh. */
+const REPOSITORIES_REFRESH_MIN_MS = 500;
+
 export default function RepositoriesPage() {
+  const isMobile = useIsMobile();
   const [refreshKey, setRefreshKey] = useState(0);
 
   const handleChanged = useCallback(() => {
     setRefreshKey((k) => k + 1);
   }, []);
 
+  // Issue #1128: pull-to-refresh bumps refreshKey (which refetches the list) and
+  // holds the spinner briefly so the gesture reads as a refresh.
+  const handlePullRefresh = useCallback(async () => {
+    setRefreshKey((k) => k + 1);
+    await new Promise((resolve) => setTimeout(resolve, REPOSITORIES_REFRESH_MIN_MS));
+  }, []);
+
   return (
     <AppShell>
-      <div className="container-custom py-8 overflow-auto h-full">
+      <PullToRefresh
+        onRefresh={handlePullRefresh}
+        enabled={isMobile}
+        className="container-custom py-8 h-full"
+      >
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-foreground mb-2">Repositories</h1>
           <p className="text-sm text-muted-foreground">
@@ -39,7 +56,7 @@ export default function RepositoriesPage() {
           <RepositoryManager onRepositoryAdded={handleChanged} />
           <RepositoryList refreshKey={refreshKey} onChanged={handleChanged} />
         </div>
-      </div>
+      </PullToRefresh>
     </AppShell>
   );
 }

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -18,6 +18,8 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import { AppShell } from '@/components/layout';
+import { PullToRefresh } from '@/components/common/PullToRefresh';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { deriveCliStatus } from '@/types/sidebar';
 import { isWorkingStatus } from '@/lib/agent-status-display';
@@ -118,7 +120,8 @@ const DEFAULT_BADGE_CLASS = 'bg-muted text-muted-foreground';
 
 export default function SessionsPage() {
   const tCommon = useTranslations('common');
-  const { worktrees, isLoading, error } = useWorktreesCacheContext();
+  const isMobile = useIsMobile();
+  const { worktrees, isLoading, error, refresh } = useWorktreesCacheContext();
   // [Issue #1050] Whether we have any data to keep mounted. Based on the raw
   // (unfiltered) list so an active text filter never unmounts the list.
   const hasWorktrees = worktrees.length > 0;
@@ -206,7 +209,14 @@ export default function SessionsPage() {
 
   return (
     <AppShell>
-      <div className="container-custom py-8 overflow-auto h-full">
+      {/* Issue #1128: pull-to-refresh (mobile) — the wrapper owns the scroll
+          container so the gesture only fires at the top and native PTR is
+          suppressed. `refresh` re-fetches the shared worktrees cache. */}
+      <PullToRefresh
+        onRefresh={refresh}
+        enabled={isMobile}
+        className="container-custom py-8 h-full"
+      >
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-foreground mb-2">Sessions</h1>
           <p className="text-sm text-muted-foreground">
@@ -224,6 +234,9 @@ export default function SessionsPage() {
             className="max-w-md flex-1"
             data-testid="sessions-filter"
             aria-label="Filter sessions by name or repository"
+            // Issue #1128: surface the search keyboard + "search" enter key on mobile.
+            inputMode="search"
+            enterKeyHint="search"
           />
           <Select value={sortKey} onValueChange={handleSortKeyChange}>
             <SelectTrigger
@@ -447,7 +460,7 @@ export default function SessionsPage() {
             )}
           </>
         )}
-      </div>
+      </PullToRefresh>
     </AppShell>
   );
 }

--- a/src/components/common/PullToRefresh.tsx
+++ b/src/components/common/PullToRefresh.tsx
@@ -1,0 +1,80 @@
+/**
+ * PullToRefresh Component (Issue #1128)
+ *
+ * Scrollable wrapper that adds a top-anchored pull-to-refresh gesture on touch
+ * devices. It owns the scroll container so the gesture can read `scrollTop` and
+ * suppress the browser's native pull-to-refresh (`overscroll-behavior-y:
+ * contain` + preventDefault inside the hook) — no double refresh.
+ */
+
+'use client';
+
+import React from 'react';
+import { Spinner } from '@/components/ui';
+import { cn } from '@/lib/utils/cn';
+import { usePullToRefresh } from '@/hooks/usePullToRefresh';
+
+/** Pull distance (px) required to trigger a refresh. */
+const PULL_THRESHOLD = 64;
+
+export interface PullToRefreshProps {
+  /** Called when a pull past the threshold is released. May be async. */
+  onRefresh: () => void | Promise<void>;
+  /** Whether the gesture is active (default: true). Gate to mobile if desired. */
+  enabled?: boolean;
+  /** Classes applied to the scroll container. */
+  className?: string;
+  /** Scrollable content. */
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps content in a scroll container with a pull-to-refresh spinner.
+ */
+export function PullToRefresh({ onRefresh, enabled = true, className, children }: PullToRefreshProps) {
+  const { containerRef, pullDistance, isRefreshing, isPulling } = usePullToRefresh({
+    onRefresh,
+    enabled,
+    threshold: PULL_THRESHOLD,
+  });
+
+  const active = isRefreshing || pullDistance > 0;
+  const indicatorOpacity = isRefreshing ? 1 : Math.min(pullDistance / PULL_THRESHOLD, 1);
+  // Smooth the release/spring-back, but track the finger 1:1 while pulling.
+  const contentTransition = isPulling ? 'none' : 'transform 0.2s ease-out';
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('relative overflow-auto', className)}
+      style={{ overscrollBehaviorY: 'contain' }}
+      data-testid="pull-to-refresh"
+    >
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center"
+        style={{
+          transform: `translateY(${active ? Math.max(pullDistance - 24, 8) : -32}px)`,
+          opacity: indicatorOpacity,
+          transition: isPulling
+            ? 'none'
+            : 'transform 0.2s ease-out, opacity 0.2s ease-out',
+        }}
+        data-testid="pull-to-refresh-indicator"
+        role="status"
+        aria-hidden={!isRefreshing}
+      >
+        <Spinner size="sm" variant="accent" />
+      </div>
+      <div
+        style={{
+          transform: active ? `translateY(${pullDistance}px)` : undefined,
+          transition: contentTransition,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default PullToRefresh;

--- a/src/components/mobile/MobilePromptSheet.tsx
+++ b/src/components/mobile/MobilePromptSheet.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary } from '@/components/error/ErrorBoundary';
 import { RadioGroup, RadioGroupItem, Spinner } from '@/components/ui';
 import { usePromptAnimation } from '@/hooks/usePromptAnimation';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { useSwipeGesture } from '@/hooks/useSwipeGesture';
 
 /** Animation duration for sheet transitions */
 const ANIMATION_DURATION_MS = 300;
@@ -70,15 +71,19 @@ export const MobilePromptSheet = memo(function MobilePromptSheet({
   });
   const labelId = useId();
 
+  const isActive = visible && promptData !== null;
+
   // [Issue #1127] Trap keyboard focus within the sheet while it is the active
   // modal surface (Tab cycling + focus restore); shares the single useFocusTrap
   // implementation with ui/Modal. The ref doubles as the sheet element ref.
   const sheetRef = useFocusTrap<HTMLDivElement>({
-    active: visible && promptData !== null,
+    active: isActive,
   });
 
-  // Swipe handling state
-  const [touchStartY, setTouchStartY] = useState<number | null>(null);
+  // Swipe-to-dismiss (Issue #1128): unified on the shared useSwipeGesture hook
+  // (was an ad-hoc touch handler). Vertical axis + direction lock keeps a
+  // horizontal drag from dismissing; onSwipeMove drives the finger-follow
+  // translate, and a downward swipe past the threshold dismisses.
   const [translateY, setTranslateY] = useState(0);
 
   // Reset translate when visibility changes
@@ -88,38 +93,37 @@ export const MobilePromptSheet = memo(function MobilePromptSheet({
     }
   }, [visible]);
 
-  /**
-   * Handle touch start
-   */
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    setTouchStartY(e.touches[0].clientY);
+  const handleSwipeMove = useCallback(({ deltaY }: { deltaX: number; deltaY: number }) => {
+    // Only follow downward drags (positive delta).
+    setTranslateY(deltaY > 0 ? deltaY : 0);
   }, []);
 
-  /**
-   * Handle touch move
-   */
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (touchStartY === null) return;
+  const handleSwipeDismiss = useCallback(() => {
+    onDismiss?.();
+  }, [onDismiss]);
 
-    const currentY = e.touches[0].clientY;
-    const deltaY = currentY - touchStartY;
-
-    // Only allow swiping down (positive delta)
-    if (deltaY > 0) {
-      setTranslateY(deltaY);
-    }
-  }, [touchStartY]);
-
-  /**
-   * Handle touch end
-   */
-  const handleTouchEnd = useCallback(() => {
-    if (translateY > SWIPE_DISMISS_THRESHOLD && onDismiss) {
-      onDismiss();
-    }
+  const handleSwipeEnd = useCallback(() => {
     setTranslateY(0);
-    setTouchStartY(null);
-  }, [translateY, onDismiss]);
+  }, []);
+
+  const { ref: swipeRef } = useSwipeGesture({
+    axis: 'vertical',
+    threshold: SWIPE_DISMISS_THRESHOLD,
+    enabled: isActive,
+    onSwipeMove: handleSwipeMove,
+    onSwipeDown: handleSwipeDismiss,
+    onSwipeEnd: handleSwipeEnd,
+  });
+
+  // Merge the focus-trap container ref (#1127) with the swipe ref (#1128) onto
+  // the single sheet element without disturbing either hook's contract.
+  const setSheetRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      (sheetRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      (swipeRef as React.MutableRefObject<HTMLElement | null>).current = el;
+    },
+    [sheetRef, swipeRef]
+  );
 
   /**
    * Handle overlay click
@@ -162,15 +166,12 @@ export const MobilePromptSheet = memo(function MobilePromptSheet({
 
       {/* Sheet */}
       <div
-        ref={sheetRef}
+        ref={setSheetRef}
         data-testid="mobile-prompt-sheet"
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelId}
         onClick={handleSheetClick}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
         style={{ transform: sheetTransform }}
         className={`fixed bottom-0 inset-x-0 bg-surface rounded-t-2xl z-50 pb-safe transform transition-transform duration-300 ${sheetAnimation}`}
       >
@@ -446,6 +447,9 @@ const MultipleChoiceActions = memo(function MultipleChoiceActions({
             onChange={(e) => onTextInputChange(e.target.value)}
             disabled={disabled}
             placeholder={t('enterValuePlaceholder')}
+            // Issue #1128: mobile keyboard hints for the custom-value field.
+            inputMode="text"
+            enterKeyHint="done"
             className="w-full px-4 py-3 border-2 border-input rounded-lg bg-surface text-foreground focus:outline-none focus:border-ring disabled:opacity-50"
           />
         </div>

--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -15,6 +15,7 @@ import { SlashCommandSelector } from './SlashCommandSelector';
 import { InterruptButton } from './InterruptButton';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import { useImageAttachment } from '@/hooks/useImageAttachment';
 import type { SlashCommand } from '@/types/slash-commands';
 import { getSlashCommandTrigger } from '@/lib/slash-command-format';
@@ -78,6 +79,13 @@ export interface MessageInputProps {
     content: string,
     options: { cliToolId: CLIToolType; instanceId?: string; imagePath?: string },
   ) => void;
+  /**
+   * Issue #1128: when true, the composer follows the software keyboard — it
+   * translates up by the keyboard height (visualViewport) so it never hides
+   * behind the keyboard on mobile. Opt-in; only the bottom-anchored mobile
+   * composer sets it (PC splits / assistant chat are not keyboard-obscured).
+   */
+  keyboardAware?: boolean;
 }
 
 /**
@@ -129,7 +137,7 @@ function migrateLegacyDraftKey(worktreeId: string): void {
   }
 }
 
-export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, instanceId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast, autoYesSlot, onOptimisticSend }: MessageInputProps) {
+export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, instanceId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast, autoYesSlot, onOptimisticSend, keyboardAware = false }: MessageInputProps) {
   const t = useTranslations('worktree');
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
@@ -147,6 +155,18 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
   // Issue #4: Pass cliToolId to filter commands by CLI tool
   const isMobile = useIsMobile();
   const { groups } = useSlashCommands(worktreeId, cliToolId);
+
+  // Issue #1128: keyboard-follow. When opted in, lift the composer by the
+  // software-keyboard height so it stays visible above the keyboard. A short
+  // transition smooths the show/hide; no offset when the keyboard is hidden.
+  const { isKeyboardVisible, keyboardHeight } = useVirtualKeyboard();
+  const keyboardFollowStyle: React.CSSProperties | undefined = keyboardAware
+    ? {
+        transform: isKeyboardVisible ? `translateY(-${keyboardHeight}px)` : undefined,
+        transition: 'transform 0.2s ease-out',
+        willChange: 'transform',
+      }
+    : undefined;
 
   // Issue #474: Image attachment hook
   const uploadFn = useCallback(
@@ -443,7 +463,12 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
   }, [showCommandSelector, isFreeInputMode, isComposing, isMobile, submitMessage, handleCommandCancel]);
 
   return (
-    <div ref={containerRef} className="space-y-2 relative">
+    <div
+      ref={containerRef}
+      className="space-y-2 relative"
+      style={keyboardFollowStyle}
+      data-testid="message-input-container"
+    >
       {/* Error display (send error or image error) */}
       {(error || imageError) && (
         <div className="p-2 bg-danger-subtle border border-danger-border rounded text-sm text-danger-foreground">
@@ -567,6 +592,10 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
             placeholder={t('composer.placeholder')}
             disabled={sending}
             rows={1}
+            // Issue #1128: mobile keyboard hints — the composer's primary action
+            // is to send, and it accepts free-form text.
+            inputMode="text"
+            enterKeyHint="send"
             className="flex-1 outline-none bg-transparent resize-none overflow-y-auto scrollbar-thin"
             style={{ minHeight: '36px', maxHeight: '160px', paddingTop: '8px', paddingBottom: '8px', lineHeight: '20px' }}
           />

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -16,7 +16,7 @@
 
 'use client';
 
-import React, { memo, useState } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { MoreHorizontal } from 'lucide-react';
 import { Spinner } from '@/components/ui/Spinner';
@@ -67,6 +67,8 @@ import { getCliToolDisplayName, getInstanceLabel, getActiveInstanceLabel } from 
 import { deriveCliStatus } from '@/types/sidebar';
 import { MoveDialog } from '@/components/worktree/MoveDialog';
 import { NewFileDialog } from '@/components/worktree/NewFileDialog';
+import { useSwipeGesture } from '@/hooks/useSwipeGesture';
+import type { MobileTab } from '@/components/mobile/MobileTabBar';
 
 // ============================================================================
 // Types
@@ -95,6 +97,27 @@ const NOOP_SELECTED_AGENTS_CHANGE = (): void => {};
  */
 const MOBILE_MESSAGE_INPUT_BOTTOM = 'calc(4rem + env(safe-area-inset-bottom, 0px))';
 const MOBILE_CONTENT_BOTTOM_PADDING = 'calc(12rem + env(safe-area-inset-bottom, 0px))';
+
+/**
+ * Issue #1128: left-to-right order of the mobile tabs, matching MobileTabBar's
+ * TABS array. Horizontal swipes step through this order (no wraparound) and the
+ * MobileTabBar indicator stays in sync because both read the same `activeTab`.
+ */
+const MOBILE_TAB_ORDER: readonly MobileTab[] = ['terminal', 'history', 'files', 'memo', 'info'];
+
+/**
+ * Issue #1128: horizontal travel (px) required to switch tabs — deliberately
+ * above the 50px default so a small horizontal wobble during a vertical scroll
+ * never flips tabs (the direction lock is the primary guard; this is a backstop).
+ */
+const TAB_SWIPE_THRESHOLD = 60;
+
+/**
+ * Issue #1128: on the Terminal tab the swipe must start within this many pixels
+ * of a screen edge. The terminal body supports text selection and reading, so
+ * central swipes are ignored and only an intentional edge swipe changes tabs.
+ */
+const TERMINAL_SWIPE_EDGE_ZONE = 32;
 
 // ============================================================================
 // Main Component
@@ -236,6 +259,31 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   const hasNewOutput = useNewOutputIndicator({
     worktreeId,
     active: activeTab === 'terminal',
+  });
+
+  // Issue #1128: step to the previous/next mobile tab (no wraparound). Keeps the
+  // MobileTabBar indicator synced since both derive from the same `activeTab`.
+  const goToAdjacentTab = useCallback(
+    (delta: number) => {
+      const index = MOBILE_TAB_ORDER.indexOf(activeTab);
+      if (index === -1) return;
+      const nextIndex = index + delta;
+      if (nextIndex < 0 || nextIndex >= MOBILE_TAB_ORDER.length) return;
+      handleMobileTabChange(MOBILE_TAB_ORDER[nextIndex]);
+    },
+    [activeTab, handleMobileTabChange]
+  );
+
+  // Issue #1128: horizontal tab-swipe over the mobile content area. Constrained
+  // to the horizontal axis with a direction lock so a vertical scroll never
+  // flips tabs; suppressed inside horizontally-scrollable panes; and restricted
+  // to the screen edges while the Terminal tab is active (text selection safe).
+  const { ref: tabSwipeRef } = useSwipeGesture({
+    axis: 'horizontal',
+    threshold: TAB_SWIPE_THRESHOLD,
+    edgeStartZone: activeTab === 'terminal' ? TERMINAL_SWIPE_EDGE_ZONE : 0,
+    onSwipeLeft: () => goToAdjacentTab(1),
+    onSwipeRight: () => goToAdjacentTab(-1),
   });
 
   // Render
@@ -459,6 +507,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
 
         <main
           className="flex-1 overflow-y-auto"
+          ref={tabSwipeRef}
           style={{
             paddingBottom: MOBILE_CONTENT_BOTTOM_PADDING,
           }}
@@ -542,6 +591,9 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               isSessionRunning={activeSessionRunning}
               pendingInsertText={pendingInsertText}
               onInsertConsumed={handleInsertConsumedSingle}
+              // Issue #1128: lift the composer above the software keyboard so it
+              // stays visible while typing (visualViewport-driven).
+              keyboardAware
               // Issue #1080: Auto-Yes now lives in the composer meta row (moved off
               // the sticky tab row). The active agent tab already names the tool, so
               // the parenthetical tool name is suppressed here (showToolName=false).

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,164 @@
+/**
+ * usePullToRefresh Hook (Issue #1128)
+ *
+ * Self-implemented pull-to-refresh for scrollable list surfaces (Sessions /
+ * Repositories). Fires only when the container is scrolled to the very top and
+ * suppresses the browser's native pull-to-refresh (via preventDefault on the
+ * pulling touchmove) so there is never a double refresh. Pair the container with
+ * `overscroll-behavior-y: contain` for the same reason.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UsePullToRefreshOptions {
+  /** Invoked when a pull past the threshold is released. May be async. */
+  onRefresh: () => void | Promise<void>;
+  /** Whether the gesture is active (default: true). */
+  enabled?: boolean;
+  /** Pull distance (px) required to trigger a refresh (default: 64). */
+  threshold?: number;
+  /** Maximum visual pull distance (px) after resistance (default: 96). */
+  maxPull?: number;
+  /** Drag resistance factor applied to raw finger travel (default: 0.5). */
+  resistance?: number;
+}
+
+export interface UsePullToRefreshReturn {
+  /** Attach to the scrollable container element. */
+  containerRef: React.RefObject<HTMLDivElement>;
+  /** Current (resisted) pull distance in pixels. */
+  pullDistance: number;
+  /** Whether a refresh is in flight. */
+  isRefreshing: boolean;
+  /** Whether the user is actively pulling. */
+  isPulling: boolean;
+}
+
+/** Default pull distance to trigger a refresh. */
+const DEFAULT_THRESHOLD = 64;
+/** Default visual pull cap. */
+const DEFAULT_MAX_PULL = 96;
+/** Default drag resistance. */
+const DEFAULT_RESISTANCE = 0.5;
+
+/**
+ * Hook implementing a top-anchored pull-to-refresh gesture.
+ */
+export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRefreshReturn {
+  const {
+    onRefresh,
+    enabled = true,
+    threshold = DEFAULT_THRESHOLD,
+    maxPull = DEFAULT_MAX_PULL,
+    resistance = DEFAULT_RESISTANCE,
+  } = options;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isPulling, setIsPulling] = useState(false);
+
+  // Gesture bookkeeping kept in refs so the (stable) native listeners always
+  // read current values without re-binding on every render.
+  const startYRef = useRef<number | null>(null);
+  const pullRef = useRef(0);
+  const isRefreshingRef = useRef(false);
+  isRefreshingRef.current = isRefreshing;
+
+  const resetPull = useCallback(() => {
+    startYRef.current = null;
+    pullRef.current = 0;
+    setPullDistance(0);
+    setIsPulling(false);
+  }, []);
+
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    if (!enabled || isRefreshingRef.current) return;
+    const el = containerRef.current;
+    // Only arm the gesture when the list is scrolled to the very top.
+    if (!el || el.scrollTop > 0) return;
+    startYRef.current = e.touches[0].clientY;
+    pullRef.current = 0;
+  }, [enabled]);
+
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    if (startYRef.current === null) return;
+    const el = containerRef.current;
+    if (!el) return;
+
+    // Content scrolled away from the top mid-gesture — hand back to native scroll.
+    if (el.scrollTop > 0) {
+      resetPull();
+      return;
+    }
+
+    const delta = e.touches[0].clientY - startYRef.current;
+    if (delta <= 0) {
+      // Upward drag: let native scrolling take over.
+      if (pullRef.current !== 0) {
+        pullRef.current = 0;
+        setPullDistance(0);
+        setIsPulling(false);
+      }
+      return;
+    }
+
+    // Downward pull at the top: suppress native scroll / browser PTR and drive
+    // our own indicator with resistance + a cap.
+    if (e.cancelable) e.preventDefault();
+    const pull = Math.min(delta * resistance, maxPull);
+    pullRef.current = pull;
+    setPullDistance(pull);
+    setIsPulling(true);
+  }, [resistance, maxPull, resetPull]);
+
+  const runRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    setIsPulling(false);
+    // Hold the indicator at the threshold while the refresh runs.
+    setPullDistance(threshold);
+    try {
+      await Promise.resolve(onRefresh());
+    } finally {
+      setIsRefreshing(false);
+      setPullDistance(0);
+    }
+  }, [onRefresh, threshold]);
+
+  const handleTouchEnd = useCallback(() => {
+    if (startYRef.current === null) return;
+    const shouldRefresh = pullRef.current >= threshold && !isRefreshingRef.current;
+    startYRef.current = null;
+    pullRef.current = 0;
+    if (shouldRefresh) {
+      void runRefresh();
+    } else {
+      setPullDistance(0);
+      setIsPulling(false);
+    }
+  }, [threshold, runRefresh]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    // touchmove must be non-passive so preventDefault can suppress native PTR.
+    el.addEventListener('touchstart', handleTouchStart, { passive: true });
+    el.addEventListener('touchmove', handleTouchMove, { passive: false });
+    el.addEventListener('touchend', handleTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', handleTouchEnd, { passive: true });
+
+    return () => {
+      el.removeEventListener('touchstart', handleTouchStart);
+      el.removeEventListener('touchmove', handleTouchMove);
+      el.removeEventListener('touchend', handleTouchEnd);
+      el.removeEventListener('touchcancel', handleTouchEnd);
+    };
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
+
+  return { containerRef, pullDistance, isRefreshing, isPulling };
+}
+
+export default usePullToRefresh;

--- a/src/hooks/useSwipeGesture.ts
+++ b/src/hooks/useSwipeGesture.ts
@@ -14,6 +14,14 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 export type SwipeDirection = 'left' | 'right' | 'up' | 'down';
 
 /**
+ * Axis the gesture is constrained to.
+ * Issue #1128: 'horizontal' powers tab switching (only left/right fire),
+ * 'vertical' powers the bottom-sheet swipe-to-dismiss (only up/down fire),
+ * 'both' preserves the original four-direction behaviour.
+ */
+export type SwipeAxis = 'horizontal' | 'vertical' | 'both';
+
+/**
  * Options for useSwipeGesture hook
  */
 export interface UseSwipeGestureOptions {
@@ -29,6 +37,53 @@ export interface UseSwipeGestureOptions {
   threshold?: number;
   /** Whether gesture detection is enabled (default: true) */
   enabled?: boolean;
+  /**
+   * Issue #1128: restrict which axis is considered. Default 'both'.
+   * When set to 'horizontal'/'vertical', only that axis's callbacks fire and
+   * the direction lock (below) defaults on so a perpendicular drag (e.g. a
+   * vertical scroll under a horizontal tab-swipe) never triggers a swipe.
+   */
+  axis?: SwipeAxis;
+  /**
+   * Issue #1128: once the gesture's dominant direction is perpendicular to
+   * `axis`, cancel it for the remainder of the touch (direction lock). This is
+   * what keeps a vertical page scroll from firing a horizontal tab swipe.
+   * Defaults to `true` when `axis` is 'horizontal'/'vertical', else `false`.
+   */
+  directionLock?: boolean;
+  /**
+   * Issue #1128: travel distance (px) at which the gesture commits to an axis
+   * for the direction lock. Default 12.
+   */
+  directionLockThreshold?: number;
+  /**
+   * Issue #1128: suppress the gesture when the touch starts inside a scrollable
+   * ancestor on the RELEVANT axis. For axis 'vertical'/'both' this checks
+   * vertical scrollability (preserves the #299 fullscreen-exit behaviour); for
+   * axis 'horizontal' it checks horizontal scrollability so a scrollable code /
+   * terminal pane keeps its own horizontal scroll and text selection.
+   * Default true.
+   */
+  suppressWhenScrollable?: boolean;
+  /**
+   * Issue #1128: when > 0, only start tracking a gesture if the touch begins
+   * within this many pixels of the element's left or right edge. Used to make
+   * tab-swipe conservative over the terminal pane (central taps/selections are
+   * left untouched; only an intentional edge swipe changes tabs).
+   */
+  edgeStartZone?: number;
+  /**
+   * Issue #1128: live progress callback fired on every tracked touchmove after
+   * suppression/direction-lock checks pass. Powers the bottom-sheet
+   * finger-follow drag. Not called for suppressed or direction-locked gestures.
+   */
+  onSwipeMove?: (delta: { deltaX: number; deltaY: number }) => void;
+  /**
+   * Issue #1128: fired once at the end of a tracked gesture (touchend/cancel),
+   * regardless of whether a swipe threshold was met. Lets consumers reset any
+   * transient drag state (e.g. reset the sheet's translateY).
+   */
+  onSwipeEnd?: () => void;
 }
 
 /**
@@ -48,25 +103,46 @@ export interface UseSwipeGestureReturn {
 /** Default swipe threshold in pixels */
 const DEFAULT_THRESHOLD = 50;
 
+/** Default direction-lock commit threshold in pixels (Issue #1128) */
+const DEFAULT_DIRECTION_LOCK_THRESHOLD = 12;
+
 /**
  * Check if an element is inside a scrollable container.
  * Used to suppress swipe gesture detection when the user is scrolling
  * within a scrollable element (e.g., preview pane, code editor).
  *
  * Issue #299: Prevents fullscreen exit when scrolling up in maximized editor.
+ * Issue #1128: `axis` selects which overflow axis is inspected so a horizontal
+ * tab-swipe suppresses on horizontally-scrollable ancestors while the original
+ * vertical use cases keep checking vertical scrollability.
  *
  * @param element - The target element to check
- * @returns true if the element is inside a vertically scrollable container
+ * @param axis - Which scroll axis to inspect (default 'vertical')
+ * @returns true if the element is inside a scrollable container on that axis
  */
-export function isInsideScrollableElement(element: HTMLElement): boolean {
+export function isInsideScrollableElement(
+  element: HTMLElement,
+  axis: 'vertical' | 'horizontal' = 'vertical'
+): boolean {
   let current: HTMLElement | null = element;
   while (current) {
-    const { overflowY } = getComputedStyle(current);
-    if (
-      (overflowY === 'auto' || overflowY === 'scroll') &&
-      current.scrollHeight > current.clientHeight
-    ) {
-      return true;
+    const style = getComputedStyle(current);
+    if (axis === 'horizontal') {
+      const { overflowX } = style;
+      if (
+        (overflowX === 'auto' || overflowX === 'scroll') &&
+        current.scrollWidth > current.clientWidth
+      ) {
+        return true;
+      }
+    } else {
+      const { overflowY } = style;
+      if (
+        (overflowY === 'auto' || overflowY === 'scroll') &&
+        current.scrollHeight > current.clientHeight
+      ) {
+        return true;
+      }
     }
     current = current.parentElement;
   }
@@ -77,6 +153,14 @@ export function isInsideScrollableElement(element: HTMLElement): boolean {
 interface TouchPosition {
   x: number;
   y: number;
+}
+
+/** Per-gesture direction-lock state (Issue #1128) */
+interface GestureLockState {
+  /** Axis the gesture has committed to, or null before commit */
+  committed: 'horizontal' | 'vertical' | null;
+  /** Whether the gesture has been cancelled by the direction lock */
+  cancelled: boolean;
 }
 
 /**
@@ -107,7 +191,21 @@ export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeG
     onSwipeDown,
     threshold = DEFAULT_THRESHOLD,
     enabled = true,
+    axis = 'both',
+    directionLock,
+    directionLockThreshold = DEFAULT_DIRECTION_LOCK_THRESHOLD,
+    suppressWhenScrollable = true,
+    edgeStartZone = 0,
+    onSwipeMove,
+    onSwipeEnd,
   } = options;
+
+  // Direction lock defaults on whenever the gesture is constrained to one axis.
+  const lockEnabled = directionLock ?? axis !== 'both';
+  // Axis inspected for scroll-container suppression.
+  const suppressionAxis = axis === 'horizontal' ? 'horizontal' : 'vertical';
+  const allowHorizontal = axis === 'both' || axis === 'horizontal';
+  const allowVertical = axis === 'both' || axis === 'vertical';
 
   const ref = useRef<HTMLElement>(null);
   const [isSwiping, setIsSwiping] = useState(false);
@@ -115,6 +213,8 @@ export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeG
 
   // Touch start coordinates
   const touchStartRef = useRef<TouchPosition | null>(null);
+  // Direction-lock bookkeeping for the in-flight gesture.
+  const lockRef = useRef<GestureLockState | null>(null);
 
   /**
    * Reset swipe direction to null
@@ -129,17 +229,34 @@ export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeG
   const handleTouchStart = useCallback((e: TouchEvent) => {
     if (!enabled) return;
 
-    // Issue #299: Suppress swipe detection inside scrollable elements
-    // to prevent unintended fullscreen exit when scrolling content
-    if (e.target instanceof HTMLElement && isInsideScrollableElement(e.target)) {
+    // Issue #299 / #1128: Suppress swipe detection inside scrollable elements
+    // (on the relevant axis) to preserve native scrolling and text selection.
+    if (
+      suppressWhenScrollable &&
+      e.target instanceof HTMLElement &&
+      isInsideScrollableElement(e.target, suppressionAxis)
+    ) {
       touchStartRef.current = null;
       return;
     }
 
     const touch = e.touches[0];
+
+    // Issue #1128: edge-start restriction (conservative tab-swipe over terminal).
+    if (edgeStartZone > 0 && ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      const fromLeft = touch.clientX - rect.left;
+      const fromRight = rect.right - touch.clientX;
+      if (fromLeft > edgeStartZone && fromRight > edgeStartZone) {
+        touchStartRef.current = null;
+        return;
+      }
+    }
+
     touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+    lockRef.current = { committed: null, cancelled: false };
     setIsSwiping(true);
-  }, [enabled]);
+  }, [enabled, suppressWhenScrollable, suppressionAxis, edgeStartZone]);
 
   /**
    * Handle touch move
@@ -154,13 +271,33 @@ export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeG
     const absX = Math.abs(deltaX);
     const absY = Math.abs(deltaY);
 
+    // Issue #1128: direction lock. Once the dominant axis is decided, a gesture
+    // perpendicular to `axis` is cancelled so it can never fire a swipe.
+    if (lockEnabled) {
+      const lock = lockRef.current;
+      if (lock) {
+        if (lock.cancelled) return;
+        if (lock.committed === null && Math.max(absX, absY) >= directionLockThreshold) {
+          const dominant = absX > absY ? 'horizontal' : 'vertical';
+          lock.committed = dominant;
+          if (dominant !== axis) {
+            lock.cancelled = true;
+            return;
+          }
+        }
+        if (lock.committed !== null && lock.committed !== axis) return;
+      }
+    }
+
     // Determine current direction while swiping
-    if (absX > absY && absX >= threshold) {
+    if (allowHorizontal && absX > absY && absX >= threshold) {
       setSwipeDirection(deltaX < 0 ? 'left' : 'right');
-    } else if (absY >= threshold) {
+    } else if (allowVertical && absY >= threshold) {
       setSwipeDirection(deltaY < 0 ? 'up' : 'down');
     }
-  }, [enabled, threshold]);
+
+    onSwipeMove?.({ deltaX, deltaY });
+  }, [enabled, threshold, axis, lockEnabled, directionLockThreshold, allowHorizontal, allowVertical, onSwipeMove]);
 
   /**
    * Handle touch end
@@ -171,41 +308,59 @@ export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeG
       return;
     }
 
+    const cancelled = lockEnabled && lockRef.current?.cancelled === true;
     const touch = e.changedTouches[0];
-    const deltaX = touch.clientX - touchStartRef.current.x;
-    const deltaY = touch.clientY - touchStartRef.current.y;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
 
-    // Determine if horizontal or vertical swipe
-    if (absX > absY) {
-      // Horizontal swipe
-      if (absX >= threshold) {
-        if (deltaX < 0) {
-          setSwipeDirection('left');
-          onSwipeLeft?.();
-        } else {
-          setSwipeDirection('right');
-          onSwipeRight?.();
+    if (!cancelled && touch) {
+      const deltaX = touch.clientX - touchStartRef.current.x;
+      const deltaY = touch.clientY - touchStartRef.current.y;
+      const absX = Math.abs(deltaX);
+      const absY = Math.abs(deltaY);
+
+      // Determine if horizontal or vertical swipe
+      if (absX > absY) {
+        // Horizontal swipe
+        if (allowHorizontal && absX >= threshold) {
+          if (deltaX < 0) {
+            setSwipeDirection('left');
+            onSwipeLeft?.();
+          } else {
+            setSwipeDirection('right');
+            onSwipeRight?.();
+          }
         }
-      }
-    } else {
-      // Vertical swipe
-      if (absY >= threshold) {
-        if (deltaY < 0) {
-          setSwipeDirection('up');
-          onSwipeUp?.();
-        } else {
-          setSwipeDirection('down');
-          onSwipeDown?.();
+      } else {
+        // Vertical swipe
+        if (allowVertical && absY >= threshold) {
+          if (deltaY < 0) {
+            setSwipeDirection('up');
+            onSwipeUp?.();
+          } else {
+            setSwipeDirection('down');
+            onSwipeDown?.();
+          }
         }
       }
     }
 
     // Reset state
     touchStartRef.current = null;
+    lockRef.current = null;
     setIsSwiping(false);
-  }, [enabled, threshold, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown]);
+    onSwipeEnd?.();
+  }, [enabled, threshold, lockEnabled, allowHorizontal, allowVertical, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown, onSwipeEnd]);
+
+  /**
+   * Handle touch cancel (Issue #1128): treat like an end with no swipe so
+   * transient drag state is always reset.
+   */
+  const handleTouchCancel = useCallback(() => {
+    if (!touchStartRef.current) return;
+    touchStartRef.current = null;
+    lockRef.current = null;
+    setIsSwiping(false);
+    onSwipeEnd?.();
+  }, [onSwipeEnd]);
 
   /**
    * Attach event listeners
@@ -217,13 +372,15 @@ export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeG
     element.addEventListener('touchstart', handleTouchStart);
     element.addEventListener('touchmove', handleTouchMove);
     element.addEventListener('touchend', handleTouchEnd);
+    element.addEventListener('touchcancel', handleTouchCancel);
 
     return () => {
       element.removeEventListener('touchstart', handleTouchStart);
       element.removeEventListener('touchmove', handleTouchMove);
       element.removeEventListener('touchend', handleTouchEnd);
+      element.removeEventListener('touchcancel', handleTouchCancel);
     };
-  }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd, handleTouchCancel]);
 
   return {
     ref,

--- a/tests/unit/components/common/PullToRefresh.test.tsx
+++ b/tests/unit/components/common/PullToRefresh.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for PullToRefresh (Issue #1128)
+ *
+ * Verifies the pull-to-refresh gesture only fires when the container is at the
+ * very top and that `onRefresh` is invoked when a pull passes the threshold.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, act, waitFor, cleanup } from '@testing-library/react';
+
+import { PullToRefresh } from '@/components/common/PullToRefresh';
+
+/** Minimal touch event (jsdom lacks Touch/TouchEvent constructors). */
+function createTouchEvent(type: string, clientY: number, target: EventTarget): TouchEvent {
+  const touch = { clientX: 0, clientY, identifier: 0, target } as unknown as Touch;
+  const event = new Event(type, { bubbles: true, cancelable: true }) as unknown as TouchEvent;
+  Object.defineProperty(event, 'touches', { value: [touch] });
+  Object.defineProperty(event, 'changedTouches', { value: [touch] });
+  Object.defineProperty(event, 'target', { value: target });
+  return event;
+}
+
+function setScrollTop(el: HTMLElement, value: number) {
+  Object.defineProperty(el, 'scrollTop', { value, configurable: true });
+}
+
+function pull(container: HTMLElement, distance: number) {
+  act(() => {
+    container.dispatchEvent(createTouchEvent('touchstart', 0, container));
+  });
+  act(() => {
+    container.dispatchEvent(createTouchEvent('touchmove', distance, container));
+  });
+  act(() => {
+    container.dispatchEvent(createTouchEvent('touchend', distance, container));
+  });
+}
+
+describe('PullToRefresh', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders its children inside a scroll container', () => {
+    render(
+      <PullToRefresh onRefresh={vi.fn()}>
+        <div data-testid="child">content</div>
+      </PullToRefresh>
+    );
+    expect(screen.getByTestId('pull-to-refresh')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('calls onRefresh when pulled past the threshold at the top', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PullToRefresh onRefresh={onRefresh}>
+        <div>content</div>
+      </PullToRefresh>
+    );
+
+    const container = screen.getByTestId('pull-to-refresh');
+    setScrollTop(container, 0);
+
+    // Raw 200px * 0.5 resistance = 100px (capped at 96) — comfortably past the
+    // 64px threshold.
+    pull(container, 200);
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does NOT call onRefresh when the container is not scrolled to the top', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PullToRefresh onRefresh={onRefresh}>
+        <div>content</div>
+      </PullToRefresh>
+    );
+
+    const container = screen.getByTestId('pull-to-refresh');
+    setScrollTop(container, 120);
+
+    pull(container, 200);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRefresh for a small pull below the threshold', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PullToRefresh onRefresh={onRefresh}>
+        <div>content</div>
+      </PullToRefresh>
+    );
+
+    const container = screen.getByTestId('pull-to-refresh');
+    setScrollTop(container, 0);
+
+    // 40px * 0.5 = 20px, well under the 64px threshold.
+    pull(container, 40);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRefresh when disabled', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PullToRefresh onRefresh={onRefresh} enabled={false}>
+        <div>content</div>
+      </PullToRefresh>
+    );
+
+    const container = screen.getByTestId('pull-to-refresh');
+    setScrollTop(container, 0);
+
+    pull(container, 200);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/mobile/MobilePromptSheet.test.tsx
+++ b/tests/unit/components/mobile/MobilePromptSheet.test.tsx
@@ -329,7 +329,7 @@ describe('MobilePromptSheet', () => {
     });
   });
 
-  describe('Swipe to Dismiss', () => {
+  describe('Swipe to Dismiss (Issue #1128: unified on useSwipeGesture)', () => {
     it('should handle swipe down gesture to dismiss when exceeding threshold', async () => {
       const onDismiss = vi.fn();
       render(
@@ -343,10 +343,11 @@ describe('MobilePromptSheet', () => {
 
       const sheet = screen.getByTestId('mobile-prompt-sheet');
 
-      // Simulate touch swipe down exceeding threshold (100px)
-      fireEvent.touchStart(sheet, { touches: [{ clientY: 0 }] });
-      fireEvent.touchMove(sheet, { touches: [{ clientY: 150 }] });
-      fireEvent.touchEnd(sheet);
+      // Simulate touch swipe down exceeding threshold (100px). The shared hook
+      // attaches native listeners and reads touchend from `changedTouches`.
+      fireEvent.touchStart(sheet, { touches: [{ clientX: 0, clientY: 0 }] });
+      fireEvent.touchMove(sheet, { touches: [{ clientX: 0, clientY: 150 }] });
+      fireEvent.touchEnd(sheet, { changedTouches: [{ clientX: 0, clientY: 150 }] });
 
       await waitFor(() => {
         expect(onDismiss).toHaveBeenCalled();
@@ -367,9 +368,31 @@ describe('MobilePromptSheet', () => {
       const sheet = screen.getByTestId('mobile-prompt-sheet');
 
       // Simulate small touch move (below threshold)
-      fireEvent.touchStart(sheet, { touches: [{ clientY: 0 }] });
-      fireEvent.touchMove(sheet, { touches: [{ clientY: 50 }] });
-      fireEvent.touchEnd(sheet);
+      fireEvent.touchStart(sheet, { touches: [{ clientX: 0, clientY: 0 }] });
+      fireEvent.touchMove(sheet, { touches: [{ clientX: 0, clientY: 50 }] });
+      fireEvent.touchEnd(sheet, { changedTouches: [{ clientX: 0, clientY: 50 }] });
+
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('should NOT dismiss on a predominantly horizontal drag (direction lock)', () => {
+      const onDismiss = vi.fn();
+      render(
+        <MobilePromptSheet
+          {...defaultProps}
+          promptData={yesNoPrompt}
+          visible={true}
+          onDismiss={onDismiss}
+        />
+      );
+
+      const sheet = screen.getByTestId('mobile-prompt-sheet');
+
+      // A horizontal-dominant gesture commits to the horizontal axis and is
+      // cancelled by the vertical-axis direction lock — no dismiss.
+      fireEvent.touchStart(sheet, { touches: [{ clientX: 0, clientY: 0 }] });
+      fireEvent.touchMove(sheet, { touches: [{ clientX: 160, clientY: 20 }] });
+      fireEvent.touchEnd(sheet, { changedTouches: [{ clientX: 160, clientY: 120 }] });
 
       expect(onDismiss).not.toHaveBeenCalled();
     });
@@ -387,9 +410,9 @@ describe('MobilePromptSheet', () => {
 
       // Should not throw when no onDismiss is provided
       expect(() => {
-        fireEvent.touchStart(sheet, { touches: [{ clientY: 0 }] });
-        fireEvent.touchMove(sheet, { touches: [{ clientY: 150 }] });
-        fireEvent.touchEnd(sheet);
+        fireEvent.touchStart(sheet, { touches: [{ clientX: 0, clientY: 0 }] });
+        fireEvent.touchMove(sheet, { touches: [{ clientX: 0, clientY: 150 }] });
+        fireEvent.touchEnd(sheet, { changedTouches: [{ clientX: 0, clientY: 150 }] });
       }).not.toThrow();
     });
   });

--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -907,4 +907,63 @@ describe('MessageInput', () => {
       });
     });
   });
+
+  // ===== Keyboard follow (Issue #1128) =====
+
+  describe('Keyboard follow (Issue #1128)', () => {
+    const originalVisualViewport = window.visualViewport;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'visualViewport', {
+        value: originalVisualViewport,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    /** Mock a visualViewport shrunk by `heightDiff` (i.e. keyboard height). */
+    function mockKeyboard(heightDiff: number) {
+      Object.defineProperty(window, 'visualViewport', {
+        value: {
+          height: window.innerHeight - heightDiff,
+          width: 375,
+          offsetTop: 0,
+          offsetLeft: 0,
+          pageTop: 0,
+          pageLeft: 0,
+          scale: 1,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        },
+        configurable: true,
+        writable: true,
+      });
+    }
+
+    it('translates the composer up by the keyboard height when keyboardAware', () => {
+      mockKeyboard(300);
+      render(<MessageInput {...defaultProps} keyboardAware />);
+
+      const container = screen.getByTestId('message-input-container');
+      expect(container.style.transform).toBe('translateY(-300px)');
+    });
+
+    it('does not translate when keyboardAware is off', () => {
+      mockKeyboard(300);
+      render(<MessageInput {...defaultProps} />);
+
+      const container = screen.getByTestId('message-input-container');
+      expect(container.style.transform).toBe('');
+    });
+
+    it('does not translate when the keyboard is hidden', () => {
+      // Below the 100px keyboard threshold → treated as no keyboard.
+      mockKeyboard(0);
+      render(<MessageInput {...defaultProps} keyboardAware />);
+
+      const container = screen.getByTestId('message-input-container');
+      expect(container.style.transform).toBe('');
+    });
+  });
 });

--- a/tests/unit/hooks/useSwipeGesture.test.ts
+++ b/tests/unit/hooks/useSwipeGesture.test.ts
@@ -510,5 +510,166 @@ describe('useSwipeGesture', () => {
 
       document.body.removeChild(grandparent);
     });
+
+    it('should detect horizontal scrollability when axis is "horizontal"', () => {
+      const element = document.createElement('div');
+      element.style.overflowX = 'auto';
+      Object.defineProperty(element, 'scrollWidth', { value: 500, configurable: true });
+      Object.defineProperty(element, 'clientWidth', { value: 200, configurable: true });
+      document.body.appendChild(element);
+
+      // Horizontally scrollable, but NOT vertically scrollable.
+      expect(isInsideScrollableElement(element, 'horizontal')).toBe(true);
+      expect(isInsideScrollableElement(element, 'vertical')).toBe(false);
+
+      document.body.removeChild(element);
+    });
+  });
+
+  describe('Issue #1128: axis, direction lock, edge zone', () => {
+    /** Minimal touch event (jsdom lacks Touch/TouchEvent constructors). */
+    function createTouchEvent(
+      type: string,
+      clientX: number,
+      clientY: number,
+      target: EventTarget
+    ): TouchEvent {
+      const touch = { clientX, clientY, identifier: 0, target } as unknown as Touch;
+      const event = new Event(type, { bubbles: true, cancelable: true }) as unknown as TouchEvent;
+      Object.defineProperty(event, 'touches', { value: [touch] });
+      Object.defineProperty(event, 'changedTouches', { value: [touch] });
+      Object.defineProperty(event, 'target', { value: target });
+      return event;
+    }
+
+    /** Render the hook with an element pre-attached to its ref. */
+    function renderHookWithElement(
+      element: HTMLElement,
+      options: Parameters<typeof useSwipeGesture>[0]
+    ) {
+      const hookResult = renderHook((props) => useSwipeGesture(props), {
+        initialProps: { ...options, enabled: false },
+      });
+      (hookResult.result.current.ref as { current: HTMLElement | null }).current = element;
+      hookResult.rerender({ ...options, enabled: true });
+      return hookResult;
+    }
+
+    function dispatch(el: HTMLElement, event: TouchEvent) {
+      act(() => {
+        el.dispatchEvent(event);
+      });
+    }
+
+    it('should fire onSwipeLeft for a horizontal-axis left swipe', () => {
+      const onSwipeLeft = vi.fn();
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      el.appendChild(child);
+      document.body.appendChild(el);
+
+      renderHookWithElement(el, { axis: 'horizontal', threshold: 60, onSwipeLeft });
+
+      dispatch(el, createTouchEvent('touchstart', 200, 100, child));
+      dispatch(el, createTouchEvent('touchmove', 100, 105, child));
+      dispatch(el, createTouchEvent('touchend', 90, 108, child));
+
+      expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+      document.body.removeChild(el);
+    });
+
+    it('should NOT fire a horizontal swipe once the gesture locks to vertical (direction lock)', () => {
+      const onSwipeLeft = vi.fn();
+      const onSwipeRight = vi.fn();
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      el.appendChild(child);
+      document.body.appendChild(el);
+
+      renderHookWithElement(el, { axis: 'horizontal', threshold: 60, onSwipeLeft, onSwipeRight });
+
+      // Vertical-dominant move commits the gesture to the vertical axis, which is
+      // perpendicular to the horizontal hook → cancelled for the rest of the touch.
+      dispatch(el, createTouchEvent('touchstart', 200, 100, child));
+      dispatch(el, createTouchEvent('touchmove', 190, 200, child));
+      dispatch(el, createTouchEvent('touchend', 90, 220, child));
+
+      expect(onSwipeLeft).not.toHaveBeenCalled();
+      expect(onSwipeRight).not.toHaveBeenCalled();
+      document.body.removeChild(el);
+    });
+
+    it('should still fire a vertical swipe on the vertical axis (bottom-sheet dismiss)', () => {
+      const onSwipeDown = vi.fn();
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      el.appendChild(child);
+      document.body.appendChild(el);
+
+      renderHookWithElement(el, { axis: 'vertical', threshold: 100, onSwipeDown });
+
+      dispatch(el, createTouchEvent('touchstart', 100, 0, child));
+      dispatch(el, createTouchEvent('touchmove', 100, 80, child));
+      dispatch(el, createTouchEvent('touchend', 100, 160, child));
+
+      expect(onSwipeDown).toHaveBeenCalledTimes(1);
+      document.body.removeChild(el);
+    });
+
+    it('should report live progress via onSwipeMove', () => {
+      const onSwipeMove = vi.fn();
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      el.appendChild(child);
+      document.body.appendChild(el);
+
+      renderHookWithElement(el, { axis: 'vertical', threshold: 100, onSwipeMove });
+
+      dispatch(el, createTouchEvent('touchstart', 100, 0, child));
+      dispatch(el, createTouchEvent('touchmove', 100, 40, child));
+
+      expect(onSwipeMove).toHaveBeenCalledWith({ deltaX: 0, deltaY: 40 });
+      document.body.removeChild(el);
+    });
+
+    it('should suppress a center-start swipe when edgeStartZone is set', () => {
+      const onSwipeRight = vi.fn();
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      el.appendChild(child);
+      document.body.appendChild(el);
+      el.getBoundingClientRect = () =>
+        ({ left: 0, right: 400, top: 0, bottom: 0, width: 400, height: 0, x: 0, y: 0, toJSON() {} }) as DOMRect;
+
+      renderHookWithElement(el, { axis: 'horizontal', threshold: 60, edgeStartZone: 32, onSwipeRight });
+
+      // Start in the centre (far from both edges) → not tracked.
+      dispatch(el, createTouchEvent('touchstart', 200, 100, child));
+      dispatch(el, createTouchEvent('touchmove', 300, 100, child));
+      dispatch(el, createTouchEvent('touchend', 320, 100, child));
+
+      expect(onSwipeRight).not.toHaveBeenCalled();
+      document.body.removeChild(el);
+    });
+
+    it('should allow an edge-start swipe when edgeStartZone is set', () => {
+      const onSwipeRight = vi.fn();
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      el.appendChild(child);
+      document.body.appendChild(el);
+      el.getBoundingClientRect = () =>
+        ({ left: 0, right: 400, top: 0, bottom: 0, width: 400, height: 0, x: 0, y: 0, toJSON() {} }) as DOMRect;
+
+      renderHookWithElement(el, { axis: 'horizontal', threshold: 60, edgeStartZone: 32, onSwipeRight });
+
+      // Start near the left edge (within 32px) → tracked, swipe right fires.
+      dispatch(el, createTouchEvent('touchstart', 10, 100, child));
+      dispatch(el, createTouchEvent('touchmove', 90, 105, child));
+      dispatch(el, createTouchEvent('touchend', 110, 108, child));
+
+      expect(onSwipeRight).toHaveBeenCalledTimes(1);
+      document.body.removeChild(el);
+    });
   });
 });


### PR DESCRIPTION
## 概要
Issue #1128 の対応。モバイルのジェスチャー体験を強化。既存の未活用フック（useSwipeGesture/useVirtualKeyboard）を本来の用途に接続。

## 変更内容
- **useSwipeGesture拡張**: axis/方向ロック/エッジ開始制限/onSwipeMove を後方互換で追加（既存MarkdownEditorの四方向スワイプ・#299スクロール抑制は不変）
- **タブ水平スワイプ切替**: worktree詳細モバイルタブ。方向ロックで縦スクロール中は無効、しきい値60px、ターミナルタブはエッジ開始領域限定で誤発火抑止、MobileTabBarインジケータは自動同期
- **pull-to-refresh**: Sessions/Repositoriesに新設（usePullToRefresh+PullToRefresh）。最上部のみ発火、overscroll-behavior:contain+preventDefaultでネイティブPTR二重発火防止
- **キーボード追従**: MessageInputをuseVirtualKeyboardに接続（keyboardAware opt-in）、enterKeyHint/inputMode付与
- MobilePromptSheetのアドホックスワイプをuseSwipeGestureへ統合（#1127のfocus trap refをマージし挙動維持）

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1128（親: #1110 UI/UX最先端化 Phase 4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)