### PR TITLE
fix(worktree): 同一ディレクトリのブランチ切替で履歴がCASCADE削除される問題を修正 (#1151)

### DIFF
--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -30,6 +30,8 @@ export {
   saveInitialBranch,
   getInitialBranch,
   getWorktreeIdsByRepository,
+  getWorktreesByRepository,
+  migrateWorktreeIdPreservingChildren,
   deleteRepositoryWorktrees,
   deleteWorktreesByIds,
 } from './worktree-db';

--- a/src/lib/db/worktree-db.ts
+++ b/src/lib/db/worktree-db.ts
@@ -298,51 +298,157 @@ export function getWorktreeById(
 }
 
 /**
- * Insert or update worktree
+ * Insert or update worktree.
+ *
+ * Issue #1151: A worktree ID is derived from its branch name
+ * (`generateWorktreeId`), so checking out a different branch in the *same*
+ * directory changes the ID even though the worktree (path) is unchanged. The
+ * previous implementation hard-deleted the existing same-path row before
+ * inserting the new ID, which CASCADE-deleted every child row (chat history,
+ * memos, todos, timers, schedules, execution logs, agent instances). To avoid
+ * that data loss we instead RENAME the existing same-path row to the new ID,
+ * carrying its child rows along, so history follows the directory across branch
+ * switches. The whole operation runs in a single transaction so the rename and
+ * the upsert are atomic.
  */
 export function upsertWorktree(
   db: Database.Database,
   worktree: Worktree
 ): void {
-  // First, remove any existing worktree with the same path but different ID
-  // This handles cases where the ID generation scheme has changed
-  db.prepare('DELETE FROM worktrees WHERE path = ? AND id != ?').run(worktree.path, worktree.id);
+  const run = db.transaction(() => {
+    // A branch switch (or a change to the ID scheme) yields a different ID for
+    // the same on-disk path. `path` is UNIQUE, so we must reconcile the stale
+    // row before inserting the new ID. Migrate it (id + child FK rows) instead
+    // of deleting so no history is lost.
+    const staleRows = db
+      .prepare('SELECT id FROM worktrees WHERE path = ? AND id != ?')
+      .all(worktree.path, worktree.id) as Array<{ id: string }>;
 
-  const stmt = db.prepare(`
-    INSERT INTO worktrees (
-      id, name, path, repository_path, repository_name, description,
-      last_user_message, last_user_message_at, last_message_summary, updated_at, cli_tool_id, branch
-    )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(id) DO UPDATE SET
-      name = excluded.name,
-      path = excluded.path,
-      repository_path = excluded.repository_path,
-      repository_name = excluded.repository_name,
-      description = COALESCE(excluded.description, worktrees.description),
-      last_user_message = COALESCE(excluded.last_user_message, worktrees.last_user_message),
-      last_user_message_at = COALESCE(excluded.last_user_message_at, worktrees.last_user_message_at),
-      last_message_summary = COALESCE(excluded.last_message_summary, worktrees.last_message_summary),
-      updated_at = COALESCE(excluded.updated_at, worktrees.updated_at),
-      cli_tool_id = COALESCE(excluded.cli_tool_id, worktrees.cli_tool_id),
-      -- Issue #1003: keep the last known branch when a non-sync writer omits it.
-      branch = COALESCE(excluded.branch, worktrees.branch)
-  `);
+    for (const { id: staleId } of staleRows) {
+      migrateWorktreeIdPreservingChildren(db, staleId, worktree.id);
+    }
 
-  stmt.run(
-    worktree.id,
-    worktree.name,
-    worktree.path,
-    worktree.repositoryPath || null,
-    worktree.repositoryName || null,
-    worktree.description || null,
-    worktree.lastUserMessage || null,
-    worktree.lastUserMessageAt?.getTime() || null,
-    worktree.lastMessageSummary || null,
-    worktree.updatedAt?.getTime() || null,
-    worktree.cliToolId || 'claude',
-    worktree.branch || null
-  );
+    const stmt = db.prepare(`
+      INSERT INTO worktrees (
+        id, name, path, repository_path, repository_name, description,
+        last_user_message, last_user_message_at, last_message_summary, updated_at, cli_tool_id, branch
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        name = excluded.name,
+        path = excluded.path,
+        repository_path = excluded.repository_path,
+        repository_name = excluded.repository_name,
+        description = COALESCE(excluded.description, worktrees.description),
+        last_user_message = COALESCE(excluded.last_user_message, worktrees.last_user_message),
+        last_user_message_at = COALESCE(excluded.last_user_message_at, worktrees.last_user_message_at),
+        last_message_summary = COALESCE(excluded.last_message_summary, worktrees.last_message_summary),
+        updated_at = COALESCE(excluded.updated_at, worktrees.updated_at),
+        cli_tool_id = COALESCE(excluded.cli_tool_id, worktrees.cli_tool_id),
+        -- Issue #1003: keep the last known branch when a non-sync writer omits it.
+        branch = COALESCE(excluded.branch, worktrees.branch)
+    `);
+
+    stmt.run(
+      worktree.id,
+      worktree.name,
+      worktree.path,
+      worktree.repositoryPath || null,
+      worktree.repositoryName || null,
+      worktree.description || null,
+      worktree.lastUserMessage || null,
+      worktree.lastUserMessageAt?.getTime() || null,
+      worktree.lastMessageSummary || null,
+      worktree.updatedAt?.getTime() || null,
+      worktree.cliToolId || 'claude',
+      worktree.branch || null
+    );
+  });
+
+  run();
+}
+
+/**
+ * Discover every table that has a foreign key referencing `worktrees(id)`,
+ * along with the referencing column. Derived dynamically from the live schema
+ * so it never drifts out of sync with future migrations that add child tables.
+ *
+ * Issue #1151.
+ */
+function getWorktreeChildTables(
+  db: Database.Database
+): Array<{ table: string; column: string }> {
+  const tables = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+    .all() as Array<{ name: string }>;
+
+  const children: Array<{ table: string; column: string }> = [];
+  for (const { name } of tables) {
+    if (name === 'worktrees') continue;
+    // PRAGMA identifiers cannot be bound; `name` comes from sqlite_master, not
+    // user input, so string interpolation here is safe.
+    const fks = db.prepare(`PRAGMA foreign_key_list("${name}")`).all() as Array<{
+      table: string;
+      from: string;
+      to: string | null;
+    }>;
+    for (const fk of fks) {
+      if (fk.table === 'worktrees' && (fk.to === 'id' || fk.to === null)) {
+        children.push({ table: name, column: fk.from });
+      }
+    }
+  }
+  return children;
+}
+
+/**
+ * Rename a worktree row's primary key from `oldId` to `newId`, re-pointing every
+ * child table's foreign key so no CASCADE deletion occurs. This is what makes a
+ * same-directory branch switch preserve chat history and all related data
+ * instead of destroying it (Issue #1151).
+ *
+ * Must be called inside a transaction. `PRAGMA defer_foreign_keys` defers FK
+ * enforcement to COMMIT, letting us repoint the parent PK and its children in
+ * any order without needing `ON UPDATE CASCADE` on every constraint.
+ */
+export function migrateWorktreeIdPreservingChildren(
+  db: Database.Database,
+  oldId: string,
+  newId: string
+): void {
+  if (oldId === newId) return;
+
+  const oldExists = db.prepare('SELECT 1 FROM worktrees WHERE id = ?').get(oldId);
+  if (!oldExists) return;
+
+  // Defer FK checks until COMMIT so the parent PK and child FKs can be updated
+  // independently. Resets automatically at the end of the transaction.
+  db.pragma('defer_foreign_keys = ON');
+
+  const newExists = db.prepare('SELECT 1 FROM worktrees WHERE id = ?').get(newId);
+  const children = getWorktreeChildTables(db);
+
+  if (newExists) {
+    // Collision guard. `path` is UNIQUE so two rows for the same directory
+    // should never coexist, but if the DB is already inconsistent keep the
+    // destination row's data and fold in the source's non-conflicting children;
+    // conflicting leftovers are removed by CASCADE when the old row is deleted.
+    for (const { table, column } of children) {
+      db.prepare(
+        `UPDATE OR IGNORE "${table}" SET "${column}" = ? WHERE "${column}" = ?`
+      ).run(newId, oldId);
+    }
+    db.prepare('DELETE FROM worktrees WHERE id = ?').run(oldId);
+    return;
+  }
+
+  // Normal rename: move the parent PK, then repoint all child rows.
+  db.prepare('UPDATE worktrees SET id = ? WHERE id = ?').run(newId, oldId);
+  for (const { table, column } of children) {
+    db.prepare(
+      `UPDATE "${table}" SET "${column}" = ? WHERE "${column}" = ?`
+    ).run(newId, oldId);
+  }
 }
 
 /**
@@ -588,6 +694,28 @@ export function getWorktreeIdsByRepository(
 
   const rows = stmt.all(repositoryPath) as Array<{ id: string }>;
   return rows.map(r => r.id);
+}
+
+/**
+ * Get all worktree rows (id + path) for a given repository path.
+ *
+ * Issue #1151: sync decides which DB rows to prune. It must key that decision on
+ * the on-disk path, not the branch-derived ID, otherwise a branch switch in the
+ * same directory looks like a "removed" worktree and gets CASCADE-deleted.
+ *
+ * @param db - Database instance
+ * @param repositoryPath - Path of the repository
+ * @returns Array of `{ id, path }` for every worktree of the repository
+ */
+export function getWorktreesByRepository(
+  db: Database.Database,
+  repositoryPath: string
+): Array<{ id: string; path: string }> {
+  const stmt = db.prepare(`
+    SELECT id, path FROM worktrees WHERE repository_path = ?
+  `);
+
+  return stmt.all(repositoryPath) as Array<{ id: string; path: string }>;
 }
 
 /**

--- a/src/lib/git/worktrees.ts
+++ b/src/lib/git/worktrees.ts
@@ -8,7 +8,7 @@ import { promisify } from 'util';
 import path from 'path';
 import type { Worktree } from '@/types/models';
 import type Database from 'better-sqlite3';
-import { upsertWorktree, getWorktreeIdsByRepository, deleteWorktreesByIds } from '@/lib/db';
+import { upsertWorktree, getWorktreesByRepository, deleteWorktreesByIds } from '@/lib/db';
 import { getEnvByKey } from '@/lib/env';
 import { createLogger } from '@/lib/logger';
 
@@ -315,14 +315,20 @@ export function syncWorktreesToDB(
   for (const [repoPath, repoWorktrees] of worktreesByRepo) {
     if (!repoPath) continue;
 
-    // Get current worktree IDs in DB for this repository
-    const existingIds = getWorktreeIdsByRepository(db, repoPath);
+    // Get current worktree rows (id + path) in DB for this repository
+    const existingRows = getWorktreesByRepository(db, repoPath);
 
-    // Get new worktree IDs from scan
-    const newIds = new Set(repoWorktrees.map(wt => wt.id));
+    // Issue #1151: prune by on-disk PATH, not by branch-derived ID. A worktree's
+    // ID changes when its branch changes (`generateWorktreeId`), so keying the
+    // "removed" decision on ID mistakes a same-directory branch switch for a
+    // deleted worktree and CASCADE-deletes its chat history and related data.
+    // Only a worktree whose PATH is gone from the scan was genuinely removed.
+    const newPaths = new Set(repoWorktrees.map(wt => path.resolve(wt.path)));
 
-    // Find worktrees that no longer exist (deleted)
-    const deletedIds = existingIds.filter(id => !newIds.has(id));
+    // Find worktrees that no longer exist on disk (genuinely deleted)
+    const deletedIds = existingRows
+      .filter(row => !newPaths.has(path.resolve(row.path)))
+      .map(row => row.id);
 
     // Delete removed worktrees from DB
     if (deletedIds.length > 0) {

--- a/tests/unit/lib/worktrees-sync.test.ts
+++ b/tests/unit/lib/worktrees-sync.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Issue #1151: same-directory branch switch must NOT CASCADE-delete history.
+ *
+ * A worktree's primary-key ID is derived from its branch name
+ * (`generateWorktreeId`). Checking out a different branch in the same directory
+ * changes the ID even though the on-disk path is unchanged. The previous sync
+ * logic treated the vanished old ID as a "removed" worktree and hard-deleted its
+ * row, which CASCADE-deleted every child table (chat history, memos, todos,
+ * timers, schedules, execution logs, agent instances, session states).
+ *
+ * These tests reproduce the branch-switch flow against a real in-memory SQLite
+ * database with `PRAGMA foreign_keys = ON` (mirroring production
+ * `db-instance.ts`) and assert that child data is preserved across branch
+ * switches while genuinely-removed worktrees are still cleaned up.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  upsertWorktree,
+  createMessage,
+  getWorktreeById,
+  migrateWorktreeIdPreservingChildren,
+} from '@/lib/db';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { syncWorktreesToDB } from '@/lib/git/worktrees';
+import type { Worktree } from '@/types/models';
+
+const REPO_PATH = '/repos/anvil';
+const WORKTREE_PATH = '/repos/anvil'; // develop lives in the primary worktree dir
+
+function makeWorktree(id: string, branch: string): Worktree {
+  return {
+    id,
+    name: branch,
+    branch,
+    path: WORKTREE_PATH,
+    repositoryPath: REPO_PATH,
+    repositoryName: 'anvil',
+  };
+}
+
+/**
+ * Insert exactly one row into every table that has an ON DELETE CASCADE FK to
+ * `worktrees(id)`, so we can assert the full blast radius of a CASCADE.
+ */
+function seedChildData(db: Database.Database, worktreeId: string): void {
+  const now = Date.now();
+
+  // chat_messages (via the production helper, to track schema drift)
+  createMessage(db, {
+    worktreeId,
+    role: 'user',
+    content: `hello from ${worktreeId}`,
+    timestamp: new Date(now),
+    messageType: 'normal',
+  });
+
+  // worktree_memos
+  db.prepare(
+    `INSERT INTO worktree_memos (id, worktree_id, title, content, position, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(`memo-${worktreeId}`, worktreeId, 'Memo', 'note', 0, now, now);
+
+  // worktree_todos
+  db.prepare(
+    `INSERT INTO worktree_todos (id, worktree_id, content, done, position, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(`todo-${worktreeId}`, worktreeId, 'do the thing', 0, 0, now, now);
+
+  // agent_instances
+  db.prepare(
+    `INSERT INTO agent_instances (worktree_id, instance_id, cli_tool_id, alias, sort_order, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(worktreeId, 'claude', 'claude', 'primary', 0, now);
+
+  // session_states
+  db.prepare(
+    `INSERT INTO session_states (worktree_id, cli_tool_id, instance_id, last_captured_line)
+     VALUES (?, ?, ?, ?)`
+  ).run(worktreeId, 'claude', 'claude', 42);
+
+  // timer_messages
+  db.prepare(
+    `INSERT INTO timer_messages (id, worktree_id, cli_tool_id, message, delay_ms, scheduled_send_time, status, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(`timer-${worktreeId}`, worktreeId, 'claude', 'ping', 1000, now + 1000, 'pending', now);
+
+  // scheduled_executions + execution_logs (log references the schedule)
+  const scheduleId = `sched-${worktreeId}`;
+  db.prepare(
+    `INSERT INTO scheduled_executions (id, worktree_id, cli_tool_id, name, message, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(scheduleId, worktreeId, 'claude', 'nightly', 'run', now, now);
+  db.prepare(
+    `INSERT INTO execution_logs (id, schedule_id, worktree_id, message, started_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(`log-${worktreeId}`, scheduleId, worktreeId, 'run', now, now);
+}
+
+const CHILD_TABLES = [
+  'chat_messages',
+  'worktree_memos',
+  'worktree_todos',
+  'agent_instances',
+  'session_states',
+  'timer_messages',
+  'scheduled_executions',
+  'execution_logs',
+];
+
+/** Count child rows keyed to a worktree ID across every CASCADE child table. */
+function countChildData(db: Database.Database, worktreeId: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const table of CHILD_TABLES) {
+    const row = db
+      .prepare(`SELECT COUNT(*) AS c FROM ${table} WHERE worktree_id = ?`)
+      .get(worktreeId) as { c: number };
+    counts[table] = row.c;
+  }
+  return counts;
+}
+
+function totalChildRows(db: Database.Database): number {
+  return CHILD_TABLES.reduce((sum, table) => {
+    const row = db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number };
+    return sum + row.c;
+  }, 0);
+}
+
+describe('Issue #1151: branch-switch history preservation', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    // Mirror production (src/lib/db/db-instance.ts): enforce FK so CASCADE fires.
+    db.pragma('foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('upsertWorktree renames stale same-path rows instead of deleting', () => {
+    it('preserves every child table when the branch changes in the same directory', () => {
+      upsertWorktree(db, makeWorktree('anvil-develop', 'develop'));
+      seedChildData(db, 'anvil-develop');
+
+      const before = countChildData(db, 'anvil-develop');
+      for (const table of CHILD_TABLES) {
+        expect(before[table], `${table} should be seeded`).toBe(1);
+      }
+
+      // Branch switch: develop -> feature-x (same path, new ID)
+      upsertWorktree(db, makeWorktree('anvil-feature-x', 'feature-x'));
+
+      // Old ID no longer exists as a row, but its data moved to the new ID.
+      expect(getWorktreeById(db, 'anvil-develop')).toBeNull();
+      const after = countChildData(db, 'anvil-feature-x');
+      for (const table of CHILD_TABLES) {
+        expect(after[table], `${table} should be carried over`).toBe(1);
+      }
+      // Nothing was CASCADE-deleted: total child rows unchanged.
+      expect(totalChildRows(db)).toBe(CHILD_TABLES.length);
+
+      // The single row keeps the new branch identity.
+      const wt = getWorktreeById(db, 'anvil-feature-x');
+      expect(wt?.path).toBe(WORKTREE_PATH);
+      expect(wt?.branch).toBe('feature-x');
+    });
+
+    it('does not touch child data when a genuinely new path is added', () => {
+      upsertWorktree(db, makeWorktree('anvil-develop', 'develop'));
+      seedChildData(db, 'anvil-develop');
+
+      // Different directory => different worktree, no rename.
+      upsertWorktree(db, {
+        id: 'anvil-feature-y',
+        name: 'feature-y',
+        branch: 'feature-y',
+        path: '/repos/anvil-feature-y',
+        repositoryPath: REPO_PATH,
+        repositoryName: 'anvil',
+      });
+
+      expect(getWorktreeById(db, 'anvil-develop')).not.toBeNull();
+      expect(countChildData(db, 'anvil-develop').chat_messages).toBe(1);
+    });
+  });
+
+  describe('syncWorktreesToDB prunes by path, not by branch-derived ID', () => {
+    it('preserves history across a develop -> feature -> develop cycle', () => {
+      // Initial sync on develop, then user works and accumulates history.
+      syncWorktreesToDB(db, [makeWorktree('anvil-develop', 'develop')]);
+      seedChildData(db, 'anvil-develop');
+      expect(countChildData(db, 'anvil-develop').chat_messages).toBe(1);
+
+      // git checkout feature-x; a sync runs (server restart / manual sync).
+      syncWorktreesToDB(db, [makeWorktree('anvil-feature-x', 'feature-x')]);
+      // History followed the directory to the new ID; nothing deleted.
+      expect(totalChildRows(db)).toBe(CHILD_TABLES.length);
+      expect(countChildData(db, 'anvil-feature-x').chat_messages).toBe(1);
+      expect(getWorktreeById(db, 'anvil-develop')).toBeNull();
+
+      // git checkout develop again; sync runs.
+      syncWorktreesToDB(db, [makeWorktree('anvil-develop', 'develop')]);
+
+      // The original develop history is intact and reachable again.
+      expect(totalChildRows(db)).toBe(CHILD_TABLES.length);
+      const restored = countChildData(db, 'anvil-develop');
+      for (const table of CHILD_TABLES) {
+        expect(restored[table], `${table} preserved after A->B->A`).toBe(1);
+      }
+      const wt = getWorktreeById(db, 'anvil-develop');
+      expect(wt?.branch).toBe('develop');
+    });
+
+    it('still cleans up (CASCADE) a worktree that is genuinely removed from disk', () => {
+      // Two worktrees in the repo: primary (develop) + a feature dir.
+      const develop = makeWorktree('anvil-develop', 'develop');
+      const feature: Worktree = {
+        id: 'anvil-feature-z',
+        name: 'feature-z',
+        branch: 'feature-z',
+        path: '/repos/anvil-feature-z',
+        repositoryPath: REPO_PATH,
+        repositoryName: 'anvil',
+      };
+      syncWorktreesToDB(db, [develop, feature]);
+      seedChildData(db, 'anvil-develop');
+      seedChildData(db, 'anvil-feature-z');
+      expect(totalChildRows(db)).toBe(CHILD_TABLES.length * 2);
+
+      // `git worktree remove` deletes the feature directory. Next sync only
+      // reports the develop path.
+      syncWorktreesToDB(db, [develop]);
+
+      // The removed worktree and its children are gone (CASCADE), develop's
+      // data is untouched.
+      expect(getWorktreeById(db, 'anvil-feature-z')).toBeNull();
+      expect(countChildData(db, 'anvil-feature-z').chat_messages).toBe(0);
+      expect(totalChildRows(db)).toBe(CHILD_TABLES.length);
+      expect(countChildData(db, 'anvil-develop').chat_messages).toBe(1);
+    });
+
+    it('does not delete anything when the scan is empty (guard)', () => {
+      syncWorktreesToDB(db, [makeWorktree('anvil-develop', 'develop')]);
+      seedChildData(db, 'anvil-develop');
+
+      const result = syncWorktreesToDB(db, []);
+
+      expect(result.deletedIds).toEqual([]);
+      expect(getWorktreeById(db, 'anvil-develop')).not.toBeNull();
+      expect(totalChildRows(db)).toBe(CHILD_TABLES.length);
+    });
+  });
+
+  describe('migrateWorktreeIdPreservingChildren', () => {
+    it('is a no-op when old and new IDs are identical', () => {
+      upsertWorktree(db, makeWorktree('anvil-develop', 'develop'));
+      seedChildData(db, 'anvil-develop');
+
+      db.transaction(() => {
+        migrateWorktreeIdPreservingChildren(db, 'anvil-develop', 'anvil-develop');
+      })();
+
+      expect(countChildData(db, 'anvil-develop').chat_messages).toBe(1);
+    });
+
+    it('is a no-op when the source ID does not exist', () => {
+      upsertWorktree(db, makeWorktree('anvil-develop', 'develop'));
+
+      db.transaction(() => {
+        migrateWorktreeIdPreservingChildren(db, 'missing', 'anvil-develop');
+      })();
+
+      expect(getWorktreeById(db, 'anvil-develop')).not.toBeNull();
+    });
+
+    it('merges into the destination without error on a (path-UNIQUE-guarded) ID collision', () => {
+      // Force two rows to coexist by using distinct paths, then migrate old->new
+      // where new already exists. Destination data wins; source folds in.
+      upsertWorktree(db, {
+        id: 'wt-old',
+        name: 'old',
+        branch: 'old',
+        path: '/repos/anvil-old',
+        repositoryPath: REPO_PATH,
+        repositoryName: 'anvil',
+      });
+      upsertWorktree(db, {
+        id: 'wt-new',
+        name: 'new',
+        branch: 'new',
+        path: '/repos/anvil-new',
+        repositoryPath: REPO_PATH,
+        repositoryName: 'anvil',
+      });
+      seedChildData(db, 'wt-old');
+      seedChildData(db, 'wt-new');
+
+      db.transaction(() => {
+        migrateWorktreeIdPreservingChildren(db, 'wt-old', 'wt-new');
+      })();
+
+      // Old row is gone; destination retains at least its own data.
+      expect(getWorktreeById(db, 'wt-old')).toBeNull();
+      expect(getWorktreeById(db, 'wt-new')).not.toBeNull();
+      expect(countChildData(db, 'wt-new').chat_messages).toBeGreaterThanOrEqual(1);
+      // No rows left orphaned on the old ID.
+      expect(countChildData(db, 'wt-old').chat_messages).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1151（**データ損失バグ**）の対応。worktree IDがブランチ由来のため、同一ディレクトリで別ブランチに切替→sync時に旧行が「削除された」と誤判定されCASCADEで会話履歴・メモ・ToDo・タイマー・スケジュール・実行ログ・エージェントインスタンス・セッション状態が物理削除されていた問題を修正。

## 変更内容（案1＋案3の組合せ）
- **syncWorktreesToDB**: prune判定を「ブランチ由来IDの不在」→「**on-diskパスの不在**」に変更（getWorktreesByRepository追加）。真に削除されたworktreeのみCASCADE整理
- **upsertWorktree**: 同一パス・別IDの旧行をDELETEする代わりに、子テーブルのFKを張り替えて id を **RENAME**（migrateWorktreeIdPreservingChildren）。 でトランザクション内FK検査をCOMMITまで遅延し、ON UPDATE CASCADE無しでも親PK・子FKを原子的に更新。子テーブルはスキーマから動的検出し将来の追加にも追従
- 副次効果: 誤検知の deletedIds 解消により、ブランチ切替でtmuxセッションが誤killされなくなる

## 検証
結合テスト（in-memory DB + migrations + FK ON）で、A→B→A切替＋sync後も8つの子テーブル行が保持されること、git worktree remove（真の削除）時は従来どおりCASCADE整理されることを検証。

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)