### PR TITLE
fix(detection): Codex v0.141ステータスバー陳腐化で処理中がready誤判定される問題を修正 (#1150)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -282,6 +282,37 @@ export const CODEX_PAGER_FOOTER_PATTERN =
   /(?:↑\/↓|pgup\/pgdn|home\/end)\s+to\s+(?:scroll|page|jump)|to\s+edit\s+(?:prev|next|message)/i;
 
 /**
+ * Codex CLI status-bar line pattern (Issue #1150)
+ *
+ * The Codex TUI renders a status bar as the bottom-most content line, just above
+ * the input area. status-detector.ts uses it as the footer boundary that separates
+ * the conversation content (thinking indicators / idle "›" prompt) from the input
+ * area, so both the selection-list check (priority 0.8) and the running/idle check
+ * (priority 2.7) depend on locating it.
+ *
+ * The format drifted across Codex versions — the "N% left ·" token was DROPPED in
+ * v0.141 (gpt-5.5), which is exactly what broke Issue #1150:
+ *   - v0.141 (gpt-5.5): "gpt-5.5 xhigh · ~/share/work/github_kewton/commandmate-issue-947"
+ *   - legacy (gpt-5.4): "gpt-5.4 high · 21% left · ~/share/work/..."
+ *   - legacy (o4-mini): "  o4-mini            50% left · /path/to/project"
+ *
+ * The previous pattern required "\d+%\s+left\s+·", so v0.141 bars never matched:
+ * the footer boundary stayed -1 and the whole Codex running/idle block was skipped,
+ * leaving generating sessions misreported as `ready` (static green dot, no glow).
+ *
+ * Version-independent anchor: a leading model token, a middle-dot "·" separator,
+ * and a filesystem path ("~/…" or "/…") at the END of the line. Any "N% left ·"
+ * segment (legacy) is absorbed by ".*·" before the trailing path. Requiring the
+ * trailing path keeps this Codex-specific (guarded by cliToolId === 'codex' in
+ * status-detector.ts) and stops ordinary conversation lines that merely contain a
+ * "·" from being mistaken for the status bar.
+ *
+ * Single-line by design (no /m, no /g): status-detector.ts tests it per content
+ * line. No nested quantifiers (ReDoS-safe; adjacent greedy quantifiers only).
+ */
+export const CODEX_STATUS_BAR_PATTERN = /^\s*\S.*·\s*~?\/\S*\s*$/;
+
+/**
  * Pasted text pattern
  *
  * Claude CLI displays this when it detects multi-line text paste in the

--- a/src/lib/detection/status-detector.ts
+++ b/src/lib/detection/status-detector.ts
@@ -24,7 +24,7 @@
  * coupling via a minimal DTO/projection type.
  */
 
-import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CODEX_PAGER_FOOTER_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN, ANTIGRAVITY_SELECTION_LIST_PATTERN } from './cli-patterns';
+import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CODEX_PAGER_FOOTER_PATTERN, CODEX_STATUS_BAR_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN, ANTIGRAVITY_SELECTION_LIST_PATTERN } from './cli-patterns';
 import { detectPrompt } from './prompt-detector';
 import type { PromptDetectionResult } from './prompt-detector';
 import type { CLIToolType } from '@/lib/cli-tools/types';
@@ -264,10 +264,11 @@ export function detectSessionStatus(
   // would allow stale "Press enter to confirm" text from already-answered approval
   // prompts high in scrollback to falsely trigger NavigationButtons.
   if (cliToolId === 'codex') {
-    const codexStatusBarPattern = /^\s*\S+.*\d+%\s+left\s+·/;
+    // Issue #1150: locate the status bar via CODEX_STATUS_BAR_PATTERN (version-
+    // independent; matches both legacy "N% left ·" and v0.141 "model · path" bars).
     let codexFooterBoundary = -1;
     for (let ci = contentLines.length - 1; ci >= Math.max(0, contentLines.length - 10); ci--) {
-      if (codexStatusBarPattern.test(contentLines[ci])) {
+      if (CODEX_STATUS_BAR_PATTERN.test(contentLines[ci])) {
         codexFooterBoundary = ci;
         break;
       }
@@ -496,11 +497,15 @@ export function detectSessionStatus(
   // A. Thinking indicators (• Ran, • Planning) in the conversation area → should show spinner
   // B. Idle prompt (›) at the end of the conversation area → should show ready
   // Strategy: find the Codex status bar, extract content above it, then check for thinking/idle.
+  //
+  // Issue #1150: the status-bar pattern was relaxed (CODEX_STATUS_BAR_PATTERN) so it
+  // matches v0.141's "model · path" bar (no "N% left ·"). Without this, codexFooterBoundary
+  // stayed -1, this whole block was skipped, and generating sessions fell through to the
+  // input-prompt check below and were misreported as `ready` (static dot, no glow).
   if (cliToolId === 'codex') {
-    const codexStatusBarPattern = /^\s*\S+.*\d+%\s+left\s+·/;
     let codexFooterBoundary = -1;
     for (let ci = contentLines.length - 1; ci >= Math.max(0, contentLines.length - 10); ci--) {
-      if (codexStatusBarPattern.test(contentLines[ci])) {
+      if (CODEX_STATUS_BAR_PATTERN.test(contentLines[ci])) {
         codexFooterBoundary = ci;
         break;
       }
@@ -549,6 +554,29 @@ export function detectSessionStatus(
         // • Ran/• Working indicators beyond the 5-line thinking window.
         // The status bar ("model · N% left · path") is always visible during Codex
         // sessions, and the only idle state (›) was checked in B above.
+        return {
+          status: 'running',
+          confidence: 'high',
+          reason: 'thinking_indicator',
+          hasActivePrompt: false,
+          promptDetection,
+        };
+      }
+    } else {
+      // D. Status-bar-independent running detection (Issue #1150, mitigation B).
+      // Defense-in-depth for the next Codex CLI status-bar format drift: if the bar
+      // can't be located (the exact failure that broke Issue #1150), fall back to the
+      // Codex thinking indicator in the wider 15-line footer window — mirroring
+      // Claude's priority 2.6 interrupt-hint net. Gated so idle frames are unaffected:
+      // only fires when the tail is NOT the idle › prompt, so an idle session still
+      // falls through to the 'ready' input-prompt check at step 3.
+      let codexTailIdx = contentLines.length - 1;
+      while (codexTailIdx >= 0 && contentLines[codexTailIdx].trim() === '') {
+        codexTailIdx--;
+      }
+      const codexTailIsIdlePrompt =
+        codexTailIdx >= 0 && CODEX_PROMPT_PATTERN.test(contentLines[codexTailIdx].trim());
+      if (!codexTailIsIdlePrompt && detectThinking('codex', lastLines)) {
         return {
           status: 'running',
           confidence: 'high',

--- a/tests/unit/lib/status-detector.test.ts
+++ b/tests/unit/lib/status-detector.test.ts
@@ -653,4 +653,121 @@ describe('status-detector', () => {
       expect(result.reason).toBe('input_prompt');
     });
   });
+
+  // =========================================================================
+  // Issue #1150: Codex processing status not detected (status-bar pattern drift)
+  //
+  // Codex v0.141 (gpt-5.5) dropped the "N% left ·" token from its status bar, so
+  // the previous pattern (/^\s*\S+.*\d+%\s+left\s+·/) never matched. The footer
+  // boundary stayed -1, the entire Codex running/idle block (priority 2.7) was
+  // skipped, and generating sessions fell through to the input-prompt check and
+  // were misreported as `ready` (static green dot, no glow).
+  //
+  // These fixtures use the REAL v0.141 bar and the legacy "% left" bar to guard
+  // against the next CLI-format drift (Acceptance Criteria: both must be covered).
+  // =========================================================================
+  describe('Issue #1150: Codex status-bar version drift', () => {
+    // Codex TUI: conversation content (top) | ~10 empty padding lines | status bar (bottom).
+    const codexFrame = (contentLines: string[], statusBar: string): string =>
+      [...contentLines, ...Array(10).fill(''), statusBar].join('\n');
+
+    // v0.141 status bar (gpt-5.5): "model effort · path", NO "% left".
+    const V0141_BAR = 'gpt-5.5 xhigh · ~/share/work/github_kewton/commandmate-issue-947';
+    // Legacy status bar (gpt-5.4 / o4-mini): includes "N% left ·".
+    const LEGACY_BAR = 'gpt-5.4 high · 21% left · ~/share/work/github_kewton/commandmate-issue-947';
+
+    it('should return running for a generating Codex frame with the v0.141 bar (fallback C)', () => {
+      // Command output (no › prompt, no • indicator in the last 5 lines) above the
+      // v0.141 bar → the status bar is located and the fallback marks it running.
+      const output = codexFrame(
+        ['Applying patch to src/foo.ts', 'Updated 3 files', 'Running build'],
+        V0141_BAR
+      );
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBe('thinking_indicator');
+      expect(result.hasActivePrompt).toBe(false);
+    });
+
+    it('should return running/thinking_indicator when a Codex thinking marker sits above the v0.141 bar (>5 lines away)', () => {
+      // The • Working indicator is pushed beyond the narrow 5-line window by the
+      // padding, so only the wider priority-2.7 content scan (restored by the fix) sees it.
+      const output = codexFrame(
+        ['user: do the thing', '', '• Working (deciding next step)'],
+        V0141_BAR
+      );
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.reason).toBe('thinking_indicator');
+    });
+
+    it('should keep the idle Codex › prompt as ready with the v0.141 bar (no over-detection)', () => {
+      const output = codexFrame(['Here is the result.', '', '›'], V0141_BAR);
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+      expect(result.hasActivePrompt).toBe(false);
+    });
+
+    it('should still return running for a generating Codex frame with the legacy "% left" bar (regression)', () => {
+      const output = codexFrame(
+        ['Applying patch to src/foo.ts', 'Updated 3 files', 'Running build'],
+        LEGACY_BAR
+      );
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.reason).toBe('thinking_indicator');
+    });
+
+    it('should still keep the idle Codex › prompt as ready with the legacy "% left" bar (regression)', () => {
+      const output = codexFrame(['Here is the result.', '', '›'], LEGACY_BAR);
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+    });
+
+    it('mitigation B: should detect running from the Codex thinking marker even when NO status bar is present', () => {
+      // Defense-in-depth for a future status-bar format drift: no bar line at all,
+      // • Working pushed beyond the 5-line window, tail is command output (not ›).
+      const output = [
+        'user prompt',
+        '• Working (Esc to interrupt)',
+        'line a',
+        'line b',
+        'line c',
+        'line d',
+        'line e',
+        'tail output line',
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.reason).toBe('thinking_indicator');
+    });
+
+    it('mitigation B: should NOT over-detect running for an idle › tail when no status bar is present', () => {
+      // Stale • Ran sits above the 5-line window and the tail is the idle › prompt,
+      // so the status-bar-independent net must defer to the ready input-prompt check.
+      const output = [
+        'user prompt',
+        '• Ran npm test',
+        'output 1',
+        'output 2',
+        'output 3',
+        'output 4',
+        'output 5',
+        '›',
+      ].join('\n');
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('ready');
+      expect(result.reason).toBe('input_prompt');
+    });
+  });
 });

--- a/tests/unit/status-detector-selection.test.ts
+++ b/tests/unit/status-detector-selection.test.ts
@@ -709,3 +709,34 @@ describe('detectSessionStatus - Antigravity permission-approval menu detection (
     expect(result.reason).not.toBe(STATUS_REASON.ANTIGRAVITY_SELECTION_LIST);
   });
 });
+
+// ===========================================================================
+// Issue #1150: Codex status-bar version drift must not break the footer boundary
+// used by selection-list detection.
+//
+// buildCodexOutput() above pins the LEGACY "N% left ·" bar; these tests use the
+// v0.141 bar ("model effort · path", no "% left") to prove the relaxed
+// CODEX_STATUS_BAR_PATTERN still anchors the footer boundary for priority 0.8.
+// ===========================================================================
+describe('detectSessionStatus - Codex selection list with v0.141 status bar (Issue #1150)', () => {
+  const V0141_BAR = 'gpt-5.5 xhigh · ~/share/work/github_kewton/commandmate-issue-947';
+
+  it('should detect the /model selection list above a v0.141 status bar (no "% left")', () => {
+    const output = [
+      'Select a model',
+      '',
+      '  ❯ gpt-5.5 (current)',
+      '    gpt-5.4',
+      '    codex-mini-latest',
+      '',
+      'press enter to confirm or esc to cancel',
+      ...Array(10).fill(''),
+      V0141_BAR,
+    ].join('\n');
+
+    const result = detectSessionStatus(output, 'codex');
+    expect(result.status).toBe('waiting');
+    expect(result.reason).toBe(STATUS_REASON.CODEX_SELECTION_LIST);
+    expect(result.hasActivePrompt).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1150 の対応。Codex CLI v0.141 (gpt-5.5) がステータスバーから "N% left ·" を削除したため、codexStatusBarPattern がマッチせずフッター境界が-1のままとなり、Codex実行中検出ブロック（priority 2.7）全体がスキップされ、生成中フレームが ready（静的緑・グローなし）と誤判定されていた問題を修正。

## 変更内容
### 対策A（パターン緩和・共有化）
- CODEX_STATUS_BAR_PATTERN を cli-patterns.ts に新設し、旧バー("model · N% left · path")とv0.141バー("model effort · path")の両方を「中黒 · + 末尾パス(~//)」構造で同定。誤検出防止のため Codex固有（cliToolId==='codex'ガード）かつ末尾パス必須
- status-detector.ts:267/:500 の重複インライン正規表現を共有定数へ置換

### 対策B（ステータスバー非依存の堅牢化）
- 2.7ブロックにフォールバックD分岐を追加。将来の再フォーマットでバー同定不可でも、Claudeのpriority 2.6相当として15行フッター窓でCodex thinkingマーカーを検出しrunningを返す。idle › プロンプトが末尾なら発火せず ready を維持

## 回帰テスト
v0.141実バー("gpt-5.5 xhigh · ~/path")と旧バー("% left ·")の両フィクスチャで検証。

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
