### PR TITLE
fix(worktree): ヘッダーのインスタンス切替をターミナルsplitに配線（PC） (#1152)

### DIFF
--- a/src/components/worktree/TerminalSplitContainer.tsx
+++ b/src/components/worktree/TerminalSplitContainer.tsx
@@ -96,6 +96,26 @@ export interface TerminalSplitContainerProps {
    * instance to the drop target split. Fires only when the change is applied.
    */
   onActiveInstanceChange?: (instanceId: string) => void;
+  /**
+   * Issue #1152: a header-initiated instance selection to route into the PRIMARY
+   * split (split 0), wiring the DesktopHeader instance switcher to the terminal
+   * that actually polls output / sends messages.
+   *
+   * Distinct from `onActiveInstanceChange` (which flows split→active): this flows
+   * header→split. It is a token-stamped object rather than a bare instanceId so
+   * the container applies it exactly ONCE per header click — the many OTHER
+   * mutations of the worktree-global `activeInstanceId` (the split 0→active
+   * mirror, drag-drop, roster reconcile, localStorage restore) must NOT reassign
+   * a split, and a value-watching effect could not tell those apart. The parent
+   * bumps `token` on every pill click; the container ignores repeats.
+   *
+   * Collision policy (S1-002 preserved — an instance never occupies two splits):
+   * when the selected instance is already shown in ANOTHER split, focus moves to
+   * that split (focus-move) instead of reassigning — non-destructive, and it
+   * satisfies the user's intent to interact with that instance. When it is shown
+   * nowhere, it is bound to split 0. When split 0 already shows it, it is a no-op.
+   */
+  headerInstanceSelection?: { instanceId: string; token: number } | null;
 }
 
 export const TerminalSplitContainer = memo(function TerminalSplitContainer({
@@ -106,6 +126,7 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
   onFocusedSplitChange,
   showToast,
   onActiveInstanceChange,
+  headerInstanceSelection,
 }: TerminalSplitContainerProps) {
   const {
     splits,
@@ -160,6 +181,42 @@ export const TerminalSplitContainer = memo(function TerminalSplitContainer({
   useEffect(() => {
     onFocusedSplitChange?.(focusedSplitIndex);
   }, [focusedSplitIndex, onFocusedSplitChange]);
+
+  /**
+   * Issue #1152: apply a header-initiated instance selection to the PRIMARY
+   * split, wiring the header instance switcher to the terminal that actually
+   * polls output / sends messages. Gated on `token` (not the instanceId) so it
+   * runs exactly once per header click and never fires on mount, roster
+   * reconcile, localStorage restore, the split 0→active mirror, or a drop — all
+   * of which mutate the shared `activeInstanceId` but must NOT reassign a split.
+   *
+   * `splits` is intentionally omitted from the deps: only a NEW token should
+   * trigger this. The classification reads the latest `splits` through a ref so a
+   * stale closure cannot mis-target the primary split.
+   */
+  const lastHeaderTokenRef = useRef(0);
+  const splitsRef = useRef(splits);
+  splitsRef.current = splits;
+  useEffect(() => {
+    if (!headerInstanceSelection) return;
+    if (headerInstanceSelection.token === lastHeaderTokenRef.current) return;
+    lastHeaderTokenRef.current = headerInstanceSelection.token;
+    const { instanceId } = headerInstanceSelection;
+    const current = splitsRef.current;
+    const shownIdx = current.findIndex((s) => s.instanceId === instanceId);
+    if (shownIdx === 0) return; // primary split already shows it — no-op
+    if (shownIdx > 0) {
+      // Collision (S1-002): the instance already occupies another split. Surface
+      // that split (focus-move) instead of duplicating/reassigning it.
+      setFocusedSplitIndex(shownIdx);
+      return;
+    }
+    // Not shown anywhere → bind it to the primary split (split 0), symmetric with
+    // the existing split 0→active mirror. Focus the primary split on success.
+    if (setSplitInstance(0, instanceId)) {
+      setFocusedSplitIndex(0);
+    }
+  }, [headerInstanceSelection, setSplitInstance, setFocusedSplitIndex]);
 
   // After lastAddedIndex changes, focus the textarea in that pane.
   useEffect(() => {

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -293,6 +293,35 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
   const handleAgentDragEnd = useCallback(() => setDraggedInstanceId(null), []);
 
   /**
+   * Issue #1152: header instance switcher → terminal wiring.
+   *
+   * Previously the DesktopHeader instance pills called `setActiveInstanceId`
+   * only, which drives the header badge / kill target / Auto-Yes UI but is NOT
+   * connected to `useTerminalSplits` (owned inside TerminalSplitContainer). So
+   * selecting "Claude" in the header left the split — and therefore the display
+   * polling and message send — pinned to whatever instance the split held (e.g.
+   * `claude-2`). This handler keeps that existing active-instance behavior AND
+   * publishes a token-stamped selection the container applies to the primary
+   * split (see `headerInstanceSelection` on TerminalSplitContainer). The token
+   * bumps per click so the container applies it exactly once and does not confuse
+   * it with the split 0→active mirror / drop / reconcile paths.
+   */
+  const [headerInstanceSelection, setHeaderInstanceSelection] =
+    React.useState<{ instanceId: string; token: number } | null>(null);
+  const headerSelectTokenRef = React.useRef(0);
+  const handleHeaderInstanceSelect = useCallback(
+    (instanceId: string) => {
+      // Preserve existing behavior: kill / Auto-Yes UI / header badge follow the
+      // active instance (the controller also mirrors activeCliTab from its CLI).
+      setActiveInstanceId(instanceId);
+      // Route the same selection into the primary terminal split.
+      headerSelectTokenRef.current += 1;
+      setHeaderInstanceSelection({ instanceId, token: headerSelectTokenRef.current });
+    },
+    [setActiveInstanceId],
+  );
+
+  /**
    * Issue #728 (R3-005): PC-only per-split polling fan-out.
    *
    * Each `TerminalSplitPaneContent` owns its own
@@ -449,12 +478,16 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
         // applied drop.
         showToast={showToast}
         onActiveInstanceChange={setActiveInstanceId}
+        // Issue #1152: route header pill selections into the primary split.
+        headerInstanceSelection={headerInstanceSelection}
       />
     ),
     // setFocusedSplitIndex / setActiveInstanceId are stable callbacks, and
     // showToast is a stable parent callback, so listing them does not
     // destabilize the memo beyond the existing per-render cadence.
-    [worktreeId, instances, rosterReady, renderSplitPane, setFocusedSplitIndex, showToast, setActiveInstanceId],
+    // headerInstanceSelection changes only on a header pill click (a user
+    // action, not the polling cadence), so re-creating the region then is fine.
+    [worktreeId, instances, rosterReady, renderSplitPane, setFocusedSplitIndex, showToast, setActiveInstanceId, headerInstanceSelection],
   );
 
   /**
@@ -674,7 +707,9 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
             sessionStatusByInstance={worktree?.sessionStatusByInstance}
             instances={instances}
             activeInstanceId={activeInstanceId}
-            onActiveInstanceChange={setActiveInstanceId}
+            // Issue #1152: header pill selection now also drives the primary
+            // terminal split (display polling + send), not just the active badge.
+            onActiveInstanceChange={handleHeaderInstanceSelect}
             // Issue #786 / #869: publish the dragged agent's instanceId so each
             // terminal split can show its dragOver allowed/forbidden ring (D-2).
             onAgentDragStart={handleAgentDragStart}

--- a/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitContainer.test.tsx
@@ -514,3 +514,143 @@ describe('TerminalSplitContainer action-bar layout (Issue #977)', () => {
     );
   });
 });
+
+// ===========================================================================
+// Issue #1152: the DesktopHeader instance switcher must drive the PRIMARY split
+// (which owns the display polling + message send), not just the worktree-global
+// active badge. The header publishes a token-stamped `headerInstanceSelection`;
+// the container applies it to split 0 (or focus-moves on an S1-002 collision).
+// Applying it to `split.instanceId` is the fix — the pane already resolves
+// `instanceId ?? cliToolId` into its /current-output poll + send (covered by
+// TerminalSplitPaneContent.test.tsx), so once the split reflects the header the
+// whole chain (display + send) follows.
+// ===========================================================================
+describe('TerminalSplitContainer header→split wiring (Issue #1152)', () => {
+  const DUAL_CLAUDE: AgentInstance[] = [
+    { id: 'claude', cliTool: 'claude', alias: 'Primary', order: 0 },
+    { id: 'claude-2', cliTool: 'claude', alias: 'Review', order: 1 },
+  ];
+
+  beforeEach(() => {
+    clearTerminalSplitsLocalStorage();
+  });
+  afterEach(() => {
+    clearTerminalSplitsLocalStorage();
+  });
+
+  /**
+   * Harness that owns the token-stamped `headerInstanceSelection` state exactly
+   * like WorktreeDetailDesktop, so tests exercise the real prop contract. The
+   * panes expose their resolved `instanceId` (the value that flows into polling +
+   * send) plus a button that drives the split-internal dropdown path.
+   */
+  function setupHeaderWiring(instances: AgentInstance[] = DUAL_CLAUDE) {
+    const onFocusedSplitChange = vi.fn();
+    function Harness() {
+      const [sel, setSel] = React.useState<{ instanceId: string; token: number } | null>(null);
+      const tokenRef = React.useRef(0);
+      const select = (id: string) => {
+        tokenRef.current += 1;
+        setSel({ instanceId: id, token: tokenRef.current });
+      };
+      return (
+        <>
+          <button type="button" data-testid="hdr-select-claude" onClick={() => select('claude')}>
+            claude
+          </button>
+          <button type="button" data-testid="hdr-select-claude-2" onClick={() => select('claude-2')}>
+            claude-2
+          </button>
+          <TerminalSplitContainer
+            worktreeId="w-1"
+            instances={instances}
+            headerInstanceSelection={sel}
+            onFocusedSplitChange={onFocusedSplitChange}
+            renderPane={({ splitIndex, instanceId, cliToolId, onInstanceChange, onFocus }) => (
+              <div data-split-index={splitIndex}>
+                <span data-testid={`pane-inst-${splitIndex}`}>{instanceId}</span>
+                <span data-testid={`pane-cli-${splitIndex}`}>{cliToolId}</span>
+                <button
+                  type="button"
+                  data-testid={`pane-dropdown-claude-2-${splitIndex}`}
+                  onClick={() => onInstanceChange('claude-2')}
+                >
+                  dropdown claude-2
+                </button>
+                <textarea data-testid={`ta-${splitIndex}`} onFocus={onFocus} />
+              </div>
+            )}
+          />
+        </>
+      );
+    }
+    const utils = render(<Harness />);
+    return { onFocusedSplitChange, ...utils };
+  }
+
+  it('header selection binds an unshown instance to the primary split (the wiring bug fix)', () => {
+    setupHeaderWiring();
+    // Default: split 0 shows the first roster instance.
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+
+    // Select "Claude 2" in the header → the primary split switches to claude-2
+    // (previously the header updated only the active badge, leaving the split —
+    // and therefore display + send — on claude).
+    fireEvent.click(screen.getByTestId('hdr-select-claude-2'));
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude-2');
+
+    // And back to claude.
+    fireEvent.click(screen.getByTestId('hdr-select-claude'));
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+  });
+
+  it('collision policy: selecting an instance already shown in another split focus-moves, no reassignment (S1-002)', () => {
+    const { onFocusedSplitChange } = setupHeaderWiring();
+    // Grow to 2 splits: [claude, claude-2].
+    fireEvent.click(screen.getByTestId('add-terminal-split'));
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+    expect(screen.getByTestId('pane-inst-1').textContent).toBe('claude-2');
+
+    // Focus split 0 so the focus-move to split 1 is an observable change.
+    fireEvent.focus(screen.getByTestId('ta-0'));
+    onFocusedSplitChange.mockClear();
+
+    // Header selects claude-2, which already lives in split 1.
+    fireEvent.click(screen.getByTestId('hdr-select-claude-2'));
+
+    // Splits are untouched — no duplication, no reassignment.
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+    expect(screen.getByTestId('pane-inst-1').textContent).toBe('claude-2');
+    // Focus moved to the split that already shows the selected instance.
+    expect(onFocusedSplitChange).toHaveBeenCalledWith(1);
+  });
+
+  it('no-op: selecting the instance already in the primary split changes nothing', () => {
+    const { onFocusedSplitChange } = setupHeaderWiring();
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+    onFocusedSplitChange.mockClear();
+
+    fireEvent.click(screen.getByTestId('hdr-select-claude'));
+
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+    expect(onFocusedSplitChange).not.toHaveBeenCalled();
+  });
+
+  it('regression: the split-internal dropdown still reassigns via onInstanceChange', () => {
+    setupHeaderWiring();
+    // split 0 starts as claude; the dropdown picks claude-2.
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+    fireEvent.click(screen.getByTestId('pane-dropdown-claude-2-0'));
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude-2');
+  });
+
+  it('applies each header click once and is a no-op without a selection', () => {
+    // No selection (sel=null) → the default split is untouched.
+    setupHeaderWiring();
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude');
+    // Repeated selection of the same target is idempotent (token gate).
+    fireEvent.click(screen.getByTestId('hdr-select-claude-2'));
+    fireEvent.click(screen.getByTestId('hdr-select-claude-2'));
+    expect(screen.getByTestId('pane-inst-0').textContent).toBe('claude-2');
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1152 の対応。PC版でヘッダーのインスタンス切替ピルが activeInstanceId のみ更新し useTerminalSplits の split.instanceId に未配線だったため、「claude を選んでも claude-2 の表示・送信が続く」配線バグを修正。

## 変更内容（対策1: ヘッダー→split配線）
- DesktopHeaderの選択をトークン付き headerInstanceSelection として primary split(0) に反映（setSplitInstance）
- トークンで1クリック1適用に限定し、split0→active ミラー / ドラッグ&ドロップ / roster reconcile / localStorage復元による activeInstanceId 変化とは区別
- **衝突ポリシー（S1-002維持）**: 対象インスタンスが別splitに存在する場合はフォーカス移動（非破壊。再割当・複製しない）。どこにも無ければsplit0に束縛。split0が既に表示中ならno-op

## 回帰なし確認
split0→active片方向ミラー・ドラッグ&ドロップ・kill-session・モバイル整合（activeInstanceId駆動）

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
