### PR TITLE
fix(tmux): セッションターゲットを=厳密一致にしプレフィックス衝突インスタンスへの漏洩を防止 (#1156)

### DIFF
--- a/src/lib/cli-tools/opencode.ts
+++ b/src/lib/cli-tools/opencode.ts
@@ -17,6 +17,7 @@ import {
   sendKeys,
   sendSpecialKey,
   killSession,
+  exactTarget,
 } from '../tmux/tmux';
 import { detectAndResendIfPastedText } from '../pasted-text-helper';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
@@ -122,7 +123,8 @@ export class OpenCodeTool extends BaseCLITool {
       // [SEC-001] Uses execFile (not exec) to prevent shell meta-character injection via sessionName
       try {
         await execFileAsync('tmux', [
-          'resize-window', '-t', sessionName,
+          // Issue #1156: exact-match target so resize never leaks to a prefix-colliding instance
+          'resize-window', '-t', exactTarget(sessionName),
           '-x', '80', '-y', String(OPENCODE_PANE_HEIGHT),
         ]);
       } catch {

--- a/src/lib/tmux/tmux-control-client.ts
+++ b/src/lib/tmux/tmux-control-client.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { createLogger } from '@/lib/logger';
 import { TmuxControlParser, type TmuxControlEvent } from './tmux-control-parser';
+import { exactTarget } from './tmux';
 
 const logger = createLogger('tmux-control-client');
 const DEFAULT_CONTROL_CLIENT_IDLE_TIMEOUT_MS = 30_000;
@@ -51,7 +52,7 @@ export class TmuxControlClient {
     this.sessionName = sessionName;
     this.child = this.spawnProcess(
       this.tmuxBinary,
-      ['-C', 'attach-session', '-t', sessionName],
+      ['-C', 'attach-session', '-t', exactTarget(sessionName)],
       { stdio: 'pipe' }
     );
     this.started = true;

--- a/src/lib/tmux/tmux.ts
+++ b/src/lib/tmux/tmux.ts
@@ -15,6 +15,29 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_TIMEOUT = 5000;
 
 /**
+ * Build an exact-match tmux target specifier (Issue #1156).
+ *
+ * tmux resolves a bare `-t <name>` target with prefix/fnmatch matching whenever
+ * no session matches `<name>` exactly. Because instance session names are
+ * prefixes of one another (`mcbd-<cli>-<wt>` is a prefix of `mcbd-<cli>-<wt>-2`),
+ * an operation on the primary session silently leaks to the `-2` instance while
+ * the primary is not running: `has-session` reports it "running", `capture-pane`
+ * shows the wrong pane, `send-keys` delivers to the wrong instance, and
+ * `kill-session` can kill the wrong session.
+ *
+ * Prefixing the target with `=` disables that fuzzy matching and forces an exact
+ * session-name match. EVERY `-t` target in this module (and the control-mode
+ * attach in tmux-control-client.ts) MUST go through this helper so no call site
+ * can regress to prefix matching.
+ *
+ * @param sessionName - Exact tmux session name to target
+ * @returns Target specifier with the `=` exact-match prefix
+ */
+export function exactTarget(sessionName: string): string {
+  return `=${sessionName}`;
+}
+
+/**
  * tmux session information
  */
 export interface TmuxSession {
@@ -70,7 +93,7 @@ export async function isTmuxAvailable(): Promise<boolean> {
  */
 export async function hasSession(sessionName: string): Promise<boolean> {
   try {
-    await execFileAsync('tmux', ['has-session', '-t', sessionName], { timeout: DEFAULT_TIMEOUT });
+    await execFileAsync('tmux', ['has-session', '-t', exactTarget(sessionName)], { timeout: DEFAULT_TIMEOUT });
     return true;
   } catch {
     // tmux has-session returns non-zero exit code if session doesn't exist
@@ -192,7 +215,7 @@ export async function createSession(
     // Set history limit
     await execFileAsync(
       'tmux',
-      ['set-option', '-t', sessionName, 'history-limit', String(historyLimit)],
+      ['set-option', '-t', exactTarget(sessionName), 'history-limit', String(historyLimit)],
       { timeout: DEFAULT_TIMEOUT }
     );
   } catch (error: unknown) {
@@ -225,8 +248,8 @@ export async function sendKeys(
   // execFile() passes arguments directly without shell interpretation,
   // so no shell-level escaping is needed
   const args = sendEnter
-    ? ['send-keys', '-t', sessionName, keys, 'C-m']
-    : ['send-keys', '-t', sessionName, keys];
+    ? ['send-keys', '-t', exactTarget(sessionName), keys, 'C-m']
+    : ['send-keys', '-t', exactTarget(sessionName), keys];
 
   try {
     await execFileAsync('tmux', args, { timeout: DEFAULT_TIMEOUT });
@@ -283,7 +306,7 @@ export async function sendSpecialKeys(
 
   try {
     for (let i = 0; i < keys.length; i++) {
-      await execFileAsync('tmux', ['send-keys', '-t', sessionName, keys[i]], { timeout: DEFAULT_TIMEOUT });
+      await execFileAsync('tmux', ['send-keys', '-t', exactTarget(sessionName), keys[i]], { timeout: DEFAULT_TIMEOUT });
       // Delay between key presses (skip after the last key)
       if (i < keys.length - 1) {
         await new Promise(resolve => setTimeout(resolve, SPECIAL_KEY_DELAY_MS));
@@ -355,7 +378,7 @@ export async function capturePane(
   try {
     const { stdout } = await execFileAsync(
       'tmux',
-      ['capture-pane', '-t', sessionName, '-p', '-e', '-S', String(startLine), '-E', String(endLine)],
+      ['capture-pane', '-t', exactTarget(sessionName), '-p', '-e', '-S', String(startLine), '-E', String(endLine)],
       {
         timeout: DEFAULT_TIMEOUT,
         maxBuffer: 10 * 1024 * 1024  // 10MB buffer for large Claude outputs
@@ -384,7 +407,7 @@ export async function capturePane(
  */
 export async function killSession(sessionName: string): Promise<boolean> {
   try {
-    await execFileAsync('tmux', ['kill-session', '-t', sessionName], {
+    await execFileAsync('tmux', ['kill-session', '-t', exactTarget(sessionName)], {
       timeout: DEFAULT_TIMEOUT,
     });
     return true;
@@ -478,7 +501,7 @@ export async function sendSpecialKey(
   }
 
   try {
-    await execFileAsync('tmux', ['send-keys', '-t', sessionName, key], { timeout: DEFAULT_TIMEOUT });
+    await execFileAsync('tmux', ['send-keys', '-t', exactTarget(sessionName), key], { timeout: DEFAULT_TIMEOUT });
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to send special key: ${errorMessage}`);

--- a/tests/unit/tmux.test.ts
+++ b/tests/unit/tmux.test.ts
@@ -16,6 +16,7 @@ import {
   capturePane,
   killSession,
   ensureSession,
+  exactTarget,
   SPECIAL_KEY_VALUES,
 } from '@/lib/tmux/tmux';
 
@@ -88,7 +89,7 @@ describe('tmux library', () => {
       expect(result).toBe(true);
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['has-session', '-t', 'test-session'],
+        ['has-session', '-t', '=test-session'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -172,7 +173,7 @@ describe('tmux library', () => {
       );
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['set-option', '-t', 'test-session', 'history-limit', '50000'],
+        ['set-option', '-t', '=test-session', 'history-limit', '50000'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -199,7 +200,7 @@ describe('tmux library', () => {
       );
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['set-option', '-t', 'test-session', 'history-limit', '100000'],
+        ['set-option', '-t', '=test-session', 'history-limit', '100000'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -289,7 +290,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', 'echo hello', 'C-m'],
+        ['send-keys', '-t', '=test-session', 'echo hello', 'C-m'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -306,7 +307,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', 'echo hello'],
+        ['send-keys', '-t', '=test-session', 'echo hello'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -324,7 +325,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', "echo 'hello'", 'C-m'],
+        ['send-keys', '-t', '=test-session', "echo 'hello'", 'C-m'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -356,7 +357,7 @@ describe('tmux library', () => {
       expect(result).toBe('output');
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['capture-pane', '-t', 'test-session', '-p', '-e', '-S', '-1000', '-E', '-'],
+        ['capture-pane', '-t', '=test-session', '-p', '-e', '-S', '-1000', '-E', '-'],
         { timeout: 5000, maxBuffer: 10 * 1024 * 1024 },
         expect.any(Function)
       );
@@ -374,7 +375,7 @@ describe('tmux library', () => {
       expect(result).toBe('output');
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['capture-pane', '-t', 'test-session', '-p', '-e', '-S', '-500', '-E', '-'],
+        ['capture-pane', '-t', '=test-session', '-p', '-e', '-S', '-500', '-E', '-'],
         { timeout: 5000, maxBuffer: 10 * 1024 * 1024 },
         expect.any(Function)
       );
@@ -395,7 +396,7 @@ describe('tmux library', () => {
       expect(result).toBe('output');
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['capture-pane', '-t', 'test-session', '-p', '-e', '-S', '-10000', '-E', '-1'],
+        ['capture-pane', '-t', '=test-session', '-p', '-e', '-S', '-10000', '-E', '-1'],
         { timeout: 5000, maxBuffer: 10 * 1024 * 1024 },
         expect.any(Function)
       );
@@ -425,7 +426,7 @@ describe('tmux library', () => {
       expect(result).toBe(true);
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['kill-session', '-t', 'test-session'],
+        ['kill-session', '-t', '=test-session'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -502,7 +503,7 @@ describe('tmux library', () => {
       expect(execFile).toHaveBeenCalledTimes(1);
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['has-session', '-t', 'test-session'],
+        ['has-session', '-t', '=test-session'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -521,7 +522,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', 'Escape'],
+        ['send-keys', '-t', '=test-session', 'Escape'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -538,7 +539,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', 'C-c'],
+        ['send-keys', '-t', '=test-session', 'C-c'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -555,7 +556,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', 'C-d'],
+        ['send-keys', '-t', '=test-session', 'C-d'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -609,7 +610,7 @@ describe('tmux library', () => {
 
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', 'Down'],
+        ['send-keys', '-t', '=test-session', 'Down'],
         { timeout: 5000 },
         expect.any(Function)
       );
@@ -640,10 +641,11 @@ describe('tmux library', () => {
       const malicious = 'test"; rm -rf /; #';
       await hasSession(malicious);
 
-      // The malicious string is passed as a single argument element, not shell-interpreted
+      // The malicious string is passed as a single argument element, not shell-interpreted.
+      // Issue #1156: the target is exact-match prefixed (`=`) but still a single arg.
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['has-session', '-t', malicious],
+        ['has-session', '-t', `=${malicious}`],
         expect.any(Object),
         expect.any(Function)
       );
@@ -662,10 +664,143 @@ describe('tmux library', () => {
       // The malicious command is passed as a single argument, not interpreted by shell
       expect(execFile).toHaveBeenCalledWith(
         'tmux',
-        ['send-keys', '-t', 'test-session', maliciousCommand, 'C-m'],
+        ['send-keys', '-t', '=test-session', maliciousCommand, 'C-m'],
         expect.any(Object),
         expect.any(Function)
       );
     });
+  });
+
+  // Issue #1156: prefix-collision session leakage prevention
+  describe('exactTarget helper (Issue #1156)', () => {
+    it('should prefix the session name with = for exact matching', () => {
+      expect(exactTarget('mcbd-claude-wt')).toBe('=mcbd-claude-wt');
+    });
+
+    it('should produce distinct exact-match targets for primary and -2', () => {
+      // Both targets are exact-match forms; tmux will not resolve one from the other.
+      // (The behavioral guarantee is exercised by the leakage tests below.)
+      expect(exactTarget('mcbd-claude-wt')).toBe('=mcbd-claude-wt');
+      expect(exactTarget('mcbd-claude-wt-2')).toBe('=mcbd-claude-wt-2');
+      expect(exactTarget('mcbd-claude-wt')).not.toBe(exactTarget('mcbd-claude-wt-2'));
+    });
+  });
+
+  // Issue #1156: with a prefix-colliding pair (X and X-2), operations on the
+  // un-started primary X must NOT leak to the running X-2. We drive the real
+  // tmux functions through a mock that faithfully emulates tmux target
+  // resolution: a bare `-t <name>` falls back to prefix matching, while a
+  // `-t =<name>` target requires an exact session-name match.
+  describe('prefix collision session leakage (Issue #1156)', () => {
+    const PRIMARY = 'mcbd-claude-mycodebranchdesk-develop';
+    const SECOND = 'mcbd-claude-mycodebranchdesk-develop-2';
+
+    /**
+     * Resolve a tmux `-t` target against the set of live sessions, mirroring
+     * tmux semantics: `=name` is exact-only; a bare `name` matches exactly or,
+     * failing that, by prefix (the bug that this fix closes).
+     */
+    function resolveTarget(target: string, liveSessions: Map<string, string>): string | null {
+      if (target.startsWith('=')) {
+        const exact = target.slice(1);
+        return liveSessions.has(exact) ? exact : null;
+      }
+      if (liveSessions.has(target)) return target;
+      for (const name of liveSessions.keys()) {
+        if (name.startsWith(target)) return name;
+      }
+      return null;
+    }
+
+    /**
+     * Build an execFile mock backed by `liveSessions` (name -> pane content).
+     * Records every resolved target so tests can assert what a call touched.
+     */
+    function installTmuxMock(liveSessions: Map<string, string>): { resolvedTargets: Array<string | null> } {
+      const resolvedTargets: Array<string | null> = [];
+      vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+        const cmdArgs = args[1] as string[];
+        const callback = args[args.length - 1] as (
+          err: Error | null,
+          result: { stdout: string; stderr: string }
+        ) => void;
+        const subcommand = cmdArgs[0];
+        const tIdx = cmdArgs.indexOf('-t');
+        if (tIdx === -1) {
+          callback(null, { stdout: '', stderr: '' });
+          return {} as ReturnType<typeof execFile>;
+        }
+        const target = cmdArgs[tIdx + 1];
+        const resolved = resolveTarget(target, liveSessions);
+        resolvedTargets.push(resolved);
+        if (!resolved) {
+          callback(new Error(`can't find session: ${target.replace(/^=/, '')}`), {
+            stdout: '',
+            stderr: '',
+          });
+          return {} as ReturnType<typeof execFile>;
+        }
+        const stdout = subcommand === 'capture-pane' ? (liveSessions.get(resolved) ?? '') : '';
+        callback(null, { stdout, stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      });
+      return { resolvedTargets };
+    }
+
+    it('has-session on the un-started primary returns false (does not match -2)', async () => {
+      const { resolvedTargets } = installTmuxMock(new Map([[SECOND, 'second-content']]));
+
+      const result = await hasSession(PRIMARY);
+
+      expect(result).toBe(false);
+      expect(resolvedTargets).toEqual([null]);
+      expect(execFile).toHaveBeenCalledWith(
+        'tmux',
+        ['has-session', '-t', `=${PRIMARY}`],
+        { timeout: 5000 },
+        expect.any(Function)
+      );
+    });
+
+    it('capture-pane on the un-started primary does not return -2 content', async () => {
+      installTmuxMock(new Map([[SECOND, 'SECRET-OUTPUT-OF-INSTANCE-2']]));
+
+      await expect(capturePane(PRIMARY)).rejects.toThrow('Failed to capture pane');
+    });
+
+    it('send-keys on the un-started primary does not deliver to -2', async () => {
+      const { resolvedTargets } = installTmuxMock(new Map([[SECOND, 'second-content']]));
+
+      await expect(sendKeys(PRIMARY, 'hello')).rejects.toThrow('Failed to send keys');
+      // Never resolved to the -2 session
+      expect(resolvedTargets).toEqual([null]);
+    });
+
+    it('kill-session on the un-started primary does not kill -2', async () => {
+      const live = new Map([[SECOND, 'second-content']]);
+      installTmuxMock(live);
+
+      const killed = await killSession(PRIMARY);
+
+      expect(killed).toBe(false);
+      // The -2 session is untouched (still resolvable on its own exact target)
+      expect(resolveTargetHelper(`=${SECOND}`, live)).toBe(SECOND);
+    });
+
+    // Regression guard for the normal case: when the primary IS running, all
+    // operations still resolve to it (the = prefix does not break exact matches).
+    it('operations still work when the primary session exists', async () => {
+      installTmuxMock(new Map([[PRIMARY, 'primary-content'], [SECOND, 'second-content']]));
+
+      expect(await hasSession(PRIMARY)).toBe(true);
+      expect(await capturePane(PRIMARY)).toBe('primary-content');
+      await expect(sendKeys(PRIMARY, 'hello')).resolves.not.toThrow();
+      expect(await killSession(PRIMARY)).toBe(true);
+    });
+
+    // Local mirror of resolveTarget for post-hoc assertions (kept in scope).
+    function resolveTargetHelper(target: string, liveSessions: Map<string, string>): string | null {
+      return resolveTarget(target, liveSessions);
+    }
   });
 });


### PR DESCRIPTION
## 概要
Issue #1156 の対応。複数エージェントインスタンスでセッション名がプレフィックス衝突する（`mcbd-<cli>-<wt>` は `mcbd-<cli>-<wt>-2` のプレフィックス）ため、tmuxの `-t <name>` が厳密一致なしでプレフィックスマッチし、**primary未起動時にprimaryへの has-session/capture/send/kill が -2 に漏洩**していた問題を修正。

これにより #1152（フロントのヘッダー→split配線・マージ済み）と揃って「claude選択でclaude2が表示/送信される」症状が根本解決します。

## 変更内容
- 全 `-t` 指定を `exactTarget(sessionName)`（`=` プレフィックス）に集約しプレフィックスマッチ経路を一掃:
  - `src/lib/tmux/tmux.ts`: has-session / set-option / send-keys / capture-pane / kill-session / special-keys
  - `src/lib/tmux/tmux-control-client.ts`: control-mode attach-session
  - `src/lib/cli-tools/opencode.ts`: resize-window（同種の漏洩ベクタを追加発見・修正）

## 回帰テスト
tmuxターゲット解決を忠実に模したモック（`=name` は厳密一致のみ、bare `name` はプレフィックスマッチ）で、X未起動・X-2起動時に X への has-session/capture/send/kill が X-2 に漏れないことを検証。既存正常系も維持。

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
