### PR TITLE
fix(detection): codexの回答済み承認プロンプト陳腐化でwaiting固着する問題を修正 (#1160)

### DIFF
--- a/src/lib/detection/status-detector.ts
+++ b/src/lib/detection/status-detector.ts
@@ -138,6 +138,78 @@ export const SELECTION_LIST_REASONS = new Set<string>([
 const STALE_OUTPUT_THRESHOLD_MS: number = 5000;
 
 /**
+ * Issue #1160: anchors for the BOTTOM edge of a Codex approval / numbered-choice
+ * prompt. Used only by isCodexStalePrompt() to distinguish an ACTIVE prompt (the
+ * bottom-most interactive element → waiting) from an already-ANSWERED one lingering
+ * in scrollback with Codex processing below it (→ fall through to running detection).
+ * Detection-wide Codex patterns live in cli-patterns.ts; these stay local to the guard.
+ *
+ * CODEX_CONFIRMATION_FOOTER_PATTERN matches the "press number/enter to confirm" footer
+ * that closes a numbered prompt. CODEX_NUMBERED_OPTION_PATTERN matches an option line
+ * ("1. Yes", optionally prefixed by a ❯/›/● selection indicator). Neither pattern uses
+ * /g (keeps .test() stateless) nor nested quantifiers (ReDoS-safe).
+ */
+const CODEX_CONFIRMATION_FOOTER_PATTERN = /press\s+(?:number|enter)\s+to\s+confirm/i;
+const CODEX_NUMBERED_OPTION_PATTERN = /^\s*[❯›●]?\s*\d{1,2}[.)]\s/;
+
+/**
+ * Issue #1160: decide whether a Codex prompt that detectPrompt() matched is a stale,
+ * already-answered prompt left in the 50-line scan window rather than an active one.
+ *
+ * Codex keeps the answered "1. Yes / 2. No" block + "press number to confirm" footer in
+ * its transcript (session historyLimit 50000) instead of repainting it away like Claude,
+ * so detectPrompt() keeps matching it and detectSessionStatus() reports `waiting` even
+ * after the user answered and Codex resumed — the sidebar status dot then stays orange
+ * forever (the reported bug).
+ *
+ * Position-based guard (mirrors isCodexPromptReady()'s bottom-most-element idea): the
+ * prompt is stale when a Codex thinking indicator (• Working / • Ran / …) sits strictly
+ * BELOW the bottom-most prompt anchor (footer or numbered option) within the content
+ * above the status bar. An UNANSWERED prompt has no running indicator below its block,
+ * so this returns false and the caller keeps reporting `waiting` (Auto-Yes unaffected).
+ *
+ * The bare "›" input-line case ("answered, then › below") is already handled upstream by
+ * detectPrompt()'s user-input barrier (prompt-detect-multiple-choice.ts), which returns
+ * isPrompt=false before this guard runs, so only the thinking-indicator signal is needed
+ * here — keeping the guard conservative against flipping a genuine prompt to running.
+ */
+function isCodexStalePrompt(contentLines: string[]): boolean {
+  // Locate the Codex status bar (version-independent, Issue #1150). The content of
+  // interest is above it — same footer-boundary scan as priority 2.7 below.
+  let footerBoundary = -1;
+  for (let ci = contentLines.length - 1; ci >= Math.max(0, contentLines.length - 10); ci--) {
+    if (CODEX_STATUS_BAR_PATTERN.test(contentLines[ci])) {
+      footerBoundary = ci;
+      break;
+    }
+  }
+  const end = footerBoundary >= 0 ? footerBoundary : contentLines.length;
+
+  let lastPromptIdx = -1;
+  let lastThinkingIdx = -1;
+  for (let i = 0; i < end; i++) {
+    const line = contentLines[i];
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    if (
+      CODEX_CONFIRMATION_FOOTER_PATTERN.test(trimmed) ||
+      CODEX_NUMBERED_OPTION_PATTERN.test(trimmed)
+    ) {
+      lastPromptIdx = i;
+    }
+    // detectThinking('codex', …) requires the "•" activity prefix, so option text that
+    // merely contains a word like "Running" cannot be mistaken for a running indicator.
+    if (detectThinking('codex', line)) {
+      lastThinkingIdx = i;
+    }
+  }
+
+  return lastPromptIdx >= 0 && lastThinkingIdx > lastPromptIdx;
+}
+
+/**
  * Detect session status with confidence level
  *
  * Priority order:
@@ -329,15 +401,31 @@ export function detectSessionStatus(
   const promptInput = (cliToolId === 'opencode' || cliToolId === 'codex' || cliToolId === 'claude' || cliToolId === 'copilot')
     ? stripBoxDrawing(cleanOutput)
     : stripBoxDrawing(lastLines);
-  const promptDetection = detectPrompt(promptInput, promptOptions);
+  let promptDetection = detectPrompt(promptInput, promptOptions);
   if (promptDetection.isPrompt) {
-    return {
-      status: 'waiting',
-      confidence: 'high',
-      reason: 'prompt_detected',
-      hasActivePrompt: true,
-      promptDetection,
-    };
+    // Issue #1160: Codex keeps an ANSWERED approval / numbered-choice block
+    // ("1. Yes / 2. No" + "press number to confirm" footer) in its transcript
+    // (historyLimit 50000) instead of repainting it away like Claude. detectPrompt's
+    // 50-line window then keeps matching that dead prompt, so this priority-1 branch
+    // returns `waiting` even after the user answered and Codex resumed — the sidebar
+    // status dot stays orange forever (the reported bug). Guard with a position check:
+    // treat the prompt as active only when it is the bottom-most interactive element.
+    // If a Codex thinking indicator (• Working / • Ran / …) sits BELOW the prompt block,
+    // it is stale scrollback — neutralize the detection (so Auto-Yes and the sidebar
+    // never act on a dead prompt) and fall through to the priority-2.7 running/idle
+    // check. Unanswered prompts (nothing running below the block) still return `waiting`,
+    // so Auto-Yes is unaffected.
+    if (cliToolId === 'codex' && isCodexStalePrompt(contentLines)) {
+      promptDetection = { ...promptDetection, isPrompt: false, promptData: undefined };
+    } else {
+      return {
+        status: 'waiting',
+        confidence: 'high',
+        reason: 'prompt_detected',
+        hasActivePrompt: true,
+        promptDetection,
+      };
+    }
   }
 
   // 1.5. Claude CLI selection list detection

--- a/tests/unit/lib/status-detector.test.ts
+++ b/tests/unit/lib/status-detector.test.ts
@@ -770,4 +770,116 @@ describe('status-detector', () => {
       expect(result.reason).toBe('input_prompt');
     });
   });
+
+  // =========================================================================
+  // Issue #1160: Codex answered-approval-prompt staleness
+  //
+  // Codex keeps the answered "1. Yes / 2. No" block + "press number to confirm"
+  // footer in its transcript (historyLimit 50000) instead of repainting it away
+  // like Claude. detectPrompt()'s 50-line window then keeps matching that dead
+  // prompt, so priority-1 returned `waiting` even after the user answered and Codex
+  // resumed — the sidebar status dot stayed orange forever (the reported bug).
+  //
+  // The position guard treats the prompt as active only when it is the bottom-most
+  // interactive element: if a Codex thinking indicator (• Working / • Ran) sits below
+  // the prompt block, the prompt is stale and status detection falls through to the
+  // running/idle check. Unanswered prompts (nothing running below) still wait, so
+  // Auto-Yes is unaffected.
+  // =========================================================================
+  describe('Issue #1160: Codex answered approval prompt staleness', () => {
+    // Codex TUI: conversation content (top) | ~10 empty padding lines | status bar.
+    const codexFrame = (contentLines: string[], statusBar: string): string =>
+      [...contentLines, ...Array(10).fill(''), statusBar].join('\n');
+    const V0141_BAR = 'gpt-5.5 xhigh · ~/share/work/github_kewton/commandmate-issue-947';
+
+    const APPROVAL_BLOCK = [
+      'Allow Codex to run `rm -rf build`?',
+      '',
+      '1. Yes',
+      '2. No, and tell Codex what to do differently',
+      'press number to confirm · esc to cancel',
+    ];
+
+    it('answered approval + processing below → running (not the stale waiting)', () => {
+      // The • Ran indicator sits directly below the answered block: the prompt is
+      // stale scrollback, so the guard falls through to the running detection.
+      const output = codexFrame([...APPROVAL_BLOCK, '• Ran rm -rf build'], V0141_BAR);
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBe('thinking_indicator');
+      expect(result.hasActivePrompt).toBe(false);
+      // Neutralized so Auto-Yes / the sidebar never act on the dead prompt
+      // (hasActivePrompt === promptDetection.isPrompt invariant).
+      expect(result.promptDetection.isPrompt).toBe(false);
+    });
+
+    it('answered approval + thinking indicator beyond the 5-line window → running (fallback C)', () => {
+      // The • Working indicator is pushed above the narrow 5-line thinking window by
+      // trailing command output, but the position guard still sees it below the prompt
+      // block, so the prompt is treated as stale and priority-2.7 fallback C runs.
+      const output = codexFrame(
+        [
+          ...APPROVAL_BLOCK,
+          '• Working (running the build)',
+          'compiling module a',
+          'compiling module b',
+          'compiling module c',
+          'compiling module d',
+          'compiling module e',
+        ],
+        V0141_BAR
+      );
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.reason).toBe('thinking_indicator');
+      expect(result.hasActivePrompt).toBe(false);
+      expect(result.promptDetection.isPrompt).toBe(false);
+    });
+
+    it('unanswered approval (nothing running below) → waiting (Auto-Yes preserved)', () => {
+      // No running indicator below the block: the prompt is the bottom-most element,
+      // so it must still be reported as waiting — the over-fix guardrail.
+      const output = codexFrame(APPROVAL_BLOCK, V0141_BAR);
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('waiting');
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBe('prompt_detected');
+      expect(result.hasActivePrompt).toBe(true);
+      expect(result.promptDetection.isPrompt).toBe(true);
+    });
+
+    it('answered approval + bare › input line below → running (detectPrompt barrier)', () => {
+      // A bare › below the answered block trips detectPrompt()'s user-input barrier
+      // (isPrompt=false) before the guard runs; Codex is still working, so the frame
+      // resolves to running rather than sticking at waiting.
+      const output = codexFrame(
+        [...APPROVAL_BLOCK, '›', '• Working (deciding next step)'],
+        V0141_BAR
+      );
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('running');
+      expect(result.reason).toBe('thinking_indicator');
+      expect(result.hasActivePrompt).toBe(false);
+      expect(result.promptDetection.isPrompt).toBe(false);
+    });
+
+    it('does not regress a genuine numbered prompt when a stale • Ran sits ABOVE it', () => {
+      // A leftover • Ran from a prior command above the current prompt block must not
+      // make the active prompt look stale (thinking is above, not below, the block).
+      const output = codexFrame(
+        ['• Ran npm test', 'All tests passed', '', ...APPROVAL_BLOCK],
+        V0141_BAR
+      );
+
+      const result = detectSessionStatus(output, 'codex');
+      expect(result.status).toBe('waiting');
+      expect(result.reason).toBe('prompt_detected');
+      expect(result.hasActivePrompt).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## 概要
Issue #1160 の対応。codexは回答済みの承認/番号プロンプト（`1. Yes / 2. No` ブロックや `press number to confirm` フッター）をトランスクリプト（historyLimit 50000）に残すため、`detectPrompt` の末尾50行窓が古いプロンプトにマッチし続け、優先度1が `waiting` を返して優先度2.7の処理中検出に到達しなかった。結果、ユーザーが回答してcodexが処理を再開してもサイドバーのステータスドットがオレンジのまま固着していた。

## 修正（対策1: 位置ベースのプロンプト鮮度ガード）
- `isCodexStalePrompt()` を追加し、codexの検出プロンプトを「**最下部のインタラクティブ要素であるときのみアクティブ**」と扱う
- プロンプトブロック（フッター/番号オプション）より下にcodexの処理中インジケータ（`• Working`/`• Ran`）があれば古いプロンプトと判定 → 検出を無効化し優先度2.7のrunning/idle検出へフォールスルー
- **過修正防止**: 未回答の承認プロンプト（下に処理中出力なし）は従来どおり `waiting` を返す → Auto-Yes動作に回帰なし。bare `›` が下にある場合は既存detectPromptバリアが先に処理するため、本ガードはthinking-indicatorシグナルのみに限定

## 回帰テスト
status-detectorに追加: 回答済み承認＋下に処理中→running / 5行窓外の処理中→running(fallback C) / 未回答承認→waiting / 回答済み承認＋下にbare `›`→running / プロンプト上の残存`• Ran`を非誤判定。codexガードのみのためClaude等他ツールに回帰なし。

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
