### PR TITLE
feat(ui): コックピット画面ポリッシュ（Agent Instances表示改善・ショートカットヘルプ） (#1130)

### DIFF
--- a/locales/en/commandPalette.json
+++ b/locales/en/commandPalette.json
@@ -26,7 +26,8 @@
     "syncSuccess": "Repositories synced",
     "syncError": "Failed to sync repositories",
     "switchLanguage": "Switch language",
-    "openGitHub": "Open GitHub"
+    "openGitHub": "Open GitHub",
+    "keyboardShortcuts": "Keyboard shortcuts"
   },
   "footer": {
     "navigate": "Navigate",

--- a/locales/en/keyboardShortcuts.json
+++ b/locales/en/keyboardShortcuts.json
@@ -1,0 +1,17 @@
+{
+  "title": "Keyboard shortcuts",
+  "scopes": {
+    "global": "Global",
+    "terminal": "Terminal",
+    "composer": "Composer"
+  },
+  "shortcuts": {
+    "commandPalette": "Open command palette",
+    "keyboardHelp": "Show keyboard shortcuts",
+    "closeOverlay": "Close overlay or dialog",
+    "navigateList": "Move selection up / down",
+    "terminalSearch": "Search terminal output",
+    "sendMessage": "Send message",
+    "composerNewline": "Insert a new line"
+  }
+}

--- a/locales/en/schedule.json
+++ b/locales/en/schedule.json
@@ -63,6 +63,7 @@
   "agentInstanceDelete": "Delete instance",
   "agentInstanceMoveUp": "Move up",
   "agentInstanceMoveDown": "Move down",
+  "agentInstanceActions": "Instance actions",
   "memoMoveUp": "Move up",
   "memoMoveDown": "Move down",
   "agentInstanceMax": "Up to {max} instances can be added.",

--- a/locales/ja/commandPalette.json
+++ b/locales/ja/commandPalette.json
@@ -26,7 +26,8 @@
     "syncSuccess": "リポジトリを同期しました",
     "syncError": "リポジトリの同期に失敗しました",
     "switchLanguage": "言語を切り替え",
-    "openGitHub": "GitHub を開く"
+    "openGitHub": "GitHub を開く",
+    "keyboardShortcuts": "キーボードショートカット"
   },
   "footer": {
     "navigate": "移動",

--- a/locales/ja/keyboardShortcuts.json
+++ b/locales/ja/keyboardShortcuts.json
@@ -1,0 +1,17 @@
+{
+  "title": "キーボードショートカット",
+  "scopes": {
+    "global": "グローバル",
+    "terminal": "ターミナル",
+    "composer": "入力欄"
+  },
+  "shortcuts": {
+    "commandPalette": "コマンドパレットを開く",
+    "keyboardHelp": "キーボードショートカットを表示",
+    "closeOverlay": "オーバーレイ・ダイアログを閉じる",
+    "navigateList": "選択を上下に移動",
+    "terminalSearch": "ターミナル出力を検索",
+    "sendMessage": "メッセージを送信",
+    "composerNewline": "改行を挿入"
+  }
+}

--- a/locales/ja/schedule.json
+++ b/locales/ja/schedule.json
@@ -63,6 +63,7 @@
   "agentInstanceDelete": "インスタンスを削除",
   "agentInstanceMoveUp": "上へ移動",
   "agentInstanceMoveDown": "下へ移動",
+  "agentInstanceActions": "インスタンス操作",
   "memoMoveUp": "上へ移動",
   "memoMoveDown": "下へ移動",
   "agentInstanceMax": "インスタンスは最大{max}個まで追加できます。",

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -44,10 +44,12 @@ import {
   RefreshCw,
   Languages,
   Github,
+  Keyboard,
 } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 import { Z_INDEX } from '@/config/z-index';
 import { useCommandPalette } from '@/contexts/CommandPaletteContext';
+import { useKeyboardShortcuts } from '@/contexts/KeyboardShortcutsContext';
 import { usePcDisplaySizeContext } from '@/contexts/PcDisplaySizeContext';
 import { useOptionalWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { PC_DISPLAY_SIZE_ORDER } from '@/hooks/usePcDisplaySize';
@@ -195,6 +197,7 @@ interface RecentRow {
  */
 export function CommandPalette() {
   const { open, setOpen } = useCommandPalette();
+  const { setOpen: setShortcutsOpen } = useKeyboardShortcuts();
   const router = useRouter();
   const t = useTranslations('commandPalette');
   const tCommon = useTranslations('common');
@@ -351,6 +354,13 @@ export function CommandPalette() {
           '_blank',
           'noopener,noreferrer'
         ),
+    },
+    {
+      // Issue #1130: opens the `?` keyboard-shortcuts help overlay.
+      id: 'keyboardShortcuts',
+      label: t('actions.keyboardShortcuts'),
+      icon: Keyboard,
+      run: () => setShortcutsOpen(true),
     },
   ];
 

--- a/src/components/common/KeyboardShortcutsOverlay.tsx
+++ b/src/components/common/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,106 @@
+/**
+ * KeyboardShortcutsOverlay (Issue #1130)
+ *
+ * The `?` keyboard-shortcuts help modal. Mounted once under AppShell (next to
+ * the CommandPalette). It owns the single global `?` keydown listener and reads
+ * the shortcut list from the central registry (@/config/keyboard-shortcuts),
+ * grouping it by scope and rendering each binding with <Kbd> caps.
+ *
+ * The `?` key never opens the overlay while the user is typing: it reuses the
+ * command palette's shared `isTypingTarget` guard (input / textarea / select /
+ * contentEditable / terminal `role="log"`) and additionally ignores IME
+ * composition (`isComposing` / keyCode 229), matching the composer's flow. It
+ * also stands down while the command palette is open so the two never stack.
+ *
+ * SSR-safe: 'use client' and platform detection runs only after mount.
+ */
+
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Modal } from '@/components/ui/Modal';
+import { Kbd } from '@/components/ui/Kbd';
+import { isTypingTarget } from '@/components/common/CommandPalette';
+import { useKeyboardShortcuts } from '@/contexts/KeyboardShortcutsContext';
+import { useCommandPalette } from '@/contexts/CommandPaletteContext';
+import {
+  groupShortcutsByScope,
+  isMacPlatform,
+  resolveShortcutKey,
+} from '@/config/keyboard-shortcuts';
+
+/** Global keyboard-shortcuts help overlay opened by `?`. */
+export function KeyboardShortcutsOverlay() {
+  const { open, setOpen } = useKeyboardShortcuts();
+  const { open: paletteOpen } = useCommandPalette();
+  const t = useTranslations('keyboardShortcuts');
+
+  // Resolve the platform mod symbol only after mount (SSR safety).
+  const [isMac, setIsMac] = useState(false);
+  useEffect(() => setIsMac(isMacPlatform()), []);
+
+  // Mirror the latest state into refs so the stable listener reads fresh values.
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+  const paletteOpenRef = useRef(paletteOpen);
+  useEffect(() => {
+    paletteOpenRef.current = paletteOpen;
+  }, [paletteOpen]);
+
+  // Single global `?` listener. Guarded against typing / IME / palette-open so
+  // it never steals the keystroke from a text-entry context (Issue #1130).
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== '?') return;
+      // IME composition: keydown fires with isComposing / keyCode 229 mid-convert.
+      if (event.isComposing || event.keyCode === 229) return;
+      if (isTypingTarget(event.target)) return;
+      if (paletteOpenRef.current) return;
+      if (openRef.current) return;
+      event.preventDefault();
+      setOpen(true);
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [setOpen]);
+
+  const groups = groupShortcutsByScope();
+
+  return (
+    <Modal isOpen={open} onClose={() => setOpen(false)} title={t('title')} size="md">
+      <div data-testid="keyboard-shortcuts-overlay" className="space-y-6">
+        {groups.map(({ scope, shortcuts }) => (
+          <section key={scope} data-testid={`keyboard-shortcuts-scope-${scope}`}>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t(`scopes.${scope}`)}
+            </h4>
+            <ul className="divide-y divide-border">
+              {shortcuts.map((shortcut) => (
+                <li
+                  key={shortcut.id}
+                  data-testid={`keyboard-shortcut-${shortcut.id}`}
+                  className="flex items-center justify-between gap-4 py-2"
+                >
+                  <span className="text-sm text-foreground">
+                    {t(`shortcuts.${shortcut.id}`)}
+                  </span>
+                  <span className="flex flex-shrink-0 items-center gap-1">
+                    {shortcut.keys.map((key, index) => (
+                      <Kbd key={index}>{resolveShortcutKey(key, isMac)}</Kbd>
+                    ))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </Modal>
+  );
+}
+
+export default KeyboardShortcutsOverlay;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -19,6 +19,7 @@ import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
 import { CommandPalette } from '@/components/common/CommandPalette';
+import { KeyboardShortcutsOverlay } from '@/components/common/KeyboardShortcutsOverlay';
 import { Z_INDEX } from '@/config/z-index';
 
 // ============================================================================
@@ -138,6 +139,8 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
 
         {/* Global command palette (⌘K / Ctrl+K) - single instance (Issue #1053) */}
         <CommandPalette />
+        {/* Global keyboard-shortcuts help overlay (?) - single instance (Issue #1130) */}
+        <KeyboardShortcutsOverlay />
       </div>
     );
   }
@@ -193,6 +196,8 @@ export const AppShell = memo(function AppShell({ children }: AppShellProps) {
 
       {/* Global command palette (⌘K / Ctrl+K) - single instance (Issue #1053) */}
       <CommandPalette />
+      {/* Global keyboard-shortcuts help overlay (?) - single instance (Issue #1130) */}
+      <KeyboardShortcutsOverlay />
     </div>
   );
 });

--- a/src/components/providers/AppProviders.tsx
+++ b/src/components/providers/AppProviders.tsx
@@ -17,6 +17,7 @@ import { SidebarProvider } from '@/contexts/SidebarContext';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { PcDisplaySizeProvider } from '@/contexts/PcDisplaySizeContext';
 import { CommandPaletteProvider } from '@/contexts/CommandPaletteContext';
+import { KeyboardShortcutsProvider } from '@/contexts/KeyboardShortcutsContext';
 import { WorktreesCacheProvider } from '@/components/providers/WorktreesCacheProvider';
 import { ViewTransitionsProvider } from '@/components/providers/ViewTransitionsProvider';
 import { RealtimeProvider } from '@/hooks/useRealtimeConnection';
@@ -55,15 +56,18 @@ export function AppProviders({ children, locale, messages, timeZone, authEnabled
               <RealtimeProvider>
                 <WorktreesCacheProvider>
                   <CommandPaletteProvider>
-                    <ConfirmProvider>
-                      {/* Issue #1141: View Transitions wraps the routed content. */}
-                      <ViewTransitionsProvider>
-                        {children}
-                      </ViewTransitionsProvider>
-                      {/* Issue #1124: registers the Service Worker (prod only)
-                          and shows the update-available prompt. */}
-                      <ServiceWorkerRegistrar />
-                    </ConfirmProvider>
+                    {/* Issue #1130: `?` keyboard-shortcuts help overlay open state. */}
+                    <KeyboardShortcutsProvider>
+                      <ConfirmProvider>
+                        {/* Issue #1141: View Transitions wraps the routed content. */}
+                        <ViewTransitionsProvider>
+                          {children}
+                        </ViewTransitionsProvider>
+                        {/* Issue #1124: registers the Service Worker (prod only)
+                            and shows the update-available prompt. */}
+                        <ServiceWorkerRegistrar />
+                      </ConfirmProvider>
+                    </KeyboardShortcutsProvider>
                   </CommandPaletteProvider>
                 </WorktreesCacheProvider>
               </RealtimeProvider>

--- a/src/components/worktree/AgentInstancesPane.tsx
+++ b/src/components/worktree/AgentInstancesPane.tsx
@@ -17,7 +17,7 @@
 
 import React, { useState, useCallback, memo } from 'react';
 import { useTranslations } from 'next-intl';
-import { GripVertical, ChevronUp, ChevronDown, Trash2, Plus } from 'lucide-react';
+import { GripVertical, ChevronUp, ChevronDown, Trash2, Plus, MoreVertical } from 'lucide-react';
 import {
   CLI_TOOL_IDS,
   getCliToolDisplayName,
@@ -29,6 +29,14 @@ import {
 import { MIN_AGENT_INSTANCES } from '@/lib/agent-instances-validator';
 import { VibeLocalSettings } from '@/components/worktree/VibeLocalSettings';
 import { Spinner } from '@/components/ui/Spinner';
+import { TruncationTooltip } from '@/components/common/TruncationTooltip';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu';
 
 // ============================================================================
 // Types
@@ -215,7 +223,7 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
                 setDraggingIndex(null);
               }}
               onDragEnd={() => setDraggingIndex(null)}
-              className={`flex items-center gap-2 p-2 rounded-lg border border-border bg-surface ${
+              className={`flex items-center gap-2 p-2 rounded-lg border border-border bg-surface transition-colors hover:border-accent-300 dark:hover:border-accent-700 focus-within:border-accent-500 ${
                 isDragging ? 'opacity-50' : ''
               }`}
             >
@@ -226,6 +234,10 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
                 <GripVertical className="w-4 h-4" />
               </span>
 
+              {/* Issue #1130: name is primary — the alias input takes the full row
+                  width and the base-tool name gets a TruncationTooltip so it stays
+                  readable in the narrow activity column. Reorder/delete moved to
+                  the kebab menu so they no longer compete for horizontal space. */}
               <div className="flex-1 min-w-0">
                 <input
                   type="text"
@@ -244,46 +256,54 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
                   }}
                   className="w-full text-sm font-medium border border-input rounded-md px-2 py-1 bg-surface dark:bg-surface-2 text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-accent-500 disabled:opacity-50"
                 />
-                <span className="block text-xs text-muted-foreground mt-0.5 truncate">
-                  {getCliToolDisplayName(inst.cliTool)}
-                </span>
+                <TruncationTooltip
+                  content={getCliToolDisplayName(inst.cliTool)}
+                  className="mt-0.5 block truncate text-xs text-muted-foreground"
+                />
               </div>
 
-              <div className="flex items-center gap-1 shrink-0">
-                <button
-                  type="button"
-                  data-testid={`agent-instance-move-up-${inst.id}`}
-                  aria-label={t('agentInstanceMoveUp')}
-                  title={t('agentInstanceMoveUp')}
-                  disabled={saving || index === 0}
-                  onClick={() => handleMove(index, -1)}
-                  className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
-                >
-                  <ChevronUp className="w-4 h-4" />
-                </button>
-                <button
-                  type="button"
-                  data-testid={`agent-instance-move-down-${inst.id}`}
-                  aria-label={t('agentInstanceMoveDown')}
-                  title={t('agentInstanceMoveDown')}
-                  disabled={saving || index === instances.length - 1}
-                  onClick={() => handleMove(index, 1)}
-                  className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
-                >
-                  <ChevronDown className="w-4 h-4" />
-                </button>
-                <button
-                  type="button"
-                  data-testid={`agent-instance-delete-${inst.id}`}
-                  aria-label={t('agentInstanceDelete')}
-                  title={t('agentInstanceDelete')}
-                  disabled={saving || atMin}
-                  onClick={() => handleDelete(inst.id)}
-                  className="p-1 rounded text-muted-foreground hover:text-danger-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
-                >
-                  <Trash2 className="w-4 h-4" />
-                </button>
-              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    data-testid={`agent-instance-menu-${inst.id}`}
+                    aria-label={t('agentInstanceActions')}
+                    title={t('agentInstanceActions')}
+                    disabled={saving}
+                    className="shrink-0 p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <MoreVertical className="w-4 h-4" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    data-testid={`agent-instance-move-up-${inst.id}`}
+                    disabled={index === 0}
+                    onSelect={() => handleMove(index, -1)}
+                  >
+                    <ChevronUp className="w-4 h-4" />
+                    {t('agentInstanceMoveUp')}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    data-testid={`agent-instance-move-down-${inst.id}`}
+                    disabled={index === instances.length - 1}
+                    onSelect={() => handleMove(index, 1)}
+                  >
+                    <ChevronDown className="w-4 h-4" />
+                    {t('agentInstanceMoveDown')}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    data-testid={`agent-instance-delete-${inst.id}`}
+                    disabled={atMin}
+                    onSelect={() => handleDelete(inst.id)}
+                    className="text-danger-foreground focus:text-danger-foreground"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                    {t('agentInstanceDelete')}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           );
         })}

--- a/src/config/keyboard-shortcuts.ts
+++ b/src/config/keyboard-shortcuts.ts
@@ -1,0 +1,89 @@
+/**
+ * Keyboard shortcut registry (Issue #1130)
+ *
+ * Single source of truth for the app's keyboard shortcuts, consumed by the `?`
+ * help overlay ({@link KeyboardShortcutsOverlay}) and the command palette's
+ * "Keyboard shortcuts" action. Display-only: the actual key handling still lives
+ * in each feature (command palette, terminal search, composer). Registering a
+ * shortcut here does NOT wire a handler — it only documents an existing binding.
+ *
+ * `keys` render as {@link Kbd} caps in order; the {@link MOD_KEY_TOKEN} token
+ * resolves to ⌘ on macOS and Ctrl elsewhere at render time (SSR-safe). Human
+ * descriptions come from the `keyboardShortcuts` i18n namespace
+ * (`shortcuts.<id>`); scope headings from `scopes.<scope>`.
+ */
+
+/** Grouping bucket for a shortcut in the help overlay. */
+export type ShortcutScope = 'global' | 'terminal' | 'composer';
+
+/** Placeholder key cap that renders as ⌘ (macOS) or Ctrl (everywhere else). */
+export const MOD_KEY_TOKEN = 'MOD';
+
+export interface KeyboardShortcut {
+  /** Stable id; also the i18n description key suffix and the overlay row key. */
+  id: string;
+  /** Key caps to render (in order). Use {@link MOD_KEY_TOKEN} for the mod key. */
+  keys: string[];
+  /** Which group the shortcut appears under. */
+  scope: ShortcutScope;
+}
+
+/** Scope order used for grouping/rendering the overlay. */
+export const SHORTCUT_SCOPES: readonly ShortcutScope[] = [
+  'global',
+  'terminal',
+  'composer',
+] as const;
+
+/**
+ * The registered shortcuts. Mirrors the bindings scattered across the app:
+ *   - command palette toggle + Escape (CommandPalette.tsx)
+ *   - terminal search (TerminalDisplay.tsx)
+ *   - composer submit / newline (MessageInput.tsx)
+ */
+export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
+  { id: 'commandPalette', keys: [MOD_KEY_TOKEN, 'K'], scope: 'global' },
+  { id: 'keyboardHelp', keys: ['?'], scope: 'global' },
+  { id: 'closeOverlay', keys: ['Esc'], scope: 'global' },
+  { id: 'navigateList', keys: ['↑', '↓'], scope: 'global' },
+  { id: 'terminalSearch', keys: [MOD_KEY_TOKEN, 'F'], scope: 'terminal' },
+  { id: 'sendMessage', keys: ['↵'], scope: 'composer' },
+  { id: 'composerNewline', keys: ['Shift', '↵'], scope: 'composer' },
+] as const;
+
+/**
+ * True on macOS-family platforms (where the mod key renders as ⌘). SSR-safe:
+ * returns `false` when `navigator` is unavailable.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const source = navigator.platform || navigator.userAgent || '';
+  return /Mac|iPhone|iPad|iPod/.test(source);
+}
+
+/**
+ * Resolve one key cap for display, expanding {@link MOD_KEY_TOKEN} per platform.
+ */
+export function resolveShortcutKey(key: string, mac: boolean): string {
+  if (key === MOD_KEY_TOKEN) return mac ? '⌘' : 'Ctrl';
+  return key;
+}
+
+/** A scope with the shortcuts that belong to it (non-empty scopes only). */
+export interface ShortcutGroup {
+  scope: ShortcutScope;
+  shortcuts: KeyboardShortcut[];
+}
+
+/**
+ * Group the registry by scope, preserving {@link SHORTCUT_SCOPES} order and
+ * dropping any scope with no shortcuts.
+ */
+export function groupShortcutsByScope(
+  shortcuts: readonly KeyboardShortcut[] = KEYBOARD_SHORTCUTS
+): ShortcutGroup[] {
+  return SHORTCUT_SCOPES.map((scope) => ({
+    scope,
+    shortcuts: shortcuts.filter((s) => s.scope === scope),
+  })).filter((group) => group.shortcuts.length > 0);
+}

--- a/src/contexts/KeyboardShortcutsContext.tsx
+++ b/src/contexts/KeyboardShortcutsContext.tsx
@@ -1,0 +1,64 @@
+/**
+ * KeyboardShortcutsContext (Issue #1130)
+ *
+ * Shares the open/closed state of the global keyboard-shortcuts help overlay
+ * (opened by `?`) so that a single overlay instance (mounted in AppShell) can be
+ * opened both by the global `?` key and by the command palette's "Keyboard
+ * shortcuts" action.
+ *
+ * The context has a non-throwing default so components remain usable without an
+ * explicit provider (e.g. isolated unit tests) — matching CommandPaletteContext.
+ */
+
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/** Context value for the keyboard-shortcuts overlay open state. */
+export interface KeyboardShortcutsContextValue {
+  /** Whether the overlay is currently open. */
+  open: boolean;
+  /** Set the open state explicitly. */
+  setOpen: (open: boolean) => void;
+  /** Toggle the open state. */
+  toggle: () => void;
+}
+
+const DEFAULT_CONTEXT_VALUE: KeyboardShortcutsContextValue = {
+  open: false,
+  setOpen: () => {},
+  toggle: () => {},
+};
+
+const KeyboardShortcutsContext = createContext<KeyboardShortcutsContextValue>(
+  DEFAULT_CONTEXT_VALUE
+);
+
+/** Provider that owns the shortcuts-overlay open state. */
+export function KeyboardShortcutsProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  const value = useMemo<KeyboardShortcutsContextValue>(
+    () => ({ open, setOpen, toggle }),
+    [open, toggle]
+  );
+
+  return (
+    <KeyboardShortcutsContext.Provider value={value}>
+      {children}
+    </KeyboardShortcutsContext.Provider>
+  );
+}
+
+/** Access the keyboard-shortcuts overlay open state. */
+export function useKeyboardShortcuts(): KeyboardShortcutsContextValue {
+  return useContext(KeyboardShortcutsContext);
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,7 +22,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   }
 
   // Load all namespace files and merge them
-  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette, home, review, pwa, notifications] = await Promise.all([
+  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette, home, review, pwa, notifications, keyboardShortcuts] = await Promise.all([
     import(`../locales/${locale}/common.json`),
     import(`../locales/${locale}/worktree.json`),
     import(`../locales/${locale}/autoYes.json`),
@@ -35,6 +35,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
     import(`../locales/${locale}/review.json`),
     import(`../locales/${locale}/pwa.json`),
     import(`../locales/${locale}/notifications.json`),
+    import(`../locales/${locale}/keyboardShortcuts.json`),
   ]);
 
   return {
@@ -54,6 +55,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
       review: review.default,
       pwa: pwa.default,
       notifications: notifications.default,
+      keyboardShortcuts: keyboardShortcuts.default,
     },
   };
 });

--- a/tests/integration/i18n-namespace-loading.test.ts
+++ b/tests/integration/i18n-namespace-loading.test.ts
@@ -22,8 +22,9 @@ const LOCALES_DIR = path.resolve(__dirname, '../../locales');
  * Issue #1113: Added 'review' namespace
  * Issue #1124: Added 'pwa' namespace
  * Issue #1125: Added 'notifications' namespace
+ * Issue #1130: Added 'keyboardShortcuts' namespace
  */
-const EXPECTED_NAMESPACES = ['common', 'worktree', 'autoYes', 'error', 'prompt', 'auth', 'schedule', 'commandPalette', 'home', 'review', 'pwa', 'notifications'] as const;
+const EXPECTED_NAMESPACES = ['common', 'worktree', 'autoYes', 'error', 'prompt', 'auth', 'schedule', 'commandPalette', 'home', 'review', 'pwa', 'notifications', 'keyboardShortcuts'] as const;
 
 describe('i18n Namespace Loading', () => {
   for (const locale of SUPPORTED_LOCALES) {

--- a/tests/unit/components/common/CommandPalette.test.tsx
+++ b/tests/unit/components/common/CommandPalette.test.tsx
@@ -75,6 +75,8 @@ vi.mock('@/hooks/useLocaleSwitch', () => ({
 
 import { CommandPalette, isTypingTarget } from '@/components/common/CommandPalette';
 import { CommandPaletteProvider } from '@/contexts/CommandPaletteContext';
+import { KeyboardShortcutsProvider } from '@/contexts/KeyboardShortcutsContext';
+import { KeyboardShortcutsOverlay } from '@/components/common/KeyboardShortcutsOverlay';
 import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
 import { Header } from '@/components/layout/Header';
 
@@ -429,6 +431,24 @@ describe('CommandPalette (Issue #1053)', () => {
     expect(screen.queryByTestId('command-palette')).toBeNull();
     fireEvent.click(screen.getByTestId('header-command-palette-trigger'));
     expect(screen.getByTestId('command-palette')).toBeInTheDocument();
+  });
+
+  it('opens the keyboard-shortcuts overlay from the Actions group (Issue #1130)', () => {
+    render(
+      <CommandPaletteProvider>
+        <KeyboardShortcutsProvider>
+          <CommandPalette />
+          <KeyboardShortcutsOverlay />
+        </KeyboardShortcutsProvider>
+      </CommandPaletteProvider>
+    );
+    pressKey(window, { key: 'k', metaKey: true });
+    expect(screen.queryByTestId('keyboard-shortcuts-overlay')).toBeNull();
+
+    fireEvent.click(screen.getByText('commandPalette.actions.keyboardShortcuts'));
+    // Palette closes and the overlay opens.
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+    expect(screen.getByTestId('keyboard-shortcuts-overlay')).toBeInTheDocument();
   });
 
   it('syncs repositories from the Actions group and shows a success toast', async () => {

--- a/tests/unit/components/common/KeyboardShortcutsOverlay.test.tsx
+++ b/tests/unit/components/common/KeyboardShortcutsOverlay.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for KeyboardShortcutsOverlay (Issue #1130).
+ *
+ * Covers: opening via `?`, the typing-context guard (input / textarea /
+ * contentEditable), the IME-composition guard, closing via Escape, rendering
+ * every registered shortcut grouped by scope, and standing down while the
+ * command palette is open.
+ *
+ * next-intl is globally mocked (tests/setup.ts) to echo the full key, so
+ * assertions reference keys like `keyboardShortcuts.title`.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React, { useEffect } from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react';
+import { KeyboardShortcutsOverlay } from '@/components/common/KeyboardShortcutsOverlay';
+import {
+  KeyboardShortcutsProvider,
+} from '@/contexts/KeyboardShortcutsContext';
+import {
+  CommandPaletteProvider,
+  useCommandPalette,
+} from '@/contexts/CommandPaletteContext';
+import { KEYBOARD_SHORTCUTS } from '@/config/keyboard-shortcuts';
+
+afterEach(() => cleanup());
+
+/** Render the overlay inside both providers (palette guard reads its context). */
+function renderOverlay(extra?: React.ReactNode) {
+  return render(
+    <CommandPaletteProvider>
+      <KeyboardShortcutsProvider>
+        {extra}
+        <KeyboardShortcutsOverlay />
+      </KeyboardShortcutsProvider>
+    </CommandPaletteProvider>,
+  );
+}
+
+/** Dispatch a `?` keydown on the given target (defaults to document.body). */
+function pressHelpKey(
+  target: Element | Document | Window = document.body,
+  init: KeyboardEventInit = {},
+) {
+  act(() => {
+    fireEvent.keyDown(target, { key: '?', ...init });
+  });
+}
+
+describe('KeyboardShortcutsOverlay (Issue #1130)', () => {
+  it('is closed initially and opens on `?`', () => {
+    renderOverlay();
+    expect(screen.queryByTestId('keyboard-shortcuts-overlay')).toBeNull();
+
+    pressHelpKey();
+    expect(screen.getByTestId('keyboard-shortcuts-overlay')).toBeInTheDocument();
+    expect(screen.getByText('keyboardShortcuts.title')).toBeInTheDocument();
+  });
+
+  it('does NOT open while typing in an input / textarea / contentEditable', () => {
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const editable = document.createElement('div');
+    // jsdom does not derive isContentEditable from the attribute; set it like
+    // the shared isTypingTarget test does.
+    Object.defineProperty(editable, 'isContentEditable', { value: true });
+    document.body.append(input, textarea, editable);
+
+    renderOverlay();
+    pressHelpKey(input);
+    pressHelpKey(textarea);
+    pressHelpKey(editable);
+    expect(screen.queryByTestId('keyboard-shortcuts-overlay')).toBeNull();
+
+    input.remove();
+    textarea.remove();
+    editable.remove();
+  });
+
+  it('does NOT open during IME composition', () => {
+    renderOverlay();
+    pressHelpKey(document.body, { isComposing: true });
+    expect(screen.queryByTestId('keyboard-shortcuts-overlay')).toBeNull();
+
+    // A real (non-composing) `?` still opens it.
+    pressHelpKey();
+    expect(screen.getByTestId('keyboard-shortcuts-overlay')).toBeInTheDocument();
+  });
+
+  it('does NOT open while the command palette is open', () => {
+    function OpenPalette() {
+      const { setOpen } = useCommandPalette();
+      useEffect(() => setOpen(true), [setOpen]);
+      return null;
+    }
+    renderOverlay(<OpenPalette />);
+    pressHelpKey();
+    expect(screen.queryByTestId('keyboard-shortcuts-overlay')).toBeNull();
+  });
+
+  it('closes on Escape', async () => {
+    renderOverlay();
+    pressHelpKey();
+    expect(screen.getByTestId('keyboard-shortcuts-overlay')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    await waitFor(() =>
+      expect(screen.queryByTestId('keyboard-shortcuts-overlay')).toBeNull(),
+    );
+  });
+
+  it('renders every registered shortcut grouped by scope', () => {
+    renderOverlay();
+    pressHelpKey();
+
+    for (const shortcut of KEYBOARD_SHORTCUTS) {
+      expect(screen.getByTestId(`keyboard-shortcut-${shortcut.id}`)).toBeInTheDocument();
+      expect(
+        screen.getByText(`keyboardShortcuts.shortcuts.${shortcut.id}`),
+      ).toBeInTheDocument();
+    }
+    // Scope headings for the non-empty scopes.
+    expect(screen.getByTestId('keyboard-shortcuts-scope-global')).toBeInTheDocument();
+    expect(screen.getByTestId('keyboard-shortcuts-scope-terminal')).toBeInTheDocument();
+    expect(screen.getByTestId('keyboard-shortcuts-scope-composer')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/worktree/AgentInstancesPane.test.tsx
+++ b/tests/unit/components/worktree/AgentInstancesPane.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { AgentInstancesPane } from '@/components/worktree/AgentInstancesPane';
 import {
@@ -19,9 +19,18 @@ import {
   type AgentInstance,
   type CLIToolType,
 } from '@/lib/cli-tools/types';
+import { installRadixJsdomPolyfills } from '@tests/helpers/radix-jsdom';
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
+
+// Issue #1130: reorder/delete now live in a Radix DropdownMenu kebab. Open a
+// row's menu (keyboard-open is the reliable path in jsdom) so its items mount.
+function openRowMenu(id: string): void {
+  fireEvent.keyDown(screen.getByTestId(`agent-instance-menu-${id}`), { key: 'Enter' });
+}
+
+beforeAll(() => installRadixJsdomPolyfills());
 
 /** Build a primary AgentInstance (id === cliTool). */
 function primary(cliTool: CLIToolType, order: number, alias?: string): AgentInstance {
@@ -170,6 +179,7 @@ describe('AgentInstancesPane (Issue #869)', () => {
           instances={[primary('claude', 0), primary('codex', 1), primary('gemini', 2)]}
         />,
       );
+      openRowMenu('claude');
       fireEvent.click(screen.getByTestId('agent-instance-delete-claude'));
       await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
       const body = patchBody();
@@ -179,7 +189,8 @@ describe('AgentInstancesPane (Issue #869)', () => {
 
     it('disables delete at MIN (single instance) and shows the min hint', () => {
       render(<AgentInstancesPane {...baseProps} instances={[primary('claude', 0)]} />);
-      expect(screen.getByTestId('agent-instance-delete-claude')).toBeDisabled();
+      openRowMenu('claude');
+      expect(screen.getByTestId('agent-instance-delete-claude')).toHaveAttribute('data-disabled');
       expect(screen.getByText('schedule.agentInstanceMin')).toBeInTheDocument();
     });
   });
@@ -192,6 +203,7 @@ describe('AgentInstancesPane (Issue #869)', () => {
           instances={[primary('claude', 0), primary('codex', 1), primary('gemini', 2)]}
         />,
       );
+      openRowMenu('claude');
       fireEvent.click(screen.getByTestId('agent-instance-move-down-claude'));
       await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
       const body = patchBody();
@@ -206,11 +218,20 @@ describe('AgentInstancesPane (Issue #869)', () => {
           instances={[primary('claude', 0), primary('codex', 1)]}
         />,
       );
-      expect(screen.getByTestId('agent-instance-move-up-claude')).toBeDisabled();
-      expect(screen.getByTestId('agent-instance-move-down-codex')).toBeDisabled();
-      // Interior moves remain enabled.
-      expect(screen.getByTestId('agent-instance-move-down-claude')).not.toBeDisabled();
-      expect(screen.getByTestId('agent-instance-move-up-codex')).not.toBeDisabled();
+      // First row (claude): move-up disabled, move-down enabled.
+      openRowMenu('claude');
+      expect(screen.getByTestId('agent-instance-move-up-claude')).toHaveAttribute('data-disabled');
+      expect(screen.getByTestId('agent-instance-move-down-claude')).not.toHaveAttribute(
+        'data-disabled',
+      );
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+
+      // Last row (codex): move-down disabled, move-up enabled.
+      openRowMenu('codex');
+      expect(screen.getByTestId('agent-instance-move-down-codex')).toHaveAttribute('data-disabled');
+      expect(screen.getByTestId('agent-instance-move-up-codex')).not.toHaveAttribute(
+        'data-disabled',
+      );
     });
   });
 
@@ -251,6 +272,7 @@ describe('AgentInstancesPane (Issue #869)', () => {
           instances={[primary('claude', 0), primary('codex', 1)]}
         />,
       );
+      openRowMenu('claude');
       fireEvent.click(screen.getByTestId('agent-instance-delete-claude'));
       await waitFor(() =>
         expect(screen.getByTestId('agent-instances-error')).toBeInTheDocument(),

--- a/tests/unit/config/keyboard-shortcuts.test.ts
+++ b/tests/unit/config/keyboard-shortcuts.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the keyboard-shortcuts registry (Issue #1130).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  KEYBOARD_SHORTCUTS,
+  SHORTCUT_SCOPES,
+  MOD_KEY_TOKEN,
+  groupShortcutsByScope,
+  resolveShortcutKey,
+  type ShortcutScope,
+} from '@/config/keyboard-shortcuts';
+
+describe('keyboard-shortcuts registry', () => {
+  it('has unique, non-empty shortcut ids', () => {
+    const ids = KEYBOARD_SHORTCUTS.map((s) => s.id);
+    expect(ids.every((id) => id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every shortcut has at least one key and a known scope', () => {
+    for (const shortcut of KEYBOARD_SHORTCUTS) {
+      expect(shortcut.keys.length).toBeGreaterThan(0);
+      expect(SHORTCUT_SCOPES).toContain(shortcut.scope);
+    }
+  });
+
+  it('registers the command-palette, help, terminal-search and composer bindings', () => {
+    const ids = KEYBOARD_SHORTCUTS.map((s) => s.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'commandPalette',
+        'keyboardHelp',
+        'terminalSearch',
+        'sendMessage',
+        'composerNewline',
+      ]),
+    );
+  });
+
+  describe('groupShortcutsByScope', () => {
+    it('groups shortcuts under their scope in SHORTCUT_SCOPES order', () => {
+      const groups = groupShortcutsByScope();
+      const scopes = groups.map((g) => g.scope);
+      // Order matches SHORTCUT_SCOPES (filtered to non-empty).
+      expect(scopes).toEqual(SHORTCUT_SCOPES.filter((s) => scopes.includes(s)));
+    });
+
+    it('covers every registered shortcut exactly once', () => {
+      const grouped = groupShortcutsByScope().flatMap((g) => g.shortcuts);
+      expect(grouped).toHaveLength(KEYBOARD_SHORTCUTS.length);
+      expect(new Set(grouped.map((s) => s.id)).size).toBe(KEYBOARD_SHORTCUTS.length);
+    });
+
+    it('drops scopes that have no shortcuts', () => {
+      const single = groupShortcutsByScope([
+        { id: 'x', keys: ['X'], scope: 'terminal' as ShortcutScope },
+      ]);
+      expect(single).toHaveLength(1);
+      expect(single[0].scope).toBe('terminal');
+    });
+  });
+
+  describe('resolveShortcutKey', () => {
+    it('renders the mod token as ⌘ on macOS and Ctrl elsewhere', () => {
+      expect(resolveShortcutKey(MOD_KEY_TOKEN, true)).toBe('⌘');
+      expect(resolveShortcutKey(MOD_KEY_TOKEN, false)).toBe('Ctrl');
+    });
+
+    it('passes plain keys through unchanged', () => {
+      expect(resolveShortcutKey('K', true)).toBe('K');
+      expect(resolveShortcutKey('?', false)).toBe('?');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1130（親 #1110 Phase 5）の対応。メイン作業画面（コックピット）の磨き込み。

## 変更内容
- **Agent Instances表示改善**: カードの操作（並び替え・削除）をRadix DropdownMenuケバブに集約し、エイリアス入力を全幅化。基底ツール名に TruncationTooltip を適用し狭幅でも判読可能に。カード枠をヘッダーピルと同系のアクセント枠（hover/focus-within）へ統一
- **ショートカットヘルプ**: キーボードショートカット一元レジストリ（`src/config/keyboard-shortcuts.ts`）を新設、`?` キーで一覧オーバーレイ表示（typing/IMEガード付き、Escapeで閉じる）、スコープ別グルーピング、Modal + Kbd で描画。コマンドパレットに「Keyboard shortcuts」アクション追加
- 文言は next-intl 辞書（en/ja、keyboardShortcuts名前空間）へ
- **#1152のヘッダー配線（headerInstanceSelection）・ドラッグ並び替えは非改変**

## 品質ゲート
lint / tsc / test:unit / test:integration / build 全PASS、NULバイト0件

Refs #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
