### PR TITLE
fix(mobile): キーボード表示時に入力欄が上部へ飛ぶ問題をvisualViewport高さ追従で解消 (#1166)

### DIFF
--- a/src/components/mobile/MobileTabBar.tsx
+++ b/src/components/mobile/MobileTabBar.tsx
@@ -36,6 +36,15 @@ export interface MobileTabBarProps {
    * memo -> 'notes', others map 1:1.
    */
   onSearchParamsChange?: (pane: DeepLinkPane) => void;
+  /**
+   * Issue #1166: when true, render in normal document flow (static,
+   * `flex-shrink-0`) instead of `position: fixed`. The worktree mobile shell
+   * sizes its container to `visualViewport.height` and lays the tab bar out as
+   * the bottom flex child, so it docks above the software keyboard without the
+   * fixed-to-layout-viewport positioning that hid it behind the keyboard.
+   * Defaults to false (legacy fixed-bottom positioning) for other callers.
+   */
+  inFlow?: boolean;
 }
 
 /**
@@ -82,6 +91,7 @@ export function MobileTabBar({
   hasPrompt = false,
   hasUpdate = false,
   onSearchParamsChange,
+  inFlow = false,
 }: MobileTabBarProps) {
   // [Issue #1127] Button refs for the ARIA tabs roving-tabindex pattern: arrow
   // keys move focus (and selection) to the neighbouring tab element directly.
@@ -179,7 +189,12 @@ export function MobileTabBar({
       data-testid="mobile-tab-bar"
       role="tablist"
       aria-label="Mobile navigation"
-      className="fixed bottom-0 inset-x-0 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md flex pb-safe z-40"
+      // Issue #1166: `inFlow` renders the bar as a static bottom flex child so it
+      // follows the visualViewport-sized shell above the keyboard; the default
+      // keeps the legacy fixed-to-viewport-bottom positioning for other callers.
+      className={`${
+        inFlow ? 'flex-shrink-0' : 'fixed bottom-0'
+      } inset-x-0 border-t border-border bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur-md flex pb-safe z-40`}
     >
       {TABS.map((tab, index) => (
         <button

--- a/src/components/worktree/MessageInput.tsx
+++ b/src/components/worktree/MessageInput.tsx
@@ -15,7 +15,6 @@ import { SlashCommandSelector } from './SlashCommandSelector';
 import { InterruptButton } from './InterruptButton';
 import { useSlashCommands } from '@/hooks/useSlashCommands';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import { useImageAttachment } from '@/hooks/useImageAttachment';
 import type { SlashCommand } from '@/types/slash-commands';
 import { getSlashCommandTrigger } from '@/lib/slash-command-format';
@@ -79,13 +78,6 @@ export interface MessageInputProps {
     content: string,
     options: { cliToolId: CLIToolType; instanceId?: string; imagePath?: string },
   ) => void;
-  /**
-   * Issue #1128: when true, the composer follows the software keyboard — it
-   * translates up by the keyboard height (visualViewport) so it never hides
-   * behind the keyboard on mobile. Opt-in; only the bottom-anchored mobile
-   * composer sets it (PC splits / assistant chat are not keyboard-obscured).
-   */
-  keyboardAware?: boolean;
 }
 
 /**
@@ -137,7 +129,7 @@ function migrateLegacyDraftKey(worktreeId: string): void {
   }
 }
 
-export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, instanceId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast, autoYesSlot, onOptimisticSend, keyboardAware = false }: MessageInputProps) {
+export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSent, cliToolId, instanceId, isSessionRunning = false, pendingInsertText, onInsertConsumed, splitIndex = 0, onFocus, isProcessing = false, showToast, autoYesSlot, onOptimisticSend }: MessageInputProps) {
   const t = useTranslations('worktree');
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
@@ -156,17 +148,11 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
   const isMobile = useIsMobile();
   const { groups } = useSlashCommands(worktreeId, cliToolId);
 
-  // Issue #1128: keyboard-follow. When opted in, lift the composer by the
-  // software-keyboard height so it stays visible above the keyboard. A short
-  // transition smooths the show/hide; no offset when the keyboard is hidden.
-  const { isKeyboardVisible, keyboardHeight } = useVirtualKeyboard();
-  const keyboardFollowStyle: React.CSSProperties | undefined = keyboardAware
-    ? {
-        transform: isKeyboardVisible ? `translateY(-${keyboardHeight}px)` : undefined,
-        transition: 'transform 0.2s ease-out',
-        willChange: 'transform',
-      }
-    : undefined;
+  // Issue #1166: the composer no longer lifts itself with a translateY hack.
+  // The mobile shell (WorktreeDetailRefactored) now sizes its container to
+  // visualViewport.height and places this composer in normal flow at the bottom,
+  // so it docks above the software keyboard without any transform. This keeps
+  // the composer a plain in-flow element on every surface (mobile / PC / chat).
 
   // Issue #474: Image attachment hook
   const uploadFn = useCallback(
@@ -466,7 +452,6 @@ export const MessageInput = memo(function MessageInput({ worktreeId, onMessageSe
     <div
       ref={containerRef}
       className="space-y-2 relative"
-      style={keyboardFollowStyle}
       data-testid="message-input-container"
     >
       {/* Error display (send error or image error) */}

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -68,6 +68,7 @@ import { deriveCliStatus } from '@/types/sidebar';
 import { MoveDialog } from '@/components/worktree/MoveDialog';
 import { NewFileDialog } from '@/components/worktree/NewFileDialog';
 import { useSwipeGesture } from '@/hooks/useSwipeGesture';
+import { useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import type { MobileTab } from '@/components/mobile/MobileTabBar';
 
 // ============================================================================
@@ -88,15 +89,6 @@ export interface WorktreeDetailRefactoredProps {
  * without recreating a function on every render.
  */
 const NOOP_SELECTED_AGENTS_CHANGE = (): void => {};
-
-/**
- * Mobile bottom-anchored layout offsets (both include the iOS safe-area inset).
- * The MobileTabBar is 4rem tall and the fixed MessageInput sits directly above
- * it; the scrollable content reserves 12rem so nothing is hidden behind the
- * input stack + tab bar.
- */
-const MOBILE_MESSAGE_INPUT_BOTTOM = 'calc(4rem + env(safe-area-inset-bottom, 0px))';
-const MOBILE_CONTENT_BOTTOM_PADDING = 'calc(12rem + env(safe-area-inset-bottom, 0px))';
 
 /**
  * Issue #1128: left-to-right order of the mobile tabs, matching MobileTabBar's
@@ -260,6 +252,13 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     worktreeId,
     active: activeTab === 'terminal',
   });
+
+  // Issue #1166: track the visible viewport height so the mobile shell can pin
+  // its container to it. When the software keyboard opens, visualViewport.height
+  // shrinks (Android resizes-visual / iOS Safari) while the layout viewport does
+  // not; sizing the flex column to this height keeps the in-flow composer + tab
+  // bar docked directly above the keyboard (replaces the fixed+translateY hack).
+  const { viewportHeight } = useVirtualKeyboard();
 
   // Issue #1128: step to the previous/next mobile tab (no wraparound). Keeps the
   // MobileTabBar indicator synced since both derive from the same `activeTab`.
@@ -428,21 +427,38 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   }
 
   // Render mobile layout
+  //
+  // Issue #1166: the mobile shell is a flex column whose height tracks the
+  // *visible* viewport (visualViewport.height), mirroring the proven
+  // FullScreenModal pattern. Header / instance-tabs / composer / tab bar are all
+  // `flex-shrink-0` in normal flow and the scrollable content is `flex-1
+  // min-h-0`, so when the keyboard opens the container shrinks and the composer
+  // + tab bar stay docked directly above it — no `position: fixed` and no
+  // `translateY` lift (which mis-referenced the layout-viewport bottom and made
+  // the composer fly off-screen on Android Chrome). Falls back to `100%` (fill
+  // the AppShell main) until visualViewport is measured / on unsupported
+  // browsers, preserving the pre-#1166 full-height behavior.
   return (
     <ErrorBoundary componentName="WorktreeDetailRefactored">
-      <div className="h-full flex flex-col">
-        <MobileHeader
-          worktreeName={worktreeName}
-          repositoryName={worktree?.repositoryName}
-          status={worktreeStatus}
-          gitStatus={worktree?.gitStatus}
-          onBackClick={handleBackClick}
-          onMenuClick={openMobileDrawer}
-        />
+      <div
+        className="flex flex-col overflow-hidden"
+        style={{ height: viewportHeight != null ? `${viewportHeight}px` : '100%' }}
+        data-testid="mobile-worktree-shell"
+      >
+        <div className="flex-shrink-0">
+          <MobileHeader
+            worktreeName={worktreeName}
+            repositoryName={worktree?.repositoryName}
+            status={worktreeStatus}
+            gitStatus={worktree?.gitStatus}
+            onBackClick={handleBackClick}
+            onMenuClick={openMobileDrawer}
+          />
+        </div>
 
         {/* Issue #111: Branch mismatch warning (Mobile) */}
         {worktree?.gitStatus && worktree.gitStatus.isBranchMismatch && (
-          <div className="z-35">
+          <div className="z-35 flex-shrink-0">
             <BranchMismatchAlert
               isBranchMismatch={worktree.gitStatus.isBranchMismatch}
               currentBranch={worktree.gitStatus.currentBranch}
@@ -453,8 +469,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
 
         {/* Agent-instance tabs row (Mobile, Issue #1080) — dedicated to the
             per-instance tabs. Auto-Yes moved into the composer meta row; terminal
-            search + End moved into the "more actions" bottom sheet. */}
-        <div className="sticky top-0 z-30 flex items-center gap-2 px-3 py-1.5 bg-surface-2 border-b border-border">
+            search + End moved into the "more actions" bottom sheet.
+            Issue #1166: `flex-shrink-0` in the viewport-height flex column (the
+            row no longer needs `sticky` — the shell itself does not scroll). */}
+        <div className="flex-shrink-0 z-30 flex items-center gap-2 px-3 py-1.5 bg-surface-2 border-b border-border">
           {/* CLI tool tabs — horizontally scrollable so 3+ agents never overflow
               off-screen (Issue #958). `min-w-0` releases the flex item's default
               min-width:auto so the nav scrolls instead of expanding.
@@ -505,12 +523,14 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           </button>
         </div>
 
+        {/* Issue #1166: `flex-1 min-h-0 overflow-y-auto` — the only element that
+            absorbs the flex column's remaining space and scrolls internally, so
+            the fixed-height header/tabs/composer/tab bar keep their size when the
+            keyboard shrinks the shell. The old 12rem bottom padding is gone: the
+            composer + tab bar are now in-flow siblings, not fixed overlays. */}
         <main
-          className="flex-1 overflow-y-auto"
+          className="flex-1 min-h-0 overflow-y-auto"
           ref={tabSwipeRef}
-          style={{
-            paddingBottom: MOBILE_CONTENT_BOTTOM_PADDING,
-          }}
         >
           <MobileContent
             activeTab={activeTab}
@@ -565,11 +585,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           />
         </main>
 
-        {/* Message Input - fixed above tab bar */}
-        <div
-          className="fixed left-0 right-0 border-t border-border bg-surface z-30"
-          style={{ bottom: MOBILE_MESSAGE_INPUT_BOTTOM }}
-        >
+        {/* Message Input — Issue #1166: in-flow bottom bar (`flex-shrink-0`).
+            The viewport-height shell keeps this docked above the software
+            keyboard, so it no longer needs `position: fixed` + a translateY lift. */}
+        <div className="flex-shrink-0 border-t border-border bg-surface z-30">
           {/* Issue #473: Navigation buttons for OpenCode TUI selection list (mobile) */}
           {isSelectionListActive && (
             <div className="px-2 pt-1 border-b border-border">
@@ -591,9 +610,6 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               isSessionRunning={activeSessionRunning}
               pendingInsertText={pendingInsertText}
               onInsertConsumed={handleInsertConsumedSingle}
-              // Issue #1128: lift the composer above the software keyboard so it
-              // stays visible while typing (visualViewport-driven).
-              keyboardAware
               // Issue #1080: Auto-Yes now lives in the composer meta row (moved off
               // the sticky tab row). The active agent tab already names the tool, so
               // the parenthetical tool name is suppressed here (showToolName=false).
@@ -612,12 +628,15 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           </div>
         </div>
 
+        {/* Issue #1166: `inFlow` renders the tab bar as the bottom flex child
+            (static) so it tracks the viewport-height shell above the keyboard. */}
         <MobileTabBar
           activeTab={activeTab}
           onTabChange={handleMobileTabChange}
           hasNewOutput={hasNewOutput}
           hasPrompt={state.prompt.visible}
           hasUpdate={hasUpdate}
+          inFlow
         />
 
         {!autoYesEnabled && (

--- a/src/hooks/useVirtualKeyboard.ts
+++ b/src/hooks/useVirtualKeyboard.ts
@@ -16,6 +16,16 @@ export interface UseVirtualKeyboardReturn {
   isKeyboardVisible: boolean;
   /** Height of the virtual keyboard in pixels */
   keyboardHeight: number;
+  /**
+   * Issue #1166: current `visualViewport.height` in px, or `null` when the API
+   * is unavailable (SSR / older browsers). Consumers size a container to this
+   * value so a bottom-anchored composer follows the software keyboard — the
+   * visual viewport shrinks when the keyboard opens while the layout viewport
+   * does not (Android `resizes-visual` / iOS Safari). Mirrors the proven
+   * FullScreenModal viewport-tracking pattern and replaces the fixed+translateY
+   * lift that mis-referenced the layout-viewport bottom.
+   */
+  viewportHeight: number | null;
 }
 
 /**
@@ -54,6 +64,9 @@ const isVisualViewportSupported = (): boolean =>
 export function useVirtualKeyboard(): UseVirtualKeyboardReturn {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
+  // Issue #1166: track the visible viewport height so callers can pin a layout
+  // container to it. `null` until measured (SSR / unsupported browsers).
+  const [viewportHeight, setViewportHeight] = useState<number | null>(null);
 
   /**
    * Calculate keyboard height and visibility
@@ -65,13 +78,15 @@ export function useVirtualKeyboard(): UseVirtualKeyboardReturn {
 
     const viewport = window.visualViewport!;
     const windowHeight = window.innerHeight;
-    const viewportHeight = viewport.height;
-    const heightDiff = windowHeight - viewportHeight;
+    const currentViewportHeight = viewport.height;
+    const heightDiff = windowHeight - currentViewportHeight;
 
     // Only consider keyboard visible if the difference exceeds threshold
     const isVisible = heightDiff > KEYBOARD_THRESHOLD;
     setIsKeyboardVisible(isVisible);
     setKeyboardHeight(isVisible ? heightDiff : 0);
+    // Issue #1166: expose the raw visible height for viewport-following layouts.
+    setViewportHeight(currentViewportHeight);
   }, []);
 
   /**
@@ -98,6 +113,7 @@ export function useVirtualKeyboard(): UseVirtualKeyboardReturn {
   return {
     isKeyboardVisible,
     keyboardHeight,
+    viewportHeight,
   };
 }
 

--- a/tests/unit/components/mobile/MobileTabBar.test.tsx
+++ b/tests/unit/components/mobile/MobileTabBar.test.tsx
@@ -214,6 +214,29 @@ describe('MobileTabBar', () => {
     });
   });
 
+  // Issue #1166: the worktree mobile shell tracks visualViewport.height and lays
+  // the tab bar out as an in-flow bottom flex child (above the keyboard), so it
+  // opts into a static variant instead of the default fixed-to-viewport-bottom.
+  describe('In-flow variant (Issue #1166)', () => {
+    it('is fixed to the viewport bottom by default', () => {
+      render(<MobileTabBar {...defaultProps} />);
+
+      const tabBar = screen.getByTestId('mobile-tab-bar');
+      expect(tabBar.className).toContain('fixed');
+      expect(tabBar.className).toContain('bottom-0');
+      expect(tabBar.className).not.toContain('flex-shrink-0');
+    });
+
+    it('renders in normal flow (flex-shrink-0, not fixed) when inFlow is set', () => {
+      render(<MobileTabBar {...defaultProps} inFlow />);
+
+      const tabBar = screen.getByTestId('mobile-tab-bar');
+      expect(tabBar.className).toContain('flex-shrink-0');
+      expect(tabBar.className).not.toContain('fixed');
+      expect(tabBar.className).not.toContain('bottom-0');
+    });
+  });
+
   describe('Accessibility', () => {
     it('should have correct ARIA attributes on tabs', () => {
       render(<MobileTabBar {...defaultProps} activeTab="terminal" />);

--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -908,9 +908,13 @@ describe('MessageInput', () => {
     });
   });
 
-  // ===== Keyboard follow (Issue #1128) =====
-
-  describe('Keyboard follow (Issue #1128)', () => {
+  // ===== No self-lift transform (Issue #1166) =====
+  //
+  // The old #1128 translateY hack was removed: the mobile shell
+  // (WorktreeDetailRefactored) now sizes its container to visualViewport.height
+  // and places the composer in normal flow, so MessageInput must never apply a
+  // transform of its own regardless of the software-keyboard state.
+  describe('No self-lift transform (Issue #1166)', () => {
     const originalVisualViewport = window.visualViewport;
 
     afterEach(() => {
@@ -941,15 +945,7 @@ describe('MessageInput', () => {
       });
     }
 
-    it('translates the composer up by the keyboard height when keyboardAware', () => {
-      mockKeyboard(300);
-      render(<MessageInput {...defaultProps} keyboardAware />);
-
-      const container = screen.getByTestId('message-input-container');
-      expect(container.style.transform).toBe('translateY(-300px)');
-    });
-
-    it('does not translate when keyboardAware is off', () => {
+    it('never applies an inline transform when the keyboard is open', () => {
       mockKeyboard(300);
       render(<MessageInput {...defaultProps} />);
 
@@ -957,10 +953,9 @@ describe('MessageInput', () => {
       expect(container.style.transform).toBe('');
     });
 
-    it('does not translate when the keyboard is hidden', () => {
-      // Below the 100px keyboard threshold → treated as no keyboard.
+    it('never applies an inline transform when the keyboard is closed', () => {
       mockKeyboard(0);
-      render(<MessageInput {...defaultProps} keyboardAware />);
+      render(<MessageInput {...defaultProps} />);
 
       const container = screen.getByTestId('message-input-container');
       expect(container.style.transform).toBe('');

--- a/tests/unit/components/worktree/WorktreeDetailRefactored-keyboard-layout.test.tsx
+++ b/tests/unit/components/worktree/WorktreeDetailRefactored-keyboard-layout.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * WorktreeDetailRefactored Mobile Keyboard Layout Tests
+ * Issue #1166: Android Chrome composer flies off-screen when the keyboard opens.
+ *
+ * Root-cause fix (案B): stop lifting a `position: fixed` composer with a JS
+ * `translateY`, and instead size the mobile shell to `visualViewport.height`
+ * with the composer + tab bar as in-flow flex children docked above the
+ * keyboard (the proven FullScreenModal pattern).
+ *
+ * Approach: source-level verification. WorktreeDetailRefactored is a large
+ * component with many contexts/hooks that make full rendering impractical, so —
+ * mirroring WorktreeDetailRefactored-mobile-overflow.test.tsx (Issue #548) — we
+ * assert on the source to lock in the structural contract of the fix.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('WorktreeDetailRefactored mobile keyboard layout (Issue #1166)', () => {
+  const source = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../src/components/worktree/WorktreeDetailRefactored.tsx',
+    ),
+    'utf-8',
+  );
+
+  it('sizes the mobile shell to the visible viewport height (visualViewport)', () => {
+    expect(source).toContain('useVirtualKeyboard');
+    expect(source).toContain('viewportHeight');
+    // The shell height follows visualViewport.height, falling back until measured.
+    expect(source).toMatch(/height:\s*viewportHeight\s*!=\s*null\s*\?/);
+  });
+
+  it('removes the fixed message-input bar and its bottom-offset constants', () => {
+    expect(source).not.toContain('MOBILE_MESSAGE_INPUT_BOTTOM');
+    expect(source).not.toContain('MOBILE_CONTENT_BOTTOM_PADDING');
+    // The composer wrapper is no longer position:fixed.
+    expect(source).not.toContain('fixed left-0 right-0');
+  });
+
+  it('drops the composer translateY hack (keyboardAware no longer passed)', () => {
+    expect(source).not.toContain('keyboardAware');
+  });
+
+  it('lays the tab bar out in normal flow via the inFlow variant', () => {
+    expect(source).toMatch(/<MobileTabBar[\s\S]*?inFlow[\s\S]*?\/>/);
+  });
+
+  it('keeps the scrollable content as the single flex-1 min-h-0 scroller', () => {
+    // The content <main> absorbs the remaining space and scrolls internally so
+    // the header/tabs/composer/tab bar keep their size when the shell shrinks.
+    expect(source).toMatch(/className="flex-1 min-h-0 overflow-y-auto"/);
+  });
+});

--- a/tests/unit/hooks/useVirtualKeyboard.test.ts
+++ b/tests/unit/hooks/useVirtualKeyboard.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 
 import { useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 
@@ -149,6 +149,8 @@ describe('useVirtualKeyboard', () => {
       expect(result.current).toEqual({
         isKeyboardVisible: false,
         keyboardHeight: 0,
+        // Issue #1166: viewportHeight stays null when the API is unavailable.
+        viewportHeight: null,
       });
     });
   });
@@ -257,6 +259,45 @@ describe('useVirtualKeyboard', () => {
 
       expect(result.current.isKeyboardVisible).toBe(false);
       expect(result.current.keyboardHeight).toBe(0);
+    });
+  });
+
+  // Issue #1166: expose the raw visible viewport height for containers that
+  // follow the software keyboard (visualViewport-height layout).
+  describe('viewportHeight (Issue #1166)', () => {
+    it('returns the current visualViewport height when supported', () => {
+      mockVisualViewport({ height: 640 });
+
+      const { result } = renderHook(() => useVirtualKeyboard());
+
+      expect(result.current.viewportHeight).toBe(640);
+    });
+
+    it('returns null when visualViewport is not supported', () => {
+      Object.defineProperty(window, 'visualViewport', {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useVirtualKeyboard());
+
+      expect(result.current.viewportHeight).toBeNull();
+    });
+
+    it('updates viewportHeight when the visual viewport resizes', () => {
+      const viewport = mockVisualViewport({ height: 800 });
+
+      const { result } = renderHook(() => useVirtualKeyboard());
+      expect(result.current.viewportHeight).toBe(800);
+
+      // Simulate the keyboard opening: the visible viewport shrinks.
+      act(() => {
+        (viewport as unknown as { height: number }).height = 500;
+        viewport._triggerResize();
+      });
+
+      expect(result.current.viewportHeight).toBe(500);
     });
   });
 });


### PR DESCRIPTION
## 概要
Android Chromeでキーボード表示時にモバイル入力欄が上部へ飛ぶ不具合を、**根本対策（案B: visualViewport高さ追従レイアウト）**で解消。`fixed`＋`translateY` ハックを撤去し、モバイルシェルを `visualViewport.height` のflex columnにして composer / tab bar を通常フロー最下段へ配置する。

## 根本原因
固定バー（`position:fixed; bottom:calc(4rem+safe-area)`）＋`translateY(-keyboardHeight)` の基準ズレ。固定バーの基準が「縮まないレイアウトビューポート下端＝キーボード裏」のため、translateで持ち上げてもキーボード直上に収まらず浮き上がっていた。

## 変更内容
- `WorktreeDetailRefactored.tsx`: モバイルシェルを `height: visualViewport.height` のflex columnへ。header/instance-tabs/composer/tab barを `flex-shrink-0`、コンテンツを `flex-1 min-h-0 overflow-y-auto` に。定数 `MOBILE_MESSAGE_INPUT_BOTTOM`/`MOBILE_CONTENT_BOTTOM_PADDING` と固定バー・12rem paddingを撤去
- `MessageInput.tsx`: `keyboardAware` prop と `translateY` ハックを削除（純粋なin-flow要素化）
- `useVirtualKeyboard.ts`: `viewportHeight` を追加（`isKeyboardVisible`/`keyboardHeight` は MarkdownEditor が継続使用のため維持）
- `MobileTabBar.tsx`: `inFlow` prop 追加（static配置）

## レビュー観点（確認済み）
- AppShellがモバイルで `h-screen`＋`overflow-hidden` の非スクロール構成のため、iOSでも `visualViewport.offsetTop`＝0が保たれ、`position:fixed`/`scrollIntoView` なしで composer がキーボード直上にドックする
- `/worktrees/` は `showGlobalNav:false` のため main に `pb-14` は付かず高さ競合なし
- 参照元 FullScreenModal と同じ `resize` 購読

## テスト
- `npm run test:unit` 全パス（541ファイル/9097）／`npm run build` 成功／`tsc --noEmit`・`lint` クリーン
- ⚠️ 実機（iOS Safari / Android Chrome）でのキーボード開閉・回転・アドレスバー挙動は develop マージ後の実機確認が必要

Refs #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
