### PR TITLE
fix(terminal): 1000行ペインのプロンプト処理を安定化

### DIFF
--- a/src/app/api/worktrees/[id]/prompt-response/route.ts
+++ b/src/app/api/worktrees/[id]/prompt-response/route.ts
@@ -17,6 +17,8 @@ import { isValidWorktreeId } from '@/lib/security/path-validator';
 import type { PromptType, SubmitMode } from '@/types/models';
 import { isValidSubmitMode } from '@/types/models';
 import { createLogger } from '@/lib/logger';
+import { startPolling } from '@/lib/polling/response-poller';
+import { broadcastTerminalSnapshotAfterInteraction } from '@/lib/realtime/terminal-broadcast';
 
 const logger = createLogger('api/prompt-response');
 
@@ -151,6 +153,11 @@ export async function POST(
         { status: 500 }
       );
     }
+
+    // The prompt poller normally stops while waiting for input. Resume response
+    // persistence and independently push the TUI redraw after this interaction.
+    startPolling(params.id, cliToolId, instanceId);
+    void broadcastTerminalSnapshotAfterInteraction(params.id, cliToolId, instanceId);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/worktrees/[id]/respond/route.ts
+++ b/src/app/api/worktrees/[id]/respond/route.ts
@@ -12,6 +12,7 @@ import { startPolling } from '@/lib/polling/response-poller';
 import { getAnswerInput } from '@/lib/detection/prompt-detector';
 import { broadcastMessage } from '@/lib/ws-server';
 import { createLogger } from '@/lib/logger';
+import { broadcastTerminalSnapshotAfterInteraction } from '@/lib/realtime/terminal-broadcast';
 
 const logger = createLogger('api/respond');
 
@@ -178,6 +179,7 @@ export async function POST(
 
     // Resume polling for CLI tool's next response
     startPolling(params.id, cliToolId, instanceId);
+    void broadcastTerminalSnapshotAfterInteraction(params.id, cliToolId, instanceId);
 
     logger.info('resumed-polling-for');
 

--- a/src/app/api/worktrees/[id]/special-keys/route.ts
+++ b/src/app/api/worktrees/[id]/special-keys/route.ts
@@ -15,6 +15,7 @@ import { getWorktreeById } from '@/lib/db';
 import { getDbInstance } from '@/lib/db/db-instance';
 import { hasSession, isAllowedSpecialKey, sendSpecialKeysAndInvalidate } from '@/lib/tmux/tmux';
 import { createLogger } from '@/lib/logger';
+import { broadcastTerminalSnapshotAfterInteraction } from '@/lib/realtime/terminal-broadcast';
 
 const logger = createLogger('api/special-keys');
 
@@ -106,6 +107,7 @@ export async function POST(
 
     // 6. Send special keys and invalidate cache [DR1-003]
     await sendSpecialKeysAndInvalidate(sessionName, keys);
+    void broadcastTerminalSnapshotAfterInteraction(params.id, cliToolId, instanceId as string | undefined);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/components/worktree/TerminalEscapeHatch.tsx
+++ b/src/components/worktree/TerminalEscapeHatch.tsx
@@ -9,12 +9,10 @@
  * and the session becomes unreachable — exactly the failure this issue fixes for
  * the Codex pager (via CODEX_PAGER_FOOTER_PATTERN).
  *
- * This component is the permanent insurance against the NEXT undetected TUI mode:
- * a minimal Esc / q affordance that the caller renders whenever the session is
- * interactive but in an unclassified state (no prompt, no selection list). Esc
- * exits/interrupts most modes; q quits pager-style views. It is intentionally NOT
- * shown at a normal idle input prompt (status 'ready'), where 'q' would insert the
- * literal character — the caller gates on that.
+ * This component is the permanent insurance against the NEXT undetected TUI mode.
+ * Esc is safe across supported CLIs; q is exposed only for Codex, where it is a
+ * known pager quit key. The caller renders it only for a confirmed unclassified
+ * state, never at a normal input prompt or over a detected prompt/navigation UI.
  */
 
 import { useCallback, useState } from 'react';
@@ -32,14 +30,20 @@ export interface TerminalEscapeHatchProps {
   onKeysSent?: () => void;
 }
 
-const ESCAPE_KEYS: ReadonlyArray<{ key: NavigationKey; label: string; ariaLabel: string }> = [
-  { key: 'Escape', label: 'Esc', ariaLabel: 'Send Escape' },
-  { key: 'q', label: 'q', ariaLabel: 'Send q (quit)' },
+const ESCAPE_KEY: { key: NavigationKey; label: string; ariaLabel: string } =
+  { key: 'Escape', label: 'Esc', ariaLabel: 'Send Escape' };
+const CODEX_QUIT_KEY: { key: NavigationKey; label: string; ariaLabel: string } =
+  { key: 'q', label: 'q', ariaLabel: 'Send q (quit)' };
+
+const CODEX_ESCAPE_KEYS: ReadonlyArray<{ key: NavigationKey; label: string; ariaLabel: string }> = [
+  ESCAPE_KEY,
+  CODEX_QUIT_KEY,
 ];
 
 export function TerminalEscapeHatch({ worktreeId, cliToolId, instanceId, onKeysSent }: TerminalEscapeHatchProps) {
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const send = useSpecialKeys(worktreeId, cliToolId, instanceId, onKeysSent);
+  const escapeKeys = cliToolId === 'codex' ? CODEX_ESCAPE_KEYS : [ESCAPE_KEY];
 
   const handleClick = useCallback(
     (key: NavigationKey) => {
@@ -59,7 +63,7 @@ export function TerminalEscapeHatch({ worktreeId, cliToolId, instanceId, onKeysS
       <span className="text-xs text-amber-700 dark:text-amber-400 mx-2" title="Send an escape key when the terminal is stuck in a TUI mode">
         Escape
       </span>
-      {ESCAPE_KEYS.map(({ key, label, ariaLabel }) => (
+      {escapeKeys.map(({ key, label, ariaLabel }) => (
         <button
           key={key}
           type="button"

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -280,7 +280,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   const showEscapeHatch =
     terminal.isUnclassifiedActive &&
     !showNav &&
-    !showPrompt;
+    !prompt.visible;
 
   // Issue #744: the embedded HistoryPane for THIS split. Receives this split's
   // own messages (useSplitMessages) and the per-split highlight namespace via

--- a/src/config/auto-yes-config.ts
+++ b/src/config/auto-yes-config.ts
@@ -10,6 +10,7 @@
  */
 
 import safeRegex from 'safe-regex2';
+import { TUI_PANE_HEIGHT } from '@/config/tmux-pane-config';
 
 /** Allowed Auto-Yes durations in milliseconds */
 export const ALLOWED_DURATIONS = [3600000, 10800000, 28800000] as const;
@@ -43,7 +44,10 @@ export function isAllowedDuration(value: unknown): value is AutoYesDuration {
 export const THINKING_POLLING_INTERVAL_MS = 5000;
 
 /** Reduced capture lines when stopPattern is not set (Issue #499 Item 3) */
-export const REDUCED_CAPTURE_LINES = 300;
+// Issue #1167: a 1000-row alternate-screen frame can place an active prompt
+// near the top and a task panel at the bottom. Capture the whole current frame
+// before applying semantic detection normalization.
+export const REDUCED_CAPTURE_LINES = TUI_PANE_HEIGHT;
 
 /** Full capture lines when stopPattern is set (Issue #499 Item 3) */
 export const FULL_CAPTURE_LINES = 5000;

--- a/src/hooks/useTerminalPanePolling.ts
+++ b/src/hooks/useTerminalPanePolling.ts
@@ -44,6 +44,11 @@ export const IDLE_POLLING_INTERVAL_MS = 5000;
  * a slow fallback that only recovers if push delivery stalls.
  */
 export const WS_CONNECTED_POLLING_INTERVAL_MS = 15000;
+/** Push is unhealthy when no terminal snapshot heartbeat arrives in this window. */
+export const WS_PUSH_STALE_AFTER_MS = 5000;
+/** Require two consecutive low-confidence frames before exposing escape controls. */
+export const UNCLASSIFIED_CONFIRMATION_COUNT = 2;
+export const UNCLASSIFIED_CONFIRMATION_DELAY_MS = 500;
 
 export interface PaneTerminalState {
   output: string;
@@ -162,9 +167,22 @@ export function useTerminalPanePolling({
   // `terminal_snapshot` while a session generates; `version` guards against
   // out-of-order deliveries (parity with the poll's requestId stale-guard).
   const { connected, subscribe, unsubscribe, addListener } = useRealtime();
-  const connectedRef = useRef(connected);
-  connectedRef.current = connected;
   const lastSnapshotVersionRef = useRef(0);
+  const unclassifiedCountRef = useRef(0);
+  const unclassifiedSinceRef = useRef<number | null>(null);
+  const pushStaleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [pushHealthy, setPushHealthy] = useState(false);
+
+  const markPushHealthy = useCallback(() => {
+    setPushHealthy(true);
+    if (pushStaleTimerRef.current !== null) {
+      clearTimeout(pushStaleTimerRef.current);
+    }
+    pushStaleTimerRef.current = setTimeout(() => {
+      pushStaleTimerRef.current = null;
+      setPushHealthy(false);
+    }, WS_PUSH_STALE_AFTER_MS);
+  }, []);
 
   /**
    * Apply a normalized output snapshot (from a poll response or a WS push) to the
@@ -183,6 +201,21 @@ export function useTerminalPanePolling({
       promptData?: PromptData | null;
     }): void => {
       const nextOutput = data.fullOutput ?? data.realtimeSnippet ?? '';
+      const rawUnclassified = data.isUnclassifiedActive === true
+        && data.isPromptWaiting !== true
+        && data.isSelectionListActive !== true
+        && data.isPagerActive !== true;
+      if (rawUnclassified) {
+        unclassifiedCountRef.current += 1;
+        unclassifiedSinceRef.current ??= Date.now();
+      } else {
+        unclassifiedCountRef.current = 0;
+        unclassifiedSinceRef.current = null;
+      }
+      const confirmedUnclassified =
+        unclassifiedCountRef.current >= UNCLASSIFIED_CONFIRMATION_COUNT
+        && unclassifiedSinceRef.current !== null
+        && Date.now() - unclassifiedSinceRef.current >= UNCLASSIFIED_CONFIRMATION_DELAY_MS;
 
       setTerminal(prev => {
         // Overwrite output if we have content or the session is still running.
@@ -198,7 +231,7 @@ export function useTerminalPanePolling({
           isThinking: data.thinking ?? false,
           isSelectionListActive: data.isSelectionListActive ?? false,
           isPagerActive: data.isPagerActive ?? false,
-          isUnclassifiedActive: data.isUnclassifiedActive ?? false,
+          isUnclassifiedActive: confirmedUnclassified,
           attaching: false,
         };
       });
@@ -266,6 +299,13 @@ export function useTerminalPanePolling({
     // Issue #1120: reset the push version guard so the new session's snapshots
     // (which restart their own version counter) are not rejected as stale.
     lastSnapshotVersionRef.current = 0;
+    unclassifiedCountRef.current = 0;
+    unclassifiedSinceRef.current = null;
+    setPushHealthy(false);
+    if (pushStaleTimerRef.current !== null) {
+      clearTimeout(pushStaleTimerRef.current);
+      pushStaleTimerRef.current = null;
+    }
     setTerminal(prev => ({
       ...prev,
       output: '',
@@ -290,8 +330,19 @@ export function useTerminalPanePolling({
   // Issue #1120: a fresh connection resets the push version guard so snapshots
   // are accepted after a server restart (which restarts server-side counters).
   useEffect(() => {
-    if (connected) lastSnapshotVersionRef.current = 0;
+    lastSnapshotVersionRef.current = 0;
+    setPushHealthy(false);
+    if (pushStaleTimerRef.current !== null) {
+      clearTimeout(pushStaleTimerRef.current);
+      pushStaleTimerRef.current = null;
+    }
   }, [connected]);
+
+  useEffect(() => () => {
+    if (pushStaleTimerRef.current !== null) {
+      clearTimeout(pushStaleTimerRef.current);
+    }
+  }, []);
 
   // Issue #1120: apply pushed terminal snapshots for this exact pane.
   useEffect(() => {
@@ -309,6 +360,7 @@ export function useTerminalPanePolling({
       // Version guard: drop out-of-order / stale deliveries.
       if (snap.version <= lastSnapshotVersionRef.current) return;
       lastSnapshotVersionRef.current = snap.version;
+      markPushHealthy();
 
       const realtimeSnippet = snap.output.split('\n').slice(-100).join('\n');
       applySnapshot({
@@ -323,7 +375,7 @@ export function useTerminalPanePolling({
         promptData: snap.promptData ?? null,
       });
     });
-  }, [enabled, worktreeId, addListener, applySnapshot]);
+  }, [enabled, worktreeId, addListener, applySnapshot, markPushHealthy]);
 
   // Initial + interval polling. Pauses when hidden, resumes on visible.
   // Cadence depends on isRunning (active=2s, idle=5s); while a WS push
@@ -339,9 +391,13 @@ export function useTerminalPanePolling({
       }, ms);
     };
 
-    const intervalMs = connected
+    const interactionActive = prompt.visible
+      || terminal.isSelectionListActive
+      || terminal.isPagerActive
+      || terminal.isUnclassifiedActive;
+    const intervalMs = connected && pushHealthy && !interactionActive
       ? WS_CONNECTED_POLLING_INTERVAL_MS
-      : terminal.isRunning
+      : terminal.isRunning || interactionActive
         ? ACTIVE_POLLING_INTERVAL_MS
         : IDLE_POLLING_INTERVAL_MS;
     let intervalId: ReturnType<typeof setInterval> | null = startInterval(intervalMs);
@@ -371,7 +427,17 @@ export function useTerminalPanePolling({
     //   - the cadence-driving isRunning flips
     //   - the WS connection state flips (Issue #1120)
     //   - fetchCurrentOutput identity changes (cliToolId / worktreeId)
-  }, [enabled, connected, terminal.isRunning, fetchCurrentOutput]);
+  }, [
+    enabled,
+    connected,
+    pushHealthy,
+    terminal.isRunning,
+    terminal.isSelectionListActive,
+    terminal.isPagerActive,
+    terminal.isUnclassifiedActive,
+    prompt.visible,
+    fetchCurrentOutput,
+  ]);
 
   const setAutoScroll = useCallback((next: boolean) => {
     setTerminal(prev => (prev.autoScroll === next ? prev : { ...prev, autoScroll: next }));

--- a/src/lib/auto-yes-poller.ts
+++ b/src/lib/auto-yes-poller.ts
@@ -384,6 +384,16 @@ export async function detectAndRespondToPrompt(
 
     logger.info('poller:response-sent', { worktreeId, cliToolId, instanceId });
 
+    // Dynamic imports avoid a module cycle through terminal-broadcast ->
+    // current-output-builder -> auto-yes-manager -> this poller.
+    const [{ startPolling: startResponsePolling }, { broadcastTerminalSnapshotAfterInteraction }] =
+      await Promise.all([
+        import('@/lib/polling/response-poller'),
+        import('@/lib/realtime/terminal-broadcast'),
+      ]);
+    startResponsePolling(worktreeId, cliToolId, instanceId);
+    void broadcastTerminalSnapshotAfterInteraction(worktreeId, cliToolId, instanceId);
+
     return 'responded';
   } catch {
     incrementErrorCount(compositeKey);

--- a/src/lib/cli-tools/antigravity.ts
+++ b/src/lib/cli-tools/antigravity.ts
@@ -141,6 +141,7 @@ export class AntigravityTool extends BaseCLITool {
     // Check if session already exists
     const exists = await hasSession(sessionName);
     if (exists) {
+      await this.reconcileExistingSession(sessionName);
       logger.info('antigravity-session-exists');
       return;
     }

--- a/src/lib/cli-tools/base.ts
+++ b/src/lib/cli-tools/base.ts
@@ -8,7 +8,7 @@ import { promisify } from 'util';
 import type { ICLITool, CLIToolType } from './types';
 import { deriveSessionSuffix } from './types';
 import { validateSessionName } from './validation';
-import { sendSpecialKey } from '../tmux/tmux';
+import { reconcileSessionGeometry, sendSpecialKey, type SessionGeometryOptions } from '../tmux/tmux';
 
 const execAsync = promisify(exec);
 
@@ -66,6 +66,14 @@ export abstract class BaseCLITool implements ICLITool {
   abstract startSession(worktreeId: string, worktreePath: string, instanceId?: string): Promise<void>;
   abstract sendMessage(worktreeId: string, message: string, instanceId?: string): Promise<void>;
   abstract killSession(worktreeId: string, instanceId?: string): Promise<void>;
+
+  /** Repair geometry when reusing a tmux session that predates the current defaults. */
+  protected async reconcileExistingSession(
+    sessionName: string,
+    options?: SessionGeometryOptions,
+  ): Promise<void> {
+    await reconcileSessionGeometry(sessionName, options);
+  }
 
   /**
    * Interrupt processing by sending Escape key

--- a/src/lib/cli-tools/codex.ts
+++ b/src/lib/cli-tools/codex.ts
@@ -85,6 +85,7 @@ export class CodexTool extends BaseCLITool {
     // Check if session already exists
     const exists = await hasSession(sessionName);
     if (exists) {
+      await this.reconcileExistingSession(sessionName);
       logger.info('codex-session-sessionname');
       return;
     }

--- a/src/lib/cli-tools/copilot.ts
+++ b/src/lib/cli-tools/copilot.ts
@@ -123,6 +123,7 @@ export class CopilotTool extends BaseCLITool {
     // Check if session already exists
     const exists = await hasSession(sessionName);
     if (exists) {
+      await this.reconcileExistingSession(sessionName);
       logger.info('copilot-session-exists');
       return;
     }

--- a/src/lib/cli-tools/gemini.ts
+++ b/src/lib/cli-tools/gemini.ts
@@ -93,6 +93,7 @@ export class GeminiTool extends BaseCLITool {
     // Check if session already exists
     const exists = await hasSession(sessionName);
     if (exists) {
+      await this.reconcileExistingSession(sessionName);
       logger.info('gemini-session-sessionname');
       return;
     }

--- a/src/lib/cli-tools/opencode.ts
+++ b/src/lib/cli-tools/opencode.ts
@@ -101,6 +101,10 @@ export class OpenCodeTool extends BaseCLITool {
 
     const exists = await hasSession(sessionName);
     if (exists) {
+      await this.reconcileExistingSession(sessionName, {
+        windowWidth: 80,
+        windowHeight: OPENCODE_PANE_HEIGHT,
+      });
       logger.info('opencode-session-sessionname');
       return;
     }

--- a/src/lib/cli-tools/vibe-local.ts
+++ b/src/lib/cli-tools/vibe-local.ts
@@ -80,6 +80,7 @@ export class VibeLocalTool extends BaseCLITool {
 
     const exists = await hasSession(sessionName);
     if (exists) {
+      await this.reconcileExistingSession(sessionName);
       logger.info('vibe-local-session');
       return;
     }

--- a/src/lib/detection/prompt-detect-multiple-choice.ts
+++ b/src/lib/detection/prompt-detect-multiple-choice.ts
@@ -2,6 +2,7 @@
 
 import type { DetectPromptOptions, PromptDetectionResult } from './types';
 import type { SubmitMode } from '@/types/models';
+import { normalizeTuiFrameForDetection } from './tui-detection-frame';
 
 // ============================================================================
 // Constants
@@ -602,6 +603,7 @@ export function detectMultipleChoicePrompt(
   options: DetectPromptOptions | undefined,
   truncateRawContentFn: (content: string) => string,
 ): PromptDetectionResult {
+  output = normalizeTuiFrameForDetection(output);
   // C-003: Use ?? true for readability instead of !== false double negation
   const requireDefault = options?.requireDefaultIndicator ?? true;
 

--- a/src/lib/detection/prompt-detector.ts
+++ b/src/lib/detection/prompt-detector.ts
@@ -7,6 +7,7 @@
 import { createLogger } from '@/lib/logger';
 import { detectMultipleChoicePrompt } from './prompt-detect-multiple-choice';
 import type { DetectPromptOptions, PromptDetectionResult } from './types';
+import { normalizeTuiFrameForDetection } from './tui-detection-frame';
 
 // Re-export types for backward compatibility (existing import paths)
 export type { DetectPromptOptions, PromptDetectionResult } from './types';
@@ -141,12 +142,15 @@ function yesNoPromptResult(
  * ```
  */
 export function detectPrompt(output: string, options?: DetectPromptOptions): PromptDetectionResult {
+  const detectionOutput = normalizeTuiFrameForDetection(output);
   // D2-001: Extract tail 50 lines for duplicate log suppression.
   // Reuse `lines` for both dedup check and yes/no pattern matching below.
   // detectMultipleChoicePrompt() has its own independent split() in its
   // own scope -- this is intentional function encapsulation [S1-004][S2-001].
   // Issue #499 Item 4: Use precomputedLines when provided to avoid redundant split.
-  const lines = options?.precomputedLines ?? output.split('\n');
+  const lines = detectionOutput === output && options?.precomputedLines
+    ? options.precomputedLines
+    : detectionOutput.split('\n');
   const tailForDedup = lines.slice(-50).join('\n');
   const isDuplicate = tailForDedup === lastOutputTail;
 
@@ -155,7 +159,7 @@ export function detectPrompt(output: string, options?: DetectPromptOptions): Pro
   // If log suppression grows complex (e.g., per-worktree cache), extract
   // to shouldSuppressLog(output): boolean helper.]
   if (!isDuplicate) {
-    logger.debug('detectPrompt:start', { outputLength: output.length });
+    logger.debug('detectPrompt:start', { outputLength: detectionOutput.length });
   }
 
   // D2-003: Update cache (affects logging only, never return values)
@@ -170,7 +174,7 @@ export function detectPrompt(output: string, options?: DetectPromptOptions): Pro
   // ❯ 1. Yes
   //   2. No
   //   3. Cancel
-  const multipleChoiceResult = detectMultipleChoicePrompt(output, options, truncateRawContent);
+  const multipleChoiceResult = detectMultipleChoicePrompt(detectionOutput, options, truncateRawContent);
   if (multipleChoiceResult.isPrompt) {
     // D2-004: Suppress duplicate multipleChoice info log
     if (!isDuplicate) {
@@ -212,7 +216,7 @@ export function detectPrompt(output: string, options?: DetectPromptOptions): Pro
   }
   return {
     isPrompt: false,
-    cleanContent: output.trim(),
+    cleanContent: detectionOutput.trim(),
   };
 }
 

--- a/src/lib/detection/status-detector.ts
+++ b/src/lib/detection/status-detector.ts
@@ -26,6 +26,7 @@
 
 import { stripAnsi, stripBoxDrawing, detectThinking, getCliToolPatterns, buildDetectPromptOptions, OPENCODE_RESPONSE_COMPLETE, OPENCODE_PROCESSING_INDICATOR, OPENCODE_SELECTION_LIST_PATTERN, CLAUDE_SELECTION_LIST_FOOTER, COPILOT_SELECTION_LIST_PATTERN, CODEX_PROMPT_PATTERN, CODEX_SELECTION_LIST_PATTERN, CODEX_PAGER_FOOTER_PATTERN, CODEX_STATUS_BAR_PATTERN, CLAUDE_INTERRUPT_HINT_PATTERN, ANTIGRAVITY_SELECTION_LIST_PATTERN } from './cli-patterns';
 import { detectPrompt } from './prompt-detector';
+import { normalizeTuiFrameForDetection } from './tui-detection-frame';
 import type { PromptDetectionResult } from './prompt-detector';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import { THINKING_TAIL_LINE_COUNT } from '@/config/thinking-constants';
@@ -231,7 +232,7 @@ export function detectSessionStatus(
   lastOutputTimestamp?: Date
 ): StatusDetectionResult {
   // Strip ANSI codes and get last N lines for analysis
-  const cleanOutput = stripAnsi(output);
+  const cleanOutput = normalizeTuiFrameForDetection(stripAnsi(output));
   const lines = cleanOutput.split('\n');
   // Strip trailing empty lines (tmux terminal padding) before windowing.
   // tmux buffers often end with many empty padding lines that would otherwise

--- a/src/lib/detection/tui-detection-frame.ts
+++ b/src/lib/detection/tui-detection-frame.ts
@@ -1,0 +1,72 @@
+/**
+ * Build a compact copy of a TUI frame for detection only.
+ *
+ * Alternate-screen CLIs may anchor interactive content near the top of a large
+ * pane and a status/task panel at the bottom. Raw tail windows therefore lose
+ * the prompt even though it is still visible. This helper never changes the
+ * display output; it only removes layout-only blank rows and, for Claude's
+ * known prompt footers, excludes overlays rendered below the active prompt.
+ */
+
+const CLAUDE_PROMPT_FOOTER_PATTERN = /Esc\s+to\s+cancel\s*[·•]\s*Tab\s+to\s+amend/i;
+const CLAUDE_PICKER_FOOTER_PATTERN = /Enter\s+to\s+select\b.*\bnavigate\b/i;
+
+// A prompt/thinking/input anchor below a footer means that footer belongs to an
+// older frame. Task-panel rows intentionally do not match these patterns.
+const CLAUDE_LOWER_INTERACTIVE_ANCHOR =
+  /^\s*[>❯]\s*(?:\d{1,2}[.)])?|esc\s+to\s+interrupt|[✻✽✶✢✳⦿◉●⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\s+.+…/i;
+
+function isClaudeFooter(line: string): boolean {
+  return CLAUDE_PROMPT_FOOTER_PATTERN.test(line) || CLAUDE_PICKER_FOOTER_PATTERN.test(line);
+}
+
+function compactBlankRows(lines: string[]): string[] {
+  const compacted: string[] = [];
+  let previousWasBlank = false;
+
+  for (const line of lines) {
+    const isBlank = line.trim() === '';
+    if (isBlank && previousWasBlank) continue;
+    compacted.push(line);
+    previousWasBlank = isBlank;
+  }
+
+  while (compacted.length > 0 && compacted[compacted.length - 1].trim() === '') {
+    compacted.pop();
+  }
+  return compacted;
+}
+
+/**
+ * Normalize a captured frame for prompt/status detection.
+ * The operation is idempotent and preserves all non-empty line ordering.
+ */
+export function normalizeTuiFrameForDetection(output: string): string {
+  if (output === '') return '';
+
+  const lines = output.split('\n');
+  let footerIndex = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (isClaudeFooter(lines[i])) {
+      footerIndex = i;
+      break;
+    }
+  }
+
+  let detectionLines = lines;
+  if (footerIndex >= 0) {
+    const hasNewerInteractiveAnchor = lines
+      .slice(footerIndex + 1)
+      .some(line => CLAUDE_LOWER_INTERACTIVE_ANCHOR.test(line));
+
+    if (hasNewerInteractiveAnchor) {
+      // The footer belongs to scrollback/an older frame. Analyze only the
+      // newer active region so its options cannot be resurrected.
+      detectionLines = lines.slice(footerIndex + 1);
+    } else {
+      detectionLines = lines.slice(0, footerIndex + 1);
+    }
+  }
+
+  return compactBlankRows(detectionLines).join('\n');
+}

--- a/src/lib/realtime/terminal-broadcast.ts
+++ b/src/lib/realtime/terminal-broadcast.ts
@@ -15,10 +15,14 @@ import { getDbInstance } from '@/lib/db/db-instance';
 import { buildCurrentOutput } from '@/lib/session/current-output-builder';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import { createLogger } from '@/lib/logger';
+import { CLIToolManager } from '@/lib/cli-tools/manager';
+import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
 
 const logger = createLogger('terminal-broadcast');
 
 const versionCounters = new Map<string, number>();
+
+export const INTERACTION_SNAPSHOT_RETRY_DELAYS_MS = [100, 250, 500, 750] as const;
 
 function nextVersion(key: string): number {
   const version = (versionCounters.get(key) ?? 0) + 1;
@@ -41,27 +45,93 @@ export async function broadcastTerminalSnapshot(
   try {
     const db = getDbInstance();
     const payload = await buildCurrentOutput(db, worktreeId, cliToolId, instanceId);
-    const resolvedInstanceId = instanceId ?? cliToolId;
-    const key = `${worktreeId}:${cliToolId}:${resolvedInstanceId}`;
-
-    broadcast(worktreeId, {
-      type: 'terminal_snapshot',
-      worktreeId,
-      cliToolId,
-      instanceId: resolvedInstanceId,
-      output: payload.fullOutput ?? '',
-      isRunning: payload.isRunning,
-      thinking: payload.thinking ?? false,
-      isPromptWaiting: payload.isPromptWaiting ?? false,
-      promptData: payload.promptData ?? null,
-      isSelectionListActive: payload.isSelectionListActive ?? false,
-      isPagerActive: payload.isPagerActive ?? false,
-      isUnclassifiedActive: payload.isUnclassifiedActive ?? false,
-      version: nextVersion(key),
-    });
+    emitTerminalSnapshot(worktreeId, cliToolId, payload, instanceId);
   } catch (error) {
     logger.error('terminal-snapshot:failed', {
       worktreeId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function snapshotFingerprint(payload: Awaited<ReturnType<typeof buildCurrentOutput>>): string {
+  return JSON.stringify([
+    payload.fullOutput ?? '',
+    payload.isRunning,
+    payload.thinking ?? false,
+    payload.isPromptWaiting ?? false,
+    payload.isSelectionListActive ?? false,
+    payload.isPagerActive ?? false,
+    payload.isUnclassifiedActive ?? false,
+  ]);
+}
+
+async function captureFreshPayload(
+  worktreeId: string,
+  cliToolId: CLIToolType,
+  instanceId?: string,
+): Promise<Awaited<ReturnType<typeof buildCurrentOutput>>> {
+  const tool = CLIToolManager.getInstance().getTool(cliToolId);
+  invalidateCache(tool.getSessionName(worktreeId, instanceId));
+  return buildCurrentOutput(getDbInstance(), worktreeId, cliToolId, instanceId);
+}
+
+function emitTerminalSnapshot(
+  worktreeId: string,
+  cliToolId: CLIToolType,
+  payload: Awaited<ReturnType<typeof buildCurrentOutput>>,
+  instanceId?: string,
+): void {
+  const resolvedInstanceId = instanceId ?? cliToolId;
+  const key = `${worktreeId}:${cliToolId}:${resolvedInstanceId}`;
+  broadcast(worktreeId, {
+    type: 'terminal_snapshot',
+    worktreeId,
+    cliToolId,
+    instanceId: resolvedInstanceId,
+    output: payload.fullOutput ?? '',
+    isRunning: payload.isRunning,
+    thinking: payload.thinking ?? false,
+    isPromptWaiting: payload.isPromptWaiting ?? false,
+    promptData: payload.promptData ?? null,
+    isSelectionListActive: payload.isSelectionListActive ?? false,
+    isPagerActive: payload.isPagerActive ?? false,
+    isUnclassifiedActive: payload.isUnclassifiedActive ?? false,
+    version: nextVersion(key),
+  });
+}
+
+/**
+ * Push an immediate fresh frame after an interactive key/answer, then watch for
+ * one bounded redraw. The second push is emitted only when the frame actually
+ * changes, so slow TUI repaint does not leave clients on the pre-action frame.
+ */
+export async function broadcastTerminalSnapshotAfterInteraction(
+  worktreeId: string,
+  cliToolId: CLIToolType,
+  instanceId?: string,
+  retryDelaysMs: readonly number[] = INTERACTION_SNAPSHOT_RETRY_DELAYS_MS,
+): Promise<void> {
+  if (!hasRoomSubscribers(worktreeId)) return;
+
+  try {
+    const initialPayload = await captureFreshPayload(worktreeId, cliToolId, instanceId);
+    const initialFingerprint = snapshotFingerprint(initialPayload);
+    emitTerminalSnapshot(worktreeId, cliToolId, initialPayload, instanceId);
+
+    for (const delayMs of retryDelaysMs) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      const payload = await captureFreshPayload(worktreeId, cliToolId, instanceId);
+      if (snapshotFingerprint(payload) !== initialFingerprint) {
+        emitTerminalSnapshot(worktreeId, cliToolId, payload, instanceId);
+        return;
+      }
+    }
+  } catch (error) {
+    logger.error('terminal-snapshot:interaction-refresh-failed', {
+      worktreeId,
+      cliToolId,
+      instanceId,
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/src/lib/session/claude-session.ts
+++ b/src/lib/session/claude-session.ts
@@ -9,6 +9,7 @@ import {
   sendKeys,
   capturePane,
   killSession,
+  reconcileSessionGeometry,
 } from '@/lib/tmux/tmux';
 import {
   CLAUDE_PROMPT_PATTERN,
@@ -575,6 +576,7 @@ export async function startClaudeSession(
     // SF-S2-004: Health check on existing session
     const healthy = await ensureHealthySession(sessionName);
     if (healthy) {
+      await reconcileSessionGeometry(sessionName);
       logger.info('claude-session-sessionname');
       return;
     }

--- a/src/lib/tmux/tmux.ts
+++ b/src/lib/tmux/tmux.ts
@@ -7,8 +7,10 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { invalidateCache } from './tmux-capture-cache';
 import { TUI_PANE_HEIGHT, TUI_PANE_WIDTH } from '@/config/tmux-pane-config';
+import { createLogger } from '@/lib/logger';
 
 const execFileAsync = promisify(execFile);
+const logger = createLogger('tmux');
 
 /**
  * Default timeout for tmux commands (5 seconds)
@@ -66,6 +68,79 @@ export interface CreateSessionOptions {
   historyLimit?: number;  // scrollback バッファサイズ（デフォルト: 50000）
   windowWidth?: number;   // ペイン幅（デフォルト: TUI_PANE_WIDTH）
   windowHeight?: number;  // ペイン高さ（デフォルト: TUI_PANE_HEIGHT、alternate screen TUIで十分な表示行数を確保。Issue #1163）
+}
+
+export interface SessionGeometryOptions {
+  windowWidth?: number;
+  windowHeight?: number;
+}
+
+/**
+ * Reconcile a session's window geometry without disrupting the running process.
+ * Failures are intentionally non-fatal: geometry improves capture fidelity but
+ * must never make an otherwise healthy CLI session unusable.
+ *
+ * @returns true when at least one tmux option was changed.
+ */
+export async function reconcileSessionGeometry(
+  sessionName: string,
+  options: SessionGeometryOptions = {},
+): Promise<boolean> {
+  const windowWidth = options.windowWidth ?? TUI_PANE_WIDTH;
+  const windowHeight = options.windowHeight ?? TUI_PANE_HEIGHT;
+  const target = exactTarget(sessionName);
+
+  let currentMode: string | undefined;
+  let currentWidth: number | undefined;
+  let currentHeight: number | undefined;
+
+  try {
+    const modeResult = await execFileAsync(
+      'tmux',
+      ['show-window-options', '-v', '-t', target, 'window-size'],
+      { timeout: DEFAULT_TIMEOUT },
+    );
+    currentMode = modeResult.stdout.trim();
+
+    const sizeResult = await execFileAsync(
+      'tmux',
+      ['display-message', '-p', '-t', target, '#{window_width}|#{window_height}'],
+      { timeout: DEFAULT_TIMEOUT },
+    );
+    const [width, height] = sizeResult.stdout.trim().split('|').map(Number);
+    if (Number.isFinite(width)) currentWidth = width;
+    if (Number.isFinite(height)) currentHeight = height;
+  } catch {
+    // Query failure is not decisive. Attempt the idempotent set/resize below.
+  }
+
+  const modeMatches = currentMode === 'manual';
+  const sizeMatches = currentWidth === windowWidth && currentHeight === windowHeight;
+  if (modeMatches && sizeMatches) return false;
+
+  try {
+    if (!modeMatches) {
+      await execFileAsync(
+        'tmux',
+        ['set-window-option', '-t', target, 'window-size', 'manual'],
+        { timeout: DEFAULT_TIMEOUT },
+      );
+    }
+    if (!sizeMatches) {
+      await execFileAsync(
+        'tmux',
+        ['resize-window', '-t', target, '-x', String(windowWidth), '-y', String(windowHeight)],
+        { timeout: DEFAULT_TIMEOUT },
+      );
+    }
+    return true;
+  } catch (error: unknown) {
+    logger.warn('session-geometry:reconcile-failed', {
+      sessionName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
 }
 
 /**
@@ -234,21 +309,7 @@ export async function createSession(
     // tracking (the global option is never touched), and an explicit
     // `resize-window` then locks in the intended geometry. Best-effort: a failure
     // here must not abort session creation (some environments restrict resize).
-    try {
-      await execFileAsync(
-        'tmux',
-        ['set-window-option', '-t', exactTarget(sessionName), 'window-size', 'manual'],
-        { timeout: DEFAULT_TIMEOUT }
-      );
-      await execFileAsync(
-        'tmux',
-        ['resize-window', '-t', exactTarget(sessionName), '-x', String(windowWidth), '-y', String(windowHeight)],
-        { timeout: DEFAULT_TIMEOUT }
-      );
-    } catch {
-      // Non-fatal: window-size/resize is a display enhancement, not required for
-      // the session to function.
-    }
+    await reconcileSessionGeometry(sessionName, { windowWidth, windowHeight });
 
     // Set history limit
     await execFileAsync(

--- a/tests/fixtures/claude-1000-row-prompt.ts
+++ b/tests/fixtures/claude-1000-row-prompt.ts
@@ -1,0 +1,17 @@
+/** Synthetic Claude frame matching the 1000-row layout from Issue #1167. */
+export function buildClaude1000RowPermissionFrame(): string {
+  const lines = Array<string>(1000).fill('');
+  lines[44] = 'Do you want to make this edit to useVirtualKeyboard.ts?';
+  lines[45] = '❯ 1. Yes';
+  lines[46] = '  2. Yes, allow all edits during this session (shift+tab)';
+  lines[47] = '  3. No';
+  lines[49] = 'Esc to cancel · Tab to amend';
+  lines[992] = '6 tasks (0 done, 1 in progress, 5 open)';
+  lines[993] = '◼ Update implementation';
+  lines[994] = '◻ Add regression tests';
+  lines[995] = '◻ Run validation';
+  lines[996] = '◻ Review output';
+  lines[997] = '◻ Prepare report';
+  lines[998] = '… +1 pending';
+  return lines.join('\n');
+}

--- a/tests/integration/api-prompt-handling.test.ts
+++ b/tests/integration/api-prompt-handling.test.ts
@@ -57,6 +57,9 @@ vi.mock('@/lib/session/claude-session', () => ({
 vi.mock('@/lib/ws-server', () => ({
   broadcastMessage: vi.fn(),
 }));
+vi.mock('@/lib/realtime/terminal-broadcast', () => ({
+  broadcastTerminalSnapshotAfterInteraction: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe('POST /api/worktrees/:id/respond', () => {
   let db: Database.Database;

--- a/tests/integration/api-respond-cli-tool.test.ts
+++ b/tests/integration/api-respond-cli-tool.test.ts
@@ -22,6 +22,9 @@ vi.mock('@/lib/tmux/tmux', () => ({
 vi.mock('@/lib/ws-server', () => ({
   broadcastMessage: vi.fn(),
 }));
+vi.mock('@/lib/realtime/terminal-broadcast', () => ({
+  broadcastTerminalSnapshotAfterInteraction: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Declare mock function type
 declare module '@/lib/db/db-instance' {

--- a/tests/integration/issue-265-acceptance.test.ts
+++ b/tests/integration/issue-265-acceptance.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendKeys: vi.fn(),
   capturePane: vi.fn(),
   killSession: vi.fn(),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 // Mock pasted-text-helper
@@ -51,7 +52,7 @@ import {
   CLAUDE_POST_PROMPT_DELAY,
   CLAUDE_INIT_TIMEOUT,
 } from '@/lib/session/claude-session';
-import { hasSession, createSession, sendKeys, capturePane, killSession } from '@/lib/tmux/tmux';
+import { hasSession, createSession, sendKeys, capturePane, killSession, reconcileSessionGeometry } from '@/lib/tmux/tmux';
 import {
   CLAUDE_SESSION_ERROR_PATTERNS,
   CLAUDE_SESSION_ERROR_REGEX_PATTERNS,
@@ -312,9 +313,7 @@ describe('Issue #265 Acceptance Test: CLI path cache invalidation and broken ses
       expect(true).toBe(true); // Test passes = overhead is within budget
     });
 
-    it('should not add overhead to healthy session reuse', async () => {
-      // When session exists and is healthy, only isSessionHealthy check runs
-      // isSessionHealthy does capturePane + pattern matching (~50ms)
+    it('should reuse a healthy session after non-blocking geometry reconciliation', async () => {
       vi.mocked(hasSession).mockResolvedValue(true);
       vi.mocked(capturePane).mockResolvedValue('Some Claude output\n> ');
 
@@ -323,6 +322,7 @@ describe('Issue #265 Acceptance Test: CLI path cache invalidation and broken ses
       // No createSession, no sanitizeSessionEnvironment
       expect(createSession).not.toHaveBeenCalled();
       expect(sendKeys).not.toHaveBeenCalled();
+      expect(reconcileSessionGeometry).toHaveBeenCalledWith(TEST_SESSION_NAME);
     });
 
     it('should ensure CLAUDE_INIT_TIMEOUT allows sufficient time with sanitization overhead', () => {

--- a/tests/integration/ws-realtime-fallback.test.tsx
+++ b/tests/integration/ws-realtime-fallback.test.tsx
@@ -17,6 +17,7 @@ import {
   ACTIVE_POLLING_INTERVAL_MS,
   IDLE_POLLING_INTERVAL_MS,
   WS_CONNECTED_POLLING_INTERVAL_MS,
+  WS_PUSH_STALE_AFTER_MS,
 } from '@/hooks/useTerminalPanePolling';
 import { MockWebSocket, installMockWebSocket } from '@tests/helpers/mock-websocket';
 
@@ -51,7 +52,25 @@ describe('WS ↔ polling fallback (Issue #1120)', () => {
     delete (globalThis as { fetch?: unknown }).fetch;
   });
 
-  it('throttles polling while connected and restores it on disconnect/reconnect', async () => {
+  function terminalSnapshot(version: number): string {
+    return JSON.stringify({
+      type: 'terminal_snapshot',
+      worktreeId: 'wt-1',
+      cliToolId: 'claude',
+      instanceId: 'claude',
+      output: 'stable output',
+      isRunning: false,
+      thinking: false,
+      isPromptWaiting: false,
+      promptData: null,
+      isSelectionListActive: false,
+      isPagerActive: false,
+      isUnclassifiedActive: false,
+      version,
+    });
+  }
+
+  it('throttles only while terminal snapshot heartbeats are healthy', async () => {
     renderHook(
       () => useTerminalPanePolling({ worktreeId: 'wt-1', cliToolId: 'claude' }),
       { wrapper },
@@ -70,22 +89,35 @@ describe('WS ↔ polling fallback (Issue #1120)', () => {
     });
     expect(fetchMock.mock.calls.length).toBeGreaterThan(before);
 
-    // --- Connect: cadence throttled to the slow WS fallback interval. ---
+    // A connected socket without snapshots is not considered a healthy producer.
     await act(async () => {
       ws.mockOpen();
       await vi.advanceTimersByTimeAsync(0);
     });
-    const afterConnect = fetchMock.mock.calls.length; // includes the effect re-run kick
-    // Below the throttled interval → no new poll while connected.
+    before = fetchMock.mock.calls.length;
     await act(async () => {
       await vi.advanceTimersByTimeAsync(IDLE_POLLING_INTERVAL_MS);
     });
-    expect(fetchMock.mock.calls.length).toBe(afterConnect);
-    // Reaching the throttled interval → exactly one poll.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(before);
+
+    // Once snapshots arrive, keep their watchdog alive and verify the 15s cadence.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(WS_CONNECTED_POLLING_INTERVAL_MS - IDLE_POLLING_INTERVAL_MS);
+      ws.mockMessage(terminalSnapshot(1));
+      await vi.advanceTimersByTimeAsync(0);
     });
-    expect(fetchMock.mock.calls.length).toBe(afterConnect + 1);
+    const afterHealthyPush = fetchMock.mock.calls.length;
+    for (let version = 2; version <= 4; version++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+        ws.mockMessage(terminalSnapshot(version));
+        await vi.advanceTimersByTimeAsync(0);
+      });
+    }
+    expect(fetchMock.mock.calls.length).toBe(afterHealthyPush);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(fetchMock.mock.calls.length).toBe(afterHealthyPush + 1);
 
     // --- Disconnect: fast polling resumes (fallback). ---
     await act(async () => {
@@ -98,19 +130,44 @@ describe('WS ↔ polling fallback (Issue #1120)', () => {
     });
     expect(fetchMock.mock.calls.length).toBeGreaterThan(before);
 
-    // --- Reconnect: throttled again. ---
+    // Reconnect requires a new snapshot before it is considered healthy again.
     // The reconnect timer (base 1s backoff) fires during the advance above; open it.
     const ws2 = MockWebSocket.last();
     expect(ws2).not.toBe(ws);
     await act(async () => {
       ws2.mockOpen();
       await vi.advanceTimersByTimeAsync(0);
+      ws2.mockMessage(terminalSnapshot(5));
+      await vi.advanceTimersByTimeAsync(0);
     });
     const afterReconnect = fetchMock.mock.calls.length;
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(IDLE_POLLING_INTERVAL_MS);
+      await vi.advanceTimersByTimeAsync(WS_PUSH_STALE_AFTER_MS - 1);
     });
     expect(fetchMock.mock.calls.length).toBe(afterReconnect);
+  });
+
+  it('falls back before 15 seconds when push stops on a connected socket', async () => {
+    renderHook(
+      () => useTerminalPanePolling({ worktreeId: 'wt-1', cliToolId: 'claude' }),
+      { wrapper },
+    );
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+    const ws = MockWebSocket.last();
+    await act(async () => {
+      ws.mockOpen();
+      ws.mockMessage(terminalSnapshot(1));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const afterPush = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WS_PUSH_STALE_AFTER_MS + ACTIVE_POLLING_INTERVAL_MS);
+    });
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(afterPush);
+    expect(WS_PUSH_STALE_AFTER_MS + ACTIVE_POLLING_INTERVAL_MS)
+      .toBeLessThan(WS_CONNECTED_POLLING_INTERVAL_MS);
   });
 
   it('sanity: the throttled interval is larger than the active poll interval', () => {

--- a/tests/unit/api/prompt-response-verification.test.ts
+++ b/tests/unit/api/prompt-response-verification.test.ts
@@ -18,6 +18,8 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '@/lib/db/db-migrations';
 import { upsertWorktree } from '@/lib/db';
 import type { Worktree, PromptType } from '@/types/models';
+import { startPolling } from '@/lib/polling/response-poller';
+import { broadcastTerminalSnapshotAfterInteraction } from '@/lib/realtime/terminal-broadcast';
 
 // --- Mocks ---
 
@@ -50,6 +52,10 @@ vi.mock('@/lib/tmux/tmux', () => ({
 vi.mock('@/lib/session/cli-session', () => ({
   captureSessionOutput: vi.fn().mockResolvedValue(''),
   captureSessionOutputFresh: vi.fn().mockResolvedValue(''),
+}));
+vi.mock('@/lib/polling/response-poller', () => ({ startPolling: vi.fn() }));
+vi.mock('@/lib/realtime/terminal-broadcast', () => ({
+  broadcastTerminalSnapshotAfterInteraction: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock prompt-detector
@@ -161,6 +167,12 @@ describe('POST /api/worktrees/:id/prompt-response - Prompt re-verification (Issu
     expect(data.success).toBe(true);
     // Issue #193: Claude multi-choice uses sendSpecialKeys (cursor-based navigation)
     expect(sendSpecialKeys).toHaveBeenCalled();
+    expect(startPolling).toHaveBeenCalledWith('test-wt', 'claude', undefined);
+    expect(broadcastTerminalSnapshotAfterInteraction).toHaveBeenCalledWith(
+      'test-wt',
+      'claude',
+      undefined,
+    );
   });
 
   it('should NOT send keys when prompt has disappeared (race condition)', async () => {

--- a/tests/unit/cli-tools/antigravity.test.ts
+++ b/tests/unit/cli-tools/antigravity.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendSpecialKey: vi.fn().mockResolvedValue(undefined),
   killSession: vi.fn().mockResolvedValue(true),
   capturePane: vi.fn().mockResolvedValue(''),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock('@/lib/pasted-text-helper', () => ({

--- a/tests/unit/cli-tools/codex-startup-dialog.test.ts
+++ b/tests/unit/cli-tools/codex-startup-dialog.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   killSession: vi.fn(),
   sendSpecialKey: vi.fn(),
   sendSpecialKeys: vi.fn(),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock('@/lib/pasted-text-helper', () => ({
@@ -47,7 +48,7 @@ vi.mock('util', async (importOriginal) => {
 });
 
 import { CodexTool } from '@/lib/cli-tools/codex';
-import { hasSession, createSession, sendKeys, sendSpecialKey, capturePane } from '@/lib/tmux/tmux';
+import { hasSession, createSession, sendKeys, sendSpecialKey, capturePane, reconcileSessionGeometry } from '@/lib/tmux/tmux';
 
 const WORKTREE_ID = 'test-worktree';
 const SESSION = 'mcbd-codex-test-worktree';
@@ -112,6 +113,18 @@ describe('CodexTool first-launch dialog handling (Issue #890)', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it('reconciles geometry when reusing an existing Codex session', async () => {
+    vi.mocked(hasSession).mockResolvedValue(true);
+
+    await tool.startSession(WORKTREE_ID, '/test/path', 'codex-2');
+
+    expect(createSession).not.toHaveBeenCalled();
+    expect(reconcileSessionGeometry).toHaveBeenCalledWith(
+      'mcbd-codex-test-worktree-2',
+      undefined,
+    );
   });
 
   describe('waitForReady (A: no stray Enter on number selections)', () => {

--- a/tests/unit/cli-tools/copilot.test.ts
+++ b/tests/unit/cli-tools/copilot.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendSpecialKey: vi.fn().mockResolvedValue(undefined),
   killSession: vi.fn().mockResolvedValue(true),
   capturePane: vi.fn().mockResolvedValue(''),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock('@/lib/pasted-text-helper', () => ({

--- a/tests/unit/cli-tools/gemini-prompt-detection.test.ts
+++ b/tests/unit/cli-tools/gemini-prompt-detection.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendSpecialKey: vi.fn(),
   killSession: vi.fn(),
   capturePane: vi.fn(),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock('@/lib/pasted-text-helper', () => ({

--- a/tests/unit/cli-tools/opencode.test.ts
+++ b/tests/unit/cli-tools/opencode.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendKeys: vi.fn(),
   sendSpecialKey: vi.fn(),
   killSession: vi.fn(),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 // Mock opencode-config module

--- a/tests/unit/components/worktree/TerminalEscapeHatch.test.tsx
+++ b/tests/unit/components/worktree/TerminalEscapeHatch.test.tsx
@@ -28,6 +28,12 @@ describe('TerminalEscapeHatch', () => {
     expect(screen.getByLabelText('Send q (quit)')).toBeInTheDocument();
   });
 
+  it('renders Escape only for Claude so q cannot reach the input prompt', () => {
+    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="claude" />);
+    expect(screen.getByLabelText('Send Escape')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Send q (quit)')).not.toBeInTheDocument();
+  });
+
   it('sends Escape via the special-keys API', async () => {
     render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="codex" />);
     fireEvent.click(screen.getByLabelText('Send Escape'));

--- a/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
@@ -330,8 +330,13 @@ describe('TerminalSplitPaneContent', () => {
   });
 
   it('renders the C-lite escape hatch for an unclassified running session (Issue #1017)', async () => {
-    mockFetch.mockImplementation(() =>
-      okJson({
+    let fetchCount = 0;
+    mockFetch.mockImplementation(async () => {
+      fetchCount += 1;
+      if (fetchCount > 1) {
+        await new Promise(resolve => setTimeout(resolve, 550));
+      }
+      return okJson({
         isRunning: true,
         fullOutput: 'stuck in an unknown TUI mode',
         thinking: false,
@@ -340,8 +345,8 @@ describe('TerminalSplitPaneContent', () => {
         isPagerActive: false,
         isPromptWaiting: false,
         isUnclassifiedActive: true,
-      }),
-    );
+      });
+    });
 
     render(
       <TerminalSplitPaneContent
@@ -357,7 +362,7 @@ describe('TerminalSplitPaneContent', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('terminal-escape-hatch')).toBeInTheDocument();
-    });
+    }, { timeout: 1500 });
     expect(screen.getByTestId('terminal-escape-hatch').getAttribute('data-cli-tool-id')).toBe('codex');
   });
 
@@ -433,6 +438,7 @@ describe('TerminalSplitPaneContent', () => {
         fullOutput: '',
         thinking: false,
         isPromptWaiting: true,
+        isUnclassifiedActive: true,
         promptData: { type: 'yes_no', question: 'Continue?' },
       }),
     );
@@ -452,6 +458,7 @@ describe('TerminalSplitPaneContent', () => {
       await Promise.resolve();
     });
     expect(screen.queryByTestId('prompt-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terminal-escape-hatch')).not.toBeInTheDocument();
   });
 
   it('shows attach skeleton until the first /current-output resolves', async () => {

--- a/tests/unit/config/auto-yes-config.test.ts
+++ b/tests/unit/config/auto-yes-config.test.ts
@@ -298,8 +298,8 @@ describe('auto-yes-config', () => {
       expect(THINKING_POLLING_INTERVAL_MS).toBe(5000);
     });
 
-    it('REDUCED_CAPTURE_LINES should be 300', () => {
-      expect(REDUCED_CAPTURE_LINES).toBe(300);
+    it('REDUCED_CAPTURE_LINES should cover the fixed TUI pane', () => {
+      expect(REDUCED_CAPTURE_LINES).toBe(1000);
     });
 
     it('FULL_CAPTURE_LINES should be 5000', () => {

--- a/tests/unit/hooks/useTerminalPanePolling.test.ts
+++ b/tests/unit/hooks/useTerminalPanePolling.test.ts
@@ -144,6 +144,35 @@ describe('useTerminalPanePolling', () => {
     expect(result.current.terminal.output).toBe('second');
   });
 
+  it('requires consecutive unclassified snapshots and resets when a prompt is found', async () => {
+    mockFetch.mockImplementation(() => okJson({
+      isRunning: true,
+      fullOutput: 'unknown TUI',
+      isUnclassifiedActive: true,
+    }));
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude' }),
+    );
+
+    await waitFor(() => expect(result.current.terminal.attaching).toBe(false));
+    expect(result.current.terminal.isUnclassifiedActive).toBe(false);
+
+    await new Promise(resolve => setTimeout(resolve, 550));
+    await act(async () => result.current.refresh());
+    expect(result.current.terminal.isUnclassifiedActive).toBe(true);
+
+    mockFetch.mockImplementation(() => okJson({
+      isRunning: true,
+      fullOutput: 'permission prompt',
+      isUnclassifiedActive: true,
+      isPromptWaiting: true,
+      promptData: { type: 'yes_no', question: 'Continue?' },
+    }));
+    await act(async () => result.current.refresh());
+    expect(result.current.terminal.isUnclassifiedActive).toBe(false);
+    expect(result.current.prompt.visible).toBe(true);
+  });
+
   it('does not fetch when enabled=false', async () => {
     mockFetch.mockImplementation(() =>
       okJson({ isRunning: false, fullOutput: 'never', thinking: false }),

--- a/tests/unit/lib/auto-yes-manager.test.ts
+++ b/tests/unit/lib/auto-yes-manager.test.ts
@@ -37,10 +37,17 @@ import {
   FULL_CAPTURE_LINES,
   AUTO_STOP_ERROR_THRESHOLD,
 } from '@/config/auto-yes-config';
+import { buildClaude1000RowPermissionFrame } from '../../fixtures/claude-1000-row-prompt';
 
 // Mock modules for pollAutoYes testing (Issue #161)
 vi.mock('@/lib/session/cli-session', () => ({
   captureSessionOutput: vi.fn(),
+}));
+vi.mock('@/lib/polling/response-poller', () => ({
+  startPolling: vi.fn(),
+}));
+vi.mock('@/lib/realtime/terminal-broadcast', () => ({
+  broadcastTerminalSnapshotAfterInteraction: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@/lib/tmux/tmux', () => ({
   sendKeys: vi.fn(),
@@ -1628,6 +1635,34 @@ describe('auto-yes-manager', () => {
   // Issue #323: detectAndRespondToPrompt unit tests (timer-independent)
   // ==========================================================================
   describe('Issue #323: detectAndRespondToPrompt', () => {
+    it('answers the Issue #1167 1000-row prompt exactly once', async () => {
+      const { sendSpecialKeys } = await import('@/lib/tmux/tmux');
+      const { startPolling } = await import('@/lib/polling/response-poller');
+      const { broadcastTerminalSnapshotAfterInteraction } = await import('@/lib/realtime/terminal-broadcast');
+      vi.mocked(sendSpecialKeys).mockReset();
+      vi.mocked(sendSpecialKeys).mockResolvedValue(undefined);
+      vi.mocked(startPolling).mockClear();
+      vi.mocked(broadcastTerminalSnapshotAfterInteraction).mockClear();
+
+      const pollerState = createTestPollerState();
+      globalThis.__autoYesPollerStates?.set('test-wt-1167:claude', pollerState);
+      const frame = buildClaude1000RowPermissionFrame();
+
+      expect(await detectAndRespondToPrompt('test-wt-1167', pollerState, 'claude', frame))
+        .toBe('responded');
+      expect(await detectAndRespondToPrompt('test-wt-1167', pollerState, 'claude', frame))
+        .toBe('duplicate');
+      expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
+      expect(startPolling).toHaveBeenCalledTimes(1);
+      expect(broadcastTerminalSnapshotAfterInteraction).toHaveBeenCalledWith(
+        'test-wt-1167',
+        'claude',
+        undefined,
+      );
+
+      globalThis.__autoYesPollerStates?.delete('test-wt-1167:claude');
+    });
+
     it('should return no_prompt when no prompt detected', async () => {
       const pollerState = createTestPollerState();
 
@@ -2126,7 +2161,7 @@ describe('auto-yes-manager', () => {
       // Call with explicit REDUCED_CAPTURE_LINES
       // Issue #896: instanceId is passed as 4th arg (undefined for primary)
       await captureAndCleanOutput('test-wt', 'claude', REDUCED_CAPTURE_LINES);
-      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 300, undefined);
+      expect(captureSessionOutput).toHaveBeenCalledWith('test-wt', 'claude', 1000, undefined);
 
       vi.mocked(captureSessionOutput).mockReset();
       vi.mocked(captureSessionOutput).mockResolvedValue('test output');
@@ -2138,8 +2173,8 @@ describe('auto-yes-manager', () => {
       vi.mocked(captureSessionOutput).mockReset();
     });
 
-    it('Item 3: REDUCED_CAPTURE_LINES should be 300 and FULL_CAPTURE_LINES should be 5000', () => {
-      expect(REDUCED_CAPTURE_LINES).toBe(300);
+    it('Item 3: REDUCED_CAPTURE_LINES should cover the 1000-row frame', () => {
+      expect(REDUCED_CAPTURE_LINES).toBe(1000);
       expect(FULL_CAPTURE_LINES).toBe(5000);
     });
 

--- a/tests/unit/lib/claude-session.test.ts
+++ b/tests/unit/lib/claude-session.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/tmux/tmux', () => ({
   capturePane: vi.fn(),
   killSession: vi.fn(),
   sendSpecialKey: vi.fn(),
+  reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
 // Mock pasted-text-helper (Issue #212)
@@ -69,7 +70,7 @@ import {
   CLAUDE_PROMPT_POLL_INTERVAL,
   CLAUDE_SEND_PROMPT_WAIT_TIMEOUT,
 } from '@/lib/session/claude-session';
-import { hasSession, createSession, sendKeys, capturePane, killSession, sendSpecialKey } from '@/lib/tmux/tmux';
+import { hasSession, createSession, sendKeys, capturePane, killSession, sendSpecialKey, reconcileSessionGeometry } from '@/lib/tmux/tmux';
 import {
   CLAUDE_PROMPT_PATTERN,
   CLAUDE_SEPARATOR_PATTERN,
@@ -322,6 +323,7 @@ describe('claude-session - Issue #152 improvements', () => {
       await startClaudeSession(TEST_SESSION_OPTIONS);
 
       expect(createSession).not.toHaveBeenCalled();
+      expect(reconcileSessionGeometry).toHaveBeenCalledWith('mcbd-claude-test-worktree');
     });
 
     it('should recreate unhealthy existing session (Issue #265, Bug 2)', async () => {

--- a/tests/unit/lib/current-output-builder.test.ts
+++ b/tests/unit/lib/current-output-builder.test.ts
@@ -1,0 +1,46 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+import { buildClaude1000RowPermissionFrame } from '../../fixtures/claude-1000-row-prompt';
+
+vi.mock('@/lib/db', () => ({ getSessionState: vi.fn(() => null) }));
+vi.mock('@/lib/cli-tools/manager', () => ({
+  CLIToolManager: {
+    getInstance: () => ({
+      getTool: () => ({ isRunning: vi.fn().mockResolvedValue(true) }),
+    }),
+  },
+}));
+vi.mock('@/lib/session/cli-session', () => ({ captureSessionOutput: vi.fn() }));
+vi.mock('@/lib/polling/auto-yes-manager', () => ({
+  getAutoYesState: vi.fn(() => undefined),
+  getLastServerResponseTimestamp: vi.fn(() => null),
+  isPollerActive: vi.fn(() => true),
+  buildCompositeKey: vi.fn(() => 'wt-1:claude'),
+}));
+
+import { captureSessionOutput } from '@/lib/session/cli-session';
+import { buildCurrentOutput } from '@/lib/session/current-output-builder';
+
+describe('buildCurrentOutput Issue #1167 frame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(captureSessionOutput).mockResolvedValue(buildClaude1000RowPermissionFrame());
+  });
+
+  it('surfaces prompt data and never exposes the unclassified fallback', async () => {
+    const payload = await buildCurrentOutput(
+      {} as Database.Database,
+      'wt-1',
+      'claude',
+      'claude-2',
+    );
+
+    expect(payload.isPromptWaiting).toBe(true);
+    expect(payload.promptData?.type).toBe('multiple_choice');
+    expect(payload.sessionStatus).toBe('waiting');
+    expect(payload.sessionStatusReason).toBe('prompt_detected');
+    expect(payload.isUnclassifiedActive).toBe(false);
+  });
+});

--- a/tests/unit/lib/detection/prompt-detect-multiple-choice.test.ts
+++ b/tests/unit/lib/detection/prompt-detect-multiple-choice.test.ts
@@ -26,6 +26,7 @@ import {
 } from '@/lib/detection/prompt-detect-multiple-choice';
 import type { DetectPromptOptions } from '@/lib/detection/types';
 import type { MultipleChoicePromptData } from '@/types/models';
+import { buildClaude1000RowPermissionFrame } from '../../../fixtures/claude-1000-row-prompt';
 
 /** Identity truncation: the unit under test only needs a passthrough. */
 const truncate = (s: string) => s;
@@ -71,6 +72,18 @@ const PICKER_WITH_TASK_PANEL = [
 ].join('\n');
 
 describe('detectMultipleChoicePrompt - Issue #807 AskUserQuestion picker', () => {
+  describe('Issue #1167 1000-row frame', () => {
+    it('finds the prompt above internal padding and excludes the task panel', () => {
+      const promptData = asMultipleChoice(buildClaude1000RowPermissionFrame());
+
+      expect(promptData).not.toBeNull();
+      expect(promptData?.question).toContain('Do you want to make this edit');
+      expect(promptData?.options.map(option => option.number)).toEqual([1, 2, 3]);
+      expect(promptData?.options.some(option => option.label.includes('tasks'))).toBe(false);
+      expect(promptData?.options.some(option => option.label.includes('pending'))).toBe(false);
+    });
+  });
+
   describe('clean picker (no trailing task panel)', () => {
     it('detects all 5 options including the divider-separated meta options', () => {
       const promptData = asMultipleChoice(PICKER_CLEAN);

--- a/tests/unit/lib/status-detector.test.ts
+++ b/tests/unit/lib/status-detector.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { detectSessionStatus } from '@/lib/detection/status-detector';
 import { resetDetectPromptCache } from '@/lib/detection/prompt-detector';
+import { buildClaude1000RowPermissionFrame } from '../../fixtures/claude-1000-row-prompt';
 
 // Named constants for Unicode characters used in tmux output simulation.
 // These match the actual characters produced by Claude CLI and detected by cli-patterns.ts.
@@ -42,6 +43,25 @@ function activeThinking(activity: string): string {
 }
 
 describe('status-detector', () => {
+  describe('Issue #1167 1000-row Claude frame', () => {
+    it('classifies a permission prompt above a bottom task panel as waiting', () => {
+      const result = detectSessionStatus(buildClaude1000RowPermissionFrame(), 'claude');
+
+      expect(result.status).toBe('waiting');
+      expect(result.reason).toBe('prompt_detected');
+      expect(result.hasActivePrompt).toBe(true);
+      expect(result.promptDetection.promptData?.type).toBe('multiple_choice');
+    });
+
+    it('does not resurrect an old footer when a newer input prompt is below it', () => {
+      const output = `${buildClaude1000RowPermissionFrame()}\n❯\n? for shortcuts`;
+      const result = detectSessionStatus(output, 'claude');
+
+      expect(result.hasActivePrompt).toBe(false);
+      expect(result.status).toBe('ready');
+    });
+  });
+
   // Issue #402: Reset duplicate log suppression cache for test isolation
   beforeEach(() => {
     resetDetectPromptCache();

--- a/tests/unit/special-keys-route.test.ts
+++ b/tests/unit/special-keys-route.test.ts
@@ -40,11 +40,15 @@ vi.mock('@/lib/tmux/tmux', () => ({
 vi.mock('@/lib/tmux/tmux-capture-cache', () => ({
   invalidateCache: vi.fn(),
 }));
+vi.mock('@/lib/realtime/terminal-broadcast', () => ({
+  broadcastTerminalSnapshotAfterInteraction: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { POST } from '@/app/api/worktrees/[id]/special-keys/route';
 import { getWorktreeById } from '@/lib/db';
 import { hasSession, sendSpecialKeysAndInvalidate } from '@/lib/tmux/tmux';
 import { isCliToolType } from '@/lib/cli-tools/types';
+import { broadcastTerminalSnapshotAfterInteraction } from '@/lib/realtime/terminal-broadcast';
 
 function createRequest(body: unknown): NextRequest {
   const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
@@ -82,6 +86,11 @@ describe('POST /api/worktrees/[id]/special-keys', () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(sendSpecialKeysAndInvalidate).toHaveBeenCalledWith('mcbd-opencode-wt-1', ['Up']);
+    expect(broadcastTerminalSnapshotAfterInteraction).toHaveBeenCalledWith(
+      'wt-1',
+      'opencode',
+      undefined,
+    );
   });
 
   it('should accept multiple valid keys', async () => {

--- a/tests/unit/terminal-broadcast.test.ts
+++ b/tests/unit/terminal-broadcast.test.ts
@@ -2,13 +2,24 @@
  * Unit tests for the server-side realtime broadcasters (Issue #1120).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@/lib/ws-server', () => ({
   broadcast: vi.fn(),
   hasRoomSubscribers: vi.fn(() => true),
 }));
 vi.mock('@/lib/db/db-instance', () => ({ getDbInstance: vi.fn(() => ({})) }));
+vi.mock('@/lib/cli-tools/manager', () => ({
+  CLIToolManager: {
+    getInstance: () => ({
+      getTool: (cliToolId: string) => ({
+        getSessionName: (worktreeId: string, instanceId?: string) =>
+          `mcbd-${cliToolId}-${worktreeId}-${instanceId ?? cliToolId}`,
+      }),
+    }),
+  },
+}));
+vi.mock('@/lib/tmux/tmux-capture-cache', () => ({ invalidateCache: vi.fn() }));
 vi.mock('@/lib/session/current-output-builder', () => ({
   buildCurrentOutput: vi.fn(async () => ({
     isRunning: true,
@@ -28,8 +39,11 @@ vi.mock('@/lib/session/current-output-builder', () => ({
 }));
 
 import { broadcast, hasRoomSubscribers } from '@/lib/ws-server';
+import { buildCurrentOutput } from '@/lib/session/current-output-builder';
+import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
 import {
   broadcastTerminalSnapshot,
+  broadcastTerminalSnapshotAfterInteraction,
   broadcastSessionStatus,
   __resetTerminalBroadcastState,
 } from '@/lib/realtime/terminal-broadcast';
@@ -41,7 +55,24 @@ beforeEach(() => {
   vi.clearAllMocks();
   __resetTerminalBroadcastState();
   mockHasSubscribers.mockReturnValue(true);
+  vi.mocked(buildCurrentOutput).mockResolvedValue({
+    isRunning: true,
+    cliToolId: 'claude',
+    sessionStatus: 'running',
+    sessionStatusReason: 'thinking_indicator',
+    content: '',
+    fullOutput: 'terminal out',
+    thinking: true,
+    isPromptWaiting: false,
+    promptData: null,
+    isSelectionListActive: false,
+    isPagerActive: false,
+    isUnclassifiedActive: false,
+    lineCount: 1,
+  });
 });
+
+afterEach(() => vi.useRealTimers());
 
 describe('broadcastTerminalSnapshot', () => {
   it('no-ops (no capture) when the room has no subscribers', async () => {
@@ -74,6 +105,64 @@ describe('broadcastTerminalSnapshot', () => {
     await broadcastTerminalSnapshot('wt-1', 'claude', 'claude-2');
     expect(mockBroadcast.mock.calls[0][1]).toMatchObject({ instanceId: 'claude', version: 1 });
     expect(mockBroadcast.mock.calls[1][1]).toMatchObject({ instanceId: 'claude-2', version: 1 });
+  });
+});
+
+describe('broadcastTerminalSnapshotAfterInteraction', () => {
+  it('pushes immediately, invalidates the target instance cache, and pushes one changed redraw', async () => {
+    vi.useFakeTimers();
+    vi.mocked(buildCurrentOutput)
+      .mockResolvedValueOnce({
+        isRunning: true,
+        cliToolId: 'claude',
+        sessionStatus: 'waiting',
+        sessionStatusReason: 'prompt_detected',
+        content: '',
+        fullOutput: 'old frame',
+        lineCount: 1,
+      })
+      .mockResolvedValueOnce({
+        isRunning: true,
+        cliToolId: 'claude',
+        sessionStatus: 'running',
+        sessionStatusReason: 'thinking_indicator',
+        content: '',
+        fullOutput: 'redrawn frame',
+        thinking: true,
+        lineCount: 1,
+      });
+
+    const pending = broadcastTerminalSnapshotAfterInteraction(
+      'wt-1',
+      'claude',
+      'claude-2',
+      [10],
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    await pending;
+
+    expect(invalidateCache).toHaveBeenCalledTimes(2);
+    expect(invalidateCache).toHaveBeenCalledWith('mcbd-claude-wt-1-claude-2');
+    expect(mockBroadcast).toHaveBeenCalledTimes(2);
+    expect(mockBroadcast.mock.calls[0][1]).toMatchObject({
+      instanceId: 'claude-2',
+      output: 'old frame',
+      version: 1,
+    });
+    expect(mockBroadcast.mock.calls[1][1]).toMatchObject({
+      instanceId: 'claude-2',
+      output: 'redrawn frame',
+      version: 2,
+    });
+  });
+
+  it('does not duplicate the initial snapshot when retry frames are unchanged', async () => {
+    vi.useFakeTimers();
+    const pending = broadcastTerminalSnapshotAfterInteraction('wt-1', 'claude', undefined, [5, 5]);
+    await vi.advanceTimersByTimeAsync(10);
+    await pending;
+
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/tmux.test.ts
+++ b/tests/unit/tmux.test.ts
@@ -17,6 +17,7 @@ import {
   killSession,
   ensureSession,
   exactTarget,
+  reconcileSessionGeometry,
   SPECIAL_KEY_VALUES,
 } from '@/lib/tmux/tmux';
 
@@ -411,6 +412,69 @@ describe('tmux library', () => {
     });
   });
 
+  describe('reconcileSessionGeometry (Issue #1167)', () => {
+    function installGeometryMock(mode: string, size: string): void {
+      vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+        const cmdArgs = args[1] as string[];
+        const callback = args[args.length - 1] as (
+          err: Error | null,
+          result: { stdout: string; stderr: string }
+        ) => void;
+        const stdout = cmdArgs[0] === 'show-window-options'
+          ? mode
+          : cmdArgs[0] === 'display-message'
+            ? size
+            : '';
+        callback(null, { stdout, stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      });
+    }
+
+    it('is a no-op when the existing session already has the expected geometry', async () => {
+      installGeometryMock('manual\n', '200|1000\n');
+
+      await expect(reconcileSessionGeometry('mcbd-claude-wt')).resolves.toBe(false);
+
+      const subcommands = vi.mocked(execFile).mock.calls.map(call => (call[1] as string[])[0]);
+      expect(subcommands).toEqual(['show-window-options', 'display-message']);
+    });
+
+    it('repairs a legacy latest/72-row session without touching global options', async () => {
+      installGeometryMock('latest\n', '271|72\n');
+
+      await expect(reconcileSessionGeometry('mcbd-claude-wt')).resolves.toBe(true);
+
+      expect(execFile).toHaveBeenCalledWith(
+        'tmux',
+        ['set-window-option', '-t', '=mcbd-claude-wt:', 'window-size', 'manual'],
+        { timeout: 5000 },
+        expect.any(Function),
+      );
+      expect(execFile).toHaveBeenCalledWith(
+        'tmux',
+        ['resize-window', '-t', '=mcbd-claude-wt:', '-x', '200', '-y', '1000'],
+        { timeout: 5000 },
+        expect.any(Function),
+      );
+      for (const call of vi.mocked(execFile).mock.calls) {
+        expect(call[1] as string[]).not.toContain('-g');
+      }
+    });
+
+    it('keeps the session usable when reconciliation fails', async () => {
+      vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+        const callback = args[args.length - 1] as (
+          err: Error | null,
+          result: { stdout: string; stderr: string }
+        ) => void;
+        callback(new Error('resize denied'), { stdout: '', stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      });
+
+      await expect(reconcileSessionGeometry('mcbd-claude-wt')).resolves.toBe(false);
+    });
+  });
+
   describe('sendKeys', () => {
     it('should send keys with Enter', async () => {
       vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
@@ -618,9 +682,8 @@ describe('tmux library', () => {
 
       await ensureSession('test-session', '/path/to/cwd');
 
-      // Should call has-session, new-session, set-window-option (window-size manual),
-      // resize-window, and set-option (Issue #1163 adds the window-size + resize calls)
-      expect(execFile).toHaveBeenCalledTimes(5);
+      // Includes two geometry inspection calls before the window-size writes.
+      expect(execFile).toHaveBeenCalledTimes(7);
     });
 
     it('should not create session if it already exists', async () => {


### PR DESCRIPTION
## 概要

Issue #1167で報告された、1000行固定のtmuxペインにおいてClaudeの選択プロンプトと下部タスク表示の間に大量の空行が入り、プロンプト検出・Auto-Yes・画面更新が不安定になる問題を修正します。

## 原因

- 検出処理が表示用の生出力を狭いtail範囲で評価しており、上方に残ったClaudeプロンプトを取りこぼしていた
- 下部のタスクパネルや古いフッターが、現在の対話状態として誤認される場合があった
- 既存tmuxセッションのウィンドウサイズが再利用時に調整されなかった
- 応答・特殊キー操作後に最新スナップショットが即時配信されず、WebSocket push停止時もHTTPポーリングの復帰が遅かった
- Claudeに対して`q`が安全な脱出キーとして表示されていた

## 変更内容

- 1000行TUI出力を対象に、表示内容を変更しない検出専用フレーム正規化を追加
- Auto-Yesのキャプチャ範囲を1000行へ拡張
- 既存tmuxセッション再利用時にウィンドウ単位でgeometryを調整
- 応答・特殊キー・Auto-Yesの成功後に端末スナップショットを即時配信し、短時間の限定再試行を追加
- WebSocket pushのwatchdogとHTTPポーリング復帰、未分類状態のヒステリシスを追加
- ClaudeではEscのみ、CodexではEsc/qを表示するよう安全性を改善
- 1000行再現フィクスチャと単体・統合回帰テストを追加

## ユーザーへの影響

大量の空行を含むClaude画面でもプロンプトと待機状態を安定して検出でき、Auto-Yesおよび手動応答後のUI更新が速やかに反映されます。

## 検証

- `npm run test:unit` — 542 files / 9,116 tests passed
- `npm run test:integration` — 50 files / 680 tests passed
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

Closes #1167