### PR TITLE
feat(terminal): Claude/Codexの1000行ペインで表示専用に空行を圧縮 (#1172)

### DIFF
--- a/src/components/worktree/TerminalDisplay.tsx
+++ b/src/components/worktree/TerminalDisplay.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useRef, useState, useMemo, memo, useCallback } from '
 import { ArrowUp, ArrowDown } from 'lucide-react';
 import { sanitizeTerminalOutput } from '@/lib/security/sanitize';
 import { computeTerminalUpdate } from '@/lib/terminal/terminal-diff';
+import { normalizeTerminalOutputForDisplay } from '@/lib/terminal/terminal-display-normalizer';
 import { useTerminalScroll } from '@/hooks/useTerminalScroll';
 import { useTerminalSearch } from '@/hooks/useTerminalSearch';
 import { TerminalSearchBar } from '@/components/worktree/TerminalSearchBar';
@@ -37,6 +38,14 @@ export interface TerminalDisplayProps {
   onScrollChange?: (enabled: boolean) => void;
   /** Disable auto-follow on new content (for TUI tools like OpenCode) */
   disableAutoFollow?: boolean;
+  /**
+   * Issue #1172: opt-in display-only compression of layout blank rows for
+   * Claude/Codex 1000-row panes. When true, the rendered/searched/scrolled text
+   * is derived from `normalizeTerminalOutputForDisplay(output)`; the raw `output`
+   * (and every consumer of it) is untouched. Default false — no other CLI's
+   * display changes.
+   */
+  compactTuiLayoutPadding?: boolean;
   /** Additional CSS classes */
   className?: string;
 }
@@ -81,6 +90,7 @@ export const TerminalDisplay = memo(function TerminalDisplay({
   autoScroll: initialAutoScroll = true,
   onScrollChange,
   disableAutoFollow = false,
+  compactTuiLayoutPadding = false,
   className = '',
 }: TerminalDisplayProps) {
   const { scrollRef, autoScroll, handleScroll, scrollToBottom, scrollToTop } =
@@ -88,6 +98,22 @@ export const TerminalDisplay = memo(function TerminalDisplay({
       initialAutoScroll,
       onAutoScrollChange: onScrollChange,
     });
+
+  // Issue #1172: `rawOutput` stays authoritative for lifecycle (attaching /
+  // never-started / ended). `displayOutput` is the opt-in compacted text that
+  // drives rendering, search, diffing and auto-scroll. When compaction is off
+  // (default) they are identical, so non-Claude/Codex panes render byte-for-byte
+  // as before. Because JS strings compare by value, a raw-only frame change that
+  // yields an identical `displayOutput` is `Object.is`-equal here, so downstream
+  // memos/effects do not re-render, re-search or re-scroll.
+  const rawOutput = output ?? '';
+  const displayOutput = useMemo(
+    () =>
+      compactTuiLayoutPadding
+        ? normalizeTerminalOutputForDisplay(rawOutput)
+        : rawOutput,
+    [compactTuiLayoutPadding, rawOutput]
+  );
 
   // [Issue #47] Terminal search - scrollRef is reused as containerRef
   const {
@@ -101,7 +127,7 @@ export const TerminalDisplay = memo(function TerminalDisplay({
     setQuery: setSearchQuery,
     nextMatch,
     prevMatch,
-  } = useTerminalSearch({ output, containerRef: scrollRef });
+  } = useTerminalSearch({ output: displayOutput, containerRef: scrollRef });
 
   // [Issue #47] Ctrl+F / Cmd+F handler to open search (suppresses browser find)
   const handleKeyDown = useCallback(
@@ -128,16 +154,15 @@ export const TerminalDisplay = memo(function TerminalDisplay({
   // it) untouched and only mounts the appended node. Divergence falls back to a
   // full replace (single fresh chunk).
   const MAX_RENDERED_CHUNKS = 400;
-  const safeOutput = output ?? '';
   const [renderedChunks, setRenderedChunks] = useState<Array<{ key: number; html: string }>>(() =>
-    safeOutput ? [{ key: 0, html: sanitizeTerminalOutput(safeOutput) }] : []
+    displayOutput ? [{ key: 0, html: sanitizeTerminalOutput(displayOutput) }] : []
   );
-  const prevOutputRef = useRef(safeOutput);
+  const prevOutputRef = useRef(displayOutput);
   const chunkKeyRef = useRef(0);
 
   useEffect(() => {
-    const update = computeTerminalUpdate(prevOutputRef.current, safeOutput);
-    prevOutputRef.current = safeOutput;
+    const update = computeTerminalUpdate(prevOutputRef.current, displayOutput);
+    prevOutputRef.current = displayOutput;
     if (update.mode === 'noop') return;
 
     if (update.mode === 'append') {
@@ -145,7 +170,7 @@ export const TerminalDisplay = memo(function TerminalDisplay({
         chunkKeyRef.current += 1;
         // Coalesce back to a single chunk if the DOM node count grows unbounded.
         if (prev.length >= MAX_RENDERED_CHUNKS) {
-          return [{ key: chunkKeyRef.current, html: sanitizeTerminalOutput(safeOutput) }];
+          return [{ key: chunkKeyRef.current, html: sanitizeTerminalOutput(displayOutput) }];
         }
         return [...prev, { key: chunkKeyRef.current, html: sanitizeTerminalOutput(update.appended) }];
       });
@@ -155,9 +180,9 @@ export const TerminalDisplay = memo(function TerminalDisplay({
     // replace
     chunkKeyRef.current += 1;
     setRenderedChunks(
-      safeOutput ? [{ key: chunkKeyRef.current, html: sanitizeTerminalOutput(safeOutput) }] : []
+      displayOutput ? [{ key: chunkKeyRef.current, html: sanitizeTerminalOutput(displayOutput) }] : []
     );
-  }, [safeOutput]);
+  }, [displayOutput]);
 
   // Issue #842: distinguish "loading (attaching)" / "not-started" / "ended" so an
   // empty terminal does not ambiguously read as a dead session. We only show the
@@ -198,7 +223,7 @@ export const TerminalDisplay = memo(function TerminalDisplay({
     if (!scrollRef.current) return;
 
     // Issue #379: Scroll to top once when content first arrives in disableAutoFollow mode
-    if (needsScrollToTopRef.current && disableAutoFollow && output) {
+    if (needsScrollToTopRef.current && disableAutoFollow && displayOutput) {
       scrollRef.current.scrollTo({ top: 0, behavior: 'instant' });
       needsScrollToTopRef.current = false;
       return;
@@ -210,7 +235,9 @@ export const TerminalDisplay = memo(function TerminalDisplay({
         behavior: 'instant',
       });
     }
-  }, [renderedChunks, output, autoScroll, disableAutoFollow, scrollRef]);
+    // Issue #1172: keyed on displayOutput (not raw output) so a raw-only frame
+    // change that compacts to an identical display does not re-trigger scroll.
+  }, [renderedChunks, displayOutput, autoScroll, disableAutoFollow, scrollRef]);
 
   // Memoized CSS classes for performance
   const containerClasses = useMemo(

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -208,6 +208,10 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   // would hide the menus at the top of the screen.
   const disableAutoFollow = cliToolId === 'opencode' || cliToolId === 'copilot';
 
+  // Issue #1172: Claude/Codex pin a 1000-row pane and pad the layout with
+  // hundreds of blank rows; compact them for display only (raw output untouched).
+  const compactTuiLayoutPadding = cliToolId === 'claude' || cliToolId === 'codex';
+
   const handleAutoScrollChange = useCallback(
     (enabled: boolean) => setAutoScroll(enabled),
     [setAutoScroll],
@@ -340,6 +344,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
         autoScroll={terminal.autoScroll}
         onScrollChange={handleAutoScrollChange}
         disableAutoFollow={disableAutoFollow}
+        compactTuiLayoutPadding={compactTuiLayoutPadding}
       />
     ),
     [
@@ -350,6 +355,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
       terminal.autoScroll,
       handleAutoScrollChange,
       disableAutoFollow,
+      compactTuiLayoutPadding,
     ],
   );
 

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -220,6 +220,8 @@ const MobileTerminalTab = memo(function MobileTerminalTab({
   disableAutoFollow?: boolean;
 }) {
   const { terminal, setAutoScroll } = useTerminalPanePolling({ worktreeId, cliToolId, instanceId });
+  // Issue #1172: compact the 1000-row layout padding for Claude/Codex (display only).
+  const compactTuiLayoutPadding = cliToolId === 'claude' || cliToolId === 'codex';
   return (
     <TerminalDisplay
       output={terminal.output}
@@ -228,6 +230,7 @@ const MobileTerminalTab = memo(function MobileTerminalTab({
       autoScroll={terminal.autoScroll}
       onScrollChange={setAutoScroll}
       disableAutoFollow={disableAutoFollow}
+      compactTuiLayoutPadding={compactTuiLayoutPadding}
       className="h-full"
     />
   );

--- a/src/lib/detection/ansi.ts
+++ b/src/lib/detection/ansi.ts
@@ -1,0 +1,37 @@
+/**
+ * Dependency-free ANSI escape-sequence primitives.
+ *
+ * These live in their own leaf module (no logger/db/server imports) so both
+ * server-side detection code (`cli-patterns.ts`, which re-exports them) and
+ * client components (the terminal display normalizer, Issue #1172) can share the
+ * exact same tested pattern without pulling Node-only modules into the browser
+ * bundle.
+ *
+ * Covers:
+ * - SGR sequences: ESC[Nm (colors, bold, underline, etc.)
+ * - OSC sequences: ESC]...BEL (window title, hyperlinks, etc.)
+ * - CSI sequences: ESC[...letter (cursor movement, erase, etc.)
+ *
+ * Known limitations (SEC-002): 8-bit CSI (0x9B), DEC private modes (ESC[?25h),
+ * character-set switching (ESC(0), and some RGB color forms may not match. In
+ * practice tmux capture-pane output rarely contains these.
+ */
+
+export const ANSI_PATTERN = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\[[0-9;]*m/g;
+
+/** Remove all ANSI escape sequences from a string. */
+export function stripAnsi(str: string): string {
+  return str.replace(ANSI_PATTERN, '');
+}
+
+/**
+ * Extract the ANSI escape sequences from a string, in order, discarding all
+ * other characters. Reuses the same tested pattern as {@link stripAnsi} so the
+ * two stay in lock-step. Used when collapsing blank layout rows for display
+ * (Issue #1172): the visible glyphs are dropped but any color/reset sequences
+ * that alter how subsequent rows render must be preserved.
+ */
+export function extractAnsiSequences(str: string): string {
+  const matches = str.match(ANSI_PATTERN);
+  return matches ? matches.join('') : '';
+}

--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -773,30 +773,10 @@ export function getCliToolPatterns(cliToolId: CLIToolType): {
   }
 }
 
-/**
- * Strip ANSI escape codes from a string.
- * Optimized version at module level for performance.
- *
- * Covers:
- * - SGR sequences: ESC[Nm (colors, bold, underline, etc.)
- * - OSC sequences: ESC]...BEL (window title, hyperlinks, etc.)
- * - CSI sequences: ESC[...letter (cursor movement, erase, etc.)
- *
- * Known limitations (SEC-002):
- * - 8-bit CSI (0x9B): C1 control code form of CSI is not covered
- * - DEC private modes: ESC[?25h and similar are not covered
- * - Character set switching: ESC(0, ESC(B are not covered
- * - Some RGB color forms: ESC[38;2;r;g;bm may not be fully matched
- *
- * In practice, tmux capture-pane output rarely contains these sequences,
- * so the risk is low. Future consideration: adopt the `strip-ansi` npm package
- * for more comprehensive coverage.
- */
-const ANSI_PATTERN = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\[[0-9;]*m/g;
-
-export function stripAnsi(str: string): string {
-  return str.replace(ANSI_PATTERN, '');
-}
+// ANSI primitives live in a dependency-free leaf module so client components can
+// reuse the same tested pattern without pulling this file's server-only imports
+// (logger/db) into the browser bundle. Re-exported here for existing importers.
+export { stripAnsi, extractAnsiSequences } from './ansi';
 
 /**
  * Strip box-drawing border characters from CLI output.

--- a/src/lib/terminal/terminal-display-normalizer.ts
+++ b/src/lib/terminal/terminal-display-normalizer.ts
@@ -1,0 +1,77 @@
+/**
+ * Display-only whitespace normalization for TUI terminal panes (Issue #1172).
+ *
+ * Claude Code / Codex run in tmux's alternate screen pinned to a fixed
+ * `TUI_PANE_HEIGHT` (1000 rows, see `src/config/tmux-pane-config.ts`). The
+ * captured frame anchors interactive content near the top and a task panel near
+ * the bottom, leaving hundreds of layout-only blank rows in between. Rendered
+ * verbatim, the Web UI auto-follows to the bottom and the user must scroll up
+ * hundreds of rows to see the prompt.
+ *
+ * This helper compresses runs of visually-blank rows for DISPLAY ONLY. It never
+ * touches the raw output used for status/prompt detection, Auto-Yes, response
+ * saving, transport, or line counting — those keep full fidelity. The transform
+ * is pure and idempotent, preserves every non-blank line (content, order,
+ * duplicates), and generates no HTML (the result still flows through
+ * `sanitizeTerminalOutput()` / DOMPurify downstream).
+ */
+
+import { stripAnsi, extractAnsiSequences } from '@/lib/detection/ansi';
+
+/** A line is visually blank if it has no printable content once ANSI is stripped. */
+function isVisuallyBlank(line: string): boolean {
+  return stripAnsi(line).trim() === '';
+}
+
+/**
+ * Normalize terminal output for display.
+ *
+ * Rules (see Issue #1172 acceptance criteria):
+ * 1. Line visibility is judged on `stripAnsi(line).trim()`.
+ * 2. Leading and trailing blank runs are removed (trimmed to 0 rows).
+ * 3. An internal blank run of 1–2 rows is kept verbatim.
+ * 4. An internal blank run of 3+ rows collapses to exactly ONE blank row that
+ *    carries the run's ANSI escape sequences (in order) so color/reset state
+ *    spanning the gap still applies to subsequent rows. Whitespace glyphs are
+ *    dropped; ANSI-only rows are not simply deleted, their sequences survive.
+ * 5. Non-blank lines are never altered.
+ * 6. No artificial "N rows omitted" marker is inserted.
+ */
+export function normalizeTerminalOutputForDisplay(output: string): string {
+  if (output === '') return '';
+
+  const lines = output.split('\n');
+  const result: string[] = [];
+  let seenContent = false;
+  let i = 0;
+
+  while (i < lines.length) {
+    if (!isVisuallyBlank(lines[i])) {
+      result.push(lines[i]);
+      seenContent = true;
+      i++;
+      continue;
+    }
+
+    // Consume the full run of consecutive blank lines starting at i.
+    let j = i;
+    while (j < lines.length && isVisuallyBlank(lines[j])) j++;
+    const runLength = j - i;
+    const isLeading = !seenContent;
+    const isTrailing = j >= lines.length;
+
+    if (!isLeading && !isTrailing) {
+      if (runLength <= 2) {
+        for (let k = i; k < j; k++) result.push(lines[k]);
+      } else {
+        // Collapse to a single blank row, preserving any ANSI state transitions.
+        result.push(extractAnsiSequences(lines.slice(i, j).join('')));
+      }
+    }
+    // Leading/trailing blank runs are dropped entirely (trimmed to 0 rows).
+
+    i = j;
+  }
+
+  return result.join('\n');
+}

--- a/tests/fixtures/codex-1000-row-approval.ts
+++ b/tests/fixtures/codex-1000-row-approval.ts
@@ -1,0 +1,18 @@
+/**
+ * Synthetic Codex frame matching the 1000-row TUI layout (Issue #1172).
+ *
+ * Like the Claude fixture, Codex anchors its approval prompt near the top of the
+ * pinned 1000-row pane and a status/usage footer near the bottom, leaving a
+ * large layout-only blank gap between them.
+ */
+export function buildCodex1000RowApprovalFrame(): string {
+  const lines = Array<string>(1000).fill('');
+  lines[40] = 'Allow command to run?';
+  lines[41] = '  $ rm -rf build';
+  lines[43] = '❯ 1. Yes';
+  lines[44] = "  2. Yes, and don't ask again for this command";
+  lines[45] = '  3. No, and tell Codex what to do differently';
+  lines[992] = 'token usage: 12,345 / 200,000';
+  lines[993] = 'esc to interrupt';
+  return lines.join('\n');
+}

--- a/tests/unit/components/TerminalDisplay.test.tsx
+++ b/tests/unit/components/TerminalDisplay.test.tsx
@@ -9,6 +9,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import { TerminalDisplay } from '@/components/worktree/TerminalDisplay';
+import { buildClaude1000RowPermissionFrame } from '../../fixtures/claude-1000-row-prompt';
+import { buildCodex1000RowApprovalFrame } from '../../fixtures/codex-1000-row-approval';
 
 describe('TerminalDisplay', () => {
   beforeEach(() => {
@@ -348,6 +350,174 @@ describe('TerminalDisplay', () => {
     it('does NOT show the loading placeholder once output has arrived', () => {
       render(<TerminalDisplay output="arrived" isActive={true} attaching={false} />);
       expect(screen.queryByTestId('terminal-loading-placeholder')).not.toBeInTheDocument();
+    });
+  });
+
+  // ============================================================================
+  // [Issue #1172] compact TUI layout padding (Claude/Codex 1000-row panes)
+  // ============================================================================
+
+  describe('[Issue #1172] compact TUI layout padding', () => {
+    let scrollToSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      // Explicitly mock scroll geometry/behavior (JSDOM does not implement them)
+      // so we can assert on scroll calls and rendered line counts, not just that
+      // a DOM node exists.
+      scrollToSpy = vi.fn();
+      Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+        value: scrollToSpy,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        value: 5000,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+        value: 800,
+        writable: true,
+        configurable: true,
+      });
+      // CSS custom highlight API used by terminal search.
+      Object.defineProperty(globalThis, 'CSS', {
+        value: { highlights: { set: vi.fn(), delete: vi.fn(), has: vi.fn() } },
+        writable: true,
+        configurable: true,
+      });
+      function MockHighlight(..._args: unknown[]) { return {}; }
+      Object.defineProperty(globalThis, 'Highlight', {
+        value: MockHighlight,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      cleanup();
+    });
+
+    /** Count rendered display lines via the <br> separators sanitize emits for '\n'. */
+    const renderedLineCount = (container: HTMLElement) =>
+      container.querySelectorAll('br').length + 1;
+
+    it('renders input byte-for-byte when the prop is false (default)', () => {
+      const raw = buildClaude1000RowPermissionFrame();
+      const { container } = render(<TerminalDisplay output={raw} isActive={true} />);
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      // 1000 raw rows → 999 <br> separators.
+      expect(renderedLineCount(log)).toBe(1000);
+    });
+
+    it('renders the Claude 1000-row fixture as 14 display lines when enabled', () => {
+      const raw = buildClaude1000RowPermissionFrame();
+      const { container } = render(
+        <TerminalDisplay output={raw} isActive={true} compactTuiLayoutPadding />,
+      );
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      expect(renderedLineCount(log)).toBe(14);
+      // Both the top prompt and the bottom task panel survive the collapse.
+      expect(log.textContent).toContain('Do you want to make this edit to useVirtualKeyboard.ts?');
+      expect(log.textContent).toContain('Esc to cancel · Tab to amend');
+      expect(log.textContent).toContain('6 tasks (0 done, 1 in progress, 5 open)');
+    });
+
+    it('collapses the Codex 1000-row layout gap when enabled', () => {
+      const raw = buildCodex1000RowApprovalFrame();
+      const { container } = render(
+        <TerminalDisplay output={raw} isActive={true} compactTuiLayoutPadding />,
+      );
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      expect(renderedLineCount(log)).toBeLessThan(50);
+      expect(log.textContent).toContain('Allow command to run?');
+      expect(log.textContent).toContain('token usage:');
+    });
+
+    it('does NOT show the ended placeholder for an active all-blank frame', () => {
+      // Raw is a full 1000-row blank frame (truthy string); display compacts to ''.
+      const blankFrame = Array<string>(1000).fill('').join('\n');
+      render(
+        <TerminalDisplay
+          output={blankFrame}
+          isActive={true}
+          attaching={false}
+          compactTuiLayoutPadding
+        />,
+      );
+      expect(screen.queryByTestId('terminal-ended-placeholder')).not.toBeInTheDocument();
+    });
+
+    it('auto-follows to the bottom when new visible content is appended', () => {
+      const first = 'line 1\nline 2';
+      const { rerender } = render(
+        <TerminalDisplay output={first} isActive={true} compactTuiLayoutPadding />,
+      );
+      scrollToSpy.mockClear();
+      rerender(
+        <TerminalDisplay output={`${first}\nline 3`} isActive={true} compactTuiLayoutPadding />,
+      );
+      expect(scrollToSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 5000, behavior: 'instant' }),
+      );
+    });
+
+    it('does NOT re-scroll when a raw-only change compacts to an identical display', () => {
+      // Both frames normalize to 'A\n\nB'; only the raw blank-run length differs.
+      const frameA = ['A', '', '', '', '', 'B'].join('\n');
+      const frameB = ['A', '', '', '', '', '', '', '', 'B'].join('\n');
+      const { rerender } = render(
+        <TerminalDisplay output={frameA} isActive={true} compactTuiLayoutPadding />,
+      );
+      scrollToSpy.mockClear();
+      rerender(<TerminalDisplay output={frameB} isActive={true} compactTuiLayoutPadding />);
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    });
+
+    it('disables auto-follow when the user scrolls up (compact mode)', () => {
+      const onScrollChange = vi.fn();
+      const raw = buildClaude1000RowPermissionFrame();
+      const { container } = render(
+        <TerminalDisplay
+          output={raw}
+          isActive={true}
+          compactTuiLayoutPadding
+          onScrollChange={onScrollChange}
+        />,
+      );
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      // Simulate the user scrolling away from the bottom.
+      Object.defineProperty(log, 'scrollTop', { value: 0, configurable: true });
+      fireEvent.scroll(log);
+      expect(onScrollChange).toHaveBeenCalledWith(false);
+    });
+
+    it('keeps ANSI styling and XSS sanitization in compact mode', () => {
+      const raw = ['A', '', '', '', '\x1b[31mError\x1b[0m', '<script>alert(1)</script>'].join('\n');
+      const { container } = render(
+        <TerminalDisplay output={raw} isActive={true} compactTuiLayoutPadding />,
+      );
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      expect(log.innerHTML).not.toContain('<script>');
+      expect(log.textContent).toContain('Error');
+      expect(log.innerHTML).toContain('style=');
+    });
+
+    it('search operates over the compacted DOM text', async () => {
+      const raw = buildClaude1000RowPermissionFrame();
+      const { container } = render(
+        <TerminalDisplay output={raw} isActive={true} compactTuiLayoutPadding />,
+      );
+      const log = container.querySelector('[role="log"]') as HTMLElement;
+      // The search source is container.textContent; the huge blank gap is gone,
+      // so a term that only appears once is found exactly once.
+      fireEvent.keyDown(log, { key: 'f', ctrlKey: true });
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'tasks' } });
+      await waitFor(
+        () => expect(screen.getByText(/1\s*\/\s*1/)).toBeInTheDocument(),
+        { timeout: 1000 },
+      );
     });
   });
 });

--- a/tests/unit/lib/terminal-display-normalizer.test.ts
+++ b/tests/unit/lib/terminal-display-normalizer.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for normalizeTerminalOutputForDisplay (Issue #1172).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeTerminalOutputForDisplay } from '@/lib/terminal/terminal-display-normalizer';
+import { stripAnsi } from '@/lib/detection/ansi';
+import { buildClaude1000RowPermissionFrame } from '../../fixtures/claude-1000-row-prompt';
+import { buildCodex1000RowApprovalFrame } from '../../fixtures/codex-1000-row-approval';
+
+const lineCount = (s: string) => (s === '' ? 0 : s.split('\n').length);
+
+describe('normalizeTerminalOutputForDisplay', () => {
+  describe('trivial inputs', () => {
+    it('returns "" for empty string', () => {
+      expect(normalizeTerminalOutputForDisplay('')).toBe('');
+    });
+
+    it('returns a single non-blank line unchanged', () => {
+      expect(normalizeTerminalOutputForDisplay('hello')).toBe('hello');
+    });
+
+    it('collapses an all-blank input to ""', () => {
+      expect(normalizeTerminalOutputForDisplay('\n\n\n\n\n')).toBe('');
+    });
+
+    it('treats whitespace-only lines as blank', () => {
+      expect(normalizeTerminalOutputForDisplay('   \n\t\n  ')).toBe('');
+    });
+  });
+
+  describe('leading / trailing trim', () => {
+    it('removes leading blank lines', () => {
+      expect(normalizeTerminalOutputForDisplay('\n\n\ncontent')).toBe('content');
+    });
+
+    it('removes trailing blank lines', () => {
+      expect(normalizeTerminalOutputForDisplay('content\n\n\n')).toBe('content');
+    });
+
+    it('removes both leading and trailing blank lines', () => {
+      expect(normalizeTerminalOutputForDisplay('\n\n\nA\nB\n\n\n')).toBe('A\nB');
+    });
+  });
+
+  describe('internal blank runs', () => {
+    it('keeps an internal single blank line', () => {
+      expect(normalizeTerminalOutputForDisplay('A\n\nB')).toBe('A\n\nB');
+    });
+
+    it('keeps an internal 2-blank run verbatim', () => {
+      expect(normalizeTerminalOutputForDisplay('A\n\n\nB')).toBe('A\n\n\nB');
+    });
+
+    it('collapses an internal 3-blank run to exactly one blank line', () => {
+      expect(normalizeTerminalOutputForDisplay('A\n\n\n\nB')).toBe('A\n\nB');
+    });
+
+    it('collapses a large internal blank run (942) to one blank line', () => {
+      const input = ['A', ...Array<string>(942).fill(''), 'B'].join('\n');
+      const out = normalizeTerminalOutputForDisplay(input);
+      expect(out).toBe('A\n\nB');
+      expect(lineCount(out)).toBe(3);
+    });
+
+    it('handles multiple independent internal runs', () => {
+      expect(normalizeTerminalOutputForDisplay('A\n\n\n\nB\n\nC\n\n\n\n\nD')).toBe(
+        'A\n\nB\n\nC\n\nD',
+      );
+    });
+  });
+
+  describe('non-blank content preservation', () => {
+    it('never removes or reorders non-blank lines', () => {
+      const input = 'z\ny\nx\nz\ny\nx';
+      expect(normalizeTerminalOutputForDisplay(input)).toBe(input);
+    });
+
+    it('preserves duplicate non-blank lines', () => {
+      const input = 'same\nsame\nsame';
+      expect(normalizeTerminalOutputForDisplay(input)).toBe(input);
+    });
+
+    it('keeps 1000 dense non-blank lines intact', () => {
+      const input = Array.from({ length: 1000 }, (_, i) => `line-${i}`).join('\n');
+      const out = normalizeTerminalOutputForDisplay(input);
+      expect(out).toBe(input);
+      expect(lineCount(out)).toBe(1000);
+    });
+  });
+
+  describe('ANSI handling', () => {
+    it('classifies ANSI-only lines as blank', () => {
+      expect(normalizeTerminalOutputForDisplay('A\n\x1b[31m\n\x1b[0m\n\x1b[32m\nB')).not.toContain(
+        'placeholder',
+      );
+    });
+
+    it('preserves color/reset sequences that span a collapsed run', () => {
+      // Red is opened on a blank row, content follows after 3+ blank rows.
+      const input = ['A', '\x1b[31m', '', '', '', 'B'].join('\n');
+      const out = normalizeTerminalOutputForDisplay(input);
+      // Collapsed to A, one blank row carrying \x1b[31m, then B.
+      expect(out).toBe('A\n\x1b[31m\nB');
+      // The color sequence survives so B still renders red.
+      expect(out).toContain('\x1b[31m');
+    });
+
+    it('preserves both start and reset sequences inside a collapsed run', () => {
+      const input = ['A', '\x1b[31m', '', '', '\x1b[0m', 'B'].join('\n');
+      const out = normalizeTerminalOutputForDisplay(input);
+      expect(out).toBe('A\n\x1b[31m\x1b[0m\nB');
+    });
+
+    it('the collapsed ANSI row is still visually blank', () => {
+      const input = ['A', '\x1b[31m', '', '', '\x1b[0m', 'B'].join('\n');
+      const out = normalizeTerminalOutputForDisplay(input);
+      const collapsedRow = out.split('\n')[1];
+      expect(stripAnsi(collapsedRow).trim()).toBe('');
+    });
+  });
+
+  describe('idempotency', () => {
+    const cases = [
+      '',
+      'A',
+      '\n\n\n',
+      '\n\n\nA\nB\n\n\n',
+      'A\n\n\n\nB',
+      ['A', ...Array<string>(942).fill(''), 'B'].join('\n'),
+      ['A', '\x1b[31m', '', '', '\x1b[0m', 'B'].join('\n'),
+      buildClaude1000RowPermissionFrame(),
+      buildCodex1000RowApprovalFrame(),
+    ];
+
+    it.each(cases.map((c, i) => [i, c] as const))('is idempotent for case %i', (_i, input) => {
+      const once = normalizeTerminalOutputForDisplay(input);
+      expect(normalizeTerminalOutputForDisplay(once)).toBe(once);
+    });
+  });
+
+  describe('Claude 1000-row fixture', () => {
+    it('keeps raw at 1000 lines but renders 14 display lines', () => {
+      const raw = buildClaude1000RowPermissionFrame();
+      expect(lineCount(raw)).toBe(1000);
+
+      const display = normalizeTerminalOutputForDisplay(raw);
+      expect(lineCount(display)).toBe(14);
+
+      // The prompt and the task panel both survive the collapse.
+      expect(display).toContain('Do you want to make this edit to useVirtualKeyboard.ts?');
+      expect(display).toContain('Esc to cancel · Tab to amend');
+      expect(display).toContain('6 tasks (0 done, 1 in progress, 5 open)');
+      expect(display).toContain('… +1 pending');
+    });
+  });
+
+  describe('Codex 1000-row fixture', () => {
+    it('collapses the layout gap while preserving the approval prompt and footer', () => {
+      const raw = buildCodex1000RowApprovalFrame();
+      expect(lineCount(raw)).toBe(1000);
+
+      const display = normalizeTerminalOutputForDisplay(raw);
+      expect(lineCount(display)).toBeLessThan(50);
+      expect(display).toContain('Allow command to run?');
+      expect(display).toContain('token usage:');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1172 — Claude/Codexの1000行ペインで大量の空行スクロールを解消する。

Claude/Codex表示時のみ、レイアウト用の空行を**表示専用**に決定的ルールで圧縮する。tmux geometry（1000行固定・生出力）とdetection/保存/line count/realtime snippetは一切変更せず、`TerminalDisplay` の displayOutput 分離で対応。

## 主な変更
- `src/lib/terminal/terminal-display-normalizer.ts`（新規）: 表示専用の空行圧縮ロジック
- `src/components/worktree/TerminalDisplay.tsx`: `compactTuiLayoutPadding?: boolean`（default false）でopt-in
- `TerminalSplitPaneContent.tsx` / `WorktreeDetailMobile.tsx`: Claude/Codex時にpropを渡す
- `src/lib/detection/ansi.ts`, `cli-patterns.ts`: ANSI処理補助
- TDD: normalizer unit + TerminalDisplay component tests、Codex 1000行fixture追加

## 制約遵守
- rawOutput（status/prompt検出・Auto-Yes・保存・transport）は変更なし
- tmux geometry（`src/config/tmux-pane-config.ts`）は変更なし

## 品質チェック（オーケストレーターが独立検証）
- lint: Pass / tsc --noEmit: Pass
- test:unit: 543 files / 9155 tests Pass
- build: Pass（36/36）

関連: #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
