### PR TITLE
feat(terminal): PC各ターミナルsplitにセッション終了ボタンを追加 (#1171)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -87,7 +87,8 @@
     "selectInstance": "Select agent instance for {split}",
     "moreActions": "More actions",
     "searchTerminal": "Search terminal",
-    "endSession": "End session"
+    "endSession": "End session",
+    "endSessionFor": "End session for {name}"
   },
   "todo": {
     "addPlaceholder": "Add a todo…",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -87,7 +87,8 @@
     "selectInstance": "{split} のエージェントインスタンスを選択",
     "moreActions": "その他の操作",
     "searchTerminal": "ターミナル内を検索",
-    "endSession": "セッションを終了"
+    "endSession": "セッションを終了",
+    "endSessionFor": "{name}のセッションを終了"
   },
   "todo": {
     "addPlaceholder": "ToDoを追加…",

--- a/src/app/api/worktrees/[id]/kill-session/route.ts
+++ b/src/app/api/worktrees/[id]/kill-session/route.ts
@@ -11,7 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getDbInstance } from '@/lib/db/db-instance';
-import { getWorktreeById, deleteSessionState, deleteAllMessages, deleteMessagesByCliTool, deleteMessagesByInstance, clearLastUserMessage, getAgentInstances, getAgentInstance } from '@/lib/db';
+import { getWorktreeById, deleteSessionState, deleteAllMessages, deleteMessagesByCliTool, deleteMessagesByInstance, recomputeLastUserMessage, getAgentInstances, getAgentInstance } from '@/lib/db';
 import { CLIToolManager } from '@/lib/cli-tools/manager';
 import { killSession } from '@/lib/tmux/tmux';
 import { broadcast } from '@/lib/ws-server';
@@ -154,8 +154,11 @@ export async function POST(
       deleteAllMessages(db, params.id);
     }
 
-    // Issue #168: Clear last_user_message after archiving to prevent stale sidebar data
-    clearLastUserMessage(db, params.id);
+    // Issue #168 / #1171: recompute last_user_message from the remaining active
+    // messages after archiving. A targeted (instance / CLI) kill only archives
+    // that scope's messages, so other instances' un-archived user messages must
+    // keep driving the sidebar metadata; only when none remain is it cleared.
+    recomputeLastUserMessage(db, params.id);
 
     // Broadcast session status change via WebSocket
     // Issue #4: Include cliTool in payload for targeted updates

--- a/src/components/worktree/TerminalSplitPane.tsx
+++ b/src/components/worktree/TerminalSplitPane.tsx
@@ -69,7 +69,11 @@ export interface TerminalSplitPaneProps {
   onFocus: () => void;
   /** Whether tmux attach is in progress for this split. */
   attaching?: boolean;
-  /** Rendered above the instance selector — usually empty (`null`). */
+  /**
+   * Rendered directly after the instance selector (Dropdown) and before the
+   * search button (Issue #1171). Usually the per-split session End (×) button;
+   * empty (`null`) when the split's session is not running.
+   */
   headerExtras?: React.ReactNode;
   /** Terminal output area (TerminalDisplay). */
   terminal: React.ReactNode;
@@ -256,6 +260,12 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
           </DropdownMenuContent>
         </DropdownMenu>
 
+        {/* Issue #1171: session-scoped extras (the End × button) sit directly
+            after the instance selector, before the search button, so the
+            terminate action reads as tied to the selected session. The search
+            button keeps `ml-auto` and stays pinned to the right edge. */}
+        {headerExtras}
+
         <button
           type="button"
           onClick={handleSearchClick}
@@ -279,7 +289,6 @@ export const TerminalSplitPane = memo(function TerminalSplitPane({
             />
           </svg>
         </button>
-        {headerExtras}
       </div>
 
       {/* Body: terminal display (or attach skeleton) */}

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -23,6 +23,7 @@
 'use client';
 
 import React, { memo, useCallback, useMemo } from 'react';
+import { X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { AgentInstance, CLIToolType } from '@/lib/cli-tools/types';
 import { TerminalSplitPane } from '@/components/worktree/TerminalSplitPane';
@@ -43,11 +44,12 @@ import { usePendingMessages, type OptimisticSendOptions } from '@/hooks/usePendi
 import { useHistoryPaneState } from '@/hooks/useHistoryPaneState';
 import { worktreeApi } from '@/lib/api-client';
 import { buildPromptResponseBody } from '@/lib/prompt-response-body-builder';
-import { getCliToolDisplayName } from '@/lib/cli-tools/types';
+import { getCliToolDisplayName, getInstanceLabel } from '@/lib/cli-tools/types';
 import type {
   TerminalSplitPaneCoreProps,
   SplitAutoYesProps,
   HistoryPaneProps,
+  SessionKillTarget,
 } from '@/types/terminal-split-pane';
 
 /**
@@ -88,6 +90,14 @@ export interface TerminalSplitPaneContentProps extends TerminalSplitPaneCoreProp
   onDropInstance?: (instanceId: string) => void;
   /** Issue #786 / #869 (D-2): published instanceId being dragged, for the dragOver ring. */
   draggedInstanceId?: string | null;
+  /**
+   * Issue #1171: request ending THIS split's session. The split builds its own
+   * {@link SessionKillTarget} snapshot (its cliToolId / resolved instanceId /
+   * alias-first label) and hands it up so the confirm dialog terminates exactly
+   * the session this split shows — never the globally-active one. Optional; when
+   * omitted the End (×) button is not rendered (backward compatible).
+   */
+  onRequestSessionEnd?: (target: SessionKillTarget) => void;
 }
 
 export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
@@ -108,6 +118,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   history,
   onDropInstance,
   draggedInstanceId,
+  onRequestSessionEnd,
 }: TerminalSplitPaneContentProps) {
   // Issue #869: resolve the instance id this split targets. Defaults to the
   // primary instance (`=== cliToolId`) so pre-#869 single-instance behavior —
@@ -529,6 +540,44 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
     ],
   );
 
+  // Issue #1171: alias-first display name for THIS split's session, snapshotted
+  // into the kill target and shown in the End button tooltip / aria-label.
+  const endTargetLabel = getInstanceLabel(instance ?? { cliTool: cliToolId });
+
+  // Issue #1171: build this split's own kill-target snapshot and request the
+  // confirm dialog. Uses THIS split's cliToolId / resolved instanceId, so a
+  // non-focused split terminates exactly the session it displays.
+  const handleRequestSessionEnd = useCallback(() => {
+    onRequestSessionEnd?.({
+      cliToolId,
+      instanceId: resolvedInstanceId,
+      label: endTargetLabel,
+    });
+  }, [onRequestSessionEnd, cliToolId, resolvedInstanceId, endTargetLabel]);
+
+  // Issue #1171: the End (×) button, rendered as `headerExtras` (Dropdown-adjacent).
+  // Shown ONLY when THIS split's own session is running (terminal.isRunning) —
+  // independent of other splits or the DesktopHeader — and never during
+  // attaching / stopped states. Memoized so a steady polling tick (isRunning
+  // unchanged) does not recreate the element and re-render the memoized
+  // TerminalSplitPane.
+  const endSessionExtras = useMemo(() => {
+    if (!onRequestSessionEnd || !terminal.isRunning) return null;
+    const label = t('terminal.endSessionFor', { name: endTargetLabel });
+    return (
+      <button
+        type="button"
+        onClick={handleRequestSessionEnd}
+        aria-label={label}
+        title={label}
+        data-testid={`terminal-end-session-button-${splitIndex}`}
+        className="flex items-center justify-center p-0.5 rounded text-muted-foreground hover:text-danger focus:text-danger hover:bg-danger/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-danger/50 transition-colors"
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    );
+  }, [onRequestSessionEnd, terminal.isRunning, t, endTargetLabel, handleRequestSessionEnd, splitIndex]);
+
   return (
     <TerminalSplitPane
       worktreeId={worktreeId}
@@ -538,6 +587,7 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
       instance={instance}
       availableInstances={availableInstances}
       onInstanceChange={onInstanceChange}
+      headerExtras={endSessionExtras}
       // Issue #1079: the derived agent status now renders as a StatusDot inside
       // the selector trigger (session title bar). BranchStatus ⊂ StatusDotStatus.
       status={cliStatus}

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -50,6 +50,7 @@ import { DesktopHeader, InfoModal } from '@/components/worktree/WorktreeDetailSu
 import { UPLOADABLE_EXTENSIONS } from '@/config/uploadable-extensions';
 import { deriveCliStatus } from '@/types/sidebar';
 import { getCliToolDisplayName, type AgentInstance, type CLIToolType } from '@/lib/cli-tools/types';
+import type { SessionKillTarget } from '@/types/terminal-split-pane';
 import type { AutoYesToggleParams } from '@/components/worktree/AutoYesToggle';
 import type { ShowToast } from '@/types/markdown-editor';
 import type { Worktree, FileContent } from '@/types/models';
@@ -159,10 +160,15 @@ export interface WorktreeDetailDesktopProps {
   fileInputRef: React.RefObject<HTMLInputElement>;
   onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 
-  // Kill session confirmation
-  /** Opens the kill confirmation modal for the active CLI session (Issue #784). */
+  // Kill session confirmation (Issue #1171: target-snapshot based)
+  /** Opens the kill confirmation modal for the active agent instance (DesktopHeader, Issue #784). */
   onKillSession: () => void;
-  showKillConfirm: boolean;
+  /** Issue #1171: open the confirm dialog for a specific split's snapshotted target. */
+  onRequestSessionEnd: (target: SessionKillTarget) => void;
+  /** Issue #1171: the snapshotted kill target; non-null opens the dialog (no separate boolean). */
+  killTarget: SessionKillTarget | null;
+  /** Issue #1171: true while the kill POST is in flight (disables Confirm, blocks double-submit). */
+  isKillPending: boolean;
   onKillCancel: () => void;
   onKillConfirm: () => void;
 
@@ -257,7 +263,9 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
   fileInputRef,
   onFileInputChange,
   onKillSession,
-  showKillConfirm,
+  onRequestSessionEnd,
+  killTarget,
+  isKillPending,
   onKillCancel,
   onKillConfirm,
   moveTarget,
@@ -430,6 +438,9 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
           // the dragOver ring (D-2). The hover ring state stays child-local (D-3).
           onDropInstance={onDropInstance}
           draggedInstanceId={draggedInstanceId}
+          // Issue #1171: the split builds its own kill-target snapshot and calls
+          // this to open the confirm dialog for exactly the session it shows.
+          onRequestSessionEnd={onRequestSessionEnd}
         />
       );
     },
@@ -461,6 +472,8 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       // changes so each split's dragOver ring reflects the in-flight drag
       // (drag-time only, not a polling-cadence re-render).
       draggedInstanceId,
+      // Issue #1171: stable controller callback; listed for exhaustive-deps.
+      onRequestSessionEnd,
     ],
   );
 
@@ -762,9 +775,11 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
           className="hidden"
           aria-label="Upload file"
         />
-        {/* Kill session confirmation dialog */}
+        {/* Kill session confirmation dialog (Issue #1171: target-snapshot based;
+            `killTarget !== null` is the single open-state source, and Confirm is
+            disabled while the POST is in flight to prevent a double-submit). */}
         <Modal
-          isOpen={showKillConfirm}
+          isOpen={killTarget !== null}
           onClose={onKillCancel}
           title={killDialogTitle}
           size="sm"
@@ -785,7 +800,9 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
               <button
                 type="button"
                 onClick={onKillConfirm}
-                className="px-4 py-2 text-sm font-medium rounded-md bg-danger hover:bg-danger/90 text-white"
+                disabled={isKillPending}
+                data-testid="kill-session-confirm-button"
+                className="px-4 py-2 text-sm font-medium rounded-md bg-danger hover:bg-danger/90 text-white disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {endLabel}
               </button>

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -171,7 +171,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     handleInsertToSplit,
     handleKillCancel,
     handleKillConfirm,
-    handleKillSession,
+    openKillConfirm,
+    openActiveKillConfirm,
+    killTarget,
+    isKillPending,
     handleLoadContent,
     handleLoadError,
     handleMessageSent,
@@ -224,7 +227,6 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
     setIsEditorMaximized,
     setWorktree,
     showArchived,
-    showKillConfirm,
     showNewFileDialog,
     showToast,
     state,
@@ -304,6 +306,12 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
   // display name when no alias is set or the active instance is stale).
   const activeInstanceLabel = getActiveInstanceLabel(agentInstances, activeInstanceId, activeCliTab);
 
+  // Issue #1171: the kill-confirm dialog title uses the SNAPSHOTTED target label
+  // (captured at button press) so it stays fixed even if the active instance /
+  // focused split / Dropdown selection changes while the dialog is open. Falls
+  // back to the active instance label when no target is set (dialog closed).
+  const killDialogLabel = killTarget?.label ?? activeInstanceLabel;
+
   // Issue #960: derive the active session's running state per-instance優先
   // （PC版と整合）so the End button and MessageInput reflect the selected
   // instance rather than the per-CLI aggregate. Falls back to the per-CLI map
@@ -381,8 +389,10 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           onWorktreeUpdate={setWorktree}
           fileInputRef={fileInputRef}
           onFileInputChange={handleFileInputChange}
-          onKillSession={handleKillSession}
-          showKillConfirm={showKillConfirm}
+          onKillSession={openActiveKillConfirm}
+          onRequestSessionEnd={openKillConfirm}
+          killTarget={killTarget}
+          isKillPending={isKillPending}
           onKillCancel={handleKillCancel}
           onKillConfirm={handleKillConfirm}
           moveTarget={moveTarget}
@@ -395,7 +405,7 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           onNewFileCancel={handleNewFileCancel}
           toasts={toasts}
           onToastClose={removeToast}
-          killDialogTitle={tWorktree('session.confirmEnd', { tool: activeInstanceLabel })}
+          killDialogTitle={tWorktree('session.confirmEnd', { tool: killDialogLabel })}
           killDialogWarning={tWorktree('session.endWarning')}
           cancelLabel={tCommon('cancel')}
           endLabel={tCommon('end')}
@@ -651,13 +661,13 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
         )}
 
         {/* Issue #1080: terminal secondary actions (search + End) bottom sheet.
-            End defers to handleKillSession, which opens the existing kill-confirm
-            dialog (destructive confirmation preserved). */}
+            Issue #1171: End defers to openActiveKillConfirm, which snapshots the
+            active instance as the kill target and opens the confirm dialog. */}
         <MobileTerminalActionsSheet
           open={showActionsSheet}
           onClose={() => setShowActionsSheet(false)}
           onSearch={() => window.dispatchEvent(new CustomEvent('terminal-search-open'))}
-          onEnd={handleKillSession}
+          onEnd={openActiveKillConfirm}
           endDisabled={!activeSessionRunning}
         />
 
@@ -699,11 +709,13 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
           className="hidden"
           aria-label="Upload file"
         />
-        {/* Kill session confirmation dialog (Mobile) */}
+        {/* Kill session confirmation dialog (Mobile) — Issue #1171: same
+            target-snapshot model as PC (killTarget drives open-state + title;
+            Confirm disabled while the POST is in flight). */}
         <Modal
-          isOpen={showKillConfirm}
+          isOpen={killTarget !== null}
           onClose={handleKillCancel}
-          title={tWorktree('session.confirmEnd', { tool: activeInstanceLabel })}
+          title={tWorktree('session.confirmEnd', { tool: killDialogLabel })}
           size="sm"
           showCloseButton={true}
         >
@@ -722,7 +734,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
               <button
                 type="button"
                 onClick={handleKillConfirm}
-                className="px-4 py-2 text-sm font-medium rounded-md bg-danger hover:bg-danger/90 text-white"
+                disabled={isKillPending}
+                className="px-4 py-2 text-sm font-medium rounded-md bg-danger hover:bg-danger/90 text-white disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {tCommon('end')}
               </button>

--- a/src/hooks/useSplitMessages.ts
+++ b/src/hooks/useSplitMessages.ts
@@ -25,6 +25,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import type { ChatMessage } from '@/types/models';
+import { useRealtime } from '@/hooks/useRealtimeConnection';
+import type { RealtimeEvent, SessionStatusEvent } from '@/lib/realtime/types';
 
 /** Polling cadence for per-split message history (ms). */
 export const SPLIT_MESSAGES_POLL_INTERVAL_MS = 5000;
@@ -71,6 +73,10 @@ export function useSplitMessages({
 }: UseSplitMessagesOptions): UseSplitMessagesReturn {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Issue #1171: realtime access so a targeted kill (matching scoped stop event)
+  // refreshes THIS split's history immediately instead of waiting for the 5s poll.
+  const { subscribe, unsubscribe, addListener } = useRealtime();
 
   // Resolve to the primary instance when omitted (instanceId === cliToolId).
   const resolvedInstanceId = instanceId ?? cliToolId;
@@ -167,6 +173,31 @@ export function useSplitMessages({
       document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [enabled, fetchMessages]);
+
+  // Issue #1171: join the worktree room so scoped stop events are delivered
+  // (ref-counted, so sharing the room with useTerminalPanePolling is harmless).
+  useEffect(() => {
+    if (!enabled) return;
+    subscribe(worktreeId);
+    return () => unsubscribe(worktreeId);
+  }, [enabled, worktreeId, subscribe, unsubscribe]);
+
+  // Issue #1171: when THIS split's session is terminated (matching scoped stop
+  // event; messages were archived server-side), re-fetch so the current session
+  // history clears immediately. Scoped events for other splits are ignored, so a
+  // sibling's kill never refetches — and thus never disturbs — this split.
+  useEffect(() => {
+    if (!enabled) return;
+    return addListener((event: RealtimeEvent) => {
+      if (event.type !== 'session_status_changed') return;
+      const evt = event as SessionStatusEvent;
+      if (evt.worktreeId !== worktreeId) return;
+      if (evt.isRunning !== false) return;
+      if (evt.instance != null && evt.instance !== inFlightInstanceRef.current) return;
+      if (evt.cliTool != null && evt.cliTool !== inFlightCliToolRef.current) return;
+      void fetchMessages();
+    });
+  }, [enabled, worktreeId, addListener, fetchMessages]);
 
   const refresh = useCallback(() => fetchMessages(), [fetchMessages]);
 

--- a/src/hooks/useTerminalPanePolling.ts
+++ b/src/hooks/useTerminalPanePolling.ts
@@ -33,7 +33,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import type { PromptData } from '@/types/models';
 import { useRealtime } from '@/hooks/useRealtimeConnection';
-import type { RealtimeEvent, TerminalSnapshotEvent } from '@/lib/realtime/types';
+import type { RealtimeEvent, TerminalSnapshotEvent, SessionStatusEvent } from '@/lib/realtime/types';
 
 export const ACTIVE_POLLING_INTERVAL_MS = 2000;
 export const IDLE_POLLING_INTERVAL_MS = 5000;
@@ -376,6 +376,40 @@ export function useTerminalPanePolling({
       });
     });
   }, [enabled, worktreeId, addListener, applySnapshot, markPushHealthy]);
+
+  // Issue #1171: apply a matching scoped session-stop event immediately so a
+  // targeted kill flips THIS pane to the terminated placeholder (#842) without
+  // waiting for the throttled HTTP fallback poll (up to 15s while a WS push is
+  // healthy). Matching rules: worktreeId exact; when the event carries an
+  // `instance` it must equal this pane's resolved instance; when it carries a
+  // `cliTool` it must equal this pane's cliTool. An unscoped kill-all
+  // (instance == null && cliTool == null) applies to every pane. Scoped events
+  // for another split are ignored, so a sibling's kill never blanks this pane.
+  useEffect(() => {
+    if (!enabled) return;
+    return addListener((event: RealtimeEvent) => {
+      if (event.type !== 'session_status_changed') return;
+      const evt = event as SessionStatusEvent;
+      if (evt.worktreeId !== worktreeId) return;
+      if (evt.isRunning !== false) return;
+      if (evt.instance != null && evt.instance !== inFlightInstanceRef.current) return;
+      if (evt.cliTool != null && evt.cliTool !== inFlightCliToolRef.current) return;
+      // Reset the push version guard so a subsequent restart's snapshots (which
+      // restart their own version counter) are not rejected as stale.
+      lastSnapshotVersionRef.current = 0;
+      applySnapshot({
+        fullOutput: '',
+        realtimeSnippet: '',
+        isRunning: false,
+        thinking: false,
+        isSelectionListActive: false,
+        isPagerActive: false,
+        isUnclassifiedActive: false,
+        isPromptWaiting: false,
+        promptData: null,
+      });
+    });
+  }, [enabled, worktreeId, addListener, applySnapshot]);
 
   // Initial + interval polling. Pauses when hidden, resumes on visible.
   // Cadence depends on isRunning (active=2s, idle=5s); while a WS push

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -49,9 +49,12 @@ import {
   isCliToolType,
   isValidInstanceId,
   agentInstancesFromSelectedAgents,
+  getActiveInstanceLabel,
   type CLIToolType,
   type AgentInstance,
 } from '@/lib/cli-tools/types';
+import { worktreeApi, ApiError } from '@/lib/api-client';
+import type { SessionKillTarget } from '@/types/terminal-split-pane';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
 import { useMobileSelectedInstances } from '@/hooks/useMobileSelectedInstances';
 import { useTranslations } from 'next-intl';
@@ -985,40 +988,92 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     [makeAutoYesToggleHandler, activeCliTab, activeInstanceId],
   );
 
-  /** Issue #4: Kill session confirmation dialog state */
-  const [showKillConfirm, setShowKillConfirm] = useState(false);
+  /**
+   * Issue #1171: kill-session confirmation is driven by a target *snapshot*
+   * value, not a separate boolean. `killTarget !== null` opens the dialog; the
+   * captured (cliToolId, instanceId, label) is the sole source of truth for what
+   * gets terminated — never re-derived from active/focus state at confirm time.
+   */
+  const [killTarget, setKillTarget] = useState<SessionKillTarget | null>(null);
+  /**
+   * Issue #1171: in-flight POST guard. Disables the Confirm button (prevents a
+   * double-submit) and makes Cancel/close a no-op so the target is preserved
+   * until the request settles. A ref mirror backs the SYNCHRONOUS guard: React
+   * state is stale within a rapid double-click's shared closure, so the ref is
+   * the authoritative "already submitting" check while `isKillPending` drives UI.
+   */
+  const [isKillPending, setIsKillPending] = useState(false);
+  const isKillPendingRef = useRef(false);
 
-  /** Issue #4: Show confirmation dialog before killing session */
-  const handleKillSession = useCallback((): void => {
-    setShowKillConfirm(true);
+  /**
+   * Issue #1171: open the confirm dialog for an explicit target snapshot. Used
+   * by each PC terminal split's End button, which builds its OWN target from its
+   * own instance so a non-focused split terminates exactly the session it shows.
+   */
+  const openKillConfirm = useCallback((target: SessionKillTarget): void => {
+    setKillTarget(target);
   }, []);
 
-  /** Issue #4: Execute session kill after confirmation */
-  const handleKillConfirm = useCallback(async (): Promise<void> => {
-    setShowKillConfirm(false);
-    try {
-      // Issue #874/#875: always scope the kill to the active agent instance, on
-      // PC as well as mobile. The primary instance uses instanceId === cliToolId
-      // (byte-identical session name), so this is unchanged for primary
-      // instances; for alias instances it terminates only that instance's
-      // session instead of every session of the backing CLI tool.
-      const killUrl =
-        `/api/worktrees/${worktreeId}/kill-session?cliTool=${activeCliTab}&instance=${encodeURIComponent(activeInstanceIdRef.current)}`;
-      const response = await fetch(killUrl, { method: 'POST' });
-      if (!response.ok) return;
-      actions.clearMessages();
-      // Issue #736: terminal reset reflected by useTerminalPanePolling on the
-      // next poll (session no longer running); only non-terminal state cleared here.
-      actions.clearPrompt();
-      await fetchWorktree();
-    } catch (err) {
-      console.error('[WorktreeDetailRefactored] Error killing session:', err);
-    }
-  }, [worktreeId, activeCliTab, actions, fetchWorktree]);
+  /**
+   * Issue #1171: open the confirm dialog for the CURRENT active agent instance.
+   * Used by the DesktopHeader / Mobile End buttons (whose target is the active
+   * instance). The target is snapshotted here at press time via refs.
+   */
+  const openActiveKillConfirm = useCallback((): void => {
+    const instanceId = activeInstanceIdRef.current;
+    const cliToolId = activeCliTabRef.current;
+    const label = getActiveInstanceLabel(agentInstancesRef.current, instanceId, cliToolId);
+    setKillTarget({ cliToolId, instanceId, label });
+  }, []);
 
-  /** Issue #4: Cancel session kill */
+  /** Issue #1171: execute the kill for the snapshotted target only. */
+  const handleKillConfirm = useCallback(async (): Promise<void> => {
+    const target = killTarget;
+    if (!target || isKillPendingRef.current) return;
+    isKillPendingRef.current = true;
+    setIsKillPending(true);
+
+    // Issue #1171: only wipe the GLOBAL (mobile-consumed / active-scoped) message
+    // + prompt state when the killed target IS the active instance. A PC split
+    // ending a non-active instance must not clear the active view's state.
+    const syncActiveGlobalState = () => {
+      if (target.instanceId === activeInstanceIdRef.current) {
+        actions.clearMessages();
+        // Issue #736: terminal reset is reflected per-split by
+        // useTerminalPanePolling; only non-terminal global state is cleared here.
+        actions.clearPrompt();
+      }
+    };
+
+    try {
+      // Issue #874/#875: always scope the kill to the target agent instance. The
+      // primary instance uses instanceId === cliToolId (byte-identical session
+      // name); alias instances terminate only that instance's session.
+      await worktreeApi.killSession(worktreeId, target.cliToolId, target.instanceId);
+      syncActiveGlobalState();
+      await fetchWorktree();
+      setKillTarget(null);
+    } catch (err) {
+      // Issue #1171: a 404 means the session already ended (natural-termination
+      // race). The goal is achieved, so re-sync and close rather than error.
+      if (err instanceof ApiError && err.status === 404) {
+        syncActiveGlobalState();
+        await fetchWorktree();
+        setKillTarget(null);
+      } else {
+        // Keep the target so the user can retry; surface a failure toast.
+        showToast(tWorktree('session.failedToKill'), 'error');
+      }
+    } finally {
+      isKillPendingRef.current = false;
+      setIsKillPending(false);
+    }
+  }, [killTarget, worktreeId, actions, fetchWorktree, showToast, tWorktree]);
+
+  /** Issue #1171: cancel — a no-op while a kill POST is in flight (keeps target). */
   const handleKillCancel = useCallback((): void => {
-    setShowKillConfirm(false);
+    if (isKillPendingRef.current) return;
+    setKillTarget(null);
   }, []);
 
   // ========================================================================
@@ -1468,7 +1523,10 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     handleInsertToSplit,
     handleKillCancel,
     handleKillConfirm,
-    handleKillSession,
+    openKillConfirm,
+    openActiveKillConfirm,
+    killTarget,
+    isKillPending,
     handleLoadContent,
     handleLoadError,
     handleMessageSent,
@@ -1525,7 +1583,6 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     setIsEditorMaximized,
     setWorktree,
     showArchived,
-    showKillConfirm,
     showNewFileDialog,
     showToast,
     state,

--- a/src/hooks/useWorktreesCache.ts
+++ b/src/hooks/useWorktreesCache.ts
@@ -227,6 +227,20 @@ export function useWorktreesCache(): UseWorktreesCacheReturn {
         const targetId = event.worktreeId;
         const isRunning = (event as { isRunning?: boolean }).isRunning;
         if (typeof isRunning !== 'boolean') return;
+        // Issue #1171: a SCOPED stop (a single agent instance / CLI ended, so the
+        // event carries a `cliTool` or `instance`) does NOT imply the whole
+        // worktree stopped — another instance may still be running. Forcing the
+        // aggregate `isSessionRunning` to false here would flip the sidebar/header
+        // to idle while a sibling session runs. Re-fetch the server-computed
+        // aggregate instead. Unscoped stops (kill-all) and any running transition
+        // keep the direct set below (unchanged behavior).
+        const scoped =
+          (event as { cliTool?: string | null }).cliTool != null ||
+          (event as { instance?: string | null }).instance != null;
+        if (scoped && isRunning === false) {
+          void refresh();
+          return;
+        }
         startTransition(() => {
           setWorktrees((prev) => {
             let changed = false;

--- a/src/lib/db/chat-db.ts
+++ b/src/lib/db/chat-db.ts
@@ -414,6 +414,32 @@ export function clearLastUserMessage(
   stmt.run(worktreeId);
 }
 
+/**
+ * Recompute worktree's last_user_message from the remaining active (non-archived)
+ * user messages (Issue #1171).
+ *
+ * A targeted (single-instance / single-CLI) kill archives only that scope's
+ * messages, so other instances' un-archived user messages may still exist. In
+ * that case the sidebar's last_user_message must reflect the newest *remaining*
+ * message rather than being wiped — unconditionally clearing it (the pre-#1171
+ * behavior) would drop metadata that belongs to a still-running instance.
+ *
+ * When no active user message remains (e.g. a kill-all, or the last message was
+ * the archived one), this falls back to clearing the fields — matching the old
+ * behavior for that case.
+ */
+export function recomputeLastUserMessage(
+  db: Database.Database,
+  worktreeId: string
+): void {
+  const latest = getLastUserMessage(db, worktreeId);
+  if (latest) {
+    updateLastUserMessage(db, worktreeId, latest.content, latest.timestamp);
+  } else {
+    clearLastUserMessage(db, worktreeId);
+  }
+}
+
 /** Options for getMessagesByDateRange query */
 export interface GetMessagesByDateRangeOptions {
   after: Date;

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -50,6 +50,7 @@ export {
   deleteMessagesByInstance,
   updateLastUserMessage,
   clearLastUserMessage,
+  recomputeLastUserMessage,
   getMessageById,
   updatePromptData,
   markPendingPromptsAsAnswered,

--- a/src/types/terminal-split-pane.ts
+++ b/src/types/terminal-split-pane.ts
@@ -22,6 +22,23 @@ import type { HistoryDisplayLimit } from '@/config/history-display-config';
 import type { AutoYesToggleParams } from '@/types/auto-yes';
 import type { ShowToast } from '@/types/markdown-editor';
 
+/**
+ * A session-kill target captured as a value at the moment the End (×) button is
+ * pressed (Issue #1171).
+ *
+ * The kill confirmation dialog is a destructive operation, so its target must
+ * NOT be re-derived from global active/focus state at confirm time (the active
+ * instance, focused split, or Dropdown selection may have changed while the
+ * dialog was open). Each caller snapshots the exact (cliToolId, instanceId) and
+ * a press-time display `label`; the confirm handler acts only on this snapshot.
+ */
+export interface SessionKillTarget {
+  cliToolId: CLIToolType;
+  instanceId: string;
+  /** Alias-first display name captured at press time (for tooltip / dialog). */
+  label: string;
+}
+
 /** Identity + derived status of a single terminal split (Issue #756). */
 export interface TerminalSplitPaneCoreProps {
   worktreeId: string;

--- a/tests/integration/api-kill-session-cli-tool.test.ts
+++ b/tests/integration/api-kill-session-cli-tool.test.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server';
 import { POST as killSession } from '@/app/api/worktrees/[id]/kill-session/route';
 import Database from 'better-sqlite3';
 import { runMigrations } from '@/lib/db/db-migrations';
-import { upsertWorktree } from '@/lib/db';
+import { upsertWorktree, createMessage, getWorktreeById } from '@/lib/db';
 import type { Worktree } from '@/types/models';
 
 // Mock tmux
@@ -221,6 +221,97 @@ describe('POST /api/worktrees/:id/kill-session - CLI Tool Support', () => {
       expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.error).toContain('No active session');
+    });
+  });
+
+  describe('last_user_message recompute (Issue #1171)', () => {
+    it('recomputes last_user_message from remaining messages after a targeted instance kill', async () => {
+      const { CLIToolManager } = await import('@/lib/cli-tools/manager');
+      const claudeTool = CLIToolManager.getInstance().getTool('claude');
+      vi.spyOn(claudeTool, 'isRunning').mockResolvedValue(true);
+
+      const worktree: Worktree = {
+        id: 'wt-metadata',
+        name: 'Metadata Test',
+        path: '/path/to/meta',
+        repositoryPath: '/path/to/repo',
+        repositoryName: 'TestRepo',
+        cliToolId: 'claude',
+      };
+      upsertWorktree(db, worktree);
+
+      // Primary-instance user message (older) — must remain and drive metadata.
+      createMessage(db, {
+        worktreeId: 'wt-metadata',
+        role: 'user',
+        content: 'primary remains',
+        timestamp: new Date(1000),
+        messageType: 'normal',
+        cliToolId: 'claude',
+        instanceId: 'claude',
+      });
+      // Alias-instance user message (newer) — archived by the targeted kill.
+      createMessage(db, {
+        worktreeId: 'wt-metadata',
+        role: 'user',
+        content: 'alias goes away',
+        timestamp: new Date(2000),
+        messageType: 'normal',
+        cliToolId: 'claude',
+        instanceId: 'claude-2',
+      });
+
+      // Before the kill: last_user_message is the newest (alias) message.
+      expect(getWorktreeById(db, 'wt-metadata')?.lastUserMessage).toBe('alias goes away');
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/worktrees/wt-metadata/kill-session?cliTool=claude&instance=claude-2',
+        { method: 'POST' },
+      );
+      const response = await killSession(request, { params: { id: 'wt-metadata' } });
+      expect(response.status).toBe(200);
+
+      // The alias message was archived; last_user_message falls back to the
+      // still-active primary message rather than being cleared.
+      expect(getWorktreeById(db, 'wt-metadata')?.lastUserMessage).toBe('primary remains');
+    });
+
+    it('clears last_user_message when the kill archives the last remaining message', async () => {
+      const { CLIToolManager } = await import('@/lib/cli-tools/manager');
+      const claudeTool = CLIToolManager.getInstance().getTool('claude');
+      vi.spyOn(claudeTool, 'isRunning').mockResolvedValue(true);
+
+      const worktree: Worktree = {
+        id: 'wt-metadata-clear',
+        name: 'Metadata Clear',
+        path: '/path/to/meta2',
+        repositoryPath: '/path/to/repo',
+        repositoryName: 'TestRepo',
+        cliToolId: 'claude',
+      };
+      upsertWorktree(db, worktree);
+
+      createMessage(db, {
+        worktreeId: 'wt-metadata-clear',
+        role: 'user',
+        content: 'only message',
+        timestamp: new Date(1000),
+        messageType: 'normal',
+        cliToolId: 'claude',
+        instanceId: 'claude',
+      });
+      expect(getWorktreeById(db, 'wt-metadata-clear')?.lastUserMessage).toBe('only message');
+
+      // Kill the only (primary) instance; its message is the last remaining one.
+      const request = new NextRequest(
+        'http://localhost:3000/api/worktrees/wt-metadata-clear/kill-session?cliTool=claude&instance=claude',
+        { method: 'POST' },
+      );
+      const response = await killSession(request, { params: { id: 'wt-metadata-clear' } });
+      expect(response.status).toBe(200);
+
+      // No active user message remains → cleared (undefined), as before #1171.
+      expect(getWorktreeById(db, 'wt-metadata-clear')?.lastUserMessage).toBeUndefined();
     });
   });
 });

--- a/tests/unit/components/worktree/TerminalSplitPane.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPane.test.tsx
@@ -155,11 +155,23 @@ describe('TerminalSplitPane', () => {
     expect(skeleton.getAttribute('role')).toBe('status');
   });
 
-  it('renders headerExtras after the search button', () => {
+  // Issue #1171: headerExtras (the per-split End button) moved to sit directly
+  // after the instance selector and BEFORE the search button.
+  it('renders headerExtras between the instance selector and the search button', () => {
     renderPane({
       headerExtras: <span data-testid="header-extras">X</span>,
     });
-    expect(screen.getByTestId('header-extras')).toBeInTheDocument();
+    const extras = screen.getByTestId('header-extras');
+    const selector = screen.getByTestId('cli-selector-0');
+    const search = screen.getByTestId('terminal-search-button-0');
+    expect(extras).toBeInTheDocument();
+    // DOM order: selector → headerExtras → search.
+    expect(
+      selector.compareDocumentPosition(extras) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      extras.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 

--- a/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
+++ b/tests/unit/components/worktree/TerminalSplitPaneContent.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { TerminalSplitPaneContent } from '@/components/worktree/TerminalSplitPaneContent';
 import type { AgentInstance, CLIToolType } from '@/lib/cli-tools/types';
 import { installRadixJsdomPolyfills } from '@tests/helpers/radix-jsdom';
@@ -856,6 +856,153 @@ describe('TerminalSplitPaneContent', () => {
       );
       const input = await screen.findByTestId('message-input-2');
       expect(input.getAttribute('data-pending-insert')).toBe('from-parent');
+    });
+  });
+
+  // Issue #1171: per-split session End (×) button.
+  describe('per-split End (×) button (Issue #1171)', () => {
+    const reviewInstance: AgentInstance = {
+      id: 'claude-2',
+      cliTool: 'claude',
+      alias: 'Review agent',
+      order: 1,
+    };
+
+    it('shows the End button only when THIS split session is running', async () => {
+      mockFetch.mockImplementation(() =>
+        okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+      );
+      render(
+        <TerminalSplitPaneContent
+          worktreeId="w-1"
+          splitIndex={0}
+          cliToolId="claude"
+          instanceId="claude"
+          instance={inst('claude')}
+          availableInstances={[inst('claude')]}
+          onInstanceChange={vi.fn()}
+          onFocus={vi.fn()}
+          autoYes={{ onToggle: vi.fn() }}
+          onRequestSessionEnd={vi.fn()}
+        />,
+      );
+      expect(await screen.findByTestId('terminal-end-session-button-0')).toBeInTheDocument();
+    });
+
+    it('hides the End button when the split session is not running', async () => {
+      mockFetch.mockImplementation(() =>
+        okJson({ isRunning: false, fullOutput: '', thinking: false }),
+      );
+      render(
+        <TerminalSplitPaneContent
+          worktreeId="w-1"
+          splitIndex={0}
+          cliToolId="claude"
+          availableInstances={[inst('claude')]}
+          onInstanceChange={vi.fn()}
+          onFocus={vi.fn()}
+          autoYes={{ onToggle: vi.fn() }}
+          onRequestSessionEnd={vi.fn()}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('terminal-active').textContent).toBe('false'),
+      );
+      expect(screen.queryByTestId('terminal-end-session-button-0')).not.toBeInTheDocument();
+    });
+
+    it('does not render the End button when onRequestSessionEnd is omitted', async () => {
+      mockFetch.mockImplementation(() =>
+        okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+      );
+      render(
+        <TerminalSplitPaneContent
+          worktreeId="w-1"
+          splitIndex={0}
+          cliToolId="claude"
+          availableInstances={[inst('claude')]}
+          onInstanceChange={vi.fn()}
+          onFocus={vi.fn()}
+          autoYes={{ onToggle: vi.fn() }}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('terminal-active').textContent).toBe('true'),
+      );
+      expect(screen.queryByTestId('terminal-end-session-button-0')).not.toBeInTheDocument();
+    });
+
+    it('requests session end with this split OWN snapshotted target (alias-first label)', async () => {
+      mockFetch.mockImplementation(() =>
+        okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+      );
+      const onRequestSessionEnd = vi.fn();
+      render(
+        <TerminalSplitPaneContent
+          worktreeId="w-1"
+          splitIndex={1}
+          cliToolId="claude"
+          instanceId="claude-2"
+          instance={reviewInstance}
+          availableInstances={[inst('claude'), reviewInstance]}
+          onInstanceChange={vi.fn()}
+          onFocus={vi.fn()}
+          autoYes={{ onToggle: vi.fn() }}
+          onRequestSessionEnd={onRequestSessionEnd}
+        />,
+      );
+      const btn = await screen.findByTestId('terminal-end-session-button-1');
+      // Localized aria-label / tooltip present (name interpolation via i18n key).
+      expect(btn.getAttribute('aria-label')).toBeTruthy();
+      fireEvent.click(btn);
+      expect(onRequestSessionEnd).toHaveBeenCalledWith({
+        cliToolId: 'claude',
+        instanceId: 'claude-2',
+        label: 'Review agent',
+      });
+    });
+
+    it('builds independent targets for split 0 (claude) and split 1 (claude-2)', async () => {
+      mockFetch.mockImplementation(() =>
+        okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+      );
+      const end0 = vi.fn();
+      const end1 = vi.fn();
+      render(
+        <>
+          <TerminalSplitPaneContent
+            worktreeId="w-1"
+            splitIndex={0}
+            cliToolId="claude"
+            instanceId="claude"
+            instance={inst('claude')}
+            availableInstances={[inst('claude'), reviewInstance]}
+            onInstanceChange={vi.fn()}
+            onFocus={vi.fn()}
+            autoYes={{ onToggle: vi.fn() }}
+            onRequestSessionEnd={end0}
+          />
+          <TerminalSplitPaneContent
+            worktreeId="w-1"
+            splitIndex={1}
+            cliToolId="claude"
+            instanceId="claude-2"
+            instance={reviewInstance}
+            availableInstances={[inst('claude'), reviewInstance]}
+            onInstanceChange={vi.fn()}
+            onFocus={vi.fn()}
+            autoYes={{ onToggle: vi.fn() }}
+            onRequestSessionEnd={end1}
+          />
+        </>,
+      );
+      fireEvent.click(await screen.findByTestId('terminal-end-session-button-0'));
+      fireEvent.click(await screen.findByTestId('terminal-end-session-button-1'));
+      expect(end0).toHaveBeenCalledWith({ cliToolId: 'claude', instanceId: 'claude', label: 'claude' });
+      expect(end1).toHaveBeenCalledWith({ cliToolId: 'claude', instanceId: 'claude-2', label: 'Review agent' });
+      // Split 0's button never fired split 1's handler and vice versa.
+      expect(end0).toHaveBeenCalledTimes(1);
+      expect(end1).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/db-archived-messages.test.ts
+++ b/tests/unit/db-archived-messages.test.ts
@@ -14,7 +14,9 @@ import {
   getLastAssistantMessageAt,
   deleteAllMessages,
   deleteMessagesByCliTool,
+  deleteMessagesByInstance,
   clearLastUserMessage,
+  recomputeLastUserMessage,
   getMessageById,
   upsertWorktree,
   ACTIVE_FILTER,
@@ -332,6 +334,53 @@ describe('Archived Messages (Issue #168)', () => {
         .get(testWorktreeId) as { last_user_message: string | null; last_user_message_at: number | null };
       expect(after.last_user_message).toBeNull();
       expect(after.last_user_message_at).toBeNull();
+    });
+  });
+
+  describe('recomputeLastUserMessage (Issue #1171)', () => {
+    it('falls back to the newest remaining message after a targeted archive', () => {
+      createMessage(db, {
+        worktreeId: testWorktreeId,
+        role: 'user',
+        content: 'primary remains',
+        timestamp: new Date(1000),
+        messageType: 'normal',
+        cliToolId: 'claude',
+        instanceId: 'claude',
+      });
+      createMessage(db, {
+        worktreeId: testWorktreeId,
+        role: 'user',
+        content: 'alias goes away',
+        timestamp: new Date(2000),
+        messageType: 'normal',
+        cliToolId: 'claude',
+        instanceId: 'claude-2',
+      });
+      // Archive only the alias instance's messages, then recompute.
+      deleteMessagesByInstance(db, testWorktreeId, 'claude-2');
+      recomputeLastUserMessage(db, testWorktreeId);
+
+      const row = db.prepare('SELECT last_user_message FROM worktrees WHERE id = ?')
+        .get(testWorktreeId) as { last_user_message: string | null };
+      expect(row.last_user_message).toBe('primary remains');
+    });
+
+    it('clears the metadata when no active user message remains', () => {
+      createMessage(db, {
+        worktreeId: testWorktreeId,
+        role: 'user',
+        content: 'only message',
+        timestamp: new Date(1000),
+        messageType: 'normal',
+      });
+      deleteAllMessages(db, testWorktreeId);
+      recomputeLastUserMessage(db, testWorktreeId);
+
+      const row = db.prepare('SELECT last_user_message, last_user_message_at FROM worktrees WHERE id = ?')
+        .get(testWorktreeId) as { last_user_message: string | null; last_user_message_at: number | null };
+      expect(row.last_user_message).toBeNull();
+      expect(row.last_user_message_at).toBeNull();
     });
   });
 

--- a/tests/unit/hooks/useSplitMessages.test.ts
+++ b/tests/unit/hooks/useSplitMessages.test.ts
@@ -13,6 +13,33 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useSplitMessages } from '@/hooks/useSplitMessages';
 
+// Issue #1171: controllable realtime mock so tests can fire session_status_changed
+// stop events. Existing tests never emit, so their behavior is unchanged.
+const realtimeMock = vi.hoisted(() => {
+  const listeners: Array<(e: unknown) => void> = [];
+  const api = {
+    status: 'disconnected' as const,
+    connected: false,
+    subscribe: () => {},
+    unsubscribe: () => {},
+    addListener: (l: (e: unknown) => void) => {
+      listeners.push(l);
+      return () => {
+        const i = listeners.indexOf(l);
+        if (i >= 0) listeners.splice(i, 1);
+      };
+    },
+  };
+  return {
+    listeners,
+    emit: (event: unknown) => { for (const l of [...listeners]) l(event); },
+    useRealtime: () => api,
+  };
+});
+vi.mock('@/hooks/useRealtimeConnection', () => ({
+  useRealtime: realtimeMock.useRealtime,
+}));
+
 type MockFetchResponse = {
   ok: boolean;
   status?: number;
@@ -211,6 +238,57 @@ describe('useSplitMessages (Issue #744)', () => {
       await result.current.refresh();
     });
     expect(result.current.messages[0]?.content).toBe('second');
+  });
+
+  // Issue #1171: a targeted kill archives this split's messages; a matching
+  // scoped stop event triggers an immediate re-fetch so the history clears now.
+  it('re-fetches on a matching scoped session stop event', async () => {
+    let phase: 'active' | 'archived' = 'active';
+    mockFetch.mockImplementation(() =>
+      phase === 'active' ? okJson([makeMessage({ content: 'active' })]) : okJson([]),
+    );
+    const { result } = renderHook(() =>
+      useSplitMessages({ worktreeId: 'w-1', cliToolId: 'claude', instanceId: 'claude-2' }),
+    );
+    await waitFor(() => expect(result.current.messages.length).toBe(1));
+
+    phase = 'archived';
+    await act(async () => {
+      realtimeMock.emit({
+        type: 'session_status_changed',
+        worktreeId: 'w-1',
+        isRunning: false,
+        cliTool: 'claude',
+        instance: 'claude-2',
+        messagesCleared: true,
+      });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.messages.length).toBe(0));
+  });
+
+  it('does not re-fetch on a scoped stop event for a different instance', async () => {
+    const calls = { n: 0 };
+    mockFetch.mockImplementation(() => {
+      calls.n += 1;
+      return okJson([makeMessage()]);
+    });
+    renderHook(() =>
+      useSplitMessages({ worktreeId: 'w-1', cliToolId: 'claude', instanceId: 'claude-2' }),
+    );
+    await waitFor(() => expect(calls.n).toBeGreaterThan(0));
+    const before = calls.n;
+    act(() => {
+      realtimeMock.emit({
+        type: 'session_status_changed',
+        worktreeId: 'w-1',
+        isRunning: false,
+        cliTool: 'claude',
+        instance: 'claude', // primary, not this pane's claude-2
+      });
+    });
+    await Promise.resolve();
+    expect(calls.n).toBe(before);
   });
 
   it('resets messages and re-fetches when (worktreeId, cliToolId) changes', async () => {

--- a/tests/unit/hooks/useTerminalPanePolling.test.ts
+++ b/tests/unit/hooks/useTerminalPanePolling.test.ts
@@ -8,6 +8,36 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useTerminalPanePolling } from '@/hooks/useTerminalPanePolling';
 
+// Issue #1171: controllable realtime mock so tests can fire session_status_changed
+// stop events. `connected: false` preserves the pre-#1171 poll cadence (the
+// default no-op provider is also disconnected), so existing tests are unaffected.
+const realtimeMock = vi.hoisted(() => {
+  const listeners: Array<(e: unknown) => void> = [];
+  // Stable object so addListener identity does not change across renders (avoids
+  // effect re-registration churn).
+  const api = {
+    status: 'disconnected' as const,
+    connected: false,
+    subscribe: () => {},
+    unsubscribe: () => {},
+    addListener: (l: (e: unknown) => void) => {
+      listeners.push(l);
+      return () => {
+        const i = listeners.indexOf(l);
+        if (i >= 0) listeners.splice(i, 1);
+      };
+    },
+  };
+  return {
+    listeners,
+    emit: (event: unknown) => { for (const l of [...listeners]) l(event); },
+    useRealtime: () => api,
+  };
+});
+vi.mock('@/hooks/useRealtimeConnection', () => ({
+  useRealtime: realtimeMock.useRealtime,
+}));
+
 type MockFetchResponse = {
   ok: boolean;
   status?: number;
@@ -221,6 +251,110 @@ describe('useTerminalPanePolling', () => {
     });
     expect(result.current.terminal.output).toBe('steady output');
     expect(result.current.terminal.isRunning).toBe(true);
+  });
+
+  // Issue #1171: matching scoped session-stop events flip the pane to the
+  // terminated placeholder immediately (before the throttled fallback poll).
+  it('clears the pane on a matching scoped session_status_changed stop event', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({
+        isRunning: true,
+        fullOutput: 'live',
+        thinking: false,
+        isPromptWaiting: true,
+        promptData: { type: 'yes_no', question: 'Continue?' },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude', instanceId: 'claude-2' }),
+    );
+    await waitFor(() => expect(result.current.terminal.output).toBe('live'));
+    await waitFor(() => expect(result.current.prompt.visible).toBe(true));
+
+    // The session ends; subsequent polls also report stopped.
+    mockFetch.mockImplementation(() => okJson({ isRunning: false, fullOutput: '', thinking: false }));
+    await act(async () => {
+      realtimeMock.emit({
+        type: 'session_status_changed',
+        worktreeId: 'w-1',
+        isRunning: false,
+        cliTool: 'claude',
+        instance: 'claude-2',
+      });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(result.current.terminal.isRunning).toBe(false);
+      expect(result.current.terminal.output).toBe('');
+      expect(result.current.prompt.visible).toBe(false);
+    });
+  });
+
+  it('ignores a scoped stop event targeting a different instance', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+    );
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude', instanceId: 'claude-2' }),
+    );
+    await waitFor(() => expect(result.current.terminal.output).toBe('live'));
+    act(() => {
+      realtimeMock.emit({
+        type: 'session_status_changed',
+        worktreeId: 'w-1',
+        isRunning: false,
+        cliTool: 'claude',
+        instance: 'claude', // primary, not this pane's claude-2
+      });
+    });
+    expect(result.current.terminal.isRunning).toBe(true);
+    expect(result.current.terminal.output).toBe('live');
+  });
+
+  it('ignores a stop event for a different worktree', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+    );
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude' }),
+    );
+    await waitFor(() => expect(result.current.terminal.output).toBe('live'));
+    act(() => {
+      realtimeMock.emit({
+        type: 'session_status_changed',
+        worktreeId: 'w-OTHER',
+        isRunning: false,
+        cliTool: 'claude',
+        instance: 'claude',
+      });
+    });
+    expect(result.current.terminal.isRunning).toBe(true);
+    expect(result.current.terminal.output).toBe('live');
+  });
+
+  it('applies an unscoped (kill-all) stop event to the pane', async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({ isRunning: true, fullOutput: 'live', thinking: false }),
+    );
+    const { result } = renderHook(() =>
+      useTerminalPanePolling({ worktreeId: 'w-1', cliToolId: 'claude' }),
+    );
+    await waitFor(() => expect(result.current.terminal.output).toBe('live'));
+    mockFetch.mockImplementation(() => okJson({ isRunning: false, fullOutput: '', thinking: false }));
+    await act(async () => {
+      realtimeMock.emit({
+        type: 'session_status_changed',
+        worktreeId: 'w-1',
+        isRunning: false,
+        cliTool: null,
+        instance: null,
+      });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(result.current.terminal.isRunning).toBe(false);
+      expect(result.current.terminal.output).toBe('');
+    });
   });
 
   it('resets output/attaching/prompt when (worktreeId, cliToolId) changes', async () => {

--- a/tests/unit/hooks/useWorktreeDetailController.test.tsx
+++ b/tests/unit/hooks/useWorktreeDetailController.test.tsx
@@ -13,8 +13,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import type { Worktree } from '@/types/models';
+import type { SessionKillTarget } from '@/types/terminal-split-pane';
 import type { UseWorktreesCacheReturn } from '@/hooks/useWorktreesCache';
 
 // ---------------------------------------------------------------------------
@@ -186,5 +187,195 @@ describe('useWorktreeDetailController — cache priming (Issue #839)', () => {
     });
     expect(result.current.worktree?.description).toBe('full');
     expect(result.current.loading).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1171: target-snapshot kill-session flow.
+// ---------------------------------------------------------------------------
+
+/** JSON response shaped for both raw fetch and the api-client fetchApi wrapper. */
+function apiResponse(status: number, body: unknown) {
+  const ok = status >= 200 && status < 300;
+  return {
+    ok,
+    status,
+    redirected: false,
+    url: '',
+    headers: {
+      get: (h: string) =>
+        String(h).toLowerCase() === 'content-type' ? 'application/json' : null,
+    },
+    json: async () => body,
+  };
+}
+
+/** Controller fetch mock: routes every endpoint the controller touches. */
+function makeControllerFetch(
+  opts: { killStatus?: number; onKill?: (url: string) => void; detail?: Worktree } = {},
+) {
+  const { killStatus = 200, onKill, detail = makeWorktree() } = opts;
+  return (url: string) => {
+    if (typeof url === 'string' && url.includes('/kill-session')) {
+      onKill?.(url);
+      const ok = killStatus >= 200 && killStatus < 300;
+      return Promise.resolve(apiResponse(killStatus, ok ? { success: true, message: 'ok' } : { error: 'boom' }));
+    }
+    if (typeof url === 'string' && url.includes('/messages')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (typeof url === 'string' && url.includes('/current-output')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ isRunning: false }) });
+    }
+    if (typeof url === 'string' && url.includes('/auto-yes')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ instances: {} }) });
+    }
+    if (typeof url === 'string' && url.includes('/api/worktrees/')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(detail) });
+    }
+    return Promise.resolve({ ok: false, status: 404 });
+  };
+}
+
+const SNAPSHOT: SessionKillTarget = { cliToolId: 'codex', instanceId: 'codex-2', label: 'Review agent' };
+
+describe('useWorktreeDetailController — kill session (Issue #1171)', () => {
+  beforeEach(() => {
+    mockCache.current = makeCache([makeWorktree()]);
+    mockFetch.mockReset();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts with no kill target and not pending', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    expect(result.current.killTarget).toBeNull();
+    expect(result.current.isKillPending).toBe(false);
+  });
+
+  it('openKillConfirm snapshots the target; it survives active-instance changes', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+    expect(result.current.killTarget).toEqual(SNAPSHOT);
+    // Changing the active instance must NOT re-derive / mutate the snapshot.
+    act(() => result.current.setActiveInstanceId('claude'));
+    expect(result.current.killTarget).toEqual(SNAPSHOT);
+  });
+
+  it('openActiveKillConfirm snapshots the active instance as the target', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openActiveKillConfirm());
+    expect(result.current.killTarget).toEqual({
+      cliToolId: result.current.activeCliTab,
+      instanceId: result.current.activeInstanceId,
+      label: expect.any(String),
+    });
+  });
+
+  it('handleKillConfirm POSTs a kill scoped to the target and clears it on success', async () => {
+    const killUrls: string[] = [];
+    mockFetch.mockImplementation(makeControllerFetch({ onKill: (u) => killUrls.push(u) }));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+    await act(async () => { await result.current.handleKillConfirm(); });
+
+    expect(killUrls.length).toBe(1);
+    const u = new URL(killUrls[0], 'http://localhost');
+    expect(u.searchParams.get('cliTool')).toBe('codex');
+    expect(u.searchParams.get('instance')).toBe('codex-2');
+    expect(result.current.killTarget).toBeNull();
+    expect(result.current.isKillPending).toBe(false);
+  });
+
+  it('does not double-submit while a kill POST is in flight', async () => {
+    const killUrls: string[] = [];
+    let resolveKill: (() => void) | undefined;
+    mockFetch.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/kill-session')) {
+        killUrls.push(url);
+        return new Promise((res) => {
+          resolveKill = () => res(apiResponse(200, { success: true, message: 'ok' }));
+        });
+      }
+      if (typeof url === 'string' && url.includes('/api/worktrees/')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(makeWorktree()) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+
+    // Two rapid confirms in the same tick — only the first must POST.
+    await act(async () => {
+      void result.current.handleKillConfirm();
+      void result.current.handleKillConfirm();
+      await Promise.resolve();
+    });
+    expect(killUrls.length).toBe(1);
+    expect(result.current.isKillPending).toBe(true);
+
+    await act(async () => { resolveKill?.(); await Promise.resolve(); });
+    await waitFor(() => expect(result.current.killTarget).toBeNull());
+    expect(result.current.isKillPending).toBe(false);
+  });
+
+  it('keeps the target on a non-2xx failure so the user can retry', async () => {
+    mockFetch.mockImplementation(makeControllerFetch({ killStatus: 500 }));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+    await act(async () => { await result.current.handleKillConfirm(); });
+    // Target retained; not stuck pending.
+    expect(result.current.killTarget).toEqual(SNAPSHOT);
+    expect(result.current.isKillPending).toBe(false);
+  });
+
+  it('treats a 404 (session already ended) as achieved and clears the target', async () => {
+    mockFetch.mockImplementation(makeControllerFetch({ killStatus: 404 }));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+    await act(async () => { await result.current.handleKillConfirm(); });
+    expect(result.current.killTarget).toBeNull();
+    expect(result.current.isKillPending).toBe(false);
+  });
+
+  it('handleKillCancel clears the target', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+    expect(result.current.killTarget).toEqual(SNAPSHOT);
+    act(() => result.current.handleKillCancel());
+    expect(result.current.killTarget).toBeNull();
+  });
+
+  it('handleKillCancel is a no-op while a kill POST is in flight (keeps target)', async () => {
+    let resolveKill: (() => void) | undefined;
+    mockFetch.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/kill-session')) {
+        return new Promise((res) => {
+          resolveKill = () => res(apiResponse(200, { success: true, message: 'ok' }));
+        });
+      }
+      if (typeof url === 'string' && url.includes('/api/worktrees/')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(makeWorktree()) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+    const { result } = renderHook(() => useWorktreeDetailController({ worktreeId: 'wt-1' }));
+    act(() => result.current.openKillConfirm(SNAPSHOT));
+    act(() => { void result.current.handleKillConfirm(); });
+    expect(result.current.isKillPending).toBe(true);
+
+    // Cancel while pending must NOT discard the target.
+    act(() => result.current.handleKillCancel());
+    expect(result.current.killTarget).toEqual(SNAPSHOT);
+
+    await act(async () => { resolveKill?.(); await Promise.resolve(); });
+    await waitFor(() => expect(result.current.killTarget).toBeNull());
   });
 });

--- a/tests/unit/useWorktreesCache.test.ts
+++ b/tests/unit/useWorktreesCache.test.ts
@@ -12,6 +12,33 @@ import {
   POLLING_INTERVAL_IDLE,
 } from '@/hooks/useWorktreesCache';
 
+// Issue #1171: controllable realtime mock so tests can fire session_status_changed
+// events. Existing tests never emit, so their behavior is unchanged.
+const realtimeMock = vi.hoisted(() => {
+  const listeners: Array<(e: unknown) => void> = [];
+  const api = {
+    status: 'disconnected' as const,
+    connected: false,
+    subscribe: () => {},
+    unsubscribe: () => {},
+    addListener: (l: (e: unknown) => void) => {
+      listeners.push(l);
+      return () => {
+        const i = listeners.indexOf(l);
+        if (i >= 0) listeners.splice(i, 1);
+      };
+    },
+  };
+  return {
+    listeners,
+    emit: (event: unknown) => { for (const l of [...listeners]) l(event); },
+    useRealtime: () => api,
+  };
+});
+vi.mock('@/hooks/useRealtimeConnection', () => ({
+  useRealtime: realtimeMock.useRealtime,
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -390,6 +417,63 @@ describe('useWorktreesCache()', () => {
         value: false,
         configurable: true,
       });
+    });
+  });
+
+  describe('realtime session_status_changed (Issue #1171)', () => {
+    it('re-fetches instead of forcing the aggregate false on a SCOPED stop event', async () => {
+      // Initial + refresh both report running: another instance is still alive,
+      // so the server-computed aggregate stays running.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ worktrees: [{ id: 'wt-1', name: 'main', isSessionRunning: true }] }),
+      });
+      const { result } = renderHook(() => useWorktreesCache());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.worktrees[0]?.isSessionRunning).toBe(true));
+      const before = mockFetch.mock.calls.length;
+
+      await act(async () => {
+        realtimeMock.emit({
+          type: 'session_status_changed',
+          worktreeId: 'wt-1',
+          isRunning: false,
+          cliTool: 'claude',
+          instance: 'claude',
+        });
+        await Promise.resolve();
+      });
+
+      // A scoped stop cannot infer the worktree aggregate → it re-fetches...
+      await waitFor(() => expect(mockFetch.mock.calls.length).toBeGreaterThan(before));
+      // ...and the aggregate stays running (server truth; never forced false).
+      expect(result.current.worktrees[0].isSessionRunning).toBe(true);
+    });
+
+    it('directly sets the aggregate false on an UNSCOPED (kill-all) stop event', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ worktrees: [{ id: 'wt-1', name: 'main', isSessionRunning: true }] }),
+      });
+      const { result } = renderHook(() => useWorktreesCache());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.worktrees[0]?.isSessionRunning).toBe(true));
+      const before = mockFetch.mock.calls.length;
+
+      await act(async () => {
+        realtimeMock.emit({
+          type: 'session_status_changed',
+          worktreeId: 'wt-1',
+          isRunning: false,
+          cliTool: null,
+          instance: null,
+        });
+        await Promise.resolve();
+      });
+
+      // Unscoped kill-all is applied directly, with no extra re-fetch.
+      await waitFor(() => expect(result.current.worktrees[0].isSessionRunning).toBe(false));
+      expect(mockFetch.mock.calls.length).toBe(before);
     });
   });
 });


### PR DESCRIPTION
## 概要
Issue #1171 — PC版の各ターミナルsplitの選択欄直後にセッション終了「×」ボタンを追加する。

押したsplit自身の `cliToolId` / `instanceId` を終了対象として**スナップショット固定**し、確認ダイアログを経てそのセッションだけを終了・アーカイブする。グローバルなactive/focus状態から終了対象を推測しない。

## 主な変更
- `src/types/terminal-split-pane.ts`: `SessionKillTarget` 型を追加
- `src/hooks/useWorktreeDetailController.ts`: `killTarget: SessionKillTarget | null` を確認ダイアログの正本に（`showKillConfirm` boolean二重管理を廃止）
- `TerminalSplitPaneContent.tsx` / `TerminalSplitPane.tsx`: Dropdown直後・検索前にEndボタン（`headerExtras`）を配置。`terminal.isRunning === true` のときだけ表示
- `WorktreeDetailDesktop.tsx`: split1/2の終了対象解決にglobal active stateを使わない
- `src/hooks/useTerminalPanePolling.ts`: `session_status_changed` を処理し対象splitを即時終了表示へ
- `useSplitMessages.ts` / `chat-db.ts` 等: 対象履歴だけをarchive、非対象splitはclearしない
- i18n（en/ja）: セッション終了ラベル追加
- TDD: controller / pane / polling / split-messages / DB archive / integration kill-session テスト

## 品質チェック（オーケストレーターが独立検証）
- lint: Pass / tsc --noEmit: Pass
- test:unit: 542 files / 9140 tests Pass
- build: Pass（36/36）

関連: #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
