### PR TITLE
test(sidebar): CI限定でフレークする scroll position テストの waitFor race を修正 (#1182)

### DIFF
--- a/tests/unit/components/layout/Sidebar.test.tsx
+++ b/tests/unit/components/layout/Sidebar.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { Sidebar, parseGroupCollapsed } from '@/components/layout/Sidebar';
 import { SidebarProvider } from '@/contexts/SidebarContext';
@@ -46,6 +46,22 @@ import { worktreeApi, repositoryApi, ApiError } from '@/lib/api-client';
 
 const originalLocation = window.location;
 const originalFetch = global.fetch;
+
+/**
+ * Waits for Sidebar's scroll-position restore to finish.
+ *
+ * Sidebar restores the persisted scrollTop inside a requestAnimationFrame that is
+ * scheduled once the branch list first renders items. A test that writes scrollTop
+ * before that frame runs has its value overwritten by the restore, so any test
+ * driving scrollTop must wait for both the items and this frame first.
+ */
+async function flushScrollRestore(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
 
 const mockWorktrees: Worktree[] = [
   {
@@ -363,12 +379,14 @@ describe('Sidebar', () => {
         </Wrapper>
       );
 
-      const branchList = await screen.findByTestId('branch-list');
-      branchList.scrollTop = 180;
-
       await waitFor(() => {
         expect(screen.getAllByText('feature/test-2').length).toBeGreaterThanOrEqual(1);
       });
+      await flushScrollRestore();
+
+      const branchList = screen.getByTestId('branch-list');
+      branchList.scrollTop = 180;
+
       const branchItem = screen.getAllByText('feature/test-2')[0].closest('[data-testid="branch-list-item"]');
       expect(branchItem).not.toBeNull();
 
@@ -384,7 +402,12 @@ describe('Sidebar', () => {
         </Wrapper>
       );
 
-      const firstBranchList = await screen.findByTestId('branch-list');
+      await waitFor(() => {
+        expect(screen.getAllByText('feature/test-2').length).toBeGreaterThanOrEqual(1);
+      });
+      await flushScrollRestore();
+
+      const firstBranchList = screen.getByTestId('branch-list');
       firstBranchList.scrollTop = 240;
       fireEvent.scroll(firstBranchList);
 


### PR DESCRIPTION
## 概要

Issue #1182 の修正。**CI でのみ稀に失敗していた** `Sidebar.test.tsx > should save branch list scroll position on click` の waitFor race を解消する。

本番コードのバグではなく**テストの脆弱性**。#1177（Next.js 15 / React 19）の CI で顕在化したが、`Sidebar.tsx` / `Sidebar.test.tsx` は当該PRで未変更であり、アップグレード起因ではない。

## 根本原因（調査で判明した、当初仮説より精密な原因）

Issue 起票時は「`waitFor` 中の DOM ノード差し替えで `scrollTop` がリセットされる」と推定していたが、実際は:

> **Sidebar は永続化された `scrollTop` を `requestAnimationFrame` 内で復元する。この rAF はブランチリストが最初に項目を描画した時点でスケジュールされる。**

つまりテストが `scrollTop = 180` を書いた**後**にこの復元フレームが走り、**テストの書き込みを上書きする**。`vitest.config.ts` の `fileParallelism: process.env.CI !== 'true'` により CI では実行特性が変わり、タイミング次第で顕在化していた。

## 修正内容

`scrollTop` を書く前に、**項目の描画と復元フレームの完了の両方を待つ**ようにした（`act` を利用）。

```
tests/unit/components/layout/Sidebar.test.tsx | 33 +++++++++++++++++++++++----
1 file changed, 28 insertions(+), 5 deletions(-)
```

## 検証

### 完了判定: `CI=true` で10回連続実行 → **10/10 PASS**

```
CI=true NODE_ENV=test npx vitest run tests/unit/components/layout/Sidebar.test.tsx
試行1〜10: 全て Tests 63 passed (63)   → PASS=10 / FAIL=0
```

### 品質ゲート

| チェック | 結果 |
|---|---|
| ESLint | ✅ 警告0 |
| TypeScript | ✅ Pass |
| Unit | ✅ 9,186 passed |
| Integration | ✅ 682 passed |
| Build | ✅ Pass |

### skip / 削除で逃げていないこと（grep実数）

| | before | after |
|---|---|---|
| `Sidebar.test.tsx` のテスト数 | 63 | **63** ✅ |
| skip / todo マーカー | 0 | **0** ✅ |

## 関連

- 発見元: #1177 / PR #1179 の CI
- 関連: `vitest.config.ts:20` `fileParallelism: process.env.CI !== 'true'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
