### PR TITLE
fix(ui): RouteLoading を中立形状にしブランチ選択時のHome画面ちらつきを解消 (#1184)

### DIFF
--- a/src/components/common/RouteLoading.tsx
+++ b/src/components/common/RouteLoading.tsx
@@ -3,26 +3,50 @@
  * Shared route-level Suspense fallback for App Router loading.tsx files
  * (Issue #1118).
  *
- * Deliberately thin: every screen is a `'use client'` page that fetches on
- * mount, so the real loading UX lives in per-component skeletons. This
- * fallback only covers the route-segment (chunk / RSC) load and sketches a
- * generic page outline: a heading line and two content cards.
+ * Deliberately shape-free. All seven `loading.tsx` files share this one
+ * fallback, so it cannot know which screen is arriving; any page outline it
+ * draws is wrong for the other six. [Issue #1184] it drew a heading plus two
+ * side-by-side cards — the Home bento outline — so every navigation briefly
+ * flashed what read as a half-rendered Home. Keep it an indeterminate
+ * indicator, not a content skeleton.
+ *
+ * It still fills the viewport: pages render their own AppShell, so this
+ * renders with no shell around it, and covering the viewport is what keeps the
+ * swap into the real shell from flashing blank or jumping (the #1118 intent).
+ *
+ * Dots use `bg-muted-foreground`, not the `Skeleton` primitive's `bg-muted` —
+ * a slab colour for large placeholder blocks that is invisible at dot size on
+ * the light `--background`. Matches ConversationPairCard's PendingIndicator.
+ *
+ * `prefers-reduced-motion` is handled globally in globals.css (Issue #1050),
+ * which resets animation-duration/-delay — do not re-implement it here.
  */
 
-import { Skeleton } from '@/components/ui/Skeleton';
+/**
+ * Stagger for the indeterminate pulse. Whole literal class strings so the
+ * Tailwind scanner picks them up.
+ */
+const DOT_DELAYS = [
+  '[animation-delay:0ms]',
+  '[animation-delay:150ms]',
+  '[animation-delay:300ms]',
+] as const;
 
 export function RouteLoading() {
   return (
     <div
-      className="container-custom py-8"
+      className="flex min-h-screen w-full items-center justify-center p-8"
       role="status"
       aria-label="Loading page"
       data-testid="route-loading"
     >
-      <Skeleton className="mb-6 h-8 w-48 max-w-full" />
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <Skeleton className="h-40 rounded-lg" />
-        <Skeleton className="h-40 rounded-lg" />
+      <div className="flex items-center gap-2" aria-hidden="true">
+        {DOT_DELAYS.map((delay) => (
+          <span
+            key={delay}
+            className={`h-2.5 w-2.5 rounded-full bg-muted-foreground animate-pulse ${delay}`}
+          />
+        ))}
       </div>
     </div>
   );

--- a/tests/unit/components/common/RouteLoading.test.tsx
+++ b/tests/unit/components/common/RouteLoading.test.tsx
@@ -1,16 +1,19 @@
 /**
- * Tests for RouteLoading (Issue #1118: route-level loading.tsx fallback)
+ * Tests for RouteLoading (Issue #1118: route-level loading.tsx fallback;
+ * Issue #1184: neutral shape that no longer reads as a half-rendered Home).
  *
  * @vitest-environment jsdom
  */
 
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { RouteLoading } from '@/components/common/RouteLoading';
 
+afterEach(() => cleanup());
+
 describe('RouteLoading', () => {
-  it('renders a page-outline skeleton announced as status', () => {
+  it('renders a pulsing indicator announced as status', () => {
     render(<RouteLoading />);
     const root = screen.getByTestId('route-loading');
     expect(root.getAttribute('role')).toBe('status');
@@ -21,5 +24,73 @@ describe('RouteLoading', () => {
   it('contains no naked loading text', () => {
     render(<RouteLoading />);
     expect(screen.getByTestId('route-loading').textContent).toBe('');
+  });
+
+  it('hides the decorative dots from assistive tech, leaving one status label', () => {
+    render(<RouteLoading />);
+    const root = screen.getByTestId('route-loading');
+    root.querySelectorAll('.animate-pulse').forEach((dot) => {
+      expect(dot.closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+  });
+
+  it('fills the viewport and centers the indicator so the swap into the real shell stays stable', () => {
+    render(<RouteLoading />);
+    const root = screen.getByTestId('route-loading');
+    // Occupying the full viewport keeps the #1118 intent: no blank flash and no
+    // scrollbar/height jump when the real page mounts its own AppShell.
+    expect(root.className).toContain('min-h-screen');
+    expect(root.className).toContain('items-center');
+    expect(root.className).toContain('justify-center');
+  });
+
+  describe('neutral shape (Issue #1184)', () => {
+    it('does not reproduce the Home bento outline', () => {
+      render(<RouteLoading />);
+      const root = screen.getByTestId('route-loading');
+      // Home is `container-custom py-8` wrapping a heading plus a multi-column
+      // card grid. Matching that shape is what made every route — worktree
+      // detail included — flash a screen that looked like a half-drawn Home.
+      expect(root.className).not.toContain('container-custom');
+      expect(root.querySelectorAll('[class*="container-custom"]').length).toBe(0);
+      expect(root.querySelectorAll('[class*="grid-cols-"]').length).toBe(0);
+    });
+
+    it('draws no page structure — every mark is the same small dot', () => {
+      render(<RouteLoading />);
+      const marks = screen.getByTestId('route-loading').querySelectorAll('.animate-pulse');
+      expect(marks.length).toBe(3);
+      marks.forEach((mark) => {
+        expect(mark.className).toContain('rounded-full');
+        // No heading bar and no card blocks: uniform dots evoke no screen.
+        expect(mark.className).toContain('h-2.5');
+        expect(mark.className).toContain('w-2.5');
+      });
+    });
+
+    it('tints the dots with muted-foreground so they stay visible on the light background', () => {
+      render(<RouteLoading />);
+      const marks = screen.getByTestId('route-loading').querySelectorAll('.animate-pulse');
+      marks.forEach((mark) => {
+        // `bg-muted` is a slab colour for large placeholder blocks; at dot size
+        // it is invisible against the light `--background` (Issue #1184).
+        expect(mark.className).toContain('bg-muted-foreground');
+        // `\b` would not do: `-` is a word boundary, so it matches the
+        // `bg-muted` prefix of `bg-muted-foreground`.
+        expect(mark.className).not.toMatch(/(^|\s)bg-muted(\s|$)/);
+      });
+    });
+  });
+
+  it('staggers the pulse via classes covered by the global reduced-motion reset', () => {
+    render(<RouteLoading />);
+    const marks = screen.getByTestId('route-loading').querySelectorAll('.animate-pulse');
+    // globals.css (#1050) forces animation-duration/-delay under
+    // prefers-reduced-motion, so animation stays in `animate-pulse` +
+    // `animation-delay` rather than a component-local media query.
+    const delays = [...marks].map((m) =>
+      /\[animation-delay:(\d+)ms\]/.exec(m.className)?.[1]
+    );
+    expect(delays).toEqual(['0', '150', '300']);
   });
 });


### PR DESCRIPTION
## 概要

Issue #1184 の修正（**Stage 1: 根本対策**）。サイドバーからブランチ選択時に「中途半端な Home 画面」がちらつく問題を、共有スケルトン `RouteLoading` を**中立な形状**にすることで解消する。

```
src/components/common/RouteLoading.tsx             | 44 +++++++++---
tests/unit/components/common/RouteLoading.test.tsx | 79 ++++++++++++++++++++--
2 files changed, 109 insertions(+), 14 deletions(-)
```

## 根本原因

`src/app/**/loading.tsx` **7ファイルすべてが同一の `RouteLoading` を返す**。その形状（`container-custom py-8` → 見出しSkeleton → 横並び2カード）が **Home の bento グリッド（#1052）と一致**するため、worktree 詳細へ遷移する瞬間に「描画途中の Home」に見えていた。

ヘッダー・サイドバーは共有レイアウトで残るため、画面全体が Home に見える。

## 対応方針（Issue の「対応方針（決定）」に従う）

**Stage 1（本PR・必須）**: 原因である**共有コンポーネント1点**を中立形状に変更 → **全7ルートが一度に解消**。

Stage 2（画面別スケルトン）は本PRのスコープ外。

### `loading.tsx` の削除は不採用（実験で反証済み）

App Router では `loading.tsx` は**配下の全ネストセグメントに継承される**ため、`worktrees/[id]/loading.tsx` を消してもルートの `app/loading.tsx` が効き、**同じフォールバックが出続ける**。

実測（Next 15.5.20 / dev コールドスタート、`sessions/loading.tsx` を退避し `app/loading.tsx` にマーカー付与して `/sessions` へソフト遷移）:

```json
{ "rootMarker": true, "routeLoading": true }
```

→ **本PRでは `loading.tsx` 7ファイルを全て維持**している（`git show --stat` に含まれないことを確認済み）。

## 検証

| チェック | 結果 |
|---|---|
| ESLint | ✅ 警告0 |
| TypeScript | ✅ Pass |
| Unit | ✅ **9,192 passed**（before 9,186 → **+6件**。RouteLoading のテストを追加） |
| Integration | ✅ 682 passed |
| Build | ✅ Pass |

### 契約遵守（grep実数）

| 検証項目 | 結果 |
|---|---|
| `src/app/**/loading.tsx` | **7/7 維持**（削除なし）✅ |
| ローディング表示 | 維持（#1139 のレイアウトシフト低減の意図を保持）✅ |
| Home との同型性 | 解消 ✅ |

## 残作業（本PRのスコープ外）

- **Stage 2**: worktree 詳細など価値の高い画面に、実レイアウトに沿った個別スケルトンを用意する（Issue #1184 に記載）

## 関連

- 導入元: #1139（Issue #1118）
- 発見経緯: #1177 / #1178 のリビルド後に観測（**両アップグレード起因ではない**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
