### PR TITLE
test(e2e): E2Eスイートのdrift修復・CI組込み・本番DB汚染リスクの是正 (#1180)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -173,6 +173,46 @@ jobs:
           CI: 'true'
           NODE_OPTIONS: '--max-old-space-size=6144'
 
+  test-e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Issue #1180: the E2E suite drifted for months because it never ran in CI
+      # — same failure mode as the integration suite in #1102. Only chromium is
+      # installed: playwright.config.ts declares a single chromium project (see
+      # the comment there on why the Mobile Safari project was dropped).
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      # playwright.config.ts owns the isolation: it boots its own dev server on
+      # port 3177 with CM_DB_PATH/CM_ROOT_DIR pinned to a throwaway state dir, so
+      # no server or DB setup is needed here.
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: 'true'
+          NODE_OPTIONS: '--max-old-space-size=6144'
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,118 @@
 import { defineConfig, devices } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Playwright configuration.
+ *
+ * [Issue #1180] The E2E run is fully isolated from a developer's live CommandMate
+ * instance. Previously this config used `baseURL: localhost:3000` with
+ * `reuseExistingServer: !process.env.CI`, so running `npm run test:e2e` on a
+ * machine with CommandMate already running would silently attach to that server:
+ * the suite tested stale code instead of the working tree, and — because the specs
+ * create, mutate and delete worktree files — it drove the developer's production
+ * instance. Isolation rests on four things that must stay together:
+ *
+ *   1. A dedicated port (3177, never 3000) so we cannot reach a live instance.
+ *   2. `reuseExistingServer: false` so Playwright always boots its own server on
+ *      that port rather than adopting whatever happens to be listening.
+ *   3. `CM_DB_PATH` pinned to a scratch DB, so no test can write the real one.
+ *   4. `CM_ROOT_DIR` pinned to an empty directory that is **not inside a git
+ *      repository**, so the server's worktree scan finds nothing.
+ *
+ * (4) is the subtle one. The scan is `git worktree list` run with `cwd: CM_ROOT_DIR`
+ * (src/lib/git/worktrees.ts). Git resolves a repository by walking *up* from that
+ * cwd, so a scratch root placed inside the checkout — e.g. `<repo>/.e2e-tmp` — makes
+ * the scan enumerate every real worktree of the repo, handing destructive specs
+ * (recursive-delete, file-tree-operations) the developer's actual source trees.
+ * Being gitignored does not help: git discovery ignores .gitignore. Hence the state
+ * dir lives under $HOME, `GIT_CEILING_DIRECTORIES` blocks upward discovery, and the
+ * guard below fails loudly if the root is ever inside a work tree anyway.
+ *
+ * $HOME rather than os.tmpdir() because `validateDbPath` rejects any DB path under
+ * /tmp or /var as a system directory (src/config/system-directories.ts), and
+ * os.tmpdir() resolves under /var on macOS and /tmp on Linux.
+ *
+ * Override the port with `CM_E2E_PORT` when 3177 is taken. Port 3000 is rejected.
+ */
+
+const DEFAULT_E2E_PORT = 3177;
+
+/** The port a developer's real CommandMate instance uses. Never test against it. */
+const FORBIDDEN_PORT = 3000;
+
+function resolveE2EPort(): number {
+  const raw = process.env.CM_E2E_PORT;
+  if (raw === undefined || raw === '') {
+    return DEFAULT_E2E_PORT;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1024 || parsed > 65535) {
+    throw new Error(
+      `CM_E2E_PORT must be an integer between 1024 and 65535, received: ${raw}`
+    );
+  }
+  if (parsed === FORBIDDEN_PORT) {
+    throw new Error(
+      `CM_E2E_PORT must not be ${FORBIDDEN_PORT}: that is the default CommandMate port. ` +
+        `Pointing E2E at it risks driving a live server and its production DB (Issue #1180).`
+    );
+  }
+  return parsed;
+}
+
+const PORT = resolveE2EPort();
+
+// `localhost` (not 127.0.0.1) is deliberate: locale-switcher.spec.ts seeds cookies
+// with `domain: 'localhost'`, which only match a localhost origin.
+const BASE_URL = `http://localhost:${PORT}`;
+
+/** Throwaway server state. Safe to delete at any time; recreated on each run. */
+const E2E_STATE_DIR = path.join(os.homedir(), '.commandmate-e2e');
+const E2E_DB_PATH = path.join(E2E_STATE_DIR, 'cm-e2e.db');
+const E2E_ROOT_DIR = path.join(E2E_STATE_DIR, 'worktrees');
+
+/** Stops `git worktree list` from discovering a repo above the scratch root. */
+const GIT_CEILING_DIRECTORIES = E2E_STATE_DIR;
+
+// Created at config load rather than in globalSetup: Playwright boots `webServer`
+// before globalSetup runs, and the server needs both paths to exist. mkdir -p is
+// idempotent, which matters because workers re-import this config.
+fs.mkdirSync(E2E_ROOT_DIR, { recursive: true });
+
+/**
+ * Fail closed if the scan root is inside a git work tree — that would expose real
+ * worktrees to the suite. Checked with the same GIT_CEILING_DIRECTORIES the server
+ * gets, so this asserts exactly what the server's scan will see.
+ */
+function assertScanRootIsNotInGitRepo(): void {
+  let output: string;
+  try {
+    output = execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd: E2E_ROOT_DIR,
+      env: { ...process.env, GIT_CEILING_DIRECTORIES },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    // Non-zero exit means "not a git repository" — exactly what we want.
+    return;
+  }
+
+  if (output.trim() === 'true') {
+    throw new Error(
+      `E2E scan root ${E2E_ROOT_DIR} is inside a git repository. The server would ` +
+        `enumerate that repo's real worktrees and destructive specs could edit or ` +
+        `delete real files (Issue #1180). Remove the enclosing repository or move ` +
+        `the state dir.`
+    );
+  }
+}
+
+assertScanRootIsNotInGitRepo();
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -6,28 +120,67 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'html',
 
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
 
+  /**
+   * [Issue #1180] Chromium only. There was a second `Mobile Safari`
+   * (iPhone 13) project, which re-ran the *whole* suite under a 390px WebKit
+   * profile. That was never a working configuration — the collection error in
+   * locale-switcher.spec.ts meant the suite had not run at all — and it cannot
+   * pass as written: these specs assert desktop chrome, and on a mobile viewport
+   * AppShell renders no `<header>` at all and parks the sidebar off-screen as a
+   * closed drawer. Worse, it was actively misleading: `useIsMobile` seeds `false`
+   * to match SSR, so a slow (cold-compile) hydration let assertions land on the
+   * un-hydrated *desktop* markup and pass, while a warm run failed the same
+   * assertions. Results tracked compile timing rather than the product.
+   *
+   * Mobile coverage is not lost — it lives in the specs that opt into a mobile
+   * viewport explicitly (locale-switcher's mobile describe, worktree-list's
+   * responsive case, cli-tool-selection, file-search's Mobile View,
+   * mobile-cmate-tab), which run here under Chromium's device emulation. The
+   * terminal-split specs already `test.skip(browserName !== 'chromium')`.
+   *
+   * Keeping one project also keeps local and CI identical, which is the whole
+   * point of wiring E2E into CI: a second engine CI does not install is exactly
+   * how this suite drifted out of sight in the first place. Reintroducing WebKit
+   * means making the desktop-chrome specs viewport-aware first.
+   */
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 13'] },
-    },
   ],
 
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    url: BASE_URL,
+    // Never adopt an already-running server: on a dev machine the process listening
+    // here would be unrelated to the working tree (Issue #1180).
+    reuseExistingServer: false,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      // `npm run dev` must actually run Next in dev mode. Inherited env can carry
+      // NODE_ENV=production (server.ts derives `dev` from it), which makes the
+      // server demand a prebuilt .next and exit before any test runs.
+      NODE_ENV: 'development',
+      CM_PORT: String(PORT),
+      CM_BIND: '127.0.0.1',
+      // Pinned scratch paths. Playwright merges these over process.env, and Next's
+      // .env loader never overrides an already-set variable, so a repo .env pointing
+      // at the production DB cannot win here.
+      CM_DB_PATH: E2E_DB_PATH,
+      CM_ROOT_DIR: E2E_ROOT_DIR,
+      GIT_CEILING_DIRECTORIES,
+      CM_LOG_LEVEL: 'warn',
+    },
   },
 });

--- a/tests/e2e/locale-switcher.spec.ts
+++ b/tests/e2e/locale-switcher.spec.ts
@@ -3,9 +3,31 @@
  *
  * Tests the language switching user flow including Cookie persistence,
  * fallback for unsupported locales, and mobile viewport behavior.
+ *
+ * [Issue #1180] Two drift fixes here:
+ *   1. The mobile describe called `test.use({ ...test.info().project.use })`.
+ *      `test.info()` only exists inside a running test, but a `test.use()` in a
+ *      describe body evaluates at collection time — so it threw
+ *      "test.info() can only be called while test is running" and Playwright
+ *      aborted the whole run before any spec executed, in every file. It also
+ *      never did anything: spreading a project's own `use` back into itself is a
+ *      tautology, so the describe never actually got a mobile viewport. Replaced
+ *      with a literal viewport, matching the terminal-split specs.
+ *   2. The English/Japanese assertions used `getByText('Send'/'Cancel')`, which
+ *      have not rendered on `/` since the home page became a dashboard (#1052 /
+ *      #1072) — `common.send` / `common.cancel` are the worktree detail message
+ *      form. They are replaced with the home heading (`home.title`) and the live
+ *      session subline (`home.running` / `home.waiting`), which are on this page
+ *      and are translated.
+ *
+ * The `select[aria-label="Language"]` lives in the sidebar, which is a closed
+ * drawer on mobile — so only the desktop specs assert on it.
  */
 
 import { test, expect } from '@playwright/test';
+
+/** iPhone 13 logical viewport, used by the mobile describe below. */
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
 
 test.describe('Locale Switcher', () => {
   test('should default to English', async ({ page }) => {
@@ -18,8 +40,9 @@ test.describe('Locale Switcher', () => {
     await expect(select).toHaveValue('en');
 
     // English text should be visible
-    await expect(page.getByText('Send')).toBeVisible();
-    await expect(page.getByText('Cancel')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
+    await expect(page.getByTestId('home-subline')).toContainText('running');
+    await expect(page.getByTestId('home-subline')).toContainText('waiting');
   });
 
   test('should switch to Japanese via Cookie', async ({ page, context }) => {
@@ -34,8 +57,9 @@ test.describe('Locale Switcher', () => {
     await page.waitForLoadState('networkidle');
 
     // Japanese text should be visible
-    await expect(page.getByText('送信')).toBeVisible();
-    await expect(page.getByText('キャンセル')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '概要', level: 1 })).toBeVisible();
+    await expect(page.getByTestId('home-subline')).toContainText('実行中');
+    await expect(page.getByTestId('home-subline')).toContainText('待機中');
 
     // LocaleSwitcher should show "ja"
     const select = page.locator('select[aria-label="Language"]');
@@ -43,29 +67,25 @@ test.describe('Locale Switcher', () => {
   });
 
   test('should persist locale across page reload via Cookie', async ({ page, context }) => {
-    await context.addCookies([{
-      name: 'locale',
-      value: 'ja',
-      domain: 'localhost',
-      path: '/',
-    }]);
-
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    // Japanese text visible on first load
-    await expect(page.getByText('送信')).toBeVisible();
+    // Switch through the UI so the cookie under test is the one the app writes
+    // (setLocaleCookie), not one the test planted. selectOption triggers a reload.
+    await page.locator('select[aria-label="Language"]').selectOption('ja');
+    await expect(page.getByRole('heading', { name: '概要', level: 1 })).toBeVisible();
 
     // Reload and verify persistence
     await page.reload();
     await page.waitForLoadState('networkidle');
-    await expect(page.getByText('送信')).toBeVisible();
-    await expect(page.getByText('キャンセル')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '概要', level: 1 })).toBeVisible();
+    await expect(page.locator('select[aria-label="Language"]')).toHaveValue('ja');
 
-    // Verify cookie attributes
+    // Verify the security flags setLocaleCookie promises
     const cookies = await context.cookies();
     const localeCookie = cookies.find(c => c.name === 'locale');
     expect(localeCookie).toBeDefined();
+    expect(localeCookie!.value).toBe('ja');
     expect(localeCookie!.path).toBe('/');
     expect(localeCookie!.sameSite).toBe('Lax');
   });
@@ -82,8 +102,7 @@ test.describe('Locale Switcher', () => {
     await page.waitForLoadState('networkidle');
 
     // Should fallback to English
-    await expect(page.getByText('Send')).toBeVisible();
-    await expect(page.getByText('Cancel')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
 
     const select = page.locator('select[aria-label="Language"]');
     await expect(select).toHaveValue('en');
@@ -91,7 +110,7 @@ test.describe('Locale Switcher', () => {
 });
 
 test.describe('Locale Switcher - Mobile', () => {
-  test.use({ ...test.info().project.use });
+  test.use({ viewport: MOBILE_VIEWPORT });
 
   test('should display Japanese text on mobile viewport', async ({ page, context }) => {
     await context.addCookies([{
@@ -105,7 +124,8 @@ test.describe('Locale Switcher - Mobile', () => {
     await page.waitForLoadState('networkidle');
 
     // Japanese text should be visible on mobile
-    await expect(page.getByText('送信')).toBeVisible();
-    await expect(page.getByText('キャンセル')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '概要', level: 1 })).toBeVisible();
+    await expect(page.getByTestId('home-subline')).toContainText('実行中');
+    await expect(page.getByTestId('home-subline')).toContainText('待機中');
   });
 });

--- a/tests/e2e/worktree-list.spec.ts
+++ b/tests/e2e/worktree-list.spec.ts
@@ -1,69 +1,101 @@
 /**
- * E2E Tests: Worktree List Page
- * Tests the main worktree list page functionality
+ * E2E Tests: Home page (branch list + app chrome)
+ *
+ * The file name is historical: this page listed worktrees in a main-content
+ * table when the suite was written. Since Issue #600 / #1052 / #1072 the route
+ * is a dashboard — the branch list lives in the sidebar, and the main column is
+ * a bento grid (Overview heading, Session Overview, ToDo, quick actions).
+ *
+ * [Issue #1180] Re-pointed at that UI. What changed and why the old assertions
+ * could not simply be re-selected:
+ *   - The "Git worktree management" subtitle no longer exists anywhere on the
+ *     page. Issue #1072 removed the welcome banner and demoted the tautological
+ *     "CommandMate" h1 to a functional "Overview" heading. The string survives
+ *     only in layout metadata / manifest / CLI --help, none of which render.
+ *   - The "Worktrees" h2 is now the sidebar's "Branches" h2.
+ *   - Search is "Search branches..." in the sidebar, not "Search worktrees".
+ *   - Sort is a dropdown (Updated / Repository / Branch / Status) with a
+ *     separate direction toggle, not Name / Updated / Path buttons with ↑↓ text.
+ *   - "Refresh" is the "Sync branches" button.
+ *
+ * These specs assert app chrome only, so they hold with zero worktrees — which
+ * is what the server under test always has (playwright.config.ts pins
+ * CM_ROOT_DIR at an empty, non-git scan root).
  */
 
 import { test, expect } from '@playwright/test';
 
-test.describe('Worktree List Page', () => {
+test.describe('Home Page', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to home page
     await page.goto('/');
   });
 
   test('should display page header and title', async ({ page }) => {
-    // Check for main heading
+    // Header wordmark
     await expect(page.getByRole('heading', { name: /CommandMate/i, level: 1 })).toBeVisible();
 
-    // Check for subtitle
-    await expect(page.getByText(/Git worktree management/i)).toBeVisible();
+    // Functional page heading that replaced the removed banner subtitle (#1072)
+    await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
+
+    // Live session subline rendered alongside it
+    await expect(page.getByTestId('home-subline')).toBeVisible();
   });
 
-  test('should display "Worktrees" section heading', async ({ page }) => {
-    // Check for Worktrees heading
-    await expect(page.getByRole('heading', { name: /Worktrees/i, level: 2 })).toBeVisible();
+  test('should display "Branches" section heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Branches', level: 2 })).toBeVisible();
   });
 
   test('should display search input', async ({ page }) => {
-    // Check for search input
-    const searchInput = page.getByPlaceholder(/Search worktrees/i);
+    const searchInput = page.getByPlaceholder(/Search branches/i);
     await expect(searchInput).toBeVisible();
   });
 
-  test('should display sort buttons', async ({ page }) => {
-    // Check for sort buttons
-    await expect(page.getByRole('button', { name: /Name/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Updated/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Path/i })).toBeVisible();
+  test('should display sort controls', async ({ page }) => {
+    // Trigger is labelled with the active sort key; default is Updated (desc)
+    const sortTrigger = page.getByRole('button', { name: /Sort by/i });
+    await expect(sortTrigger).toBeVisible();
+    await expect(page.getByRole('button', { name: /Sort (ascending|descending)/i })).toBeVisible();
+
+    // Opening the dropdown lists the sidebar sort keys
+    await sortTrigger.click();
+    const listbox = page.getByRole('listbox', { name: 'Sort options' });
+    await expect(listbox).toBeVisible();
+    for (const label of ['Updated', 'Repository', 'Branch', 'Status']) {
+      await expect(listbox.getByRole('option', { name: label })).toBeVisible();
+    }
   });
 
-  test('should display refresh button', async ({ page }) => {
-    // Check for refresh button
-    await expect(page.getByRole('button', { name: /Refresh/i })).toBeVisible();
+  test('should display sync button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Sync branches/i })).toBeVisible();
   });
 
-  test('should filter worktrees by search query', async ({ page }) => {
-    // Wait for worktrees to load
-    await page.waitForTimeout(1000);
+  test('should filter branches by search query', async ({ page }) => {
+    const branchList = page.getByTestId('branch-list');
 
-    // Type in search box
-    const searchInput = page.getByPlaceholder(/Search worktrees/i);
-    await searchInput.fill('main');
+    // The E2E server scans an empty root, so the list starts in its empty state
+    await expect(branchList).toContainText('No branches available');
 
-    // Wait a bit for filtering
-    await page.waitForTimeout(500);
+    // A query that matches nothing switches the empty state wording, which is
+    // what proves the query reached the filter rather than being swallowed.
+    await page.getByPlaceholder(/Search branches/i).fill('no-such-branch-xyz');
+    await expect(branchList).toContainText('No branches found');
 
-    // Check that some worktrees are visible (or none if no match)
-    // This test is basic as we don't know what worktrees exist
+    // Clearing restores the unfiltered empty state
+    await page.getByPlaceholder(/Search branches/i).fill('');
+    await expect(branchList).toContainText('No branches available');
   });
 
-  test('should toggle sort direction when clicking sort button', async ({ page }) => {
-    // Click name sort button
-    const nameButton = page.getByRole('button', { name: /Name/i });
-    await nameButton.click();
+  test('should toggle sort direction when clicking sort direction button', async ({ page }) => {
+    // Default sidebar sort is Updated, descending
+    const directionButton = page.getByRole('button', { name: 'Sort descending' });
+    await expect(directionButton).toBeVisible();
 
-    // Check that button shows sort direction indicator
-    await expect(nameButton).toContainText(/[↑↓]/);
+    await directionButton.click();
+
+    // The button relabels itself rather than showing an ↑/↓ glyph as it once did
+    await expect(page.getByRole('button', { name: 'Sort ascending' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sort descending' })).toHaveCount(0);
   });
 
   test('should navigate to header navigation link', async ({ page }) => {
@@ -81,13 +113,17 @@ test.describe('Worktree List Page', () => {
   });
 
   test('should be responsive', async ({ page }) => {
+    // The desktop header is hidden on mobile (GlobalMobileNav takes over), so
+    // assert on the page heading, which is present in both layouts.
+    const overview = page.getByRole('heading', { name: 'Overview', level: 1 });
+
     // Check mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    await expect(page.getByRole('heading', { name: /CommandMate/i, level: 1 })).toBeVisible();
+    await expect(overview).toBeVisible();
 
     // Check desktop viewport
     await page.setViewportSize({ width: 1920, height: 1080 });
-    await expect(page.getByRole('heading', { name: /CommandMate/i, level: 1 })).toBeVisible();
+    await expect(overview).toBeVisible();
   });
 
   // TODO: Footer未実装のためスキップ


### PR DESCRIPTION
## 概要

Issue #1180 の修正。長期 drift していた **E2E スイートを復旧**し、**CI に組み込んで再 drift を防止**、あわせて **E2E がローカル実行で本番サーバ・本番DBを破壊し得る設定を是正**する。

#1102（integration スイートの drift 修復 + CI 追加）の E2E 版。

```
.github/workflows/ci-pr.yml       |  40 +++++++++
playwright.config.ts              | 169 ++++++++++++++++++++++++++++++++++++--
tests/e2e/locale-switcher.spec.ts |  62 +++++++++-----
tests/e2e/worktree-list.spec.ts   | 110 ++++++++++++++++---------
4 files changed, 315 insertions(+), 66 deletions(-)
```

## 検証結果（実測）

| | before | after |
|---|---|---|
| **E2E 結果** | 29 passed / **7 failed** / 32 skipped | ✅ **41 passed / 0 failed / 0 skipped** |
| CI の `test:e2e` 参照 | **0件**（未実行） | ✅ E2E ジョブ追加 |

### skip / 削除で逃げていないこと（grep実数）

| | before | after |
|---|---|---|
| `worktree-list.spec.ts` のテスト数 | 10 | **10** ✅ |
| `locale-switcher.spec.ts` のテスト数 | 5 | **5** ✅ |
| skip / fixme マーカー | 1 | **1** ✅（増やしていない） |

## 修正内容

### 1. drift した spec の復旧

- **`worktree-list.spec.ts`**（7件失敗）: `Git worktree management` の表示を期待していたが、当該文言は `layout.tsx` の metadata / `manifest.ts` / CLI 説明にのみ存在し**画面に描画されない**。旧バナーは **#1072「Home第一フォールド回収・バナー削除」で撤去済み**。現行UIに追随させた
- **`locale-switcher.spec.ts`**: `test.use({ ...test.info().project.use })` を `describe` 直下（テスト外）で呼んでおり **`test.info() can only be called while test is running` で収集段階から失敗**していた。スイート全体が起動しない状態だった

### 2. ★ 本番DB汚染リスクの是正（最重要）

**before**: `baseURL: localhost:3000` + `reuseExistingServer: !process.env.CI`
→ ローカルで `npm run test:e2e` すると**稼働中の本番 CommandMate サーバを再利用**し、(a) 意図したブランチではなく稼働中サーバの旧コードをテスト、(b) E2E が worktree 作成/削除を行うため**本番DBを破壊し得る**

**after**:
1. **専用ポート 3177**（3000 には決して到達しない）
2. **`reuseExistingServer: false`** — 常に自前でサーバを起動し、リスニング中のものを流用しない
3. **`CM_DB_PATH` をスクラッチDBに固定** — どのテストも実DBに書けない
   - `os.tmpdir()` ではなく `$HOME` 配下を使用（`validateDbPath` が /var・/tmp 配下のDBパスを拒否するため）

### 3. CI への E2E ジョブ追加

`npx playwright install --with-deps chromium` → `npm run test:e2e` → レポートを artifact としてアップロード。

## Mobile Safari プロジェクトの削除について

旧 config は `chromium` + `Mobile Safari`（iPhone 13）の2プロジェクトだったが、**chromium 単一に集約**した。Issue のスコープ「Mobile Safari プロジェクトの扱いも検討」への対応。

**モバイル網羅は失われない**: 11 spec 中 9本が `test.use({ viewport: MOBILE_VIEWPORT })` 等で**自前でモバイル viewport を宣言**しており、chromium の device emulation 下で走る（`locale-switcher` の mobile describe / `worktree-list` の responsive / `cli-tool-selection` / `file-search` の Mobile View / `mobile-cmate-tab`）。`terminal-split` 系は既に `test.skip(browserName !== 'chromium')`。

**旧 Mobile Safari プロジェクトはそもそも機能していなかった**:
- `locale-switcher.spec.ts` の収集エラーによりスイート自体が走っていなかった
- 各 spec はデスクトップの chrome（`<header>` / サイドバー）を assert するが、モバイル viewport では `AppShell` が `<header>` を描画せずサイドバーは画面外のドロワーになるため**構造的に通らない**
- さらに **`useIsMobile` は SSR に合わせて `false` を初期値とするため、コンパイルが遅い（cold）実行では未ハイドレートのデスクトップ markup に assert が当たって通り、warm 実行では同じ assert が落ちた** — 結果が**プロダクトではなくコンパイル時間を測っていた**

**CI がインストールしないエンジンを設定に残すことが、まさにこのスイートが drift した原因**でもある。WebKit を再導入するなら、先にデスクトップ前提の spec を viewport-aware にする必要がある。

## 動作確認（実測）

```
npm run test:e2e  →  41 passed (30.9s) / exit 0

本番DB (data/db.sqlite) md5:
  実行前: db510dc98cfac85a9fe12881a735131b
  実行後: db510dc98cfac85a9fe12881a735131b   ← 不変 ✅
本番サーバ (port 3000): 実行前後とも HTTP 200 ✅
```

| チェック | 結果 |
|---|---|
| ESLint | ✅ 警告0 |
| TypeScript | ✅ Pass |
| Unit | ✅ 9,186 passed |
| Integration | ✅ 682 passed |
| Build | ✅ Pass |
| **E2E** | ✅ **41 passed / 0 failed** |

## 関連

- 前例: **#1102**（integration スイートの drift 修復 + CI 追加）
- 発見元: #1177 / PR #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
