### PR TITLE
chore(deps): package-lock.json を再生成し孤児化した autoprefixer を除去 (#1188)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@radix-ui/react-tooltip": "^1.2.12",
         "@tanstack/react-virtual": "^3.13.26",
         "ansi-to-html": "^0.7.2",
-        "autoprefixer": "^10.4.22",
         "better-sqlite3": "^12.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5976,42 +5975,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -6089,6 +6052,7 @@
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
       "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6187,6 +6151,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7516,6 +7481,7 @@
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7788,6 +7754,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8526,19 +8493,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs-constants": {
@@ -12130,6 +12084,7 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -12652,12 +12607,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -14846,6 +14795,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## 概要

Issue #1188 の修正。#1178（Tailwind CSS 4）の **lockfile 再生成漏れ**により `package-lock.json` に残っていた `autoprefixer` の孤児エントリを除去する。

`package-lock.json` のみの変更（**1080 → 1077 パッケージエントリ**、6 insertions / 56 deletions）。

## 原因

#1178 は正しく対応していた:
- `package.json` から `autoprefixer: ^10.4.22` を削除
- `postcss.config.js` を `@tailwindcss/postcss` に置換し、意図もコメントに明記:
  ```js
  // [Issue #1178] Tailwind 4 ships its PostCSS integration as a separate
  // package. Autoprefixer is dropped: Tailwind 4 handles vendor prefixing
  // itself via Lightning CSS.
  ```

**しかし `package-lock.json` を再生成しなかった**ため、lock の root `dependencies` に `autoprefixer: ^10.4.22` と `node_modules/autoprefixer` エントリが取り残された。

### 孤児であることの確認

lockfile 全体を走査し、`autoprefixer` を `dependencies` / `peerDependencies` に持つパッケージを探した結果、**root（`""`）以外に要求元は存在しない**。root の `package.json` は既に持たないため、**どこからも要求されていない孤児**である。

## 影響（CIは壊れないが実害あり）

`npm ci` はこの乖離を許容するため CI は green のままだった。しかし:

1. **クリーンな worktree で `npm install` するたびに 62行の lock 差分が発生**。#1180 / #1182 / #1184 の3worktree全てで同一差分を確認。**ワーカーが誤ってコミットすればPRにノイズが載る**（実際 3本とも除外対応が必要だった）
2. 不要な依存を lock 経由でインストールし続ける

## 検証

| 検証項目 | 結果 |
|---|---|
| lock root の `autoprefixer` | ✅ **除去**（before: `^10.4.22` → after: なし） |
| `node_modules/autoprefixer` エントリ | ✅ **除去** |
| パッケージエントリ総数 | 1080 → **1077** |
| **冪等性**（再度 `npm install` して差分が出ないか） | ✅ **差分なし**（＝真に同期） |
| `npm ci` | ✅ 成功 |
| ESLint | ✅ 警告0 |
| TypeScript | ✅ Pass |
| Unit | ✅ 9,192 passed |
| Integration | ✅ 682 passed |
| Build | ✅ Pass |

### ★ 生成CSSに影響がないことの実証

autoprefixer 除去がスタイルに影響しないことを、ビルド成果物のバイト比較で確認した。

```
本PR:            .next/static/css/531c1fcb1e69d47b.css  874 bytes
develop(現状):   .next/static/css/531c1fcb1e69d47b.css  874 bytes
→ 完全一致（ハッシュ・サイズとも同一）
```

**Tailwind 4 の Lightning CSS が既に vendor prefixing を担っており、autoprefixer は実際には何もしていなかった**ことの裏付けでもある。

## 関連

- 原因: #1178 / PR #1183
- 発見経緯: #1180 / #1182 / #1184 の worktree で `npm install` 時に同一の lock 差分が出たことから判明

🤖 Generated with [Claude Code](https://claude.com/claude-code)
