### PR TITLE
chore(lint): next lint から ESLint CLI へ移行 (#1181)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build:all": "npm run build && npm run build:cli && npm run build:server",
     "prepublishOnly": "npm run build:all",
     "start": "NODE_ENV=production node dist/server/server.js",
-    "lint": "next lint",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "test": "NODE_ENV=test vitest",
     "test:ui": "NODE_ENV=test vitest --ui",
     "test:coverage": "NODE_ENV=test vitest --coverage",


### PR DESCRIPTION
## 概要

Issue #1181 の修正。Next.js 15 で **deprecated になった `next lint` を ESLint CLI へ移行**する。

```diff
-    "lint": "next lint",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
```

`package.json` の1行のみの変更。**設定ファイル（`.eslintrc.json`）の変更は不要**だった（後述の検証参照）。

## 背景

Next 15 で `next lint` を実行すると deprecation 通知が出る:

```
`next lint` is deprecated and will be removed in Next.js 16.
For existing projects, migrate to the ESLint CLI:
  npx @next/codemod@canary next-lint-to-eslint-cli .
```

Next.js 16 で削除されるため、先んじて移行する。

## なぜ1行で足りるのか（検証済み）

- `eslint` (`^8.57.0`) と `eslint-config-next` (`^15.5.20`) は**既に devDependencies に宣言済み** → 追加インストール不要
- `.eslintrc.json` は eslintrc 形式で、**ESLint 8 の CLI がそのまま解釈する** → flat config への移行は不要（ESLint 8 のままなら eslintrc がネイティブ形式）
- `next.config` に `eslint.dirs` の指定がなく、`next lint` は**既定ディレクトリ**（`app` / `pages` / `components` / `lib` / `src`）を対象にする。本リポジトリは**ルート直下に存在するのが `src/` のみ**（他はすべて `src/` 配下）なので、`eslint src` が既定スコープと一致する

## 検証: 移行前後で lint 対象・ルールに差がないこと

### 1. 対象ファイル数（grep実数）

| | 対象 | ファイル数 |
|---|---|---|
| before (`next lint`) | 既定ディレクトリ = 実質 `src/` のみ | — |
| after (`eslint src --ext .js,.jsx,.ts,.tsx`) | `src/` | **702** |

`src` 配下の実ファイル数と一致することを確認:

```
src/**/*.ts   505 ファイル
src/**/*.tsx  197 ファイル
              ---
合計          702 ファイル   ← eslint src の対象数と一致 ✅
```

`src` 配下に `.mjs` / `.cjs` は**存在しない**ため、`--ext` から漏れる拡張子はない。

### 2. ルールの同一性（プローブによる決定的検証）

`.eslintrc.json` のカスタムルール（#1113 の `window.confirm` 禁止）が**両者で同一に発火する**ことをプローブファイルで確認した。

```tsx
// src/__lint_probe.tsx（検証用・コミットしていない）
export function Probe() {
  if (window.confirm('x')) { return null; }
  return null;
}
```

| | 結果 |
|---|---|
| **after** (`eslint src`) | `2:7 error 'window.confirm' is restricted from being used. Use useConfirm() / ConfirmDialog instead of window.confirm (Issue #1113) **no-restricted-properties**` |
| **before** (`next lint`) | `2:7 Error: 'window.confirm' is restricted from being used. Use useConfirm() / ConfirmDialog instead of window.confirm (Issue #1113). **no-restricted-properties**` |

→ **同一ルールが同一に適用される**。`extends`（`next/core-web-vitals` / `next/typescript`）も `.eslintrc.json` 経由でそのまま効いている。

**ルールを緩める・off にするような変更は一切していない。**

## 検証

| チェック | 結果 |
|---|---|
| ESLint（新CLI） | ✅ 警告0・**deprecation 通知なし** |
| TypeScript | ✅ Pass |
| Unit | ✅ 9,192 passed |
| Integration | ✅ 682 passed |
| Build | ✅ Pass |

CI の Lint ジョブ（`npm run lint`）はスクリプト差し替えのみで引き続き機能する。**#1180 で追加された E2E Tests ジョブには影響しない**（`ci-pr.yml` は未変更）。

## 補足

- `next.config` の `eslint.ignoreDuringBuilds: true` は既存設定であり本PRでは変更していない（ビルド時の lint は元々スキップされ、CI の Lint ジョブが担保している）
- ESLint 9 / flat config への移行は本PRのスコープ外（`eslint@^8` のままで `next lint` の削除には対応済み）

## 関連

- 発見元: #1177 / PR #1179（Next.js 15 アップグレード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
