### PR TITLE
fix(test): GitPane DR3-004 の非同期競合を解消し CI 限定のランダム失敗を止める (#1204)

### DIFF
--- a/tests/unit/components/GitPane.test.tsx
+++ b/tests/unit/components/GitPane.test.tsx
@@ -1517,6 +1517,12 @@ describe('GitPane', () => {
       render(<GitPane {...defaultProps} />);
       await waitFor(() => expect(screen.getByTestId('git-push-button')).toBeInTheDocument());
 
+      // The toggle is rendered from /git/staged, which resolves independently of the
+      // /git/status fetch the push button waits on — wait for it before asserting.
+      await waitFor(() =>
+        expect(screen.getByTestId('git-changes-toggle-button')).toBeInTheDocument()
+      );
+
       // The staged file's Unstage toggle is enabled (busy=false) initially.
       const toggleBefore = screen.getByTestId('git-changes-toggle-button');
       expect(toggleBefore).not.toBeDisabled();
@@ -1568,6 +1574,11 @@ describe('GitPane', () => {
       // Spinner appears (fetch in-flight) but the Unstage toggle stays enabled.
       await waitFor(() =>
         expect(screen.getByTestId('git-network-operation-spinner')).toBeInTheDocument()
+      );
+      // Same race as above: the toggle comes from /git/staged, not from the fetch
+      // the spinner tracks, so its presence must be awaited before asserting on it.
+      await waitFor(() =>
+        expect(screen.getByTestId('git-changes-toggle-button')).toBeInTheDocument()
       );
       expect(screen.getByTestId('git-changes-toggle-button')).not.toBeDisabled();
 


### PR DESCRIPTION
## 概要

Issue #1204 の対応。`GitPane.test.tsx` の DR3-004 系テストが **CI でのみランダムに失敗**する問題を解消する。**テスト側の非同期競合が原因であり、プロダクトコードは変更していない**。

## 発見の経緯

PR #1203（i18n の変更のみで GitPane を一切触っていない）の Unit Tests が本テストで fail した。ローカルでは 9205 tests 全パスするため、変更が原因かを切り分けたところ、develop 時点で既に存在する潜在バグと判明した。

## 根本原因

`git-push-button` と `git-changes-toggle-button` は **別々の非同期 fetch** に依存している:

| 要素 | 依存する fetch |
|---|---|
| `git-push-button` | `/git/status` |
| `git-changes-toggle-button` | `/git/staged`（staged ファイル行として描画） |

しかしテストは **`/git/status` 側の完了だけを `waitFor` で待ち、`/git/staged` に依存する要素を `waitFor` の外で同期取得**していた。

```js
await waitFor(() => expect(screen.getByTestId('git-push-button')).toBeInTheDocument());

// ↓ /git/staged の解決を待たずに同期取得（ここが競合）
const toggleBefore = screen.getByTestId('git-changes-toggle-button');
```

`/git/staged` が先に解決するかは**タイミング依存**。ローカルは `fileParallelism=true` / `maxConcurrency=10`、CI は `maxConcurrency=1` / `fileParallelism=false`（`vitest.config.ts:19-20`）でスケジューリングが変わるため、CI でのみ露見していた。

## 変更内容

`git-changes-toggle-button` の**存在を `waitFor` で待ってから**、既存の `not.toBeDisabled()` 判定を行う。

- **アサーションの意味は変えていない**: `not.toBeDisabled()` は同期判定のまま維持している。否定アサーションを `waitFor` の中に入れると要素が出現した瞬間に真になり偽パスし得るため、あえて分離している
- 同一パターンを持つ兄弟テスト（fetch exempt, DR3-004）も併せて修正

## 検証（受入基準）

| 条件 | 修正前 | 修正後 |
|---|---|---|
| `/git/staged` に 10ms 遅延を注入（CI の遅いタイミングを模倣） | ❌ 確実に再現<br>`Unable to find [data-testid="git-changes-toggle-button"]` | ✅ **112 tests 全パス** |
| 遅延なし・`CI=true` | ✅ pass | ✅ 112 tests 全パス |
| `npm run lint` | - | ✅ 0件 |
| `npx tsc --noEmit` | - | ✅ クリーン |

再現手順は Issue #1204 に記載。develop（無変更）でも同じ遅延注入で再現することを確認済みで、**特定の PR が原因ではない**ことを実証している。

## 影響

- GitPane を触っていない PR が赤くなり**変更が原因だと誤診される**問題を解消（過去にもリリース PR で同種の混乱が発生している）
- 並列開発中の複数 PR をランダムにブロックする要因を除去

## 対象外

- プロダクトコード（`GitChangesPanel.tsx` 等）: 不具合はテスト側にあり実装は正しい
- 他テストファイルの同種パターンの一斉調査（必要なら別途）

Closes #1204
