### PR TITLE
fix(test): issue-288 Scenario 5 の非同期競合を解消し CI 限定のランダム失敗を止める (#1209)

### DIFF
--- a/tests/integration/issue-288-acceptance.test.tsx
+++ b/tests/integration/issue-288-acceptance.test.tsx
@@ -254,7 +254,15 @@ describe('Issue #288 Acceptance Tests: Free Input Mode prevents selector re-disp
         expect(worktreeApi.sendMessage).toHaveBeenCalled();
       });
 
-      // After submit, message is cleared and isFreeInputMode is reset
+      // After submit, message is cleared and isFreeInputMode is reset. sendMessage having
+      // been *called* does not mean its promise resolved and that reset landed, so wait for
+      // the cleared input — opening the selector while isFreeInputMode is still true would
+      // suppress it. (Not wrapping the assertion below in waitFor: that would re-run
+      // openSelector and type "/" repeatedly.)
+      await waitFor(() => {
+        expect(getTextarea()).toHaveValue('');
+      });
+
       openSelector();
       expect(queryDesktopSelector()).toBeInTheDocument();
     });


### PR DESCRIPTION
## 概要

Issue #1209 の対応。`issue-288-acceptance.test.tsx` の Scenario 5 が **CI でのみランダムに失敗**する問題を解消する。**テスト側の非同期競合が原因であり、プロダクトコードは変更していない**。

#1204（GitPane DR3-004）と同一クラスの競合。

## 発見の経緯

PR #1208（**CLI のみの変更**で本テスト領域を一切触っていない）の Integration Tests が本テストで fail した。切り分けたところ、develop 単体の CI でも同テストが落ちており（`6715f3d0`）、**develop 時点で既に存在する潜在バグ**と判明した。

| 対象 | Integration Tests |
|---|---|
| develop `6715f3d0` | ❌ 本テストで fail |
| develop `838b6619` / `e3795750` / `d6cdbbde`（後続3回） | ✅ pass |
| PR #1208（CLI のみの変更） | ❌ 本テストで fail |

同一コードで成否が変わるフレークであり、特定の PR が原因ではない。

## 根本原因

```js
pressEnter();

await waitFor(() => {
  expect(worktreeApi.sendMessage).toHaveBeenCalled();   // ← 「呼ばれた」だけで抜ける
});

// After submit, message is cleared and isFreeInputMode is reset
openSelector();
expect(queryDesktopSelector()).toBeInTheDocument();     // ← 同期アサート。null で落ちる
```

`sendMessage` が**呼ばれた**ことと、その Promise が解決して**状態リセット（`isFreeInputMode` = false / message クリア）が反映された**ことは別のタイミング。

`waitFor` は `sendMessage` が呼ばれた瞬間に抜けるため、`openSelector()` は **`isFreeInputMode` がまだ true のまま**実行され得る。free input mode ではセレクタが抑制されるため `queryDesktopSelector()` が `null` を返す。

モックは即時解決（`mockResolvedValue({})`）のためローカルでは通常マイクロタスクで間に合うが、CI は `maxConcurrency=1` / `fileParallelism=false`（`vitest.config.ts:19-20`）でスケジューリングが変わるため露見する。

## 変更内容

submit 完了後の状態リセットが反映されたことを、**観測可能なプロキシ（入力のクリア）で待ってから** `openSelector()` を呼ぶ。

```js
await waitFor(() => {
  expect(getTextarea()).toHaveValue('');
});

openSelector();
expect(queryDesktopSelector()).toBeInTheDocument();
```

- **アサーションの意味は変えていない**: セレクタ表示の判定は同期のまま維持
- 判定を `waitFor` で包む方法は採らない: `openSelector()` が再実行され `"/"` が重複入力されるため

## 検証（受入基準）

| 条件 | 修正前 | 修正後 |
|---|---|---|
| `sendMessage` の解決に 10ms 遅延を注入（CI の遅いタイミングを模倣） | ❌ 確実に再現<br>`Received has value: null` | ✅ **10 tests 全パス** |
| 遅延なし・`CI=true` | ✅ pass | ✅ 10 tests 全パス |
| `npm run lint` | - | ✅ 0件 |
| `npx tsc --noEmit` | - | ✅ クリーン |

再現手順は Issue #1209 に記載。develop（無変更）でも同じ遅延注入で再現することを確認済みで、**特定の PR が原因ではない**ことを実証している。

同ファイル内の他の `sendMessage` 待ちは、`waitFor` の後に依存するアサートが続かないため同種の競合はない（確認済み）。

## 影響

- 本テスト領域を触っていない PR が赤くなり**変更が原因だと誤診される**問題を解消
- develop 自体のランダムな赤を除去

## 対象外

- プロダクトコード（`MessageInput` 等）: 不具合はテスト側にあり実装は正しい

Closes #1209
