### PR TITLE
fix(i18n): Header / GlobalMobileNav の nav ラベルを i18n 化 (#1206)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -8,7 +8,9 @@
     "chat": "Chat",
     "sessions": "Sessions",
     "repositories": "Repositories",
+    "repositoriesShort": "Repos",
     "review": "Review",
+    "reviewReport": "Review/Report",
     "more": "More"
   },
   "repositories": {

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -8,7 +8,9 @@
     "chat": "チャット",
     "sessions": "セッション",
     "repositories": "リポジトリ",
+    "repositoriesShort": "リポジトリ",
     "review": "レビュー",
+    "reviewReport": "レビュー/レポート",
     "more": "その他"
   },
   "repositories": {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,15 +25,19 @@ export interface HeaderProps {
 
 /**
  * Navigation items for the PC header.
- * Each entry maps a label to a href and a pathname match function.
+ * Each entry maps a `common` translation key to a href and a pathname match function.
+ *
+ * The header abbreviates where the mobile bar does not: `repositoriesShort`
+ * ("Repos") keeps the space-x-6 row from overflowing, and `reviewReport`
+ * ("Review/Report") preserves that /review also covers reports.
  */
-const NAV_ITEMS: Array<{ label: string; href: string; isActive: (pathname: string) => boolean }> = [
-  { label: 'Home', href: '/', isActive: (p) => p === '/' },
-  { label: 'Chat', href: '/chat', isActive: (p) => p.startsWith('/chat') },
-  { label: 'Sessions', href: '/sessions', isActive: (p) => p.startsWith('/sessions') },
-  { label: 'Repos', href: '/repositories', isActive: (p) => p.startsWith('/repositories') },
-  { label: 'Review/Report', href: '/review', isActive: (p) => p.startsWith('/review') },
-  { label: 'More', href: '/more', isActive: (p) => p.startsWith('/more') },
+const NAV_ITEMS: Array<{ labelKey: string; href: string; isActive: (pathname: string) => boolean }> = [
+  { labelKey: 'nav.home', href: '/', isActive: (p) => p === '/' },
+  { labelKey: 'nav.chat', href: '/chat', isActive: (p) => p.startsWith('/chat') },
+  { labelKey: 'nav.sessions', href: '/sessions', isActive: (p) => p.startsWith('/sessions') },
+  { labelKey: 'nav.repositoriesShort', href: '/repositories', isActive: (p) => p.startsWith('/repositories') },
+  { labelKey: 'nav.reviewReport', href: '/review', isActive: (p) => p.startsWith('/review') },
+  { labelKey: 'nav.more', href: '/more', isActive: (p) => p.startsWith('/more') },
 ];
 
 /**
@@ -47,6 +51,7 @@ const NAV_ITEMS: Array<{ label: string; href: string; isActive: (pathname: strin
 export function Header({ title = 'CommandMate' }: HeaderProps) {
   const pathname = usePathname();
   const t = useTranslations('commandPalette');
+  const tCommon = useTranslations('common');
   const { setOpen } = useCommandPalette();
 
   // Platform-specific modifier resolved after mount to avoid SSR hydration
@@ -88,7 +93,7 @@ export function Header({ title = 'CommandMate' }: HeaderProps) {
                       : 'text-muted-foreground hover:text-foreground after:scale-x-0'
                   }`}
                 >
-                  {item.label}
+                  {tCommon(item.labelKey)}
                 </TransitionLink>
               );
             })}

--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -19,9 +19,10 @@ import { useCommandPalette } from '@/contexts/CommandPaletteContext';
 
 /**
  * Mobile navigation tab definition.
+ * `labelKey` resolves against the `common` namespace at render time.
  */
 interface MobileNavTab {
-  label: string;
+  labelKey: string;
   href: string;
   isActive: (pathname: string) => boolean;
   icon: React.ReactNode;
@@ -32,11 +33,11 @@ interface MobileNavTab {
  * Icons: lucide-react at 20px / strokeWidth 2 (see docs/design-system.md).
  */
 const MOBILE_NAV_TABS: MobileNavTab[] = [
-  { label: 'Home', href: '/', isActive: (p) => p === '/', icon: <Home size={20} aria-hidden="true" /> },
-  { label: 'Chat', href: '/chat', isActive: (p) => p.startsWith('/chat'), icon: <MessageSquare size={20} aria-hidden="true" /> },
-  { label: 'Sessions', href: '/sessions', isActive: (p) => p.startsWith('/sessions'), icon: <AlignJustify size={20} aria-hidden="true" /> },
-  { label: 'Review', href: '/review', isActive: (p) => p.startsWith('/review'), icon: <CircleCheck size={20} aria-hidden="true" /> },
-  { label: 'More', href: '/more', isActive: (p) => p.startsWith('/more'), icon: <MoreHorizontal size={20} aria-hidden="true" /> },
+  { labelKey: 'nav.home', href: '/', isActive: (p) => p === '/', icon: <Home size={20} aria-hidden="true" /> },
+  { labelKey: 'nav.chat', href: '/chat', isActive: (p) => p.startsWith('/chat'), icon: <MessageSquare size={20} aria-hidden="true" /> },
+  { labelKey: 'nav.sessions', href: '/sessions', isActive: (p) => p.startsWith('/sessions'), icon: <AlignJustify size={20} aria-hidden="true" /> },
+  { labelKey: 'nav.review', href: '/review', isActive: (p) => p.startsWith('/review'), icon: <CircleCheck size={20} aria-hidden="true" /> },
+  { labelKey: 'nav.more', href: '/more', isActive: (p) => p.startsWith('/more'), icon: <MoreHorizontal size={20} aria-hidden="true" /> },
 ];
 
 /**
@@ -47,6 +48,7 @@ export function GlobalMobileNav() {
   const pathname = usePathname();
   const { setOpen } = useCommandPalette();
   const t = useTranslations('commandPalette');
+  const tCommon = useTranslations('common');
 
   return (
     <nav
@@ -67,7 +69,7 @@ export function GlobalMobileNav() {
               }`}
             >
               {tab.icon}
-              <span className="mt-1">{tab.label}</span>
+              <span className="mt-1">{tCommon(tab.labelKey)}</span>
             </TransitionLink>
           );
         })}

--- a/tests/helpers/real-intl.ts
+++ b/tests/helpers/real-intl.ts
@@ -1,0 +1,89 @@
+/**
+ * Real-dictionary next-intl mock (Issue #1206).
+ *
+ * The global mock in tests/setup.ts echoes `namespace.key` back, so a component
+ * test can assert a label while the real dictionary has no such entry — the
+ * exact blind spot that let #1197's nav labels ship half-migrated. Components
+ * whose *rendered wording* is the thing under test should mock next-intl with
+ * this factory instead, so `getByText('Repos')` proves the key resolves through
+ * locales/<locale>/<namespace>.json to that literal string.
+ *
+ * Unknown keys throw rather than falling back: a silent passthrough here would
+ * recreate the very blind spot this helper exists to close.
+ *
+ * @example
+ * ```ts
+ * vi.mock('next-intl', async () => {
+ *   const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+ *   return createRealIntlMock('en');
+ * });
+ * ```
+ *
+ * @example Switching locale per test (pass a getter — vi.mock factories are hoisted)
+ * ```ts
+ * const locale = vi.hoisted(() => ({ current: 'en' }));
+ * vi.mock('next-intl', async () => {
+ *   const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+ *   return createRealIntlMock(() => locale.current);
+ * });
+ * ```
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../locales');
+
+function loadNamespace(locale: string, namespace: string): Record<string, unknown> {
+  const filePath = path.join(LOCALES_DIR, locale, `${namespace}.json`);
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+function resolve(dict: Record<string, unknown>, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], dict);
+}
+
+export interface RealIntlMock {
+  useTranslations: (
+    namespace?: string
+  ) => (key: string, params?: Record<string, string | number>) => string;
+  useLocale: () => string;
+  NextIntlClientProvider: (props: { children: unknown }) => unknown;
+}
+
+export function createRealIntlMock(locale: string | (() => string)): RealIntlMock {
+  const currentLocale = typeof locale === 'function' ? locale : () => locale;
+  const cache = new Map<string, Record<string, unknown>>();
+
+  const dictFor = (loc: string, namespace: string): Record<string, unknown> => {
+    const cacheKey = `${loc}/${namespace}`;
+    let dict = cache.get(cacheKey);
+    if (!dict) {
+      dict = loadNamespace(loc, namespace);
+      cache.set(cacheKey, dict);
+    }
+    return dict;
+  };
+
+  return {
+    useTranslations: (namespace?: string) => (key, params) => {
+      const loc = currentLocale();
+      if (!namespace) {
+        throw new Error(`real-intl: useTranslations() requires a namespace (key "${key}")`);
+      }
+      const value = resolve(dictFor(loc, namespace), key);
+      if (typeof value !== 'string') {
+        throw new Error(`real-intl: ${loc}/${namespace}.json has no string at "${key}"`);
+      }
+      if (!params) return value;
+      return Object.entries(params).reduce(
+        (str, [k, v]) => str.replace(`{${k}}`, String(v)),
+        value
+      );
+    },
+    useLocale: () => currentLocale(),
+    NextIntlClientProvider: ({ children }) => children,
+  };
+}

--- a/tests/unit/GlobalMobileNav.test.tsx
+++ b/tests/unit/GlobalMobileNav.test.tsx
@@ -26,12 +26,22 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Issue #1206: resolve labels through the real dictionary instead of the global
+// key-echoing mock in tests/setup.ts, so the English assertions below only stay
+// green while common.nav.* renders the exact wording it replaced.
+const intlLocale = vi.hoisted(() => ({ current: 'en' }));
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock(() => intlLocale.current);
+});
+
 import { GlobalMobileNav } from '@/components/mobile/GlobalMobileNav';
 
 describe('GlobalMobileNav', () => {
   beforeEach(() => {
     mockPathname.mockReturnValue('/');
     mockRouterPush.mockClear();
+    intlLocale.current = 'en';
   });
 
   it('should render 5 tabs: Home, Chat, Sessions, Review, More', () => {
@@ -111,5 +121,43 @@ describe('GlobalMobileNav', () => {
     expect(cls).toContain('supports-[backdrop-filter]:bg-background/80');
     expect(cls).toContain('backdrop-blur-md');
     expect(cls).toContain('border-border');
+  });
+
+  describe('i18n (Issue #1206)', () => {
+    it('renders every tab label in Japanese under the ja locale', () => {
+      intlLocale.current = 'ja';
+      render(<GlobalMobileNav />);
+
+      expect(screen.getByText('ホーム')).toBeDefined();
+      expect(screen.getByText('チャット')).toBeDefined();
+      expect(screen.getByText('セッション')).toBeDefined();
+      expect(screen.getByText('レビュー')).toBeDefined();
+      expect(screen.getByText('その他')).toBeDefined();
+    });
+
+    it('leaves no English tab label behind under the ja locale', () => {
+      intlLocale.current = 'ja';
+      render(<GlobalMobileNav />);
+
+      for (const label of ['Home', 'Chat', 'Sessions', 'Review', 'More']) {
+        expect(screen.queryByText(label), `"${label}" is still hardcoded English`).toBeNull();
+      }
+    });
+
+    it('still omits Repositories under the ja locale', () => {
+      intlLocale.current = 'ja';
+      render(<GlobalMobileNav />);
+      expect(screen.queryByText('リポジトリ')).toBeNull();
+    });
+
+    it('keeps hrefs and active state locale-independent', () => {
+      intlLocale.current = 'ja';
+      mockPathname.mockReturnValue('/sessions');
+      render(<GlobalMobileNav />);
+
+      const sessionsLink = screen.getByText('セッション').closest('a');
+      expect(sessionsLink?.getAttribute('href')).toBe('/sessions');
+      expect(sessionsLink?.className).toContain('text-accent-600');
+    });
   });
 });

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -31,11 +31,22 @@ vi.mock('next-themes', () => ({
   useTheme: () => ({ theme: 'dark', setTheme: vi.fn() }),
 }));
 
+// Issue #1206: resolve labels through the real dictionary instead of the global
+// key-echoing mock in tests/setup.ts. The English assertions below are the
+// pre-i18n literals, so they only stay green while common.nav.* renders the
+// exact same wording it replaced.
+const intlLocale = vi.hoisted(() => ({ current: 'en' }));
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock(() => intlLocale.current);
+});
+
 import { Header } from '@/components/layout/Header';
 
 describe('Header', () => {
   beforeEach(() => {
     mockPathname.mockReturnValue('/');
+    intlLocale.current = 'en';
   });
 
   it('should render the logo and title', () => {
@@ -122,5 +133,39 @@ describe('Header', () => {
     expect(cls).toContain('supports-[backdrop-filter]:bg-background/80');
     expect(cls).toContain('backdrop-blur-md');
     expect(cls).toContain('border-border');
+  });
+
+  describe('i18n (Issue #1206)', () => {
+    it('renders every nav label in Japanese under the ja locale', () => {
+      intlLocale.current = 'ja';
+      render(<Header />);
+
+      expect(screen.getByText('ホーム')).toBeDefined();
+      expect(screen.getByText('チャット')).toBeDefined();
+      expect(screen.getByText('セッション')).toBeDefined();
+      expect(screen.getByText('リポジトリ')).toBeDefined();
+      expect(screen.getByText('レビュー/レポート')).toBeDefined();
+      expect(screen.getByText('その他')).toBeDefined();
+    });
+
+    it('leaves no English nav label behind under the ja locale', () => {
+      intlLocale.current = 'ja';
+      render(<Header />);
+
+      for (const label of ['Home', 'Chat', 'Sessions', 'Repos', 'Review/Report', 'More']) {
+        expect(screen.queryByText(label), `"${label}" is still hardcoded English`).toBeNull();
+      }
+    });
+
+    it('keeps hrefs and active state locale-independent', () => {
+      intlLocale.current = 'ja';
+      mockPathname.mockReturnValue('/repositories');
+      render(<Header />);
+
+      const reposLink = screen.getByText('リポジトリ').closest('a');
+      expect(reposLink?.getAttribute('href')).toBe('/repositories');
+      expect(reposLink?.className).toContain('text-accent-600');
+      expect(reposLink?.getAttribute('aria-current')).toBe('page');
+    });
   });
 });

--- a/tests/unit/components/layout/Header.test.tsx
+++ b/tests/unit/components/layout/Header.test.tsx
@@ -31,6 +31,14 @@ vi.mock('@/components/layout/PcDisplaySizeSelector', () => ({
   PcDisplaySizeSelector: () => <div data-testid="pc-display-size-selector" />,
 }));
 
+// Issue #1206: the accessible names below are the real English labels, so
+// resolve them through the real dictionary rather than the key-echoing global
+// mock in tests/setup.ts.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 const NAV_LABELS = ['Home', 'Chat', 'Sessions', 'Repos', 'Review/Report', 'More'] as const;
 
 const ROUTE_CASES: Array<{ pathname: string; activeLabel: (typeof NAV_LABELS)[number] }> = [

--- a/tests/unit/i18n/common-keys.test.ts
+++ b/tests/unit/i18n/common-keys.test.ts
@@ -38,7 +38,37 @@ function resolve(dict: Record<string, unknown>, key: string): unknown {
 }
 
 /** Every nav key the palette and Home's quick actions request at runtime. */
-const NAV_KEYS = ['home', 'chat', 'sessions', 'repositories', 'review', 'more'];
+const NAV_KEYS = [
+  'home',
+  'chat',
+  'sessions',
+  'repositories',
+  'review',
+  'more',
+  // Issue #1206: Header renders abbreviated variants that must stay distinct
+  // from the full labels above — `repositories` ("Repositories") is ~2.4x too
+  // wide for the header's space-x-6 row, and `review` ("Review") would drop the
+  // "/Report" that tells users the page also covers reports.
+  'repositoriesShort',
+  'reviewReport',
+];
+
+/**
+ * Issue #1206 migrated Header / GlobalMobileNav from hardcoded English labels
+ * to `common.nav.*`. The migration must be display-neutral in English, so pin
+ * the exact pre-migration strings: any drift here is a user-visible regression
+ * that the component tests' mocked `t()` could never catch on its own.
+ */
+const EN_NAV_LABELS: Record<string, string> = {
+  home: 'Home',
+  chat: 'Chat',
+  sessions: 'Sessions',
+  repositories: 'Repositories',
+  review: 'Review',
+  more: 'More',
+  repositoriesShort: 'Repos',
+  reviewReport: 'Review/Report',
+};
 
 describe('common i18n keys (Issue #1197)', () => {
   it.each(['en', 'ja'])('%s/common.json has non-empty values for every leaf', (locale) => {
@@ -94,6 +124,24 @@ describe('common i18n keys (Issue #1197)', () => {
         `ja: nav.${key} is still the English string`
       ).not.toBe(resolve(en, `nav.${key}`));
     }
+  });
+
+  it('keeps every English nav label byte-identical to the pre-i18n markup (Issue #1206)', () => {
+    const en = loadCommon('en');
+    for (const [key, expected] of Object.entries(EN_NAV_LABELS)) {
+      expect(resolve(en, `nav.${key}`), `en: nav.${key} changed the rendered label`).toBe(expected);
+    }
+  });
+
+  /**
+   * The header deliberately abbreviates where the mobile bar does not, so the
+   * short keys must never collapse onto the full ones - that collapse is
+   * exactly what "just reuse nav.repositories" would silently do.
+   */
+  it('keeps the header abbreviations distinct from the full English labels (Issue #1206)', () => {
+    const en = loadCommon('en');
+    expect(resolve(en, 'nav.repositoriesShort')).not.toBe(resolve(en, 'nav.repositories'));
+    expect(resolve(en, 'nav.reviewReport')).not.toBe(resolve(en, 'nav.review'));
   });
 
   it('includes the repository list empty-state copy', () => {


### PR DESCRIPTION
## 概要

Issue #1206 の対応。全ページに出る主要導線（PC ヘッダー / モバイル下部ナビ）の nav ラベルが英語直書きで、日本語ロケールでも英語表示されていた。#1197 で Home 画面と CommandPalette は i18n 化済みだったため、**「Home のタイルは日本語なのにヘッダーのナビは英語」という混在状態**を解消する。

親Issue: #1193（導入・アップデート・ドキュメント体験の改善）

## 決定事項（Issue が「実装前に必須」としていた項目）

### 決定1: 現行の英語表示を一切変えない

| 画面 | 表示 | 使用キー |
|---|---|---|
| Header | Home / Chat / Sessions / More | `common.nav.home` / `chat` / `sessions` / `more`（流用） |
| Header | **Repos** | **`common.nav.repositoriesShort`（新規）** — `nav.repositories` は `Repositories` で不一致 |
| Header | **Review/Report** | **`common.nav.reviewReport`（新規）** — `nav.review` は `Review` で不一致 |
| GlobalMobileNav | Home / Chat / Sessions / Review / More | `common.nav.*` に**5件すべて完全一致** → 流用のみ |

**理由**:
1. i18n 化と文言変更を混ぜると、表示の差異が「移行の回帰」なのか「意図的な変更」なのか切り分け不能になる
2. `Repos` はヘッダーのナビ幅制約による短縮形
3. `Review/Report` は「レポートも扱うページ」という情報を持ち、`Review` に縮めると情報が落ちる
4. Header と GlobalMobileNav は同じ `/review` に対して既に意図的に異なるラベルを使っており、キーを分けるのが正しい

### 決定2: 構造リファクタは labelKey 保持方式

`NAV_ITEMS` はモジュールスコープの const 配列のため `t()` をその場で呼べない。配列は `labelKey` を保持し、描画時に解決する。**`isActive` / `href` / `icon` は無改変**。

## 追加キー

| キー | EN | JA |
|---|---|---|
| `nav.repositoriesShort` | `Repos` | `リポジトリ` |
| `nav.reviewReport` | `Review/Report` | `レビュー/レポート` |

`Repositories` と `Repos` が別物と読んで分かる命名にし、既存の `nav.repositories` / `nav.review` の直後に配置。新規 namespace ファイルは作成していない。

**JA の `nav.reviewReport` について**: 「既存訳語の流用」に厳密に従えば `レビュー` だが、それでは Header と mobile が同じ `/review` に意図的に異なるラベルを使うという区別が JA で失われ、キーを分けた意味が消える。`レポート` は `locales/ja/review.json:3` で既に使われている既存訳語であり、新規の発明ではない。

## EN 表示のバイト一致（検証済み）

| 画面 | 移行前 | 移行後の解決値 |
|---|---|---|
| Header | `Home` `Chat` `Sessions` `Repos` `Review/Report` `More` | ✅ 完全一致 |
| GlobalMobileNav | `Home` `Chat` `Sessions` `Review` `More` | ✅ 完全一致 |

## テスト戦略: モックを迂回して実辞書で検証

`tests/setup.ts` の next-intl モックは `t('k')` を `'namespace.k'` として**キーを素通しで返す**ため、**EN のバイト一致をコンポーネントテストで検証できない**（#1197 で判明した構造）。

`tests/helpers/real-intl.ts` を新設し、Header / GlobalMobileNav のテストを**実辞書バック**に切り替えた。これにより `getByText('Repos')` が意味を持ち、キー誤用や存在しないキーも捕捉できる。

### 欠陥注入による検証（ガードが空振りしないことを確認）

| 注入した欠陥 | 結果 |
|---|---|
| 片ロケール欠落（ja の `nav.reviewReport` 削除） | ✅ 3件 fail |
| **EN 文言ドリフト（`Repos` → `Repositories`）** ← 本PRの核心 | ✅ 2件 fail |
| キー素通し | ✅ 2件 fail |
| 未翻訳 | ✅ 1件 fail |
| Header でのキー誤用（`nav.repositoriesShort` → `nav.repositories`） | ✅ 9件 fail |
| 存在しないキー | ✅ 23件 fail |
| 欠陥なし（復元後） | ✅ 46 tests pass |

## 品質チェック

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ 0件 |
| `npx tsc --noEmit` | ✅ クリーン |
| `npm run test:unit` | ✅ 9,433 tests / 556 files 全パス |
| `npm run build` | ✅ 成功 |
| EN/JA キーパリティ | ✅ 差分ゼロ |

## 📱 実機計測: モバイル幅（本PRでは修正せず #1211 へ分離）

実ブラウザ（Chromium）で日本語ロケール・複数幅を計測した:

| ロケール | 幅 | スロット幅 | 最長ラベル | ラベル幅 | span 高さ | 判定 |
|---|---|---|---|---|---|---|
| ja | **320px** | 53.3px | セッション | 53.3px | **32px** | ❌ **2行に折返し** |
| ja | 375px | 62.5px | セッション | 60.0px | 16px | ✅ OK（余裕 2.5px） |
| ja | 390 / 430px | 65 / 71.7px | セッション | 60.0px | 16px | ✅ OK |
| en | 320 / 375px | 53.3 / 62.5px | Sessions | 49.3px | 16px | ✅ OK |

**375px 以上では問題なし**。プロジェクトの E2E は一貫して 375px を使用しており（`tests/e2e/cli-tool-selection.spec.ts:38` / `file-search.spec.ts:183` / `mobile-cmate-tab.spec.ts:10`）、リポジトリ内に 320px を対象とした記述・テストは存在しない。

320px での折返しは `span` に `whitespace-nowrap` / `truncate` が無いという **i18n 化以前からの構造的な脆さ**（英語ラベルが短かったため露見していなかった）。i18n 移行にスタイル変更を混ぜると切り分け不能になる（決定1の理由1と同じ）ため、**#1211 に分離**した。375px でも余裕が 2.5px しかなく将来の破綻要因である点も同Issueに記載している。

## 検証環境

実機計測は**隔離環境**（`CM_PORT=3206` / `CM_DB_PATH=/tmp/cm1206`）で実施し、本番サーバ（:3000）・本番 DB は無傷（DB の md5 が実施前後で不変であることを確認済み）。検証後に隔離環境は完全に破棄した。

## 対象外

- モバイル下部ナビの折返し対策 → #1211
- ターミナル出力面（`*Terminal*` 系）: プロジェクト方針で原状維持

Closes #1206
