### PR TITLE
fix(mobile): 下部ナビのラベルに折返し防止を追加し 320px 日本語の2行折返しを解消 (#1211)

### DIFF
--- a/src/components/mobile/GlobalMobileNav.tsx
+++ b/src/components/mobile/GlobalMobileNav.tsx
@@ -69,7 +69,7 @@ export function GlobalMobileNav() {
               }`}
             >
               {tab.icon}
-              <span className="mt-1">{tCommon(tab.labelKey)}</span>
+              <span className="mt-1 whitespace-nowrap">{tCommon(tab.labelKey)}</span>
             </TransitionLink>
           );
         })}
@@ -83,7 +83,7 @@ export function GlobalMobileNav() {
           className="flex flex-col items-center justify-center flex-1 h-full text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
           <Search size={20} aria-hidden="true" />
-          <span className="mt-1">{t('mobileLabel')}</span>
+          <span className="mt-1 whitespace-nowrap">{t('mobileLabel')}</span>
         </button>
       </div>
     </nav>

--- a/tests/unit/GlobalMobileNav.test.tsx
+++ b/tests/unit/GlobalMobileNav.test.tsx
@@ -123,6 +123,47 @@ describe('GlobalMobileNav', () => {
     expect(cls).toContain('border-border');
   });
 
+  // Issue #1211: ja labels wrapped to 2 lines at 320px, colliding with the h-14 bar.
+  // These assert the class string only — jsdom does not lay out text, so it cannot
+  // observe wrapping (getBoundingClientRect always returns 0). The no-wrap behaviour
+  // itself was measured in a real browser (ja @320px/@280px, all labels on one line);
+  // these tests exist purely to catch the class being dropped later.
+  describe('label wrapping (Issue #1211)', () => {
+    it.each([
+      ['en', ['Home', 'Chat', 'Sessions', 'Review', 'More']],
+      ['ja', ['ホーム', 'チャット', 'セッション', 'レビュー', 'その他']],
+    ] as const)('keeps every %s tab label on one line', (locale, labels) => {
+      intlLocale.current = locale;
+      render(<GlobalMobileNav />);
+
+      for (const label of labels) {
+        expect(
+          screen.getByText(label).className,
+          `"${label}" may wrap to a second line`
+        ).toContain('whitespace-nowrap');
+      }
+    });
+
+    it.each(['en', 'ja'] as const)(
+      'keeps the command palette trigger label on one line under %s',
+      (locale) => {
+        intlLocale.current = locale;
+        render(<GlobalMobileNav />);
+
+        const span = screen.getByTestId('mobile-command-palette-trigger').querySelector('span');
+        expect(span?.className).toContain('whitespace-nowrap');
+      }
+    );
+
+    it('does not change the bar height or slot layout', () => {
+      render(<GlobalMobileNav />);
+
+      expect(screen.getByTestId('global-mobile-nav').querySelector('div')?.className).toContain('h-14');
+      expect(screen.getByText('Sessions').closest('a')?.className).toContain('flex-1');
+      expect(screen.getByText('Sessions').closest('a')?.className).toContain('text-xs');
+    });
+  });
+
   describe('i18n (Issue #1206)', () => {
     it('renders every tab label in Japanese under the ja locale', () => {
       intlLocale.current = 'ja';


### PR DESCRIPTION
## 概要

Issue #1211 の対応。`GlobalMobileNav` のラベルに折返し防止が無く、**日本語ロケールの 320px 幅で「セッション」が2行に折り返して `h-14` のバーと衝突**していた。英語ラベルが短かったため露見しておらず、#1206 で日本語ラベルが表示されるようになり顕在化した。

## 変更内容

`src/components/mobile/GlobalMobileNav.tsx` の2箇所の span に `whitespace-nowrap` を追加するのみ。

```diff
-              <span className="mt-1">{tCommon(tab.labelKey)}</span>
+              <span className="mt-1 whitespace-nowrap">{tCommon(tab.labelKey)}</span>
```
```diff
-          <span className="mt-1">{t('mobileLabel')}</span>
+          <span className="mt-1 whitespace-nowrap">{t('mobileLabel')}</span>
```

`h-14` / `flex-1` / `text-xs` / icon / `isActive` / `href` は**無改変**。

## 実ブラウザで4案を比較し B を採用（Issue の当初「推奨」は誤りだった）

| 案 | ja @320px | ja @280px | 判定 |
|---|---|---|---|
| 現状（修正なし） | ❌ `セッション` が折返し | ❌ `チャット`/`セッション`/`レビュー` が折返し | — |
| **B: `whitespace-nowrap` のみ** | ✅ **全文表示・全ラベルがスロット内** | ✅ **全文表示・全ラベルがスロット内** | **採用** |
| A: `truncate` | B と挙動が同一（省略が発動しない） | 同左 | 冗長 |
| A + `min-w-0` | ❌ ラベルがスロット外へはみ出し隣と重なる | ❌ 3件が重なる | 却下 |
| C: `text-[10px]` へ縮小 | ✅ 収まる | ✅ 収まる | 不要な分岐 |

### なぜ `whitespace-nowrap` だけで足りるのか

`flex-1` は `min-width: auto` のため、**スロットはコンテンツ幅まで伸びる**。折返しを止めるだけで各スロットが実測どおりに配分され、合計が viewport に収まる:

- ja @320px: `ホーム:52 チャット:52 セッション:60 レビュー:52 その他:52 検索:52` → ちょうど収まる
- ja @280px: `ホーム:41.3 チャット:48 セッション:60 レビュー:48 その他:41.3 検索:41.3` → 収まる

### なぜ Issue が「推奨」としていた `truncate` を採らないのか

**スロットが伸びるため省略（`…`）が一度も発動せず、B と全く同じ結果になる**。`overflow:hidden` / `text-overflow:ellipsis` は効くことのない dead code になる。

**省略を強制する `truncate` + `min-w-0` は実害がある**。span は `flex-col` + `items-center` の中で shrink-to-fit のため、`min-w-0` でリンクを縮めても span 自身は縮まず、**スロット外へ描画されて隣のラベルと重なる**:

```
セッション  span=[103.3, 163.3]  link=[106.7, 160]   <== 隣と重なる
```

## 検証: 実装込みのビルドを実ブラウザで計測

CSS 注入ではなく、**この PR の実装を含むビルド**を隔離環境で起動して計測した:

| ロケール | 280px | 320px | 375px | 430px |
|---|---|---|---|---|
| ja | ✅ OK | ✅ OK | ✅ OK | ✅ OK |
| en | ✅ OK | ✅ OK | ✅ OK | ✅ OK |

各ケースで以下をすべて確認（**ALL PASS**）:
- 折返しなし（span 高さ ≤ 20px）
- 全ラベルがスロット内（隣と重ならない）
- 横方向のはみ出しなし
- `getComputedStyle(span).whiteSpace === 'nowrap'`
- nav 高さが 57px（`h-14` + border）のまま

**Tailwind が実際にユーティリティを出力していることもビルド成果物で確認**（`.next/static/css/*.css` に `.whitespace-nowrap{white-space:nowrap}` が存在）。クラス名の typo や purge はユニットテストでは緑のまま通るため。

## 品質チェック

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ 0件 |
| `npx tsc --noEmit` | ✅ クリーン |
| `npm run test:unit` | ✅ 9,438 tests / 556 files 全パス |
| `npm run build` / `build:server` | ✅ 成功 |

## ⚠️ テストの限界（正直な記載）

**追加したユニットテストはクラス文字列を見るだけで、折返しそのものは検証していない**。jsdom はレイアウトを計算しないため（`getBoundingClientRect()` は常に 0 を返す）、原理的に折返しを観測できない。

- テストは「クラスが将来削除されること」を検知するための弱いガードに留まる。その限界はテストのコメントに明記済み
- 折返しの実挙動は上記の実ブラウザ計測で担保している
- TDD は Red を踏んでいる（クラス追加前に4件 fail → 追加後 19/19 パス）
- クラスを外すと4件 fail することを確認済み

## 検証環境

実機計測は**隔離環境**（`CM_PORT=3212` / `CM_DB_PATH=/tmp/cm1211v`）で実施し、本番サーバ（:3000）・本番 DB は無傷（DB の md5 が実施前後で不変であることを確認済み）。検証後に隔離環境は完全に破棄した。

Closes #1211
