### PR TITLE
fix(test): MarkdownEditor TOC テストの非同期競合を解消し CI 限定の失敗を止める (#1216)

### DIFF
--- a/tests/unit/components/MarkdownEditor.test.tsx
+++ b/tests/unit/components/MarkdownEditor.test.tsx
@@ -76,10 +76,22 @@ class MockResizeObserver {
   disconnect = resizeDisconnectSpy;
 }
 
-/** Simulate the preview pane container resizing to `width` px. */
-function fireResize(width: number) {
+/**
+ * Simulate the preview pane container resizing to `width` px.
+ *
+ * Waits for the observer to exist first: it is constructed by the preview pane's
+ * effect, which mounts later than the textarea `waitForEditorReady()` waits on.
+ * Since the mocked `observe` is a no-op, `fireResize` is the only thing that can
+ * ever set `widthAllowsToc` — firing before construction leaves it false forever
+ * and the caller times out 1s later on a missing TOC instead of seeing the cause.
+ */
+async function fireResize(width: number) {
+  await waitFor(() => {
+    expect(lastResizeObserverCallback).not.toBeNull();
+  });
   act(() => {
-    lastResizeObserverCallback?.([{ contentRect: { width } }]);
+    // Non-optional on purpose: a silent no-op here is the bug this guards against.
+    lastResizeObserverCallback!([{ contentRect: { width } }]);
   });
 }
 
@@ -1518,7 +1530,7 @@ def hello():
       render(<MarkdownEditor {...defaultProps} />);
       await waitForEditorReady();
 
-      fireResize(700);
+      await fireResize(700);
 
       await waitFor(() => {
         expect(screen.getByTestId('markdown-preview-toc')).toBeInTheDocument();
@@ -1532,7 +1544,7 @@ def hello():
       await waitForEditorReady();
 
       // Below TOC_SIDEBAR_MIN_WIDTH_PX (480): sidebar/toggle must stay hidden.
-      fireResize(400);
+      await fireResize(400);
 
       expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
       expect(screen.queryByTestId('markdown-preview-toc-toggle')).not.toBeInTheDocument();
@@ -1547,7 +1559,7 @@ def hello():
       render(<MarkdownEditor {...defaultProps} />);
       await waitForEditorReady();
 
-      fireResize(900);
+      await fireResize(900);
 
       expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
       expect(screen.queryByTestId('markdown-preview-toc-toggle')).not.toBeInTheDocument();
@@ -1557,7 +1569,7 @@ def hello():
       render(<MarkdownEditor {...defaultProps} />);
       await waitForEditorReady();
 
-      fireResize(700);
+      await fireResize(700);
       await waitFor(() => {
         expect(screen.getByTestId('markdown-preview-toc')).toBeInTheDocument();
       });
@@ -1579,7 +1591,7 @@ def hello():
       render(<MarkdownEditor {...defaultProps} />);
       await waitForEditorReady();
 
-      fireResize(700);
+      await fireResize(700);
 
       await waitFor(() => {
         expect(screen.getByTestId('markdown-preview-toc-toggle')).toBeInTheDocument();


### PR DESCRIPTION
## 概要

Issue #1216 の対応。`MarkdownEditor.test.tsx` の TOC トグルテストが **CI でのみランダムに失敗**する問題を解消する。**テスト側の非同期競合が原因であり、プロダクトコードは変更していない**。

#1204（GitPane DR3-004）/ #1209（issue-288 Scenario 5）と同一クラスの競合。本件は加えて **`?.` が失敗を黙殺する**点が悪質だった。

## 発見の経緯

PR #1215（`api/app/update` と通知バナーのみの変更で **MarkdownEditor を一切触っていない**）の Unit Tests が本テストで fail。ローカルでは 9,488 件全パス、develop の直近3回の CI も成功。失敗までの所要 **1025ms** が `waitFor` の既定タイムアウト（1000ms）とほぼ一致していた。

## 根本原因

### モックの `observe` は no-op

```js
class MockResizeObserver {
  constructor(cb) { lastResizeObserverCallback = cb; }  // 構築時にコールバックを保持
  observe = resizeObserveSpy;                            // 何もしない spy
}
```

→ **`widthAllowsToc` が true になる経路は `fireResize()` のみ**。

### `fireResize` が黙って no-op になる

```js
function fireResize(width) {
  act(() => {
    lastResizeObserverCallback?.([{ contentRect: { width } }]);  // 未登録なら黙って何もしない
  });
}
```

### 待っている対象がずれている

`waitForEditorReady()` が待つのは **editor の textarea** だが、`ResizeObserver` を構築するのは **preview ペイン側の effect**（`MarkdownEditor.tsx` の `containerRef` を読む `useEffect`）。

→ preview のマウントが textarea より遅れると、`fireResize` の時点でコールバックが `null` → `?.` で黙殺 → **`widthAllowsToc` は永久に false** → TOC は現れず `waitFor` が 1 秒後にタイムアウト（**遅いのではなく永久に来ない**）。

ローカル（`fileParallelism=true` / `maxConcurrency=10`）では preview のマウントが先に済むため露見しないが、CI（`maxConcurrency=1` / `fileParallelism=false`、`vitest.config.ts:19-20`）ではスケジューリングが変わり顕在化する。

## 変更内容

`fireResize` をコールバックの**登録待ち**にし、呼び出しを `?.` から**非 optional** に変えた。

```js
async function fireResize(width: number) {
  await waitFor(() => {
    expect(lastResizeObserverCallback).not.toBeNull();
  });
  act(() => {
    // Non-optional on purpose: a silent no-op here is the bug this guards against.
    lastResizeObserverCallback!([{ contentRect: { width } }]);
  });
}
```

- **本来の競合を解消**: observer が遅れて登録される実シナリオでは待機してパスする
- **黙殺経路を塞ぐ**: 順序ずれが起きた場合、症状ではなく**原因**を指すエラーになる
- `async` 化に伴い**呼び出し5箇所すべてを `await` 化**（呼び出し元はいずれも `async` な `it`）
- アサーションの意味は変えていない

### 診断価値の向上（実測）

| | エラー |
|---|---|
| 修正前 | `TestingLibraryElementError: Unable to find [data-testid="markdown-preview-toc"]`<br>→ **症状**（TOC が無い）を指すだけで原因が分からない |
| 修正後 | `AssertionError: expected null not to be null`<br>→ **原因**（observer が未登録）を直接指す |

## 検証

| 条件 | 修正前 | 修正後 |
|---|---|---|
| コールバックを null に注入（CI の遅い順序を模倣） | ❌ 「TOC が無い」で 1 秒後に落ちる | ✅ 原因を指すエラーになる |
| 通常実行・`CI=true` | ✅ pass（ローカルでは露見しない） | ✅ **72 tests 全パス** |
| `npx tsc --noEmit` | - | ✅ クリーン（`await` 漏れ 0） |
| `npm run lint` | - | ✅ 0件 |

再現手順は Issue #1216 に記載。develop（無変更）でも同じ注入で CI と同一のエラーが再現することを確認済みで、**特定の PR が原因ではない**ことを実証している。

## 影響

- MarkdownEditor を触っていない PR が赤くなり**変更が原因だと誤診される**問題を解消
- develop 自体のランダムな赤を除去

## 対象外

- プロダクトコード（`MarkdownEditor.tsx` 等）: 不具合はテスト側にあり実装は正しい

Closes #1216
