### PR TITLE
feat(ui): 初回オンボーディング導線を追加（空状態CTA＋セットアップチェックリスト） (#1199)

### DIFF
--- a/locales/en/home.json
+++ b/locales/en/home.json
@@ -8,7 +8,20 @@
     "viewAll": "View all"
   },
   "recentSessions": {
-    "empty": "No recent sessions yet."
+    "empty": "No recent sessions yet.",
+    "cta": "Register a repository to get started"
+  },
+  "onboarding": {
+    "title": "Getting started",
+    "dismiss": "Dismiss getting started",
+    "steps": {
+      "registerRepository": "Register a repository",
+      "sendFirstMessage": "Send your first message to an agent"
+    },
+    "actions": {
+      "registerRepository": "Register",
+      "sendFirstMessage": "Open sessions"
+    }
   },
   "assistant": {
     "clearHistoryConfirm": "Clear all chat history for this repository and CLI? Past messages will no longer be sent back to the assistant.",

--- a/locales/ja/home.json
+++ b/locales/ja/home.json
@@ -8,7 +8,20 @@
     "viewAll": "すべて表示"
   },
   "recentSessions": {
-    "empty": "最近のセッションはまだありません。"
+    "empty": "最近のセッションはまだありません。",
+    "cta": "まずリポジトリを登録しましょう"
+  },
+  "onboarding": {
+    "title": "はじめかた",
+    "dismiss": "はじめかたを閉じる",
+    "steps": {
+      "registerRepository": "リポジトリを登録する",
+      "sendFirstMessage": "エージェントに最初のメッセージを送る"
+    },
+    "actions": {
+      "registerRepository": "登録する",
+      "sendFirstMessage": "セッションを開く"
+    }
   },
   "assistant": {
     "clearHistoryConfirm": "このリポジトリとCLIのチャット履歴をすべて削除しますか？過去のメッセージはアシスタントに送信されなくなります。",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,9 @@
  * with a live session subline (see HomeHeading). Future announcements should be
  * reintroduced as a version-keyed localStorage Announcement component rather
  * than a hard-coded dismissible banner.
+ * Issue #1199: OnboardingChecklist follows that rule with a data-keyed latch —
+ * it is derived from the cache below and disappears for good once complete, so
+ * it can never occupy the first fold of a user who has data to show.
  *
  * Session data is read from the shared worktrees cache
  * (`useWorktreesCacheContext`) instead of a page-local fetch, keeping a single
@@ -22,12 +25,13 @@
 import { AppShell } from '@/components/layout';
 import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheProvider';
 import { HomeHeading } from '@/components/home/HomeHeading';
+import { OnboardingChecklist } from '@/components/home/OnboardingChecklist';
 import { SessionOverviewTile } from '@/components/home/SessionOverviewTile';
 import { TodoWidget } from '@/components/home/TodoWidget';
 import { HomeQuickActions } from '@/components/home/HomeQuickActions';
 
 export default function Home() {
-  const { worktrees, isLoading } = useWorktreesCacheContext();
+  const { worktrees, repositories, isLoading, error } = useWorktreesCacheContext();
   // [Issue #1118] Skeletons only on the very first load; once the cache has
   // data, poll re-fetches keep the rendered content (non-blocking pattern).
   const isFirstLoad = isLoading && worktrees.length === 0;
@@ -37,6 +41,14 @@ export default function Home() {
       <div className="container-custom py-8 overflow-auto h-full">
         {/* Page heading */}
         <HomeHeading worktrees={worktrees} />
+
+        {/* First-run guidance; renders nothing once onboarding is complete. */}
+        <OnboardingChecklist
+          worktrees={worktrees}
+          repositories={repositories}
+          isLoading={isFirstLoad}
+          error={error}
+        />
 
         {/* Bento grid: 12-col on desktop, single stacked column on mobile.
             DOM order (mobile stack): Session Overview → ToDo → Quick actions. */}

--- a/src/components/home/OnboardingChecklist.tsx
+++ b/src/components/home/OnboardingChecklist.tsx
@@ -1,0 +1,147 @@
+/**
+ * OnboardingChecklist Component
+ *
+ * Issue #1199: first-run guidance for the Home page.
+ *
+ * Issue #1072 removed a hard-coded welcome banner because it kept occupying the
+ * first fold with information that had gone stale. This checklist answers that
+ * objection by construction: it is derived from real data, it only appears while
+ * Home has no data to displace, and once every step has been observed complete
+ * it latches off permanently.
+ *
+ * The latch matters because step 2 is not monotonic — kill-session clears
+ * `last_user_message_at`, which would otherwise make the checklist reappear for
+ * an experienced user.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { CircleCheck, Circle, X } from 'lucide-react';
+import { Card, Button } from '@/components/ui';
+import { useLocalStorageState } from '@/hooks/useLocalStorageState';
+import {
+  ONBOARDING_DISMISSED_KEY,
+  deriveOnboardingSteps,
+  isValidDismissed,
+} from '@/lib/onboarding';
+import type { Worktree } from '@/types/models';
+import type { RepositorySummary } from '@/lib/api-client';
+
+export interface OnboardingChecklistProps {
+  worktrees: Worktree[];
+  repositories: RepositorySummary[];
+  /** First-load gate. Callers should pass `isLoading && worktrees.length === 0`. */
+  isLoading?: boolean;
+  /** Worktrees fetch error. A failed fetch must not read as "new user". */
+  error?: Error | null;
+}
+
+const STEPS = [
+  { key: 'registerRepository', href: '/repositories' },
+  { key: 'sendFirstMessage', href: '/sessions' },
+] as const;
+
+export function OnboardingChecklist({
+  worktrees,
+  repositories,
+  isLoading = false,
+  error = null,
+}: OnboardingChecklistProps) {
+  const t = useTranslations('home');
+
+  const { value: dismissed, setValue: setDismissed } = useLocalStorageState<boolean>({
+    key: ONBOARDING_DISMISSED_KEY,
+    defaultValue: false,
+    validate: isValidDismissed,
+  });
+
+  // `useLocalStorageState` starts at defaultValue and syncs in a mount effect,
+  // so `dismissed` is false on the first render. Without this gate a warm
+  // client-side navigation (the cache provider outlives the route) would paint
+  // one frame of checklist at an already-dismissed user.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const steps = deriveOnboardingSteps(worktrees, repositories);
+  const isComplete = steps.hasRepository && steps.hasSentMessage;
+  const isReady = mounted && !isLoading && error === null;
+
+  useEffect(() => {
+    // Latch only — never unlatch, or an existing user's latch would be cleared
+    // the moment a step regresses. Depends on the primitive, not on `steps`:
+    // polling hands down a fresh array identity every few seconds.
+    if (isReady && isComplete && !dismissed) {
+      setDismissed(true);
+    }
+  }, [isReady, isComplete, dismissed, setDismissed]);
+
+  if (!isReady || isComplete || dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="mb-8">
+      <Card variant="elevated" data-testid="onboarding-checklist">
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="text-sm font-semibold text-foreground">{t('onboarding.title')}</h2>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t('onboarding.dismiss')}
+            data-testid="onboarding-dismiss"
+            onClick={() => setDismissed(true)}
+          >
+            <X size={16} aria-hidden="true" />
+          </Button>
+        </div>
+
+        <ol className="mt-3 space-y-3">
+          {STEPS.map(({ key, href }) => {
+            const complete = key === 'registerRepository' ? steps.hasRepository : steps.hasSentMessage;
+            return (
+              <li
+                key={key}
+                className="flex items-center gap-3"
+                data-testid={`onboarding-step-${key}`}
+                data-complete={complete}
+              >
+                {complete ? (
+                  <CircleCheck
+                    size={20}
+                    className="shrink-0 text-success-foreground"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Circle
+                    size={20}
+                    className="shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                )}
+                <span
+                  className={`min-w-0 flex-1 text-sm ${
+                    complete ? 'text-muted-foreground line-through' : 'text-foreground'
+                  }`}
+                >
+                  {t(`onboarding.steps.${key}`)}
+                </span>
+                {!complete && (
+                  <Link
+                    href={href}
+                    data-testid={`onboarding-action-${key}`}
+                    className="shrink-0 rounded-md bg-accent-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:bg-accent-500 dark:hover:bg-accent-600"
+                  >
+                    {t(`onboarding.actions.${key}`)}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/home/RecentSessionsList.tsx
+++ b/src/components/home/RecentSessionsList.tsx
@@ -76,13 +76,24 @@ export function RecentSessionsList({ worktrees, limit = 5, isLoading = false }: 
   }
 
   if (recent.length === 0) {
+    // Issue #1199: the empty list always means zero repositories — `repositories`
+    // is derived from the worktrees table — so the CTA has a single destination.
     return (
-      <p
-        className="text-sm text-muted-foreground"
-        data-testid="recent-sessions-empty"
-      >
-        {t('recentSessions.empty')}
-      </p>
+      <div className="space-y-2">
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="recent-sessions-empty"
+        >
+          {t('recentSessions.empty')}
+        </p>
+        <Link
+          href="/repositories"
+          data-testid="recent-sessions-cta"
+          className="inline-block text-sm font-medium text-accent-600 transition-colors hover:text-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-accent-400 dark:hover:text-accent-300"
+        >
+          {t('recentSessions.cta')}
+        </Link>
+      </div>
     );
   }
 

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,35 @@
+/**
+ * Onboarding step derivation (Issue #1199).
+ *
+ * Both steps are derived from the shared worktrees cache, which already carries
+ * `repositories` from the same /api/worktrees response (Issue #690) — so the
+ * checklist adds no fetch and no poller (Issue #709).
+ *
+ * The two steps are nested rather than independent: `repositories` is itself
+ * derived from the worktrees table, so hasSentMessage implies hasRepository.
+ */
+
+import type { Worktree } from '@/types/models';
+import type { RepositorySummary } from '@/lib/api-client';
+
+export const ONBOARDING_DISMISSED_KEY = 'commandmate:onboarding-dismissed';
+
+export interface OnboardingSteps {
+  hasRepository: boolean;
+  hasSentMessage: boolean;
+}
+
+export function deriveOnboardingSteps(
+  worktrees: Worktree[] = [],
+  repositories: RepositorySummary[] = []
+): OnboardingSteps {
+  return {
+    hasRepository: (repositories ?? []).length > 0,
+    // Truthiness only: the declared Date is an ISO string over the wire.
+    hasSentMessage: (worktrees ?? []).some((wt) => Boolean(wt.lastUserMessageAt)),
+  };
+}
+
+export function isValidDismissed(value: unknown): value is boolean {
+  return typeof value === 'boolean';
+}

--- a/tests/unit/app/page.test.tsx
+++ b/tests/unit/app/page.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1199: Home page wiring.
+ *
+ * Home had no page-level test, so nothing pinned the checklist's placement or
+ * the promise that it costs no extra request. Both are asserted here.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+const mockRefresh = vi.fn();
+let mockWorktrees: unknown[] = [];
+let mockRepositories: unknown[] = [];
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
+  useWorktreesCacheContext: () => ({
+    worktrees: mockWorktrees,
+    repositories: mockRepositories,
+    isLoading: mockIsLoading,
+    error: mockError,
+    refresh: mockRefresh,
+  }),
+}));
+
+vi.mock('@/components/layout', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: React.ComponentProps<'a'>) => (
+    <a href={href as string} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// TodoWidget owns its own fetches; they are not what this file is about.
+vi.mock('@/components/home/TodoWidget', () => ({
+  TodoWidget: () => <div data-testid="todo-widget" />,
+}));
+
+const listSpy = vi.fn();
+vi.mock('@/lib/api-client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    repositoryApi: { list: listSpy },
+  };
+});
+
+import Home from '@/app/page';
+
+const REPO = { path: '/repo', name: 'repo', worktreeCount: 1, visible: true, enabled: true };
+const WORKTREE = { id: 'wt-1', name: 'main', path: '/repo', repositoryPath: '/repo', repositoryName: 'repo' };
+
+beforeEach(() => {
+  localStorage.clear();
+  mockWorktrees = [];
+  mockRepositories = [];
+  mockIsLoading = false;
+  mockError = null;
+  listSpy.mockClear();
+  vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('no fetch expected'))));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('Home page — onboarding wiring (Issue #1199)', () => {
+  it('renders the checklist above the bento grid for a new user', () => {
+    render(<Home />);
+
+    const checklist = screen.getByTestId('onboarding-checklist');
+    const grid = screen.getByTestId('home-bento-grid');
+    // Node.compareDocumentPosition: 4 === grid follows checklist.
+    expect(checklist.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('hides the checklist for a user who already sent a message', () => {
+    mockWorktrees = [{ ...WORKTREE, lastUserMessageAt: '2026-07-15T10:00:00.000Z' }];
+    mockRepositories = [REPO];
+
+    render(<Home />);
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+    expect(screen.getByTestId('home-bento-grid')).toBeInTheDocument();
+  });
+
+  it('passes repositories through, so step 1 reflects the cache', () => {
+    mockWorktrees = [WORKTREE];
+    mockRepositories = [REPO];
+
+    render(<Home />);
+
+    expect(screen.getByTestId('onboarding-step-registerRepository')).toHaveAttribute(
+      'data-complete',
+      'true'
+    );
+  });
+
+  it('costs no extra request — the cache already carries repositories', () => {
+    render(<Home />);
+
+    expect(listSpy).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('hides the checklist while the cache is doing its first load', () => {
+    mockIsLoading = true;
+
+    render(<Home />);
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+  });
+
+  it('hides the checklist when the worktrees fetch failed', () => {
+    mockError = new Error('boom');
+
+    render(<Home />);
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+  });
+});

--- a/tests/unit/components/home/OnboardingChecklist.test.tsx
+++ b/tests/unit/components/home/OnboardingChecklist.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1199: OnboardingChecklist display gating and completion latch.
+ *
+ * The latch is the #1072 regression guard: once every step has been observed
+ * complete, the checklist must never come back — not even when kill-session
+ * clears `lastUserMessageAt` and re-opens step 2.
+ */
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { OnboardingChecklist } from '@/components/home/OnboardingChecklist';
+import { ONBOARDING_DISMISSED_KEY } from '@/lib/onboarding';
+import type { Worktree } from '@/types/models';
+import type { RepositorySummary } from '@/lib/api-client';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...rest }: React.ComponentProps<'a'>) => (
+    <a href={href as string} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const REPO: RepositorySummary = {
+  path: '/repo',
+  name: 'repo',
+  worktreeCount: 1,
+  visible: true,
+  enabled: true,
+};
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    name: 'main',
+    path: '/repo',
+    repositoryPath: '/repo',
+    repositoryName: 'repo',
+    ...overrides,
+  } as Worktree;
+}
+
+/** A worktree that has received a user message (ISO string, as over the wire). */
+const MESSAGED = makeWorktree({
+  lastUserMessageAt: '2026-07-15T10:00:00.000Z' as unknown as Date,
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('OnboardingChecklist — new user (Issue #1199)', () => {
+  it('renders with both steps incomplete when there is no data', () => {
+    render(<OnboardingChecklist worktrees={[]} repositories={[]} />);
+
+    expect(screen.getByTestId('onboarding-checklist')).toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-step-registerRepository')).toHaveAttribute(
+      'data-complete',
+      'false'
+    );
+    expect(screen.getByTestId('onboarding-step-sendFirstMessage')).toHaveAttribute(
+      'data-complete',
+      'false'
+    );
+  });
+
+  it('marks step 1 complete once a repository exists', () => {
+    render(<OnboardingChecklist worktrees={[makeWorktree()]} repositories={[REPO]} />);
+
+    expect(screen.getByTestId('onboarding-checklist')).toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-step-registerRepository')).toHaveAttribute(
+      'data-complete',
+      'true'
+    );
+    expect(screen.getByTestId('onboarding-step-sendFirstMessage')).toHaveAttribute(
+      'data-complete',
+      'false'
+    );
+  });
+
+  it('links each step to an existing flow', () => {
+    render(<OnboardingChecklist worktrees={[]} repositories={[]} />);
+
+    expect(screen.getByTestId('onboarding-action-registerRepository')).toHaveAttribute(
+      'href',
+      '/repositories'
+    );
+    expect(screen.getByTestId('onboarding-action-sendFirstMessage')).toHaveAttribute(
+      'href',
+      '/sessions'
+    );
+  });
+});
+
+describe('OnboardingChecklist — existing user (Issue #1199)', () => {
+  it('never renders for a user who already completed every step', () => {
+    render(<OnboardingChecklist worktrees={[MESSAGED]} repositories={[REPO]} />);
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+  });
+
+  it('latches completion so it cannot reappear', () => {
+    render(<OnboardingChecklist worktrees={[MESSAGED]} repositories={[REPO]} />);
+
+    expect(localStorage.getItem(ONBOARDING_DISMISSED_KEY)).toBe('true');
+  });
+
+  it('stays hidden after kill-session clears lastUserMessageAt', () => {
+    // First visit: fully onboarded -> latch.
+    const { unmount } = render(
+      <OnboardingChecklist worktrees={[MESSAGED]} repositories={[REPO]} />
+    );
+    unmount();
+
+    // kill-session nulls last_user_message_at, re-opening step 2.
+    render(<OnboardingChecklist worktrees={[makeWorktree()]} repositories={[REPO]} />);
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+  });
+});
+
+describe('OnboardingChecklist — dismiss (Issue #1199)', () => {
+  it('persists a manual dismiss across remounts', () => {
+    const { unmount } = render(
+      <OnboardingChecklist worktrees={[]} repositories={[]} />
+    );
+
+    fireEvent.click(screen.getByTestId('onboarding-dismiss'));
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+    expect(localStorage.getItem(ONBOARDING_DISMISSED_KEY)).toBe('true');
+
+    unmount();
+    render(<OnboardingChecklist worktrees={[]} repositories={[]} />);
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+  });
+
+  it('ignores a corrupted localStorage value instead of hiding', () => {
+    localStorage.setItem(ONBOARDING_DISMISSED_KEY, '{"__proto__":{"polluted":1}}');
+
+    render(<OnboardingChecklist worktrees={[]} repositories={[]} />);
+
+    expect(screen.getByTestId('onboarding-checklist')).toBeInTheDocument();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+describe('OnboardingChecklist — gating (Issue #1199)', () => {
+  it('renders nothing and latches nothing during the first load', () => {
+    render(<OnboardingChecklist worktrees={[]} repositories={[]} isLoading />);
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+    expect(localStorage.getItem(ONBOARDING_DISMISSED_KEY)).toBeNull();
+  });
+
+  it('renders nothing and latches nothing when the worktrees fetch failed', () => {
+    // A 500 leaves worktrees empty with isLoading false — an existing user must
+    // not be told to register a repository.
+    render(
+      <OnboardingChecklist
+        worktrees={[]}
+        repositories={[]}
+        error={new Error('boom')}
+      />
+    );
+
+    expect(screen.queryByTestId('onboarding-checklist')).toBeNull();
+    expect(localStorage.getItem(ONBOARDING_DISMISSED_KEY)).toBeNull();
+  });
+});
+
+describe('OnboardingChecklist — hydration (Issue #1199)', () => {
+  /**
+   * The latch lives in localStorage, which the first render cannot read. render()
+   * from RTL flushes effects before asserting, so it cannot see the frame that
+   * actually gets painted — renderToString can. If this renders anything, a
+   * dismissed user gets a frame of checklist on every warm navigation to Home.
+   */
+  it('paints nothing before effects run, even when not dismissed', () => {
+    const html = renderToString(
+      <OnboardingChecklist worktrees={[]} repositories={[]} />
+    );
+
+    expect(html).toBe('');
+  });
+});
+
+describe('OnboardingChecklist — polling (Issue #1199)', () => {
+  it('does not write to localStorage on every re-render', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+
+    const { rerender } = render(
+      <OnboardingChecklist worktrees={[MESSAGED]} repositories={[REPO]} />
+    );
+    const afterFirstRender = setItem.mock.calls.length;
+
+    // Each poll hands down a fresh array identity with identical content.
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <OnboardingChecklist worktrees={[{ ...MESSAGED }]} repositories={[{ ...REPO }]} />
+      );
+    }
+
+    expect(setItem.mock.calls.length).toBe(afterFirstRender);
+  });
+});

--- a/tests/unit/components/home/RecentSessionsList.test.tsx
+++ b/tests/unit/components/home/RecentSessionsList.test.tsx
@@ -42,6 +42,25 @@ describe('RecentSessionsList', () => {
     );
   });
 
+  // Issue #1199: an empty list always means zero repositories, so the CTA points
+  // at the only productive next action.
+  it('offers a CTA to register a repository from the empty state', () => {
+    render(<RecentSessionsList worktrees={[]} />);
+    const cta = screen.getByTestId('recent-sessions-cta');
+    expect(cta.getAttribute('href')).toBe('/repositories');
+    expect(cta.textContent).toBe('home.recentSessions.cta');
+  });
+
+  it('does not render the CTA once sessions exist', () => {
+    render(<RecentSessionsList worktrees={[createMockWorktree()]} />);
+    expect(screen.queryByTestId('recent-sessions-cta')).toBeNull();
+  });
+
+  it('does not render the CTA while loading', () => {
+    render(<RecentSessionsList worktrees={[]} isLoading />);
+    expect(screen.queryByTestId('recent-sessions-cta')).toBeNull();
+  });
+
   it('links each recent session to its worktree detail page', () => {
     const worktrees = [
       createMockWorktree({ id: 'wt-1', name: 'feature/a' }),

--- a/tests/unit/i18n/home-keys.test.ts
+++ b/tests/unit/i18n/home-keys.test.ts
@@ -76,4 +76,26 @@ describe('home i18n keys (Issue #1072)', () => {
       }
     }
   });
+
+  /**
+   * Issue #1199: OnboardingChecklist / RecentSessionsList resolve these at
+   * runtime. Same rationale as the block above — the echoing next-intl mock
+   * makes component tests blind to a missing dictionary entry.
+   */
+  it('includes the onboarding checklist and empty-state CTA keys', () => {
+    for (const locale of ['en', 'ja']) {
+      const keys = leafKeys(loadHome(locale));
+      for (const expected of [
+        'onboarding.title',
+        'onboarding.dismiss',
+        'onboarding.steps.registerRepository',
+        'onboarding.steps.sendFirstMessage',
+        'onboarding.actions.registerRepository',
+        'onboarding.actions.sendFirstMessage',
+        'recentSessions.cta',
+      ]) {
+        expect(keys, `${locale} missing ${expected}`).toContain(expected);
+      }
+    }
+  });
 });

--- a/tests/unit/lib/onboarding.test.ts
+++ b/tests/unit/lib/onboarding.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Issue #1199: onboarding step derivation.
+ *
+ * Fixtures use ISO strings for `lastUserMessageAt`, not Date objects: the type
+ * says `Date` but the value reaches the client through NextResponse.json, so
+ * production always sees a string here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveOnboardingSteps,
+  isValidDismissed,
+  ONBOARDING_DISMISSED_KEY,
+} from '@/lib/onboarding';
+import type { Worktree } from '@/types/models';
+import type { RepositorySummary } from '@/lib/api-client';
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    name: 'main',
+    path: '/repo',
+    repositoryPath: '/repo',
+    repositoryName: 'repo',
+    ...overrides,
+  } as Worktree;
+}
+
+function makeRepository(overrides: Partial<RepositorySummary> = {}): RepositorySummary {
+  return {
+    path: '/repo',
+    name: 'repo',
+    worktreeCount: 1,
+    visible: true,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe('deriveOnboardingSteps (Issue #1199)', () => {
+  it('reports both steps incomplete for a brand-new user', () => {
+    expect(deriveOnboardingSteps([], [])).toEqual({
+      hasRepository: false,
+      hasSentMessage: false,
+    });
+  });
+
+  it('completes step 1 once a repository is present', () => {
+    const steps = deriveOnboardingSteps([makeWorktree()], [makeRepository()]);
+    expect(steps).toEqual({ hasRepository: true, hasSentMessage: false });
+  });
+
+  it('completes step 2 once any worktree has a user message', () => {
+    const steps = deriveOnboardingSteps(
+      [
+        makeWorktree({ id: 'wt-1' }),
+        makeWorktree({
+          id: 'wt-2',
+          lastUserMessageAt: '2026-07-15T10:00:00.000Z' as unknown as Date,
+        }),
+      ],
+      [makeRepository()]
+    );
+    expect(steps).toEqual({ hasRepository: true, hasSentMessage: true });
+  });
+
+  it('treats a kill-session-cleared timestamp as not sent', () => {
+    // kill-session nulls last_user_message_at, which arrives as an absent key.
+    const steps = deriveOnboardingSteps(
+      [makeWorktree({ lastUserMessageAt: undefined })],
+      [makeRepository()]
+    );
+    expect(steps.hasSentMessage).toBe(false);
+  });
+
+  it('does not throw when arguments are missing', () => {
+    expect(
+      deriveOnboardingSteps(
+        undefined as unknown as Worktree[],
+        undefined as unknown as RepositorySummary[]
+      )
+    ).toEqual({ hasRepository: false, hasSentMessage: false });
+  });
+});
+
+describe('isValidDismissed (Issue #1199)', () => {
+  it('accepts booleans', () => {
+    expect(isValidDismissed(true)).toBe(true);
+    expect(isValidDismissed(false)).toBe(true);
+  });
+
+  it.each([['true'], [1], [null], [undefined], [{}], [[]]])(
+    'rejects non-boolean %s',
+    (value) => {
+      expect(isValidDismissed(value)).toBe(false);
+    }
+  );
+});
+
+describe('ONBOARDING_DISMISSED_KEY (Issue #1199)', () => {
+  it('follows the commandmate: namespace convention', () => {
+    expect(ONBOARDING_DISMISSED_KEY).toBe('commandmate:onboarding-dismissed');
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1199 の対応。新規ユーザーがアプリ内の導線だけで最初のセッション開始まで到達できるようにする。Home の welcome バナーは #1072 で削除済みで、空状態は「No recent sessions yet.」等の事実表示のみだった。

親Issue: #1193（導入・アップデート・ドキュメント体験の改善）

## ⚠️ Issue の前提をコード照合で訂正（3ステップ → 2ステップ）

Issue は「① リポジトリ登録 → ② worktree 作成 → ③ 最初のメッセージ送信」の3ステップを指定していたが、**コード照合の結果 5件中4件が事実誤認**だった。

### 最大の誤り: CommandMate に worktree 作成機能が存在しない

| 検証項目 | 結果 |
|---|---|
| `git worktree add` の実装 | **コード上に皆無** |
| `/api/worktrees` のメソッド | **GET のみ**（POST/PUT/DELETE なし） |

worktree は**リポジトリのスキャンで検出される**ため、②は**アプリ内で実行不能**かつ①と同時に自動達成される「飾り」だった。よって **① `hasRepository` / ② `hasSentMessage` の2ステップに縮約**した。

### 「リポジトリ有無で空状態を出し分ける」も到達不能だった

`repositories` は **worktrees テーブル由来**（`src/lib/db/worktree-db.ts` の `getRepositories`）。空状態では `repositories` も常に 0 件になるため、「リポジトリはあるが worktree が無い」という分岐は**存在し得ない**。**fake-green のテストでしか green にできない**指定だった。

## 追加 fetch ゼロ（Issue の指示より良い方法があった）

Issue は「`worktrees.length === 0` のときだけ `repositoryApi.list()` を1回呼ぶ」としていたが、**`repositories` は既に同じ `/api/worktrees` レスポンスに含まれており**（#690、`src/app/api/worktrees/route.ts:104-109`）、`WorktreesCacheProvider` が保持している。

→ **条件付き fetch すら不要で、追加 fetch は完全にゼロ**。新規 API・新規ポーラーも追加していない（#709 の単一ポーラー原則を維持）。

## #1072 の轍を踏まない設計

`src/app/page.tsx:10-13` の指針（陳腐化した固定バナーを第一フォールドに置かない）に対する担保:

| #1072 が削除したもの | 本 PR |
|---|---|
| 陳腐化しても出続ける固定告知 | **実データ駆動**・全ステップ達成で**自動的に消える** |
| 全ユーザーに表示 | **新規ユーザーのみ**（既存ユーザーは初回表示時点で全達成 → 一度も表示されない） |
| 実データでない情報が第一フォールドを占有 | **表示されるのは Home に実データが無い時だけ**（＝奪うものが無い） |
| 英語ハードコード | i18n 経由（EN/JA パリティ差分ゼロ） |

手動 dismiss は localStorage（`commandmate:onboarding-dismissed`、既存の命名規則に準拠）に永続化。

## 設計レビューが捕捉した欠陥（3ステージが独立して検出）

- **ハイドレーション1フレームのフラッシュ** — dismiss 済みユーザーに warm 遷移でチラつく
- **error 未考慮の fail-open** — API 500 で既存ユーザーに「リポジトリを登録」が出る
- **`text-success` がライトテーマでコントラスト 2.3:1**（WCAG AA 不合格・**CI ガードは検出しない**）→ `text-success-foreground` へ修正

## テストの実効性を欠陥注入で証明

6つのガードを実際に壊して検出を確認。特筆すべきは **`mounted` ゲートが当初 RTL テストで捕捉できていなかった**こと — `render()` が effect を同期 flush するため「実際に描画されるフレーム」を観測できない。**`renderToString` で「effect 実行前に何も描画しない」を assert** して初めて実効化した。

| 注入した欠陥 | 結果 |
|---|---|
| `hasSentMessage` を常に false（既存ユーザーにも表示される退行） | ✅ 5件 fail |
| 欠陥なし（復元後） | ✅ 31 tests pass |

`tests/setup.ts` の next-intl モックはキーを素通しで返すため、実辞書ガード（`tests/unit/i18n/home-keys.test.ts`）にも本 PR のキーを追加している。

## 品質チェック

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ 0件 |
| `npx tsc --noEmit` | ✅ クリーン |
| `npm run test:unit` | ✅ 9,523 tests 全通過 |
| `npm run build` | ✅ 成功 |
| EN/JA キーパリティ | ✅ 差分ゼロ |
| 新規 API / ポーラー | ✅ 追加なし |

## 変更内容

新規5ファイル（`OnboardingChecklist.tsx` / `lib/onboarding.ts` / テスト3件。うち **Home ページ初のテスト**）、変更6ファイル。

## 申し送り（別Issue推奨）

`RepositoryManager.tsx` にハードコード英語が15箇所ある。本 PR は `common.json` に触れないため **JA 混在を新規に作ってはいない**が、i18n 化を後続 Issue として推奨する。

## 対象外

- ツアー / コーチマーク
- サンプルリポジトリの自動登録
- ドキュメント側のチュートリアル整備

Refs #1193
Closes #1199
