### PR TITLE
fix(test): MessageInput の非同期競合3件を解消（#1209 の修正漏れ） (#1222)

### DIFF
--- a/tests/unit/components/worktree/MessageInput.test.tsx
+++ b/tests/unit/components/worktree/MessageInput.test.tsx
@@ -446,6 +446,14 @@ describe('MessageInput', () => {
           expect(worktreeApi.sendMessage).toHaveBeenCalled();
         });
 
+        // sendMessage having been *called* does not mean its promise resolved and the
+        // isFreeInputMode reset landed. Wait for the cleared input — opening the selector
+        // while free input mode is still on would suppress it. (Not wrapping the assertion
+        // below in waitFor: that would re-run openSelector and type "/" repeatedly.)
+        await waitFor(() => {
+          expect(getTextarea()).toHaveValue('');
+        });
+
         // After submit, typing '/' should show selector again
         openSelector();
         expect(queryDesktopSelector()).toBeInTheDocument();
@@ -829,8 +837,11 @@ describe('MessageInput', () => {
       typeMessage('queued while busy');
       pressEnter();
 
+      // submitMessage clears the input and fires the toast in the same block after
+      // `await sendMessage`, so a cleared input means the toast call has landed too.
+      // Asserting on sendMessage having merely been *called* would race the resolve.
       await waitFor(() => {
-        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+        expect(getTextarea()).toHaveValue('');
       });
       expect(showToast).toHaveBeenCalledWith(
         expect.stringContaining('Queued (session busy)'),
@@ -853,8 +864,11 @@ describe('MessageInput', () => {
       typeMessage('sent while idle');
       pressEnter();
 
+      // Wait for the cleared input, not for sendMessage having been called: the toast
+      // would fire in the same block as the clear, so this is the point by which a
+      // wrongly-shown toast would exist. Asserting earlier passes vacuously.
       await waitFor(() => {
-        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+        expect(getTextarea()).toHaveValue('');
       });
       expect(showToast).not.toHaveBeenCalled();
     });
@@ -868,8 +882,9 @@ describe('MessageInput', () => {
       typeMessage('no isProcessing prop');
       pressEnter();
 
+      // Same as above: wait for the clear so the negative assertion is not vacuous.
       await waitFor(() => {
-        expect(worktreeApi.sendMessage).toHaveBeenCalled();
+        expect(getTextarea()).toHaveValue('');
       });
       expect(showToast).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## 概要

Issue #1222 の対応。`MessageInput.test.tsx` の非同期競合3件を解消する。**テスト側の問題であり、プロダクトコードは変更していない**。

## ⚠️ これは #1209 の修正漏れです

**#1209 で `tests/integration/issue-288-acceptance.test.tsx` の Scenario 5 を修正したが、同一挙動をテストする本ファイルの TC-4 を見落としていた。**

#1209 の受入基準に「同ファイル内に同種パターンが他にないか確認すること」と書いたが、**確認範囲が「同ファイル内」に留まり、同じ挙動をテストする別ファイルまで広げていなかった**のが原因。

実害: **MessageInput を一切変更していない PR（#1220 = `website/` のみ）が CI で赤くなり**、変更が原因だと誤診された。

## 根本原因

`sendMessage` が**呼ばれた**ことと、その Promise が解決して後続の状態変化（input クリア / `isFreeInputMode` リセット / toast）が反映されたことは**別のタイミング**。テストは前者だけを `waitFor` で待ち、後続を同期アサートしていた。

`submitMessage` は `await sendMessage` の**直後の同一同期ブロック**で実行する:
```js
await worktreeApi.sendMessage(worktreeId, trimmed, options);
setMessage('');                                    // ← クリア
setIsFreeInputMode(false);
...
if (isProcessing) {
  showToast?.(QUEUED_BUSY_TOAST_MESSAGE, 'warning');   // ← toast
}
```

→ **「input がクリアされた」ことが3件すべてに共通の正しい待機点**になる（クリアが観測できた時点で toast 呼び出しも既に済んでいる）。

## 修正した3件（2つの異なる失敗モード）

| # | テスト | 失敗モード | 内容 |
|---|---|---|---|
| 1 | TC-4（`isFreeInputMode` のリセット） | **偽FAIL** | free input mode が残ったままセレクタを開こうとして抑制され null になる。**CI で実際に落ちた** |
| 2 | toast の肯定アサート（`isProcessing=true`） | **偽FAIL** | toast は解決後に出るため早すぎるアサートで落ちる。10ms 遅延の注入で顕在化 |
| 3 | toast の否定アサート2件（idle / prop 省略） | **偽PASS** | toast が出る前に `not.toHaveBeenCalled` を評価しており、**実装が壊れていても気づけない**状態だった |

**3 は特に重要**: 単なる flake ではなく、**テストが何も検証していなかった**。待機点を入れて初めて検証力を持つ。

## 検証

| 検証項目 | 結果 |
|---|---|
| 10ms 遅延を注入した状態で全パス（受入基準） | ✅ **48 tests 全パス**（修正前は TC-4 が落ちた） |
| **否定アサートの実効性**: 実装を壊す（idle でも toast を出す） | ✅ **2件 fail**（修正前はこの改変を検出できなかった） |
| 通常実行・`CI=true` | ✅ 48 tests 全パス |
| `npm run lint` / `npx tsc --noEmit` | ✅ クリーン |
| プロダクトコード | ✅ **無変更** |

### 網羅調査

「`sendMessage` の `waitFor` 直後に同期 `expect`」パターンを**リポジトリ全体で検索**し、本ファイルの3件のみが該当することを確認（integration 側は #1209 で修正済み）。

```
tests/unit/components/worktree/MessageInput.test.tsx:843  expect(showToast).toHaveBeenCalledWith(
tests/unit/components/worktree/MessageInput.test.tsx:867  expect(showToast).not.toHaveBeenCalled();
tests/unit/components/worktree/MessageInput.test.tsx:882  expect(showToast).not.toHaveBeenCalled();
該当: 3 件
```

## 関連

#1204（GitPane DR3-004）/ #1209（issue-288 Scenario 5）/ #1216（MarkdownEditor TOC）と同一クラスの CI 限定フレーク。**本件で4件目**。

このリポジトリには「先行する非同期処理の**完了**を待たずに後続状態を同期アサートする」テストが根深く存在し、CI（`maxConcurrency=1` / `fileParallelism=false`）でのみ露見して**無関係な PR を赤くする**。

Closes #1222
