### PR TITLE
chore(build): tsconfig の include を実ディレクトリに限定する (#1265)

### DIFF
--- a/tests/unit/config/tsconfig-scope.test.ts
+++ b/tests/unit/config/tsconfig-scope.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the root tsconfig type-check scope (Issue #1265).
+ *
+ * `npm run lint` is scoped to `eslint src`, so a stray .ts outside src/ is
+ * invisible to it and only surfaces when CI runs `npx tsc --noEmit`. Issue #1200
+ * (website/) and #1201 (scripts/spike/) both hit this. The fix anchors `include`
+ * to the directories the app actually owns; these tests are the CI guard on it,
+ * since no linter covers this file.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const TSCONFIG = path.join(REPO_ROOT, 'tsconfig.json');
+
+const raw = JSON.parse(fs.readFileSync(TSCONFIG, 'utf-8')) as {
+  include: string[];
+  exclude: string[];
+};
+
+/** The files `tsc --noEmit` would actually load, via TypeScript's own resolution. */
+function resolvedFiles(): string[] {
+  const parsed = ts.parseJsonConfigFileContent(raw, ts.sys, REPO_ROOT);
+  return parsed.fileNames.map((f) => path.relative(REPO_ROOT, f));
+}
+
+describe('Issue #1265: tsconfig include is anchored, not repo-wide', () => {
+  it('declares no repo-wide glob', () => {
+    // `**/*.ts` is what pulled website/ and scripts/spike/ into the type-check.
+    // Any pattern rooted at the repo top re-opens the whole class of bug.
+    const repoWide = raw.include.filter((p) => p.startsWith('**/'));
+    expect(repoWide).toEqual([]);
+  });
+
+  it('anchors every include entry to a directory the app owns', () => {
+    const allowedRoots = ['src/', 'tests/', 'scripts/', '.next/types/'];
+    const allowedFiles = [
+      'next-env.d.ts',
+      'server.ts',
+      'vitest.config.ts',
+      'playwright.config.ts',
+    ];
+    const unanchored = raw.include.filter(
+      (p) => !allowedRoots.some((r) => p.startsWith(r)) && !allowedFiles.includes(p),
+    );
+    expect(unanchored).toEqual([]);
+  });
+
+  it('excludes the throwaway spike directory', () => {
+    expect(raw.exclude).toContain('scripts/spike');
+  });
+});
+
+describe('Issue #1265: resolved type-check scope', () => {
+  const files = resolvedFiles();
+
+  it('keeps src/ under the type-check', () => {
+    expect(files.some((f) => f.startsWith('src/'))).toBe(true);
+  });
+
+  it('keeps tests/ under the type-check', () => {
+    expect(files.some((f) => f.startsWith('tests/'))).toBe(true);
+  });
+
+  it('keeps the real scripts/ entrypoints under the type-check', () => {
+    // scripts/init-db.ts runs via `npm run db:init`; it is maintained code and
+    // must not lose type coverage just because the spikes next to it did.
+    expect(files).toContain(path.join('scripts', 'init-db.ts'));
+  });
+
+  it('keeps server.ts under the type-check', () => {
+    expect(files).toContain('server.ts');
+  });
+
+  it('leaves scripts/spike/ out of the type-check', () => {
+    // These files exist on disk, so this assertion is not vacuous.
+    expect(fs.existsSync(path.join(REPO_ROOT, 'scripts/spike/02-migrations.ts'))).toBe(true);
+    expect(files.filter((f) => f.startsWith(path.join('scripts', 'spike')))).toEqual([]);
+  });
+
+  it('leaves website/ out of the type-check even when it holds TypeScript', () => {
+    // The LP is deployed as static files with no build step, but the type-check
+    // must not be what enforces that -- #1200 was forced into an HTML-only
+    // constraint precisely because `**/*.ts` reached in here.
+    const probe = path.join(REPO_ROOT, 'website', '__scope_probe__.ts');
+    fs.writeFileSync(probe, 'export const broken: number = "not a number";\n');
+    try {
+      expect(resolvedFiles().some((f) => f.startsWith('website/'))).toBe(false);
+    } finally {
+      fs.unlinkSync(probe);
+    }
+  });
+});

--- a/tests/unit/website/landing-page.test.ts
+++ b/tests/unit/website/landing-page.test.ts
@@ -4,7 +4,7 @@
  * The LP is plain HTML/CSS/JS with no build step, so these tests are the only
  * automated gate on it. They encode the Issue's machine-verifiable acceptance
  * criteria: the page must resolve every asset it references relative to
- * `website/`, must stay out of the Next.js type-check, and must respect the
+ * `website/`, must ship nothing that needs compiling, and must respect the
  * media budget that keeps the hero's LCP defensible.
  */
 import { describe, it, expect } from 'vitest';
@@ -52,9 +52,10 @@ describe('Issue #1200: landing page structure', () => {
     expect(fs.existsSync(INDEX_HTML)).toBe(true);
   });
 
-  it('contains no .ts/.tsx files, which the root tsconfig would type-check', () => {
-    // tsconfig.json includes **/*.ts and excludes only node_modules, so any
-    // TypeScript here would enter `npx tsc --noEmit` and break the existing CI.
+  it('ships no TypeScript, which has no build step here to compile it', () => {
+    // Not a type-check concern since #1265 anchored the root tsconfig include
+    // (tests/unit/config/tsconfig-scope.test.ts guards that). The reason now is
+    // Pages-specific: it serves website/ verbatim, so a .ts would never run.
     const typescriptFiles = walk(WEBSITE_DIR).filter((f) => /\.tsx?$/.test(f));
     expect(typescriptFiles).toEqual([]);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,17 @@
       "@tests/*": ["./tests/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "scripts/**/*.ts",
+    "server.ts",
+    "vitest.config.ts",
+    "playwright.config.ts"
+  ],
+  "exclude": ["node_modules", "scripts/spike"]
 }


### PR DESCRIPTION
## 概要

Issue #1265 の対応。`tsconfig.json` の `include` が `**/*.ts` でリポジトリ全体を拾い、`exclude` が `node_modules` のみだったため、Next.js アプリと無関係な `.ts` まで `tsc --noEmit` の対象に入っていた。

**`npm run lint` は `eslint src` スコープのため検出できず、#1200 と #1201 で2度踏んでいる。**

親Issue: #1193

## ⚠️ Issue の前提を実測で訂正

Issue は「`website/` や `scripts/` の .ts が tsc 対象に入る」としていたが、**`website/` に .ts は0件**で実際には対象外だった（#1200 が LP に HTML+CSS+JS 制約を課した結果）。

`tsc --listFiles` で実測した結果、**実際に対象から外れたのは3件のみ**:

```
scripts/spike/02-migrations.ts
scripts/spike/03-bench.ts
scripts/spike/lib/node-sqlite-adapter.mjs
```

## 修正方針: 除外リストではなく opt-in 構造にした

```diff
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "scripts/**/*.ts",
+    "server.ts",
+    "vitest.config.ts",
+    "playwright.config.ts"
+  ],
+  "exclude": ["node_modules", "scripts/spike"]
```

**`website/` を exclude に足す対症療法では、次に新しいディレクトリが増えたときに再発する。** include を実ディレクトリに限定したことで「明示的に追加しない限り入らない」構造になり、**除外リストの追記漏れで再発する経路自体を塞いだ**。

## CI ガードを追加（lint では担保できないため）

`tests/unit/config/tsconfig-scope.test.ts` を新設。TypeScript 自身の設定解決を使い、以下を検出する:

- `include` の repo-wide glob 復活
- `scripts/spike` の exclude 漏れ
- `src` / `scripts` の過剰除外

**5パターンの欠陥注入で検出を確認済み。**

## 検証

- **欠陥注入**: `src` / `tests` / `scripts` / `server.ts` / `vitest.config.ts` の型エラーが引き続き検出されることを確認（**除外しすぎていない**）
- **注入の実在を裏取り**: spike への注入は旧設定では検出・新設定では不検出（＝注入自体は実在する）
- `next build` が `tsconfig.json` を書き換えないこと、`.next/types`（111件）と `next-env.d.ts` が引き続き取り込まれることを確認

## `landing-page.test.ts` を触っている理由

`tests/unit/website/landing-page.test.ts` の「website に .ts を置かない」テストは、**その根拠が「root tsconfig が `**/*.ts` で拾うから」だった**。本 PR で根拠が変わるため、理由を Pages 固有のもの（`website/` を verbatim で配信するので .ts は実行されない）に更新した。**アサーション自体は変更していない。**

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **564 files / 9,563 tests 全パス** |
| `npm run build` | ✅ exit 0 |

## 残存する非対称（本PRでは未対応）

`lint` は `eslint src` スコープのままであり、`tsc` の対象範囲と一致していない。本 PR は tsc 側の暴走を止めるもので、この非対称自体は解消していない。

Refs #1193
Closes #1265
