### PR TITLE
fix(test): start-issue/status-issue/stop-issue が実装を検証していない問題を修正 (#1269)

### DIFF
--- a/tests/unit/cli/commands/start-issue.test.ts
+++ b/tests/unit/cli/commands/start-issue.test.ts
@@ -1,13 +1,29 @@
 /**
  * Start Command Tests - Issue #136 Extensions
- * TDD: Tests for --issue and --auto-port flags
+ * Tests for --issue and --auto-port flags, exercised against the real runStart.
+ *
+ * Issue #1269: the DaemonManager mock must be built from `function` (or `class`),
+ * never an arrow fn. `vi.fn().mockImplementation(() => ({ ... }))` has no
+ * [[Construct]], so `new DaemonManager(pid)` throws "is not a constructor".
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import { homedir } from 'os';
 
-// Mock file system operations
+const daemon = vi.hoisted(() => ({
+  ctor: vi.fn(),
+  isRunning: vi.fn(),
+  getStatus: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+const resolvers = vi.hoisted(() => ({
+  allocate: vi.fn(),
+  resolveDbPath: vi.fn(),
+}));
+
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
@@ -18,138 +34,171 @@ vi.mock('fs', async () => {
   };
 });
 
-// Mock dotenv
 vi.mock('dotenv', () => ({
   config: vi.fn().mockReturnValue({ parsed: {} }),
 }));
 
-// Mock install-context
 vi.mock('../../../../src/cli/utils/install-context', () => ({
   getConfigDir: vi.fn(() => path.join(homedir(), '.commandmate')),
   isGlobalInstall: vi.fn(() => true),
 }));
 
-// Mock child_process
 vi.mock('child_process', () => ({
-  spawn: vi.fn(() => ({
-    on: vi.fn(),
-  })),
+  spawn: vi.fn(() => ({ on: vi.fn() })),
 }));
 
-// Mock daemon
 vi.mock('../../../../src/cli/utils/daemon', () => ({
-  DaemonManager: vi.fn().mockImplementation(() => ({
-    isRunning: vi.fn().mockResolvedValue(false),
-    getStatus: vi.fn().mockResolvedValue(null),
-    start: vi.fn().mockResolvedValue(12345),
-    stop: vi.fn().mockResolvedValue(true),
-  })),
+  DaemonManager: vi.fn(function (this: Record<string, unknown>, pidFilePath: string) {
+    daemon.ctor(pidFilePath);
+    this.isRunning = daemon.isRunning;
+    this.getStatus = daemon.getStatus;
+    this.start = daemon.start;
+    this.stop = daemon.stop;
+  }),
 }));
 
-// Mock security-logger
+vi.mock('../../../../src/cli/utils/port-allocator', () => ({
+  PortAllocator: {
+    getInstance: vi.fn(() => ({ allocate: resolvers.allocate })),
+  },
+}));
+
+vi.mock('../../../../src/cli/utils/resource-resolvers', () => ({
+  DbPathResolver: vi.fn(function (this: Record<string, unknown>) {
+    this.resolve = resolvers.resolveDbPath;
+  }),
+}));
+
 vi.mock('../../../../src/cli/utils/security-logger', () => ({
   logSecurityEvent: vi.fn(),
 }));
 
-// Mock paths
 vi.mock('../../../../src/cli/utils/paths', () => ({
   getPackageRoot: vi.fn(() => '/mock/package/root'),
 }));
 
-// Mock env-setup
 vi.mock('../../../../src/cli/utils/env-setup', () => ({
-  getEnvPath: vi.fn((issueNo?: number) => {
-    if (issueNo !== undefined) {
-      return path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`);
-    }
-    return path.join(homedir(), '.commandmate', '.env');
-  }),
-  getPidFilePath: vi.fn((issueNo?: number) => {
-    if (issueNo !== undefined) {
-      return path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`);
-    }
-    return path.join(homedir(), '.commandmate', '.commandmate.pid');
-  }),
+  getEnvPath: vi.fn((issueNo?: number) =>
+    issueNo !== undefined
+      ? path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`)
+      : path.join(homedir(), '.commandmate', '.env')
+  ),
+  getPidFilePath: vi.fn((issueNo?: number) =>
+    issueNo !== undefined
+      ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
+      : path.join(homedir(), '.commandmate', '.commandmate.pid')
+  ),
 }));
 
-import { StartOptions } from '../../../../src/cli/types';
+import { runStart } from '../../../../src/cli/commands/start';
+import { ExitCode } from '../../../../src/cli/types';
+
+const pidPath = (issueNo?: number) =>
+  issueNo !== undefined
+    ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
+    : path.join(homedir(), '.commandmate', '.commandmate.pid');
 
 describe('Start Command - Issue #136 Extensions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset process.exit mock
-    vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called');
-    });
+    daemon.isRunning.mockResolvedValue(false);
+    daemon.getStatus.mockResolvedValue(null);
+    daemon.start.mockResolvedValue(12345);
+    resolvers.allocate.mockReturnValue(3135);
+    resolvers.resolveDbPath.mockReturnValue('/mock/home/.commandmate/data/cm-135.db');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  describe('StartOptions type', () => {
-    it('should accept issue option', () => {
-      const options: StartOptions = {
-        dev: false,
-        daemon: true,
-        issue: 135,
-      };
+  describe('--issue flag', () => {
+    it('should construct DaemonManager with the worktree PID file', async () => {
+      const result = await runStart({ daemon: true, issue: 135 });
 
-      expect(options.issue).toBe(135);
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135));
+      expect(result.ok).toBe(true);
+      expect(result.pid).toBe(12345);
     });
 
-    it('should accept autoPort option', () => {
-      const options: StartOptions = {
-        dev: false,
-        daemon: true,
-        autoPort: true,
-      };
+    it('should use the main PID file when no issue is given', async () => {
+      await runStart({ daemon: true });
 
-      expect(options.autoPort).toBe(true);
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath());
     });
 
-    it('should accept both issue and autoPort options', () => {
-      const options: StartOptions = {
-        dev: false,
-        daemon: true,
-        issue: 200,
-        autoPort: true,
-      };
+    it('should pass the worktree DB path to DaemonManager.start', async () => {
+      await runStart({ daemon: true, issue: 135 });
 
-      expect(options.issue).toBe(200);
-      expect(options.autoPort).toBe(true);
+      expect(resolvers.resolveDbPath).toHaveBeenCalledWith(135);
+      expect(daemon.start).toHaveBeenCalledWith(
+        expect.objectContaining({ dbPath: '/mock/home/.commandmate/data/cm-135.db' })
+      );
+    });
+
+    it('should not resolve a worktree DB path for the main server', async () => {
+      await runStart({ daemon: true });
+
+      expect(resolvers.resolveDbPath).not.toHaveBeenCalled();
+      expect(daemon.start).toHaveBeenCalledWith(
+        expect.objectContaining({ dbPath: undefined })
+      );
+    });
+
+    it('should refuse to start when the issue server is already running', async () => {
+      daemon.isRunning.mockResolvedValue(true);
+      daemon.getStatus.mockResolvedValue({ running: true, pid: 999 });
+
+      const result = await runStart({ daemon: true, issue: 135 });
+
+      expect(daemon.start).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: false, exitCode: ExitCode.START_FAILED });
+    });
+
+    it('should reject an invalid issue number before touching DaemonManager', async () => {
+      const result = await runStart({ daemon: true, issue: -5 });
+
+      expect(daemon.ctor).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: false, exitCode: ExitCode.START_FAILED });
     });
   });
 
-  describe('getEnvPath with issueNo', () => {
-    it('should return worktree-specific .env path for issue', async () => {
-      const { getEnvPath } = await import('../../../../src/cli/utils/env-setup');
+  describe('--auto-port flag', () => {
+    it('should allocate a port for the issue and pass it to DaemonManager.start', async () => {
+      const result = await runStart({ daemon: true, issue: 135, autoPort: true });
 
-      const mainEnvPath = getEnvPath();
-      const worktreeEnvPath = getEnvPath(135);
+      expect(resolvers.allocate).toHaveBeenCalledWith(135);
+      expect(daemon.start).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 3135 })
+      );
+      expect(result.url).toContain('3135');
+    });
 
-      expect(mainEnvPath).toBe(path.join(homedir(), '.commandmate', '.env'));
-      expect(worktreeEnvPath).toBe(
-        path.join(homedir(), '.commandmate', 'envs', '135.env')
+    it('should not allocate a port without --issue', async () => {
+      await runStart({ daemon: true, autoPort: true });
+
+      expect(resolvers.allocate).not.toHaveBeenCalled();
+    });
+
+    it('should honour an explicit --port over auto allocation', async () => {
+      await runStart({ daemon: true, issue: 135, port: 4000 });
+
+      expect(resolvers.allocate).not.toHaveBeenCalled();
+      expect(daemon.start).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 4000 })
       );
     });
   });
 
-  describe('getPidFilePath with issueNo', () => {
-    it('should return worktree-specific PID path for issue', async () => {
-      const { getPidFilePath } = await import(
-        '../../../../src/cli/utils/env-setup'
-      );
+  describe('daemon start failure', () => {
+    it('should return START_FAILED when DaemonManager.start throws', async () => {
+      daemon.start.mockRejectedValue(new Error('spawn failed'));
 
-      const mainPidPath = getPidFilePath();
-      const worktreePidPath = getPidFilePath(135);
+      const result = await runStart({ daemon: true, issue: 135 });
 
-      expect(mainPidPath).toBe(
-        path.join(homedir(), '.commandmate', '.commandmate.pid')
-      );
-      expect(worktreePidPath).toBe(
-        path.join(homedir(), '.commandmate', 'pids', '135.pid')
-      );
+      expect(result).toEqual({ ok: false, exitCode: ExitCode.START_FAILED });
     });
   });
 });

--- a/tests/unit/cli/commands/status-issue.test.ts
+++ b/tests/unit/cli/commands/status-issue.test.ts
@@ -1,13 +1,25 @@
 /**
  * Status Command Tests - Issue #136 Extensions
- * TDD: Tests for --issue and --all flags
+ * Tests for --issue and --all flags, exercised against the real statusCommand.
+ *
+ * Issue #1269: the DaemonManager mock must be built from `function` (or `class`),
+ * never an arrow fn. `vi.fn().mockImplementation(() => ({ ... }))` has no
+ * [[Construct]], so `new DaemonManager(pid)` throws "is not a constructor".
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import { homedir } from 'os';
+import type { DaemonStatus } from '../../../../src/cli/types';
 
-// Mock file system operations
+const daemon = vi.hoisted(() => ({
+  ctor: vi.fn(),
+  isRunning: vi.fn(),
+  getStatus: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
@@ -15,62 +27,74 @@ vi.mock('fs', async () => {
     existsSync: vi.fn().mockReturnValue(true),
     mkdirSync: vi.fn(),
     realpathSync: vi.fn((p: string) => p),
-    readdirSync: vi.fn(() => ['135.pid', '200.pid', '300.pid']),
+    readdirSync: vi.fn(() => ['135.pid', '200.pid']),
   };
 });
 
-// Mock dotenv
 vi.mock('dotenv', () => ({
   config: vi.fn().mockReturnValue({ parsed: {} }),
 }));
 
-// Mock install-context
 vi.mock('../../../../src/cli/utils/install-context', () => ({
   getConfigDir: vi.fn(() => path.join(homedir(), '.commandmate')),
   isGlobalInstall: vi.fn(() => true),
 }));
 
-// Mock daemon
 vi.mock('../../../../src/cli/utils/daemon', () => ({
-  DaemonManager: vi.fn().mockImplementation(() => ({
-    isRunning: vi.fn().mockResolvedValue(true),
-    getStatus: vi.fn().mockResolvedValue({
-      running: true,
-      pid: 12345,
-      port: 3000,
-      uptime: 3600,
-    }),
-    start: vi.fn().mockResolvedValue(12345),
-    stop: vi.fn().mockResolvedValue(true),
-  })),
+  DaemonManager: vi.fn(function (this: Record<string, unknown>, pidFilePath: string) {
+    daemon.ctor(pidFilePath);
+    this.isRunning = daemon.isRunning;
+    this.getStatus = daemon.getStatus;
+    this.start = daemon.start;
+    this.stop = daemon.stop;
+  }),
 }));
 
-// Mock env-setup
 vi.mock('../../../../src/cli/utils/env-setup', () => ({
-  getEnvPath: vi.fn((issueNo?: number) => {
-    if (issueNo !== undefined) {
-      return path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`);
-    }
-    return path.join(homedir(), '.commandmate', '.env');
-  }),
-  getPidFilePath: vi.fn((issueNo?: number) => {
-    if (issueNo !== undefined) {
-      return path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`);
-    }
-    return path.join(homedir(), '.commandmate', '.commandmate.pid');
-  }),
+  getEnvPath: vi.fn((issueNo?: number) =>
+    issueNo !== undefined
+      ? path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`)
+      : path.join(homedir(), '.commandmate', '.env')
+  ),
+  getPidFilePath: vi.fn((issueNo?: number) =>
+    issueNo !== undefined
+      ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
+      : path.join(homedir(), '.commandmate', '.commandmate.pid')
+  ),
   getPidsDir: vi.fn(() => path.join(homedir(), '.commandmate', 'pids')),
 }));
 
-import { StatusOptions } from '../../../../src/cli/types';
-import { getPidFilePath } from '../../../../src/cli/utils/env-setup';
+import { statusCommand } from '../../../../src/cli/commands/status';
+import { ExitCode } from '../../../../src/cli/types';
+import { config as dotenvConfig } from 'dotenv';
+
+const RUNNING: DaemonStatus = {
+  running: true,
+  pid: 12345,
+  port: 3135,
+  uptime: 3600,
+};
+
+const pidPath = (issueNo?: number) =>
+  issueNo !== undefined
+    ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
+    : path.join(homedir(), '.commandmate', '.commandmate.pid');
 
 describe('Status Command - Issue #136 Extensions', () => {
+  let mockExit: ReturnType<typeof vi.fn>;
+  let output: string[];
+
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset process.exit mock
-    vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called');
+    daemon.isRunning.mockResolvedValue(true);
+    daemon.getStatus.mockResolvedValue(RUNNING);
+    vi.mocked(dotenvConfig).mockReturnValue({ parsed: {} });
+
+    output = [];
+    mockExit = vi.fn();
+    vi.spyOn(process, 'exit').mockImplementation(mockExit as unknown as typeof process.exit);
+    vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+      output.push(String(msg));
     });
   });
 
@@ -78,63 +102,87 @@ describe('Status Command - Issue #136 Extensions', () => {
     vi.restoreAllMocks();
   });
 
-  describe('StatusOptions type', () => {
-    it('should accept issue option', () => {
-      const options: StatusOptions = {
-        issue: 135,
-      };
+  describe('--issue flag', () => {
+    it('should construct DaemonManager with the worktree PID file', async () => {
+      await statusCommand({ issue: 135 });
 
-      expect(options.issue).toBe(135);
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135));
+      expect(daemon.getStatus).toHaveBeenCalled();
     });
 
-    it('should accept all option', () => {
-      const options: StatusOptions = {
-        all: true,
-      };
+    it('should load the worktree .env so getStatus sees the right CM_PORT', async () => {
+      await statusCommand({ issue: 135 });
 
-      expect(options.all).toBe(true);
+      expect(dotenvConfig).toHaveBeenCalledWith({
+        path: path.join(homedir(), '.commandmate', 'envs', '135.env'),
+      });
     });
 
-    it('should work without any options (backward compatibility)', () => {
-      const options: StatusOptions = {};
+    it('should label the output with the issue number and report the status', async () => {
+      await statusCommand({ issue: 135 });
 
-      expect(options.issue).toBeUndefined();
-      expect(options.all).toBeUndefined();
+      expect(output.join('\n')).toContain('CommandMate Status - Issue #135');
+      expect(output.join('\n')).toContain('Status:  Running (PID: 12345)');
+      expect(output.join('\n')).toContain('Port:    3135');
+    });
+
+    it('should use the main PID file when no issue is given', async () => {
+      await statusCommand({});
+
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath());
+      expect(output.join('\n')).toContain('CommandMate Status - Main Server');
+    });
+
+    it('should report stopped when getStatus returns null', async () => {
+      daemon.getStatus.mockResolvedValue(null);
+
+      await statusCommand({ issue: 135 });
+
+      expect(output.join('\n')).toContain('Status:  Stopped (no PID file)');
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+    });
+
+    it('should report a stale PID file and suggest the issue-specific start command', async () => {
+      daemon.getStatus.mockResolvedValue({ running: false, pid: 12345 });
+
+      await statusCommand({ issue: 135 });
+
+      expect(output.join('\n')).toContain('Status:  Not running (stale PID file)');
+      expect(output.join('\n')).toContain('commandmate start --issue 135');
+    });
+
+    it('should reject an invalid issue number before touching DaemonManager', async () => {
+      await statusCommand({ issue: -1 });
+
+      expect(daemon.ctor).not.toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.UNEXPECTED_ERROR);
     });
   });
 
-  describe('getPidFilePath with issueNo', () => {
-    it('should return main PID path when no issue specified', () => {
-      const pidPath = getPidFilePath();
-      expect(pidPath).toBe(
-        path.join(homedir(), '.commandmate', '.commandmate.pid')
-      );
-    });
+  describe('--all flag', () => {
+    it('should report the main server plus every worktree PID file', async () => {
+      await statusCommand({ all: true });
 
-    it('should return worktree PID path when issue specified', () => {
-      const pidPath = getPidFilePath(135);
-      expect(pidPath).toBe(
-        path.join(homedir(), '.commandmate', 'pids', '135.pid')
-      );
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath());
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135));
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(200));
+      expect(daemon.ctor).toHaveBeenCalledTimes(3);
+
+      const text = output.join('\n');
+      expect(text).toContain('CommandMate Status - Main Server');
+      expect(text).toContain('CommandMate Status - Issue #135');
+      expect(text).toContain('CommandMate Status - Issue #200');
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
     });
   });
 
-  describe('Status --all flag behavior', () => {
-    it('should list all worktree PID files in pids directory', async () => {
-      const { getPidsDir } = await import(
-        '../../../../src/cli/utils/env-setup'
-      );
-      const pidsDir = getPidsDir();
+  describe('error handling', () => {
+    it('should exit with UNEXPECTED_ERROR when getStatus throws', async () => {
+      daemon.getStatus.mockRejectedValue(new Error('boom'));
 
-      expect(pidsDir).toBe(path.join(homedir(), '.commandmate', 'pids'));
-    });
+      await statusCommand({ issue: 135 });
 
-    it('should parse issue number from PID filename', () => {
-      // PID filename pattern: {issueNo}.pid
-      const filename = '135.pid';
-      const issueNo = parseInt(filename.replace('.pid', ''), 10);
-
-      expect(issueNo).toBe(135);
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.UNEXPECTED_ERROR);
     });
   });
 });

--- a/tests/unit/cli/commands/stop-issue.test.ts
+++ b/tests/unit/cli/commands/stop-issue.test.ts
@@ -1,13 +1,24 @@
 /**
  * Stop Command Tests - Issue #136 Extensions
- * TDD: Tests for --issue flag
+ * Tests for the --issue flag, exercised against the real stopCommand.
+ *
+ * Issue #1269: the DaemonManager mock must be built from `function` (or `class`),
+ * never an arrow fn. `vi.fn().mockImplementation(() => ({ ... }))` has no
+ * [[Construct]], so `new DaemonManager(pid)` throws "is not a constructor".
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import { homedir } from 'os';
 
-// Mock file system operations
+const daemon = vi.hoisted(() => ({
+  ctor: vi.fn(),
+  isRunning: vi.fn(),
+  getStatus: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
@@ -18,110 +29,141 @@ vi.mock('fs', async () => {
   };
 });
 
-// Mock install-context
 vi.mock('../../../../src/cli/utils/install-context', () => ({
   getConfigDir: vi.fn(() => path.join(homedir(), '.commandmate')),
   isGlobalInstall: vi.fn(() => true),
 }));
 
-// Mock daemon
 vi.mock('../../../../src/cli/utils/daemon', () => ({
-  DaemonManager: vi.fn().mockImplementation(() => ({
-    isRunning: vi.fn().mockResolvedValue(true),
-    getStatus: vi.fn().mockResolvedValue({ running: true, pid: 12345 }),
-    start: vi.fn().mockResolvedValue(12345),
-    stop: vi.fn().mockResolvedValue(true),
-  })),
+  DaemonManager: vi.fn(function (this: Record<string, unknown>, pidFilePath: string) {
+    daemon.ctor(pidFilePath);
+    this.isRunning = daemon.isRunning;
+    this.getStatus = daemon.getStatus;
+    this.start = daemon.start;
+    this.stop = daemon.stop;
+  }),
 }));
 
-// Mock security-logger
 vi.mock('../../../../src/cli/utils/security-logger', () => ({
   logSecurityEvent: vi.fn(),
 }));
 
-// Mock env-setup
 vi.mock('../../../../src/cli/utils/env-setup', () => ({
-  getEnvPath: vi.fn((issueNo?: number) => {
-    if (issueNo !== undefined) {
-      return path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`);
-    }
-    return path.join(homedir(), '.commandmate', '.env');
-  }),
-  getPidFilePath: vi.fn((issueNo?: number) => {
-    if (issueNo !== undefined) {
-      return path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`);
-    }
-    return path.join(homedir(), '.commandmate', '.commandmate.pid');
-  }),
+  getEnvPath: vi.fn((issueNo?: number) =>
+    issueNo !== undefined
+      ? path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`)
+      : path.join(homedir(), '.commandmate', '.env')
+  ),
+  getPidFilePath: vi.fn((issueNo?: number) =>
+    issueNo !== undefined
+      ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
+      : path.join(homedir(), '.commandmate', '.commandmate.pid')
+  ),
 }));
 
-import { StopOptions } from '../../../../src/cli/types';
-import { getPidFilePath } from '../../../../src/cli/utils/env-setup';
+import { stopCommand } from '../../../../src/cli/commands/stop';
+import { ExitCode } from '../../../../src/cli/types';
+import { logSecurityEvent } from '../../../../src/cli/utils/security-logger';
+
+const pidPath = (issueNo?: number) =>
+  issueNo !== undefined
+    ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
+    : path.join(homedir(), '.commandmate', '.commandmate.pid');
 
 describe('Stop Command - Issue #136 Extensions', () => {
+  let mockExit: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset process.exit mock
-    vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called');
-    });
+    daemon.isRunning.mockResolvedValue(true);
+    daemon.getStatus.mockResolvedValue({ running: true, pid: 12345 });
+    daemon.stop.mockResolvedValue(true);
+
+    mockExit = vi.fn();
+    vi.spyOn(process, 'exit').mockImplementation(mockExit as unknown as typeof process.exit);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  describe('StopOptions type', () => {
-    it('should accept issue option', () => {
-      const options: StopOptions = {
-        force: false,
-        issue: 135,
-      };
+  describe('--issue flag', () => {
+    it('should construct DaemonManager with the worktree PID file', async () => {
+      await stopCommand({ force: false, issue: 135 });
 
-      expect(options.issue).toBe(135);
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135));
+      expect(daemon.stop).toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
     });
 
-    it('should accept force and issue options together', () => {
-      const options: StopOptions = {
-        force: true,
-        issue: 200,
-      };
+    it('should use the main PID file when no issue is given', async () => {
+      await stopCommand({ force: false });
 
-      expect(options.force).toBe(true);
-      expect(options.issue).toBe(200);
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath());
     });
 
-    it('should work without issue option (backward compatibility)', () => {
-      const options: StopOptions = {
-        force: false,
-      };
+    it('should target different PID files for different issues', async () => {
+      await stopCommand({ force: false, issue: 135 });
+      await stopCommand({ force: false, issue: 200 });
 
-      expect(options.issue).toBeUndefined();
+      expect(daemon.ctor).toHaveBeenNthCalledWith(1, pidPath(135));
+      expect(daemon.ctor).toHaveBeenNthCalledWith(2, pidPath(200));
+    });
+
+    it('should reject an invalid issue number before touching DaemonManager', async () => {
+      await stopCommand({ force: false, issue: 0 });
+
+      expect(daemon.ctor).not.toHaveBeenCalled();
+      expect(daemon.stop).not.toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.STOP_FAILED);
     });
   });
 
-  describe('getPidFilePath with issueNo', () => {
-    it('should return main PID path when no issue specified', () => {
-      const pidPath = getPidFilePath();
-      expect(pidPath).toBe(
-        path.join(homedir(), '.commandmate', '.commandmate.pid')
+  describe('--force flag', () => {
+    it('should forward force=true to DaemonManager.stop and log a security warning', async () => {
+      await stopCommand({ force: true, issue: 135 });
+
+      expect(daemon.stop).toHaveBeenCalledWith(true);
+      expect(logSecurityEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'stop',
+          action: 'warning',
+          details: expect.stringContaining('Issue #135'),
+        })
       );
     });
 
-    it('should return worktree PID path when issue specified', () => {
-      const pidPath = getPidFilePath(135);
-      expect(pidPath).toBe(
-        path.join(homedir(), '.commandmate', 'pids', '135.pid')
-      );
+    it('should forward force=false when not forcing', async () => {
+      await stopCommand({ force: false, issue: 135 });
+
+      expect(daemon.stop).toHaveBeenCalledWith(false);
     });
+  });
 
-    it('should return different paths for different issues', () => {
-      const pidPath135 = getPidFilePath(135);
-      const pidPath200 = getPidFilePath(200);
+  describe('when not running', () => {
+    it('should exit SUCCESS without calling stop', async () => {
+      daemon.isRunning.mockResolvedValue(false);
+      daemon.getStatus.mockResolvedValue(null);
 
-      expect(pidPath135).not.toBe(pidPath200);
-      expect(pidPath135).toContain('135.pid');
-      expect(pidPath200).toContain('200.pid');
+      await stopCommand({ force: false, issue: 135 });
+
+      expect(daemon.stop).not.toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+    });
+  });
+
+  describe('when stop fails', () => {
+    it('should exit STOP_FAILED and log a failure event', async () => {
+      daemon.stop.mockResolvedValue(false);
+
+      await stopCommand({ force: false, issue: 135 });
+
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.STOP_FAILED);
+      expect(logSecurityEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'stop', action: 'failure' })
+      );
     });
   });
 });

--- a/tests/unit/lib/schedule-manager-cleanup.test.ts
+++ b/tests/unit/lib/schedule-manager-cleanup.test.ts
@@ -12,11 +12,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock croner
+// Issue #1269: must be `function`, not an arrow fn — an arrow fn has no [[Construct]],
+// so `new Cron()` in createScheduleState() would throw "is not a constructor".
 vi.mock('croner', () => ({
-  Cron: vi.fn().mockImplementation(() => ({
-    stop: vi.fn(),
-    schedule: vi.fn(),
-  })),
+  Cron: vi.fn(function (this: Record<string, unknown>) {
+    this.stop = vi.fn();
+    this.schedule = vi.fn();
+  }),
 }));
 
 // Mock db-instance


### PR DESCRIPTION
## 概要

Issue #1269 の対応。`start-issue` / `status-issue` / `stop-issue` のテストが**意図した経路を検証できていない疑い**を実測で確認した。

**仮説は正しかったが、実態はそれより重大だった。**

親Issue: #1193

## 実測で確認した2つの欠陥

### 1. `DaemonManager` モックが `new` できない（Issue の仮説どおり）

vitest 4 では arrow fn に `[[Construct]]` が無いため、`vi.fn().mockImplementation(() => ({ ... }))` を `new` すると失敗する。

```
[vitest] The vi.fn() mock did not use 'function' or 'class' in its implementation
TypeError: () => ({...}) is not a constructor
```

### 2. 🔴 そもそも実装が import されていなかった（Issue の想定より重大）

3ファイルとも**型（`StartOptions` 等）とモック済み `env-setup` しか import しておらず、`statusCommand` / `stopCommand` / `runStart` を一度も呼んでいなかった**。

**`DaemonManager` モックは到達不能な死にコード**で、欠陥1が顕在化すらしていなかった。

アサーションはすべて自作モックの戻り値を確認する**トートロジー**だった。`getPidFilePath(135)` が `135.pid` を返すのは、**テスト自身がそう書いたから**である。

## 「実装を壊すと落ちるか」の実測 — 落ちなかった

| 注入した欠陥 | 結果 |
|---|---|
| `env-setup.getPidFilePath` が `/INJECTED/BROKEN.pid` を返す | ❌ **18/18 PASS** |
| `start.ts` / `status.ts` / `stop.ts` が import 時に throw | ❌ **18/18 PASS** |

→ **Issue #136 の worktree 並列機能（`--issue` 系）は実質ノーガードだった。**

なお実 `getPidFilePath` は `env-setup.test.ts:359-420` が既にカバー済みで、当該アサーションは**重複**でもあった。

## 修正内容

実装（`statusCommand` / `stopCommand` / `runStart`）を**実際に import して呼び**、`new` 可能な `DaemonManager` モックで Issue #136 の経路を検証する形に書き換えた。

**18 tests（トートロジー）→ 27 tests（実効）**

| 対象 | 検証する経路 |
|---|---|
| `status-issue` | `--issue` / `--all` の PID・.env 経路、running / stale / null、異常系 |
| `stop-issue` | `--issue` の PID 経路、`--force` 伝播、security ログ、失敗系 |
| `start-issue` | `--issue` の PID 経路、`--auto-port` 割当、DB パス、起動済みガード |

## 同じモック形式の grep（Issue のスコープ）

`tests/unit/lib/schedule-manager-cleanup.test.ts` に**同一パターンを発見**し修正した。

```diff
 vi.mock('croner', () => ({
-  Cron: vi.fn().mockImplementation(() => ({
-    stop: vi.fn(),
-    schedule: vi.fn(),
-  })),
+  Cron: vi.fn(function (this: Record<string, unknown>) {
+    this.stop = vi.fn();
+    this.schedule = vi.fn();
+  }),
 }));
```

`createScheduleState()` の `new Cron()` が同じ理由で throw する経路だった。

## 📌 #1266 への申し送り

**`DaemonManager` モックは `new` 可能になった。** `status-issue.test.ts` の `daemon.getStatus` を差し替えれば、shell と `.env` の `CM_PORT` 不一致を**テストで固定できる**（`dotenvConfig` の呼び出し引数も検証可能）。

## プロダクトコード変更なし

テストのみ。Issue の「対象外: プロダクトコードの変更」に従っている。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **563 files / 9,563 tests 全パス** |
| `npm run build` | ✅ exit 0 |

Refs #1193
Closes #1269
