### PR TITLE
chore(lint): モジュールスコープ const の literal label を検出する ESLint ルールを追加 (#1271)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,13 @@
         "message": "Use useConfirm() / ConfirmDialog instead of window.confirm (Issue #1113)."
       }
     ],
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "selector": ":matches(:matches(:matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator, :matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator > TSAsExpression) > :matches(ArrayExpression, ObjectExpression), :matches(:matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator, :matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator > TSAsExpression) > :matches(ArrayExpression, ObjectExpression) > ObjectExpression, :matches(:matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator, :matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator > TSAsExpression) > :matches(ArrayExpression, ObjectExpression) > Property > ObjectExpression, :matches(:matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator, :matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator > TSAsExpression) > :matches(ArrayExpression, ObjectExpression) > ObjectExpression > Property > ObjectExpression, :matches(:matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator, :matches(Program, ExportNamedDeclaration) > VariableDeclaration > VariableDeclarator > TSAsExpression) > :matches(ArrayExpression, ObjectExpression) > Property > ArrayExpression > ObjectExpression) > Property[key.name=/^(label|title|description|placeholder|ariaLabel|tooltip|subtitle|heading)$/][value.type='Literal'][value.value=/[A-Za-z]/]",
+        "message": "i18n: モジュールスコープの const に表示文言が直書きされています。この位置では useTranslations() の t() を呼べないため英語が固定されます。`labelKey: 'nav.home'` のようにキーを持たせ、描画時に t(labelKey) で解決してください。技術的な値・キーコード表記など翻訳対象外の場合のみ eslint-disable-next-line に理由を添えて抑止してください (Issue #1271)。"
+      }
+    ],
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/eslint": "^8.56.12",
         "@types/http-proxy": "^1.17.17",
         "@types/node": "20.19.35",
         "@types/react": "^19.2.17",
@@ -87,6 +88,9 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -4762,6 +4766,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/eslint": {
+      "version": "8.56.12",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4801,6 +4816,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/eslint": "^8.56.12",
     "@types/http-proxy": "^1.17.17",
     "@types/node": "20.19.35",
     "@types/react": "^19.2.17",

--- a/tests/unit/config/eslint-i18n-module-scope-literal.test.ts
+++ b/tests/unit/config/eslint-i18n-module-scope-literal.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Issue #1271: モジュールスコープ const の表示文言直書きを検出する ESLint ルール
+ *
+ * このルールは `.eslintrc.json` の no-restricted-syntax セレクタとして実装されている。
+ * セレクタは可読性が低く壊れても気付きにくいため、検出可否をテストで固定する。
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ESLint } from 'eslint';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../..');
+const RULE = 'no-restricted-syntax';
+
+let eslint: ESLint;
+
+beforeAll(() => {
+  eslint = new ESLint({ cwd: ROOT, useEslintrc: true });
+});
+
+/** src 配下の .tsx として lint し、対象ルールの指摘行のみ返す */
+async function lintHits(code: string): Promise<number[]> {
+  const [result] = await eslint.lintText(code, {
+    filePath: path.join(ROOT, 'src/components/__i18n_rule_fixture__.tsx'),
+  });
+  return result.messages.filter((m) => m.ruleId === RULE).map((m) => m.line);
+}
+
+describe('i18n: module-scope literal label rule (Issue #1271)', () => {
+  it('detects the pre-fix Header.tsx shape (the regression this rule exists for)', async () => {
+    // Issue #1206 で修正される前の Header.tsx の形
+    const hits = await lintHits(`
+const NAV_ITEMS: Array<{ label: string; href: string }> = [
+  { label: 'Home', href: '/' },
+  { label: 'Chat', href: '/chat' },
+];
+`);
+    expect(hits).toEqual([3, 4]);
+  });
+
+  it('detects export const / as const / nested Record shapes', async () => {
+    const hits = await lintHits(`
+export const TABS = [{ label: 'Files' }] as const;
+export const STATUS = { idle: { label: 'Idle' } };
+export const META = { title: 'Offline' };
+`);
+    expect(hits).toEqual([2, 3, 4]);
+  });
+
+  it('does not flag the fixed labelKey form', async () => {
+    const hits = await lintHits(`
+const NAV_ITEMS = [
+  { labelKey: 'nav.home', href: '/' },
+];
+`);
+    expect(hits).toEqual([]);
+  });
+
+  it('does not flag hrefs, testids or other non-display properties', async () => {
+    const hits = await lintHits(`
+const ITEMS = [
+  { href: '/chat', id: 'chat', 'data-testid': 'nav-chat', value: 'review' },
+];
+`);
+    expect(hits).toEqual([]);
+  });
+
+  it('does not flag glyph-only labels (nothing to translate)', async () => {
+    const hits = await lintHits(`
+const KEYS = [{ label: '\\u25C0' }, { label: '\\u21B5' }];
+`);
+    expect(hits).toEqual([]);
+  });
+
+  it('does not flag literals inside a component body, where t() is reachable', async () => {
+    // t() が呼べる位置は本ルールの対象外（#1270 の領分）。
+    // ここを誤検知すると、ルールが無効化される原因になる。
+    // `const X = () => {}` / `export const X = () => {}` はいずれもモジュールスコープの
+    // VariableDeclaration なので、素朴な子孫セレクタだと関数本体まで誤検知が漏れる
+    // （src/components/worktree/ContextMenu.tsx が実例）。
+    const hits = await lintHits(`
+const Inner = () => {
+  const items = [{ label: 'Rename' }];
+  return items;
+};
+export const Menu = () => {
+  const items = [{ label: 'New File' }];
+  return items.length;
+};
+`);
+    expect(hits).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1271 の対応。**モジュールスコープの const 配列/オブジェクトに表示文言が直書きされている状態**を ESLint で検出する。

この位置では `useTranslations()` の `t()` を**呼べないため必然的に英語が固定**され、かつ「`useTranslations` 未 import を grep」型のチェックを**すり抜ける**（#1206 の `Header.tsx` / `GlobalMobileNav.tsx` が実例）。

親Issue: #1193

## 新規依存なし

eslint 8.57 + `.eslintrc.json` 構成のため、**カスタムルール用プラグインを足さず組み込みの `no-restricted-syntax`** で実装した（#1181 で `.eslintrc.json` 据え置き・flat config 見送りを決定済みのため、**設定形式は変更していない**）。

## ⚠️ 実測で訂正した Issue の前提

### 1. 🔴 `export const` が完全に抜けていた

Issue の想定形は `const NAV_ITEMS = [...]` だが、**実コードでは `export const` が検出数の過半を占める**。

素朴な `Program > VariableDeclaration` は、`export const` の `VariableDeclaration` の親が `ExportNamedDeclaration` になるため**一切マッチしない**。

**Issue が「title/description は0件」に見えたのはこの取りこぼしによる artifact** で、実際は **description=46 / title=2**。

### 2. 「モジュールスコープ const」を子孫セレクタで書くと関数本体まで誤検知する

```js
export const Menu = () => { const items = [{ label: 'New File' }] }
```

これは**モジュールスコープ const の子孫**なので、素朴な子孫結合子だと拾ってしまう（`ContextMenu.tsx` / `MemoPane.tsx` が該当）。

**ここは `t()` が呼べる位置＝本ルールの対象外**（#1270 の領分）。AST 実測で出現形が**4種に限られる**ことを確認し、**関数境界を跨げない厳密な子結合子チェーン**で実装した。

### 3. 対象プロパティは実測で確定

**対象**: `label` / `title` / `description` / `placeholder` / `ariaLabel` / `tooltip` / `subtitle` / `heading`

**除外**: `message`(11件) と `name`(1件)。`message` の実体は `src/lib/git/clone-manager.ts` の**サーバ側エラー定数**でそもそも `t()` が使えず、別の i18n 課題（**誤検知になる**）。

`href` / `data-testid` / 技術的な例示値は**プロパティ名で構造的に対象外**。

## warn 段階導入の判断根拠（Issue の指示どおり実測してから決めた）

現行コードでの検出数は **124件（116行 / 15ファイル）**。

**`error` にすると `npm run lint` が即座に落ちる**ため **`warn`** で導入する。CI（`.github/workflows/ci-pr.yml`）は `npm run lint` を **`--max-warnings` なしで実行**しており、**warn は exit 0 = CI 無影響**。

→ **#1270 で124件が解消された後に `error` へ引き上げるのが次段。**

### 内訳（誤検知率 7.3%）

| 区分 | 件数 | 内容 |
|---|---|---|
| **真の未 i18n** | **115件** | #1270 が対象とする箇所 |
| 許容する誤検知 | 8件 | `NavigationButtons` / `TerminalEscapeHatch` の**キーキャップ表記**（Esc / PgUp / PgDn / Home / End / q） |
| 許容する誤検知 | 1件 | `layout.tsx` の**ブランド名** `title: 'CommandMate'` |

抑止の要否は**実際に書き換える #1270 側で理由付きで判断する**。

なお**字形のみの label（◀▲▼▶↵）は `[value.value=/[A-Za-z]/]` で構造的に除外済み**（翻訳対象が存在しないため）。

## 検証

- **受入基準**: `Header.tsx` に**修正前の形** `{ label: 'Home', ... }` を注入 → **35行目で検出**。注入適用（**置換1件**）を grep で確認済み。復元後 HEAD と**バイト一致**
- **陰性対照**: 現行の `labelKey` 形は**非検出**
- **ground truth 突合**: セレクタ出力を **AST 直接走査**の ground truth と突合し**完全一致（124/124、過検出0・見逃し0）**

### 欠陥注入3種でテストの実効性を確認

| 注入 | 結果 |
|---|---|
| (a) ルール off | ✅ 陽性2件が落ちる |
| (b) 素朴な子孫セレクタ | ✅ 関数本体への漏れを陰性対照が捕捉 |
| (c) 子孫+export セレクタ | ✅ 同上 |

**(b) では当初のテストが素通りしたため**、実際の漏れ形（`const` / `export const` のアロー関数）に **fixture を強化**した。

## 依存

`@types/eslint` は **`^8`** を追加（`^9` は flat config API 型で**ランタイムの eslint 8.57 と不一致**）。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ **exit 0**（warn 125件・**CI 無影響**） |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **564 files / 9,560 tests 全パス** |
| `npm run build` | ✅ exit 0 |

## 次段

#1270（→ 子Issue #1273〜#1277）で124件を解消した後、本ルールを **`error`** へ引き上げる。

Refs #1193, #1270
Closes #1271
