### PR TITLE
fix(test): UpdateNotificationBanner の CI 限定フレークを解消（待つ対象の誤り・4件）

### DIFF
--- a/tests/unit/components/worktree/update-notification-banner.test.tsx
+++ b/tests/unit/components/worktree/update-notification-banner.test.tsx
@@ -240,8 +240,9 @@ describe('UpdateNotificationBanner', () => {
     it('shows the updating state and hides the button once confirmed', async () => {
       startUpdate();
 
-      await waitFor(() => expect(screen.getByTestId('update-progress')).toBeDefined());
-      expect(screen.getByText('worktree.update.updating')).toBeDefined();
+      // `update-progress` also renders for `starting`, so it appears before
+      // startUpdate() resolves. Wait for the `updating` copy itself.
+      await waitFor(() => expect(screen.getByText('worktree.update.updating')).toBeDefined());
       expect(screen.queryByTestId('update-now-button')).toBeNull();
     });
 
@@ -253,7 +254,8 @@ describe('UpdateNotificationBanner', () => {
         .mockResolvedValue(true); // back on the new version
 
       startUpdate();
-      await waitFor(() => expect(screen.getByTestId('update-progress')).toBeDefined());
+      // Polling only starts in `updating`; `update-progress` shows up earlier.
+      await waitFor(() => expect(screen.getByText('worktree.update.updating')).toBeDefined());
 
       await waitFor(() => expect(reload).toHaveBeenCalledTimes(1), { timeout: 10_000 });
     }, 15_000);
@@ -267,7 +269,8 @@ describe('UpdateNotificationBanner', () => {
       vi.mocked(appApi.ping).mockResolvedValue(true);
 
       startUpdate();
-      await waitFor(() => expect(screen.getByTestId('update-progress')).toBeDefined());
+      // Polling only starts in `updating`; `update-progress` shows up earlier.
+      await waitFor(() => expect(screen.getByText('worktree.update.updating')).toBeDefined());
       await waitFor(() => expect(appApi.ping).toHaveBeenCalled(), { timeout: 10_000 });
 
       expect(reload).not.toHaveBeenCalled();
@@ -312,7 +315,9 @@ describe('UpdateNotificationBanner', () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
       startUpdate();
-      await waitFor(() => expect(screen.getByTestId('update-progress')).toBeDefined());
+      // The timeout watcher only starts once `state === 'updating'`, so the
+      // clock must not be advanced while the banner still says `starting`.
+      await waitFor(() => expect(screen.getByText('worktree.update.updating')).toBeDefined());
 
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 2000);
 


### PR DESCRIPTION
## 概要

Issue #1286 の対応。`UpdateNotificationBanner` のテストが **CI 限定でフレーク**し、**無関係な PR（#1284 / #1271）を赤くしていた**問題を根治する。

**本リポジトリで6件目**（#1182 / #1204 / #1209 / #1216 / #1222 と同一クラス）。

## 根本原因: `update-progress` は `starting` でも描画される

`src/components/worktree/UpdateNotificationBanner.tsx:84-91`
```ts
setState('starting');                                        // ← ① ここで update-progress が出る
const result = await appApi.startUpdate();                   // ← ② 非同期境界
setState(result.willRestart ? 'updating' : 'no-restart');    // ← ③ ここで初めて 'updating'
```

`update-progress` は **`starting` と `updating` の両方**で描画される（`isBusy`）ため、**その出現は `appApi.startUpdate()` の解決を保証しない**。

負荷の高い CI では②が未解決のまま同期アサートに到達し、**`worktree.update.starting` が表示されている状態**で落ちていた。

→ **必要な要素（`worktree.update.updating`）そのものを待つ**ように変更。

## 🔬 確定再現 → 修正 → 同条件で通ることを実証

| 手順 | 結果 |
|---|---|
| develop（**プロダクトコード無変更**）で `appApi.startUpdate` に **10ms 遅延**を注入 | ❌ **2件が確定的に落ちる**（CI と同一のエラー） |
| 注入を戻す | ✅ 31/31 パス（= フレークであることの裏取り） |
| **修正後**、同じ **10ms 遅延**を注入 | ✅ **31/31 パス** |
| 修正後、さらに厳しい **250ms 遅延**を注入 | ✅ **31/31 パス** |
| 修正後、注入を戻す | ✅ 31/31 パス |

**注入が実コードに適用されたことを毎回確認**してから結果を判断している（過去に sed のパターンが実コードに一致せず「PASS した」と誤認する事故が3回発生しているため）。

## CI が踏んだのは1件だが、実際は4件直した

| テスト | 状態 |
|---|---|
| `shows the updating state and hides the button once confirmed` | CI が踏んだ1件 |
| `falls back to manual instructions when the server never returns` | **遅延注入で露見。** timeout 監視の `useEffect`（`:113-114` の `if (state !== 'updating') return;`）は `updating` でのみ起動するため、`starting` のまま時計を進めても監視が始まらず `update-timeout` が出ない |
| `reloads once the server has gone down and come back` | **同じ構造。** ping ポーリングも `updating` 開始のため。**後続の `waitFor` に救われていただけ** |
| `does not reload ...` | 同上 |

**#1222（#1209 の修正漏れ）の轍を踏まないよう、同一構造を網羅的に是正した。**

## プロダクトコード変更なし

`UpdateNotificationBanner.tsx` は**1バイトも変更していない**。テストの脆弱性であり本番バグではない。

## #1284 との関係

**PR #1284（#1271: ESLint ルール）は、このフレークで赤くなっていた。** #1271 の変更は `.eslintrc.json` / `package.json` / `package-lock.json` / 新規テスト1件のみで、**当該テストへの差分は0行**（React コンポーネントテストに影響し得ない）。

本 PR のマージ後に #1284 を再実行する。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **566 files / 9,606 tests 全パス** |
| `npm run build` | ✅ exit 0 |

## 恒久対策について

**このクラスは6件目**で、テスト作成時のレビューで構造を弾く仕組みがないため再発し続けている。恒久対策（lint ルール等）の検討は**別Issue推奨**。

Closes #1286
