### PR TITLE
fix(cli): status が実際の起動ポートを報告するよう .env の優先順位を揃える (#1266)

### DIFF
--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -396,7 +396,8 @@
 | `src/cli/utils/health-check.ts` | 更新後readiness確認（waitForReady: ready/degraded/timeout）（#1194） |
 | `src/cli/utils/worktree-servers.ts` | 稼働中worktreeサーバ列挙（listRunningWorktreeServers）（Issue #1194） |
 | `src/cli/utils/env-setup.ts` | 環境設定ファイル生成、getPidFilePath()、パストラバーサル対策（Issue #125, #136） |
-| `src/cli/utils/daemon.ts` | デーモンプロセス管理、dotenv読み込み、セキュリティ警告（Issue #125） |
+| `src/cli/utils/daemon.ts` | デーモンプロセス管理、dotenv読み込み、セキュリティ警告、getEffectiveEnv()（Issue #125, #1266） |
+| `src/cli/utils/server-url.ts` | サーバURL解決の単一情報源（resolveServerEndpoint / loadEffectiveEnv: .env が環境変数より優先）（Issue #1266） |
 | `src/cli/utils/pid-manager.ts` | PIDファイル管理（O_EXCLアトミック書き込み） |
 | `src/cli/utils/security-logger.ts` | セキュリティイベントログ |
 | `src/cli/utils/prompt.ts` | 対話形式プロンプトユーティリティ（Issue #119） |

--- a/src/cli/commands/quickstart.ts
+++ b/src/cli/commands/quickstart.ts
@@ -7,7 +7,6 @@
  */
 
 import { existsSync } from 'fs';
-import { config as dotenvConfig } from 'dotenv';
 import { ExitCode, getErrorMessage, PreflightResult } from '../types';
 import { CLILogger } from '../utils/logger';
 import { DaemonManager } from '../utils/daemon';
@@ -65,11 +64,8 @@ async function runQuickstart(options: QuickstartOptions): Promise<number> {
       return configExitCode;
     }
 
-    // PID files hold only the PID, so port/bind must come from .env before any URL is resolved
-    const parsed = dotenvConfig({ path: getEnvPath() }).parsed || {};
-
     const daemonManager = new DaemonManager(getPidFilePath());
-    const started = await ensureServerRunning(daemonManager, { ...process.env, ...parsed });
+    const started = await ensureServerRunning(daemonManager);
     if (started.exitCode !== undefined) {
       return started.exitCode;
     }
@@ -107,32 +103,20 @@ async function ensureConfiguration(): Promise<ExitCode | null> {
 }
 
 /**
- * Resolve the server URL from the effective configuration, mirroring how daemon.ts
- * builds the child environment ({...process.env, ...parsed})
- */
-function resolveServerUrl(env: NodeJS.ProcessEnv): string {
-  const port = parseInt(env.CM_PORT || '3000', 10);
-  const bind = env.CM_BIND || '127.0.0.1';
-  const protocol = env.CM_HTTPS_CERT ? 'https' : 'http';
-  return `${protocol}://${bind === '0.0.0.0' ? '127.0.0.1' : bind}:${port}`;
-}
-
-/**
  * Start the server unless it is already up
  *
  * @returns The server URL, or an exit code to stop on
  */
 async function ensureServerRunning(
-  daemonManager: DaemonManager,
-  effectiveEnv: NodeJS.ProcessEnv
+  daemonManager: DaemonManager
 ): Promise<{ url?: string; exitCode?: ExitCode }> {
   if (await daemonManager.isRunning()) {
     // start.ts reports an already-running server as START_FAILED, so it must not be called here
     const status = await daemonManager.getStatus();
     logger.info(`Server is already running (PID: ${status?.pid})`);
-    // getStatus() reads process.env, which dotenv leaves untouched when CM_PORT is already
-    // exported, so it would report the shell's port rather than the one the server is on
-    return { url: resolveServerUrl(effectiveEnv) };
+    // Issue #1266: getStatus() now gives .env precedence over exported variables, so the URL
+    // it reports is the one the server is on; this no longer needs to be re-derived here
+    return { url: status?.url };
   }
 
   const result = await runStart({ daemon: true });

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -6,7 +6,6 @@
  * Display CommandMate server status
  */
 
-import { config as dotenvConfig } from 'dotenv';
 import { readdirSync } from 'fs';
 import { ExitCode, getErrorMessage, StatusOptions } from '../types';
 import { CLILogger } from '../utils/logger';
@@ -23,10 +22,9 @@ async function showSingleStatus(issueNo?: number): Promise<void> {
   const pidFilePath = getPidFilePath(issueNo);
   const envPath = getEnvPath(issueNo);
 
-  // Load .env so getStatus() can access correct CM_PORT and CM_BIND values
-  dotenvConfig({ path: envPath });
-
-  const daemonManager = new DaemonManager(pidFilePath);
+  // Issue #1266: getStatus() resolves CM_PORT/CM_BIND from this .env, giving it precedence
+  // over exported variables the way the server itself was started
+  const daemonManager = new DaemonManager(pidFilePath, envPath);
   const status = await daemonManager.getStatus();
 
   const serverLabel = issueNo !== undefined
@@ -122,10 +120,9 @@ export async function statusCommand(options: StatusOptions = {}): Promise<void> 
     const pidFilePath = getPidFilePath(options.issue);
     const envPath = getEnvPath(options.issue);
 
-    // Load .env so getStatus() can access correct CM_PORT and CM_BIND values
-    dotenvConfig({ path: envPath });
-
-    const daemonManager = new DaemonManager(pidFilePath);
+    // Issue #1266: getStatus() resolves CM_PORT/CM_BIND from this .env, giving it precedence
+    // over exported variables the way the server itself was started
+    const daemonManager = new DaemonManager(pidFilePath, envPath);
     const status = await daemonManager.getStatus();
 
     const serverLabel = options.issue !== undefined
@@ -168,8 +165,11 @@ export async function statusCommand(options: StatusOptions = {}): Promise<void> 
     }
 
     // Issue #332: Show IP restriction status
-    if (process.env.CM_ALLOWED_IPS) {
-      console.log(`IP ACL:  ${process.env.CM_ALLOWED_IPS}`);
+    // Issue #1266: read the env the server actually runs with. An exported CM_ALLOWED_IPS
+    // shadowed the .env one here, reporting an ACL the server does not enforce.
+    const allowedIps = daemonManager.getEffectiveEnv().CM_ALLOWED_IPS;
+    if (allowedIps) {
+      console.log(`IP ACL:  ${allowedIps}`);
     }
 
     console.log('');

--- a/src/cli/utils/daemon-factory.ts
+++ b/src/cli/utils/daemon-factory.ts
@@ -13,6 +13,7 @@
 import { DaemonManager } from './daemon';
 import { PidPathResolver, DbPathResolver } from './resource-resolvers';
 import { getEnvPath } from './env-setup';
+import type { ServerEnv } from './server-url';
 import type { DaemonStatus, StartOptions } from '../types';
 
 /**
@@ -39,6 +40,12 @@ export interface IDaemonManager {
    * @returns Status object or null if no PID file
    */
   getStatus(): Promise<DaemonStatus | null>;
+
+  /**
+   * Get the configuration this server runs with (Issue #1266)
+   * @returns The effective env, with .env taking precedence over exported variables
+   */
+  getEffectiveEnv(): ServerEnv;
 
   /**
    * Check if daemon is running
@@ -93,6 +100,10 @@ export class DaemonManagerWrapper implements IDaemonManager {
     return this.innerManager.getStatus();
   }
 
+  getEffectiveEnv(): ServerEnv {
+    return this.innerManager.getEffectiveEnv();
+  }
+
   async isRunning(): Promise<boolean> {
     return this.innerManager.isRunning();
   }
@@ -139,7 +150,8 @@ export class DaemonManagerFactory {
     const dbPath = this.dbResolver.resolve(issueNo);
 
     // MF-CONS-002: Use existing DaemonManager constructor
-    const innerManager = new DaemonManager(pidPath);
+    // Issue #1266: hand it the worktree .env so getStatus() reports the right port
+    const innerManager = new DaemonManager(pidPath, envPath);
 
     // Wrap with additional configuration
     return new DaemonManagerWrapper(innerManager, {

--- a/src/cli/utils/daemon.ts
+++ b/src/cli/utils/daemon.ts
@@ -13,6 +13,7 @@ import { getPackageRoot } from './paths';
 import { getEnvPath } from './env-setup';
 import { REVERSE_PROXY_WARNING } from '../config/security-messages';
 import { CLILogger } from './logger';
+import { loadEffectiveEnv, resolveServerEndpoint, ServerEnv } from './server-url';
 
 /**
  * Daemon manager for background server process
@@ -20,10 +21,30 @@ import { CLILogger } from './logger';
 export class DaemonManager {
   private pidManager: PidManager;
   private logger: CLILogger;
+  private envPath?: string;
+  private effectiveEnv?: ServerEnv;
 
-  constructor(pidFilePath: string) {
+  /**
+   * @param pidFilePath - PID file for this server
+   * @param envPath - Issue #1266: the worktree .env this server runs with, so getStatus()
+   *   reports the port it actually listens on; omit for the main server
+   */
+  constructor(pidFilePath: string, envPath?: string) {
     this.pidManager = new PidManager(pidFilePath);
     this.logger = new CLILogger();
+    this.envPath = envPath;
+  }
+
+  /**
+   * The configuration this server runs with, with .env taking precedence over exported
+   * variables exactly as start() hands it to the child process (Issue #1266).
+   *
+   * Read once per manager: a .env cannot change within a single CLI invocation, and reading
+   * it again would emit dotenv's banner a second time.
+   */
+  getEffectiveEnv(): ServerEnv {
+    this.effectiveEnv ??= loadEffectiveEnv(this.envPath);
+    return this.effectiveEnv;
   }
 
   /**
@@ -88,7 +109,10 @@ export class DaemonManager {
     // Issue #179: Security warning for external access - recommend reverse proxy
     const bindAddress = env.CM_BIND || '127.0.0.1';
     const port = env.CM_PORT || '3000';
-    const protocol = env.CM_HTTPS_CERT ? 'https' : 'http';
+    // Issue #1266: server.ts:160 needs both cert and key to serve HTTPS; announcing https on
+    // a lone cert told the user to visit a scheme the child does not speak. The bind address
+    // is logged as configured, so this deliberately does not reuse resolveServerEndpoint().
+    const protocol = env.CM_HTTPS_CERT && env.CM_HTTPS_KEY ? 'https' : 'http';
 
     // Issue #332: Suppress warning when CM_ALLOWED_IPS is set (IP restriction provides access control)
     if (bindAddress === '0.0.0.0' && !env.CM_AUTH_TOKEN_HASH && !env.CM_ALLOWED_IPS) {
@@ -177,12 +201,9 @@ export class DaemonManager {
       return { running: false };
     }
 
-    // Get port from environment or default
-    const port = parseInt(process.env.CM_PORT || '3000', 10);
-    const bind = process.env.CM_BIND || '127.0.0.1';
-    // Issue #331: Use HTTPS protocol if certificate is configured
-    const protocol = process.env.CM_HTTPS_CERT ? 'https' : 'http';
-    const url = `${protocol}://${bind === '0.0.0.0' ? '127.0.0.1' : bind}:${port}`;
+    // Issue #1266: resolve with the same precedence start() hands the child. Reading
+    // process.env directly reported the shell's CM_PORT, not the port the server is on.
+    const { port, url } = resolveServerEndpoint(this.getEffectiveEnv());
 
     // Note: Getting accurate uptime would require storing start time
     // For now, we don't track uptime

--- a/src/cli/utils/server-url.ts
+++ b/src/cli/utils/server-url.ts
@@ -1,0 +1,63 @@
+/**
+ * Server URL Resolution
+ * Issue #1266: single source of truth for "which URL is the server actually on"
+ *
+ * dotenv never overwrites a variable the shell already exported, but daemon.ts hands the
+ * child `{...process.env, ...parsed}`, so .env wins for the process that actually serves.
+ * Resolving a URL from `process.env` alone therefore reports the shell's CM_PORT instead of
+ * the port the server listens on. Everything that reports a URL must use these helpers.
+ */
+
+import { config as dotenvConfig } from 'dotenv';
+import { getEnvPath } from './env-setup';
+
+/**
+ * An environment to resolve from. Deliberately looser than NodeJS.ProcessEnv, which Next.js
+ * augments with a required NODE_ENV that has nothing to do with resolving a server URL.
+ */
+export type ServerEnv = Readonly<Record<string, string | undefined>>;
+
+/** The address a running server is reachable at */
+export interface ServerEndpoint {
+  /** Resolved CM_PORT */
+  port: number;
+  /** Resolved CM_BIND, as configured (not rewritten for dialing) */
+  bind: string;
+  protocol: 'http' | 'https';
+  /** Dialable URL; a 0.0.0.0 bind is reported as 127.0.0.1 */
+  url: string;
+}
+
+/**
+ * Resolve the endpoint a server started with `env` is reachable at.
+ *
+ * @param env - The effective environment, built with loadEffectiveEnv()
+ */
+export function resolveServerEndpoint(env: ServerEnv): ServerEndpoint {
+  const port = parseInt(env.CM_PORT || '3000', 10);
+  const bind = env.CM_BIND || '127.0.0.1';
+  // server.ts:160 upgrades to HTTPS only when both cert and key are present
+  const protocol = env.CM_HTTPS_CERT && env.CM_HTTPS_KEY ? 'https' : 'http';
+  const host = bind === '0.0.0.0' ? '127.0.0.1' : bind;
+
+  return { port, bind, protocol, url: `${protocol}://${host}:${port}` };
+}
+
+/**
+ * Build the environment the server process actually runs with, giving .env precedence over
+ * exported variables exactly as daemon.start() does when it spawns the child.
+ *
+ * @param envPath - A worktree .env layered over the main one; omit for the main server
+ */
+export function loadEffectiveEnv(envPath?: string): NodeJS.ProcessEnv {
+  const mainEnvPath = getEnvPath();
+  const mainParsed = dotenvConfig({ path: mainEnvPath }).parsed || {};
+
+  // A worktree .env is optional: when absent, parsed is undefined and the main values stand
+  const ownParsed =
+    envPath === undefined || envPath === mainEnvPath
+      ? {}
+      : dotenvConfig({ path: envPath }).parsed || {};
+
+  return { ...process.env, ...mainParsed, ...ownParsed };
+}

--- a/tests/unit/cli/commands/quickstart.test.ts
+++ b/tests/unit/cli/commands/quickstart.test.ts
@@ -202,14 +202,13 @@ describe('quickstartCommand', () => {
       expect(mockExit).toHaveBeenCalledWith(ExitCode.START_FAILED);
     });
 
-    it('should load .env before resolving the server URL', async () => {
-      // PID files hold only the PID: port/bind are read from process.env (daemon.ts)
+    it('should announce the URL that runStart reports', async () => {
+      mockStartSucceeds('http://127.0.0.1:31951');
+
       await run();
 
-      expect(dotenvConfig).toHaveBeenCalledWith({ path: ENV_PATH });
-      expect(vi.mocked(dotenvConfig).mock.invocationCallOrder[0]).toBeLessThan(
-        vi.mocked(DaemonManager).mock.invocationCallOrder[0]
-      );
+      expect(output()).toContain('http://127.0.0.1:31951');
+      expect(openBrowser).toHaveBeenCalledWith('http://127.0.0.1:31951');
     });
   });
 
@@ -236,19 +235,25 @@ describe('quickstartCommand', () => {
       expect(waitForServer).not.toHaveBeenCalled();
     });
 
-    // getStatus() derives its URL from process.env, which dotenv will not overwrite when
-    // CM_PORT is exported, so the announced URL pointed at the shell's port instead.
-    it('should announce the .env url, not the exported CM_PORT that getStatus reports', async () => {
-      mockDaemon(true, 'http://127.0.0.1:3000');
+    // Issue #1266: getStatus() now gives .env precedence over an exported CM_PORT itself
+    // (see daemon.test.ts), so quickstart must announce the URL it reports rather than
+    // re-deriving one. Re-deriving from process.env is what announced the shell's port.
+    it('should announce the URL getStatus reports, not one derived from the environment', async () => {
+      mockDaemon(true, 'http://127.0.0.1:31951');
       vi.stubEnv('CM_PORT', '3000');
-      vi.mocked(dotenvConfig).mockReturnValue({
-        parsed: { CM_PORT: '31951', CM_BIND: '127.0.0.1' },
-      } as ReturnType<typeof dotenvConfig>);
 
       await run();
 
       expect(output()).toContain('http://127.0.0.1:31951');
       expect(openBrowser).toHaveBeenCalledWith('http://127.0.0.1:31951');
+    });
+
+    it('should not read .env itself now that getStatus resolves the URL', async () => {
+      mockDaemon(true);
+
+      await run();
+
+      expect(dotenvConfig).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/cli/commands/status-issue.test.ts
+++ b/tests/unit/cli/commands/status-issue.test.ts
@@ -16,6 +16,7 @@ const daemon = vi.hoisted(() => ({
   ctor: vi.fn(),
   isRunning: vi.fn(),
   getStatus: vi.fn(),
+  getEffectiveEnv: vi.fn(),
   start: vi.fn(),
   stop: vi.fn(),
 }));
@@ -41,10 +42,11 @@ vi.mock('../../../../src/cli/utils/install-context', () => ({
 }));
 
 vi.mock('../../../../src/cli/utils/daemon', () => ({
-  DaemonManager: vi.fn(function (this: Record<string, unknown>, pidFilePath: string) {
-    daemon.ctor(pidFilePath);
+  DaemonManager: vi.fn(function (this: Record<string, unknown>, pidFilePath: string, envPath?: string) {
+    daemon.ctor(pidFilePath, envPath);
     this.isRunning = daemon.isRunning;
     this.getStatus = daemon.getStatus;
+    this.getEffectiveEnv = daemon.getEffectiveEnv;
     this.start = daemon.start;
     this.stop = daemon.stop;
   }),
@@ -75,6 +77,11 @@ const RUNNING: DaemonStatus = {
   uptime: 3600,
 };
 
+const envPath = (issueNo?: number) =>
+  issueNo !== undefined
+    ? path.join(homedir(), '.commandmate', 'envs', `${issueNo}.env`)
+    : path.join(homedir(), '.commandmate', '.env');
+
 const pidPath = (issueNo?: number) =>
   issueNo !== undefined
     ? path.join(homedir(), '.commandmate', 'pids', `${issueNo}.pid`)
@@ -88,6 +95,7 @@ describe('Status Command - Issue #136 Extensions', () => {
     vi.clearAllMocks();
     daemon.isRunning.mockResolvedValue(true);
     daemon.getStatus.mockResolvedValue(RUNNING);
+    daemon.getEffectiveEnv.mockReturnValue({});
     vi.mocked(dotenvConfig).mockReturnValue({ parsed: {} });
 
     output = [];
@@ -106,16 +114,16 @@ describe('Status Command - Issue #136 Extensions', () => {
     it('should construct DaemonManager with the worktree PID file', async () => {
       await statusCommand({ issue: 135 });
 
-      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135));
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135), envPath(135));
       expect(daemon.getStatus).toHaveBeenCalled();
     });
 
-    it('should load the worktree .env so getStatus sees the right CM_PORT', async () => {
+    // Issue #1266: the .env is no longer loaded here — the path is handed to DaemonManager,
+    // which resolves CM_PORT from it with .env taking precedence over exported variables
+    it('should hand the worktree .env to DaemonManager so getStatus sees the right CM_PORT', async () => {
       await statusCommand({ issue: 135 });
 
-      expect(dotenvConfig).toHaveBeenCalledWith({
-        path: path.join(homedir(), '.commandmate', 'envs', '135.env'),
-      });
+      expect(daemon.ctor).toHaveBeenCalledWith(expect.any(String), envPath(135));
     });
 
     it('should label the output with the issue number and report the status', async () => {
@@ -126,10 +134,19 @@ describe('Status Command - Issue #136 Extensions', () => {
       expect(output.join('\n')).toContain('Port:    3135');
     });
 
+    // The output assertions above all run before the command finishes, so they stay green
+    // even when it throws afterwards and exits 99. Only the exit code catches that.
+    it('should exit SUCCESS rather than fail after printing the status', async () => {
+      await statusCommand({ issue: 135 });
+
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+      expect(mockExit).not.toHaveBeenCalledWith(ExitCode.UNEXPECTED_ERROR);
+    });
+
     it('should use the main PID file when no issue is given', async () => {
       await statusCommand({});
 
-      expect(daemon.ctor).toHaveBeenCalledWith(pidPath());
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(), envPath());
       expect(output.join('\n')).toContain('CommandMate Status - Main Server');
     });
 
@@ -163,9 +180,9 @@ describe('Status Command - Issue #136 Extensions', () => {
     it('should report the main server plus every worktree PID file', async () => {
       await statusCommand({ all: true });
 
-      expect(daemon.ctor).toHaveBeenCalledWith(pidPath());
-      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135));
-      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(200));
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(), envPath());
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(135), envPath(135));
+      expect(daemon.ctor).toHaveBeenCalledWith(pidPath(200), envPath(200));
       expect(daemon.ctor).toHaveBeenCalledTimes(3);
 
       const text = output.join('\n');

--- a/tests/unit/cli/commands/status.test.ts
+++ b/tests/unit/cli/commands/status.test.ts
@@ -34,6 +34,7 @@ describe('statusCommand', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe('path resolution (Issue #125)', () => {
@@ -47,15 +48,28 @@ describe('statusCommand', () => {
     });
 
     it('should load .env using dotenv for correct settings display', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('12345');
       vi.mocked(dotenv.config).mockReturnValue({
         parsed: { CM_PORT: '4000', CM_BIND: '127.0.0.1' },
       });
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
       await statusCommand();
 
       expect(dotenv.config).toHaveBeenCalledWith({ path: '/mock/home/.commandmate/.env' });
       expect(getEnvPath).toHaveBeenCalled();
+
+      killSpy.mockRestore();
+    });
+
+    // Issue #1266: with no PID file there is no server to describe, so .env is never read
+    it('should not read .env when there is no PID file', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      await statusCommand();
+
+      expect(dotenv.config).not.toHaveBeenCalled();
     });
   });
 
@@ -74,45 +88,66 @@ describe('statusCommand', () => {
       killSpy.mockRestore();
     });
 
-    it('should display port number when available', async () => {
+    // Issue #1266: the exported CM_PORT deliberately disagrees with .env here. Setting both
+    // to the same value would pass whether or not .env is honoured.
+    it('should display the .env port, not the exported CM_PORT', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue('12345');
       vi.mocked(dotenv.config).mockReturnValue({
         parsed: { CM_PORT: '4000' },
       });
-      // Set process.env for getStatus to pick up
-      process.env.CM_PORT = '4000';
+      vi.stubEnv('CM_PORT', '3000');
 
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
       await statusCommand();
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('4000'));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Port:    4000'));
       expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
 
       killSpy.mockRestore();
-      delete process.env.CM_PORT;
     });
 
-    it('should display URL when available', async () => {
+    it('should display the URL of the port the server is actually on', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue('12345');
       vi.mocked(dotenv.config).mockReturnValue({
-        parsed: { CM_PORT: '3000', CM_BIND: '127.0.0.1' },
+        parsed: { CM_PORT: '3101', CM_BIND: '127.0.0.1' },
       });
-      process.env.CM_PORT = '3000';
-      process.env.CM_BIND = '127.0.0.1';
+      vi.stubEnv('CM_PORT', '3000');
 
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
 
       await statusCommand();
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3000'));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3101'));
+      expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3000'));
       expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
 
       killSpy.mockRestore();
-      delete process.env.CM_PORT;
-      delete process.env.CM_BIND;
+    });
+
+    /**
+     * Issue #1266: reading process.env was only wrong when the two disagreed. dotenv does
+     * inject a .env value the shell never exported, so a .env-only ACL displayed correctly
+     * before this change; an exported one shadowed the ACL the server actually enforces.
+     */
+    it('should display the .env IP ACL, not the exported CM_ALLOWED_IPS', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('12345');
+      vi.mocked(dotenv.config).mockReturnValue({
+        parsed: { CM_ALLOWED_IPS: '192.168.1.0/24' },
+      });
+      vi.stubEnv('CM_ALLOWED_IPS', '10.0.0.0/8');
+
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      await statusCommand();
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('IP ACL:  192.168.1.0/24'));
+      expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('10.0.0.0/8'));
+
+      killSpy.mockRestore();
     });
   });
 

--- a/tests/unit/cli/commands/stop.test.ts
+++ b/tests/unit/cli/commands/stop.test.ts
@@ -8,9 +8,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs');
+vi.mock('dotenv', () => ({ config: vi.fn(() => ({ parsed: {} })) }));
 vi.mock('../../../../src/cli/utils/security-logger');
+// stop.ts reads the PID via getStatus(), which resolves the server URL from .env (Issue #1266)
 vi.mock('../../../../src/cli/utils/env-setup', () => ({
   getPidFilePath: vi.fn(() => '/mock/home/.commandmate/.commandmate.pid'),
+  getEnvPath: vi.fn(() => '/mock/home/.commandmate/.env'),
 }));
 
 // Import after mocking

--- a/tests/unit/cli/utils/daemon.test.ts
+++ b/tests/unit/cli/utils/daemon.test.ts
@@ -196,6 +196,66 @@ describe('DaemonManager', () => {
 
       expect(status).toBeNull();
     });
+
+    /**
+     * Issue #1266: getStatus() read process.env directly, which dotenv leaves untouched when
+     * CM_PORT is already exported, so it reported the shell's port while the server that
+     * start() spawned with {...process.env, ...parsed} was listening on the .env port.
+     */
+    describe('URL resolution (Issue #1266)', () => {
+      beforeEach(() => {
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vi.mocked(fs.readFileSync).mockReturnValue('12345');
+        vi.spyOn(process, 'kill').mockImplementation(() => true);
+      });
+
+      afterEach(() => {
+        vi.unstubAllEnvs();
+      });
+
+      it('should report the .env port, not the exported CM_PORT', async () => {
+        vi.stubEnv('CM_PORT', '3000');
+        vi.mocked(dotenv.config).mockReturnValue({ parsed: { CM_PORT: '3101' } });
+
+        const status = await daemonManager.getStatus();
+
+        expect(status?.port).toBe(3101);
+        expect(status?.url).toBe('http://127.0.0.1:3101');
+      });
+
+      it('should report the .env bind address, not the exported CM_BIND', async () => {
+        vi.stubEnv('CM_BIND', '127.0.0.1');
+        vi.mocked(dotenv.config).mockReturnValue({
+          parsed: { CM_BIND: '192.168.1.5', CM_PORT: '3101' },
+        });
+
+        const status = await daemonManager.getStatus();
+
+        expect(status?.url).toBe('http://192.168.1.5:3101');
+      });
+
+      it('should keep an exported CM_PORT that .env does not override', async () => {
+        vi.stubEnv('CM_PORT', '4000');
+        vi.mocked(dotenv.config).mockReturnValue({ parsed: { CM_BIND: '127.0.0.1' } });
+
+        const status = await daemonManager.getStatus();
+
+        expect(status?.port).toBe(4000);
+      });
+
+      it('should read the worktree .env it was constructed with', async () => {
+        const worktreeManager = new DaemonManager(testPidPath, '/mock/.commandmate/envs/135.env');
+        vi.mocked(dotenv.config).mockImplementation(((options: { path: string }) =>
+          options.path === '/mock/.commandmate/envs/135.env'
+            ? { parsed: { CM_PORT: '3135' } }
+            : { parsed: { CM_PORT: '3101' } }) as unknown as typeof dotenv.config);
+
+        const status = await worktreeManager.getStatus();
+
+        expect(dotenv.config).toHaveBeenCalledWith({ path: '/mock/.commandmate/envs/135.env' });
+        expect(status?.port).toBe(3135);
+      });
+    });
   });
 
   describe('isRunning', () => {
@@ -214,6 +274,48 @@ describe('DaemonManager', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
       expect(await daemonManager.isRunning()).toBe(false);
+    });
+  });
+
+  /**
+   * Issue #1266: server.ts:160 upgrades to HTTPS only when both cert and key are set, so the
+   * startup banner must not announce a scheme the spawned child does not actually speak.
+   */
+  describe('start startup banner protocol (Issue #1266)', () => {
+    function mockSpawnableDaemon(parsed: Record<string, string>): void {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.openSync).mockReturnValue(3);
+      vi.mocked(fs.writeSync).mockReturnValue(5);
+      vi.mocked(fs.closeSync).mockReturnValue(undefined);
+      vi.mocked(dotenv.config).mockReturnValue({ parsed });
+      vi.mocked(childProcess.spawn).mockReturnValue({
+        pid: 12345,
+        unref: vi.fn(),
+        on: vi.fn(),
+      } as unknown as childProcess.ChildProcess);
+    }
+
+    it('should announce https when both cert and key are configured', async () => {
+      mockSpawnableDaemon({
+        CM_PORT: '3101',
+        CM_HTTPS_CERT: '/certs/localhost.pem',
+        CM_HTTPS_KEY: '/certs/localhost-key.pem',
+      });
+      const logSpy = vi.spyOn(console, 'log');
+
+      await daemonManager.start({});
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('https://127.0.0.1:3101'));
+    });
+
+    it('should announce http when a cert is configured without a key', async () => {
+      mockSpawnableDaemon({ CM_PORT: '3101', CM_HTTPS_CERT: '/certs/localhost.pem' });
+      const logSpy = vi.spyOn(console, 'log');
+
+      await daemonManager.start({});
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://127.0.0.1:3101'));
+      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('https://'));
     });
   });
 

--- a/tests/unit/cli/utils/server-url.test.ts
+++ b/tests/unit/cli/utils/server-url.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Server URL Resolution Tests
+ * Issue #1266: .env must win over exported variables, because that is the precedence
+ * daemon.start() hands the child process that actually serves.
+ *
+ * loadEffectiveEnv() runs against real dotenv and real .env files on disk: mocking dotenv
+ * here would assert our own assumption about the very behaviour under test (dotenv leaves an
+ * already-exported variable untouched).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const envSetup = vi.hoisted(() => ({ getEnvPath: vi.fn() }));
+
+vi.mock('../../../../src/cli/utils/env-setup', () => ({
+  getEnvPath: envSetup.getEnvPath,
+}));
+
+import { resolveServerEndpoint, loadEffectiveEnv } from '../../../../src/cli/utils/server-url';
+
+describe('resolveServerEndpoint', () => {
+  it('should default to http://127.0.0.1:3000 when nothing is configured', () => {
+    expect(resolveServerEndpoint({})).toEqual({
+      port: 3000,
+      bind: '127.0.0.1',
+      protocol: 'http',
+      url: 'http://127.0.0.1:3000',
+    });
+  });
+
+  it('should use the configured port and bind address', () => {
+    const endpoint = resolveServerEndpoint({ CM_PORT: '3101', CM_BIND: '192.168.1.5' });
+
+    expect(endpoint.port).toBe(3101);
+    expect(endpoint.url).toBe('http://192.168.1.5:3101');
+  });
+
+  it('should report a 0.0.0.0 bind as a dialable 127.0.0.1', () => {
+    const endpoint = resolveServerEndpoint({ CM_BIND: '0.0.0.0', CM_PORT: '3101' });
+
+    expect(endpoint.bind).toBe('0.0.0.0');
+    expect(endpoint.url).toBe('http://127.0.0.1:3101');
+  });
+
+  it('should report https when both cert and key are configured', () => {
+    const endpoint = resolveServerEndpoint({
+      CM_HTTPS_CERT: '/certs/localhost.pem',
+      CM_HTTPS_KEY: '/certs/localhost-key.pem',
+    });
+
+    expect(endpoint.protocol).toBe('https');
+    expect(endpoint.url).toBe('https://127.0.0.1:3000');
+  });
+
+  // server.ts:160 serves HTTPS only when both are present, so a lone cert must stay http
+  it('should stay http when a cert is configured without a key', () => {
+    const endpoint = resolveServerEndpoint({ CM_HTTPS_CERT: '/certs/localhost.pem' });
+
+    expect(endpoint.protocol).toBe('http');
+    expect(endpoint.url).toBe('http://127.0.0.1:3000');
+  });
+});
+
+describe('loadEffectiveEnv', () => {
+  let dir: string;
+  let mainEnvPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cm-1266-'));
+    mainEnvPath = join(dir, '.env');
+    envSetup.getEnvPath.mockReturnValue(mainEnvPath);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  // The bug: the shell exports CM_PORT=3000, .env says 3101, the server listens on 3101.
+  it('should give .env precedence over an exported variable', () => {
+    writeFileSync(mainEnvPath, 'CM_PORT=3101\n');
+    vi.stubEnv('CM_PORT', '3000');
+
+    expect(loadEffectiveEnv().CM_PORT).toBe('3101');
+    expect(resolveServerEndpoint(loadEffectiveEnv()).url).toBe('http://127.0.0.1:3101');
+  });
+
+  it('should keep exported variables that .env does not define', () => {
+    writeFileSync(mainEnvPath, 'CM_PORT=3101\n');
+    vi.stubEnv('CM_BIND', '0.0.0.0');
+
+    expect(loadEffectiveEnv().CM_BIND).toBe('0.0.0.0');
+  });
+
+  it('should layer a worktree .env over the main one', () => {
+    writeFileSync(mainEnvPath, 'CM_PORT=3101\nCM_BIND=127.0.0.1\n');
+    const worktreeEnvPath = join(dir, '135.env');
+    writeFileSync(worktreeEnvPath, 'CM_PORT=3135\n');
+    vi.stubEnv('CM_PORT', '3000');
+
+    const env = loadEffectiveEnv(worktreeEnvPath);
+
+    expect(env.CM_PORT).toBe('3135');
+    // Keys the worktree .env omits still come from the main one
+    expect(env.CM_BIND).toBe('127.0.0.1');
+  });
+
+  it('should fall back to the main .env when the worktree .env is absent', () => {
+    writeFileSync(mainEnvPath, 'CM_PORT=3101\n');
+    vi.stubEnv('CM_PORT', '3000');
+
+    expect(loadEffectiveEnv(join(dir, 'missing.env')).CM_PORT).toBe('3101');
+  });
+
+  it('should not throw when no .env exists at all', () => {
+    vi.stubEnv('CM_PORT', '3000');
+
+    expect(loadEffectiveEnv().CM_PORT).toBe('3000');
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1266 の対応。`DaemonManager.getStatus()` が `process.env` を直読みしていたため、**shell が `CM_PORT` を export していると `.env` の値が dotenv に無視され、実際の起動ポートではなく shell のポートを URL として報告**していた。

親Issue: #1193

## ✅ Issue の前提は実測で正しかった

（#1193 群では珍しく）**起票時の記述がそのまま裏付けられた。**

| 前提 | 実測 |
|---|---|
| dotenv は既存の env var を上書きしない | ✅ 正しい（`parsed` には `.env` の値が入る） |
| この開発環境の shell は `CM_PORT=3000` を export している | ✅ 正しい（`CM_BIND` も） |
| `daemon.start()` は子へ `{...process.env, ...parsed}`（.env 優先）を渡す | ✅ 正しい |

**修正後の実機確認**（隔離した cwd で `.env`=3101 / shell=3000）:

```
Port: 3101
URL:  http://127.0.0.1:3101      ← 従来は 3000 を報告していた
```

## 修正: URL 解決の単一情報源を作った

`src/cli/utils/server-url.ts` を追加し、`resolveServerEndpoint()` / `loadEffectiveEnv()` に集約。

## 🔎 追加で判明した同クラスの不具合（本PRで修正）

### 1. `status` の IP ACL 表示が実態と食い違う

shell が `CM_ALLOWED_IPS` を export していると `.env` の値を隠し、**サーバが実際に適用していない ACL を表示**していた。

（`.env` のみに設定した場合は dotenv が注入するため従来も正しく表示されていた）

**セキュリティ設定の表示が実態と異なるのは、単なる表示バグより悪い。**

### 2. HTTPS 判定が server と daemon で食い違う

| 場所 | 判定 |
|---|---|
| `server.ts:160` | cert **と** key の**両方**が揃った時だけ HTTPS を提供 |
| `daemon.ts` | **cert だけ**で `https` と判定 |

→ `getStatus` と `start` の起動ログの**双方を「両方必須」に揃えた**。

## 統一（Issue のスコープ3）

#1195 の quickstart 回避策 `resolveServerUrl()` は `getStatus()` の修正で**不要になったため削除**し、`getStatus()` が返す URL に一本化した。

```
quickstart.ts の resolveServerUrl 残存: 0件
```

## テストの実効性を欠陥注入で確認（置換件数=1 を毎回確認）

| 注入 | 結果 |
|---|---|
| `getStatus` の `process.env` 直読みを復帰 | ✅ 5件 失敗 |
| `.env` 優先順位の反転 | ✅ 3件 失敗 |
| HTTPS cert 単独 | ✅ 各1件 失敗 |
| quickstart の URL 再導出 | ✅ 1件 失敗 |

## 🔴 #1269 の修正後もなお残っていた盲点を発見

**`status-issue.test.ts` は出力文字列のみを検証しており、コマンドが `exit 99` で落ちても green のままだった**（実測で確認）。

#1269 が「実装を import して呼ぶ」ところまでは直したが、**exit code は見ていなかった**。exit code を検証するテストを追加した。

## ⚠️ 利用者への影響

**shell の `CM_PORT` / `CM_BIND` / `CM_ALLOWED_IPS` と `.env` が食い違う構成のみ**、`commandmate status` / `start --daemon` の表示が変わる。

**現状が誤報だったためこれが正しい挙動。** 値が一致している構成・どちらか片方のみの構成は影響なし。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **567 files / 9,626 tests 全パス** |
| `npm run build` | ✅ exit 0 |

## 関連

- #1195: quickstart 側で回避策を入れた（本PRで削除・一本化）
- #1269: `DaemonManager` モックを `new` 可能にし、実装を検証する形にした（本PRの前提）
- #1267: 同じ env 優先順位のバグクラス（`env.ts` の silent fallback）

Refs #1193
Closes #1266
