### PR TITLE
fix(polling): Claude のフッターを抽出時点で落とし応答の重複保存を止める (#1289)

### DIFF
--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -6,6 +6,7 @@
 import type { CLIToolType } from '@/lib/cli-tools/types';
 import type { DetectPromptOptions } from './types';
 import { createLogger } from '@/lib/logger';
+import { stripAnsi } from './ansi';
 
 const logger = createLogger('cli-patterns');
 
@@ -77,6 +78,76 @@ export const CLAUDE_PROMPT_PATTERN = /^[>❯](\s*$|\s+\S)/m;
  * Claude separator pattern
  */
 export const CLAUDE_SEPARATOR_PATTERN = /^─{10,}$/m;
+
+/** How far above the last line the input box's closing separator may sit. */
+const CLAUDE_STATUS_BAR_MAX_ROWS = 4;
+
+/** How many rows the input box may span before the block stops looking like the footer. */
+const CLAUDE_INPUT_BOX_MAX_ROWS = 40;
+
+/**
+ * Locate the start of Claude Code's bottom-pinned footer within a captured pane.
+ *
+ * Claude Code v2 draws in the alternate screen and reserves the last rows of the
+ * pane for a footer that is never transcript content:
+ *
+ *     <hint row>            ← "◉ xhigh · /effort", "tmux detected · …", or blank
+ *     ────────────────────  ← separator
+ *     ❯ <input box>         ← one or more rows
+ *     ────────────────────  ← separator
+ *     ⏸ manual mode on · ? for shortcuts · ← for agents        focus
+ *
+ * The hint row rotates every few seconds while the conversation sits idle, so
+ * keeping the footer in an extracted response makes its content hash change on
+ * every poll tick. That defeated the content-based dedup added in #1268 and
+ * re-saved the same reply once per tick (#1289).
+ *
+ * The boundary is found structurally rather than by matching hint text: the hint
+ * strings are Claude Code's to change, and pattern-matching them is what let this
+ * regression through (`? for shortcuts` was already listed as a skip pattern, but
+ * the real status bar embeds it mid-line so the anchors never matched). The row
+ * above the opening separator is reserved by Claude Code's layout and stays blank
+ * even when a reply fills the whole pane, so it is always safe to drop.
+ *
+ * @param lines - Captured pane lines; trailing blank rows are tolerated
+ * @returns Index of the first footer row, or -1 when no footer is present
+ */
+export function findClaudeChromeStart(lines: string[]): number {
+  const isSeparator = (line: string): boolean => /^─{10,}$/.test(stripAnsi(line).trimEnd());
+
+  // Callers pass both trimmed panes and raw captures padded with blank rows.
+  let lastRow = lines.length - 1;
+  while (lastRow >= 0 && lines[lastRow].trim() === '') lastRow--;
+  if (lastRow < 0) return -1;
+
+  // The input box's closing separator sits just above the status bar.
+  let closingSeparator = -1;
+  for (let i = lastRow; i >= Math.max(0, lastRow - CLAUDE_STATUS_BAR_MAX_ROWS); i--) {
+    if (isSeparator(lines[i])) {
+      closingSeparator = i;
+      break;
+    }
+  }
+  if (closingSeparator < 0) return -1;
+
+  // Walk up over the input box to the opening separator.
+  let openingSeparator = -1;
+  for (let i = closingSeparator - 1; i >= Math.max(0, closingSeparator - CLAUDE_INPUT_BOX_MAX_ROWS); i--) {
+    if (isSeparator(lines[i])) {
+      openingSeparator = i;
+      break;
+    }
+  }
+  if (openingSeparator < 0) return -1;
+
+  // Confirm the rows between the separators really are the input box rather than
+  // a reply that happens to be fenced by two horizontal rules — truncating one of
+  // those would silently swallow the tail of a genuine response.
+  if (!/^[>❯]/.test(stripAnsi(lines[openingSeparator + 1] ?? ''))) return -1;
+
+  // Include the reserved hint row directly above the opening separator.
+  return Math.max(0, openingSeparator - 1);
+}
 
 /**
  * Claude trust dialog pattern (Issue #201)

--- a/src/lib/polling/response-checker.ts
+++ b/src/lib/polling/response-checker.ts
@@ -18,6 +18,7 @@ import { usesAlternateScreen, type CLIToolType } from '@/lib/cli-tools/types';
 import { parseClaudeOutput } from '@/lib/claude-output';
 import {
   getCliToolPatterns,
+  findClaudeChromeStart,
   stripAnsi,
   stripBoxDrawing,
   buildDetectPromptOptions,
@@ -156,6 +157,16 @@ export function extractResponse(
   const lines = rawLines.slice(0, trimmedLength);
   const totalLines = lines.length;
 
+  // Issue #1289: Claude Code pins a footer (rotating hint row, input box, status
+  // bar) to the bottom of the pane. It is chrome, not transcript, and its hint
+  // row rotates while the conversation is idle — so letting it reach the saved
+  // response both stores terminal furniture and re-hashes on every poll tick,
+  // defeating the content dedup from #1268. Completion detection below still
+  // reads the untouched buffer: it keys off that very footer (the input box
+  // supplies `hasPrompt`, its rules supply `hasSeparator`).
+  const chromeStart = cliToolId === 'claude' ? findClaudeChromeStart(lines) : -1;
+  const contentEnd = chromeStart >= 0 ? chromeStart : totalLines;
+
   const BUFFER_RESET_TOLERANCE = 25;
   const bufferShrank = totalLines > 0 && lastCapturedLine > BUFFER_RESET_TOLERANCE && (totalLines + BUFFER_RESET_TOLERANCE) < lastCapturedLine;
   const sessionRestarted = totalLines > 0 && lastCapturedLine > 50 && totalLines < 50;
@@ -197,7 +208,11 @@ export function extractResponse(
       userPromptPattern = /^[>❯]\s+\S/;
     }
 
-    for (let i = totalLines - 1; i >= Math.max(0, totalLines - windowSize); i--) {
+    // Issue #1289: for Claude the search stops above the footer. The text the
+    // user just typed sits in the footer's input box and matches the same "❯ …"
+    // shape as the transcript echo; anchoring on it would treat the footer as
+    // the newest turn and extract the status bar as its reply.
+    for (let i = contentEnd - 1; i >= Math.max(0, contentEnd - windowSize); i--) {
       const cleanLine = stripAnsi(lines[i]);
       if (userPromptPattern.test(cleanLine)) {
         return i;
@@ -241,7 +256,9 @@ export function extractResponse(
 
     let endIndex = totalLines;
 
-    for (let i = startIndex; i < totalLines; i++) {
+    // `contentEnd` bounds the content only; `endIndex` keeps reporting the full
+    // buffer so lineCount bookkeeping in session_states is unchanged (#1289).
+    for (let i = startIndex; i < contentEnd; i++) {
       const line = lines[i];
       const cleanLine = stripAnsi(line);
 
@@ -376,7 +393,8 @@ export function extractResponse(
     ? (recentPromptIndex >= 0 ? recentPromptIndex + 1 : Math.max(0, endIndex - 80))
     : Math.max(0, lastCapturedLine);
 
-  for (let i = startIndex; i < endIndex; i++) {
+  // Partial (still-streaming) content is bounded by the footer too (#1289).
+  for (let i = startIndex; i < Math.min(endIndex, contentEnd); i++) {
     const line = lines[i];
     const cleanLine = stripAnsi(line);
 

--- a/src/lib/response-cleaner.ts
+++ b/src/lib/response-cleaner.ts
@@ -8,6 +8,7 @@
 
 import {
   stripAnsi,
+  findClaudeChromeStart,
   PASTED_TEXT_PATTERN,
   OPENCODE_SKIP_PATTERNS,
   OPENCODE_RESPONSE_COMPLETE,
@@ -32,7 +33,14 @@ export function cleanClaudeResponse(response: string): string {
 
   // Find the LAST user prompt (> followed by content) and extract only the response after it
   // This ensures we only get the latest response, not the entire conversation history
-  const lines = cleanedResponse.split('\n');
+  const allLines = cleanedResponse.split('\n');
+
+  // Issue #1289: drop Claude Code's bottom-pinned footer before anything else.
+  // Its rotating hint row would otherwise change the saved content — and so its
+  // hash — on every poll tick, and the text sitting in its input box matches the
+  // same "❯ …" shape as the transcript echo searched for below.
+  const chromeStart = findClaudeChromeStart(allLines);
+  const lines = chromeStart >= 0 ? allLines.slice(0, chromeStart) : allLines;
 
   // Find the last user prompt line index
   let lastUserPromptIndex = -1;

--- a/tests/unit/lib/polling/response-checker-alternate-screen.test.ts
+++ b/tests/unit/lib/polling/response-checker-alternate-screen.test.ts
@@ -54,6 +54,7 @@ vi.mock('@/lib/realtime/terminal-broadcast', () => ({ broadcastTerminalSnapshot:
 
 import { checkForResponse } from '@/lib/polling/response-checker';
 import { stopPolling } from '@/lib/polling/response-poller-core';
+import { findClaudeChromeStart } from '@/lib/detection/cli-patterns';
 
 // ---------------------------------------------------------------------------
 // Fixture: a faithful Claude alternate-screen pane.
@@ -61,18 +62,40 @@ import { stopPolling } from '@/lib/polling/response-poller-core';
 
 const SEPARATOR = '─'.repeat(40);
 
+const STATUS_BAR = '  ⏸ manual mode on · ? for shortcuts · ← for agents                       focus';
+
+/**
+ * The hint row Claude Code reserves directly above its input box, transcribed
+ * from a live session. It rotates every few seconds while the conversation sits
+ * idle and is blank much of the time — the rotation is what broke #1268's
+ * content dedup (Issue #1289).
+ */
+const HINT_ROWS = [
+  '                                                              ◉ xhigh · /effort',
+  "  tmux detected · scroll with PgUp/PgDn · or add 'set -g mouse on' to ~/.tmux.conf for wheel scroll",
+  "  tmux focus-events off · add 'set -g focus-events on' to ~/.tmux.conf and reattach for focus tracking",
+  '',
+];
+
 /**
  * Build a Claude alternate-screen capture of exactly `paneHeight` lines.
  *
  * Mirrors the real structure observed via `tmux capture-pane` on a live Claude
  * session: the echoed user turn and the reply at the top, blank filler, then the
- * input box and status bar pinned to the bottom row. The last line is non-blank,
- * so extractResponse()'s trailing-blank trim leaves totalLines === paneHeight —
- * the saturation that this issue is about.
+ * footer pinned to the bottom rows — hint row, separator, input box, separator,
+ * status bar. The last line is non-blank, so extractResponse()'s trailing-blank
+ * trim leaves totalLines === paneHeight — the saturation #1268 is about.
+ *
+ * `hint` and `inputBox` are the parts that actually move on a live pane, so they
+ * are parameterised rather than frozen: a fixture that pins them to one value is
+ * what let #1289 through.
  */
-function claudePane(response: string, paneHeight = 1000): string {
+function claudePane(
+  response: string,
+  { hint = '', inputBox = '❯ ', paneHeight = 1000 }: { hint?: string; inputBox?: string; paneHeight?: number } = {},
+): string {
   const head = [`❯ summarize the project`, ...response.split('\n')];
-  const tail = [SEPARATOR, '❯ ', SEPARATOR, '  ⏸ manual mode on · ← for agents'];
+  const tail = [hint, SEPARATOR, inputBox, SEPARATOR, STATUS_BAR];
   const filler = new Array(Math.max(0, paneHeight - head.length - tail.length)).fill('');
   return [...head, ...filler, ...tail].join('\n');
 }
@@ -155,6 +178,134 @@ describe('Issue #1268: alternate-screen line-count saturation', () => {
 
     expect(saved).toBe(true);
     expect(savedAssistantContents().join('\n')).toContain('Codex reply body');
+  });
+});
+
+describe('Issue #1289: rotating footer must not defeat content dedup', () => {
+  it('sanity: the rotating hint really does change the captured pane', () => {
+    // Guards the premise this whole describe rests on. #1268's fixture pinned the
+    // footer to one static value, so its dedup tests passed while the live poller
+    // re-saved the same reply every tick. If these panes were identical the
+    // rotation tests below would pass vacuously.
+    const panes = HINT_ROWS.map(hint => claudePane(RESPONSE, { hint }));
+    expect(new Set(panes).size).toBe(HINT_ROWS.length);
+  });
+
+  it('saves one message when the response is static but the hint row rotates', async () => {
+    // The exact production sequence: the reply is finished and the transcript is
+    // frozen, but Claude keeps cycling the hint row above its input box. Pre-fix
+    // the hint reached the saved content, so the SHA-256 changed on every tick and
+    // isDuplicateResponse() never fired — one message saved per poll.
+    getSessionState.mockReturnValue({ lastCapturedLine: 1000, inProgressMessageId: null });
+    for (const hint of HINT_ROWS) {
+      captureSessionOutput.mockResolvedValueOnce(claudePane(RESPONSE, { hint }));
+    }
+
+    const results: boolean[] = [];
+    for (let i = 0; i < HINT_ROWS.length; i++) {
+      results.push(await checkForResponse('wt-1', 'claude'));
+    }
+
+    expect(results).toEqual([true, false, false, false]);
+    expect(savedAssistantContents()).toHaveLength(1);
+  });
+
+  it('keeps terminal chrome out of the saved response', async () => {
+    // The hint row and status bar are not the assistant talking, so they must not
+    // be stored at all — normalising the hash alone would still persist them.
+    getSessionState.mockReturnValue({ lastCapturedLine: 1000, inProgressMessageId: null });
+    captureSessionOutput.mockResolvedValue(
+      claudePane(RESPONSE, { hint: HINT_ROWS[0] }),
+    );
+
+    expect(await checkForResponse('wt-1', 'claude')).toBe(true);
+
+    const [saved] = savedAssistantContents();
+    expect(saved).toContain('CommandMate is a Git worktree management tool.');
+    expect(saved).not.toContain('manual mode on');
+    expect(saved).not.toContain('for shortcuts');
+    expect(saved).not.toContain('for agents');
+    expect(saved).not.toContain('◉ xhigh');
+    expect(saved).not.toContain('/effort');
+    expect(saved).not.toMatch(/─{10,}/);
+  });
+
+  it('does not save the startup screen as a reply while the message is still in the input box', async () => {
+    // Between send() and Claude echoing the turn, the typed text sits in the
+    // footer's input box and the transcript holds only the startup banner. That
+    // "❯ …" in the input box has the same shape as a transcript echo, so pre-fix
+    // it anchored extraction onto the footer and stored the status bar as a reply.
+    getSessionState.mockReturnValue({ lastCapturedLine: 0, inProgressMessageId: null });
+    const banner = [
+      '',
+      ' ▐▛███▜▌   Claude Code v2.1.211',
+      '▝▜█████▛▘  Opus 4.8 (1M context) with xhigh effort · Claude Max',
+      '  ▘▘ ▝▝    ~/share/work/github_kewton/CommandMate',
+      '',
+      ' ⚠ Your login expires in 5 days · run /login to renew',
+    ];
+    const tail = ['', SEPARATOR, '❯ summarize the project', SEPARATOR, STATUS_BAR];
+    const filler = new Array(1000 - banner.length - tail.length).fill('');
+    captureSessionOutput.mockResolvedValue([...banner, ...filler, ...tail].join('\n'));
+
+    expect(await checkForResponse('wt-1', 'claude')).toBe(false);
+    expect(savedAssistantContents()).toEqual([]);
+  });
+
+  it('still saves a long reply whose echoed turn has scrolled off the pane', async () => {
+    // Guards the fix's blast radius. A reply long enough to fill the pane pushes
+    // the "❯ summarize the project" echo off the top, leaving no anchor at all —
+    // so "no echo ⇒ no response" would silently drop exactly the long replies and
+    // reproduce #1268. Verified against a live 1200-line reply.
+    getSessionState.mockReturnValue({ lastCapturedLine: 1000, inProgressMessageId: null });
+    const body = Array.from({ length: 990 }, (_, i) => `  ${i + 1}`);
+    const tail = ['', SEPARATOR, '❯ ', SEPARATOR, STATUS_BAR];
+    captureSessionOutput.mockResolvedValue([...body, ...tail].join('\n'));
+
+    expect(await checkForResponse('wt-1', 'claude')).toBe(true);
+
+    const [saved] = savedAssistantContents();
+    expect(saved).toContain('990');
+    expect(saved).not.toContain('manual mode on');
+  });
+});
+
+describe('Issue #1289: findClaudeChromeStart', () => {
+  it('cuts from the reserved hint row through the status bar', () => {
+    const lines = ['⏺ reply', '', HINT_ROWS[0], SEPARATOR, '❯ ', SEPARATOR, STATUS_BAR];
+    expect(findClaudeChromeStart(lines)).toBe(2);
+  });
+
+  it('cuts the same rows when the hint row is blank', () => {
+    const lines = ['⏺ reply', '', '', SEPARATOR, '❯ ', SEPARATOR, STATUS_BAR];
+    expect(findClaudeChromeStart(lines)).toBe(2);
+  });
+
+  it('handles a multi-row input box', () => {
+    const lines = ['⏺ reply', '', SEPARATOR, '❯ line one', '  line two', SEPARATOR, STATUS_BAR];
+    expect(findClaudeChromeStart(lines)).toBe(1);
+  });
+
+  it('reports no footer for a pane that has none', () => {
+    expect(findClaudeChromeStart(['⏺ reply', 'more text'])).toBe(-1);
+  });
+
+  it('does not mistake a lone separator inside the transcript for a footer', () => {
+    // A reply containing a horizontal rule must not be truncated at it.
+    expect(findClaudeChromeStart(['⏺ reply', SEPARATOR, 'text after the rule'])).toBe(-1);
+  });
+
+  it('does not mistake reply text fenced by two rules for the input box', () => {
+    // The footer is separator/❯ input/separator/status bar. A reply that fences
+    // its own content in horizontal rules has the same separator spacing, so the
+    // "❯" check is what keeps its tail from being swallowed.
+    const lines = ['⏺ reply', SEPARATOR, 'fenced reply body', SEPARATOR, '❯ next message'];
+    expect(findClaudeChromeStart(lines)).toBe(-1);
+  });
+
+  it('tolerates trailing blank rows below the status bar', () => {
+    const lines = ['⏺ reply', '', SEPARATOR, '❯ ', SEPARATOR, STATUS_BAR, '', ''];
+    expect(findClaudeChromeStart(lines)).toBe(1);
   });
 });
 


### PR DESCRIPTION
## 概要

Issue #1289 の対応。**#1268 / PR #1281 の回帰**を修正する。同じ応答が毎ポーリング（約6秒ごと）重複保存されていた。

**#1268 は数時間前に私がマージしたもので、実環境を構築して初めて発覚した。**

## 根本原因: Claude Code のフッターがローテーションする

#1268 は「ターン終了後は毎回同一内容が抽出される」前提で SHA-256 の**全文一致**による内容重複判定を入れたが、**この前提が実環境で成立しない。**

Claude Code はペイン下端に固定フッターを描画し、**その最上段のヒント行が数秒ごとに入れ替わる**:

```
<ヒント行>            ← "◉ xhigh · /effort" / "tmux detected · …" / 空行
────────────────────  ← セパレータ
❯ <入力ボックス>
────────────────────  ← セパレータ
⏸ manual mode on · ? for shortcuts · ← for agents        focus
```

このフッターが**応答本文に混入したまま**なので、会話が静止していてもハッシュが毎ポーリング変わり `isDuplicateResponse()` が発火しない。

## 実測（1000x200 の実 tmux ペイン + 実 claude セッションで再現）

1通送信し、**実際の capture を6秒間隔で採取して実コードに流した**結果（修正前）:

```
cap-01 len=197 sha=2160aa0e…  ← ステータスバーのみ
cap-02 len=638 sha=930035f7…  ← 応答 + "tmux detected · …"
cap-03 len=638 sha=8c75e230…  ← 同じ応答 + "tmux focus-events off · …"
cap-04 len=438 sha=1b4782c7…  ← 同じ応答 + ヒント無し
cap-05〜14 は cap-04 と同一ハッシュ（ここで初めて dedup が効く）
```

**1通の送信に対し assistant メッセージが4件。**

## 対処: ヒント文字列の正規表現ではなく「構造」で落とす

`findClaudeChromeStart()` でフッターを**構造**（セパレータ / `❯` 入力ボックス / セパレータ / ステータスバー）で特定し、抽出時点で落とす。

**なぜ正規表現マッチを採らないか**: `? for shortcuts` は**既に skip パターンに載っていた**。しかし実際のステータスバーは行の**途中**にそれを埋め込むためアンカーが一致せず、**本回帰を通してしまった**。ヒント文言は Claude Code 側の都合で変わるので、同じ穴を再び開けることになる。

セパレータ直後が `❯` であることを確認しており、**水平線で囲まれた応答本文をフッターと誤認して末尾を切り落とすことはない**。

## ⚠️ Issue の前提を訂正

- Issue の「フッター行を落とす」は実測でも支持された。ただし**ヒント行の除去だけでは不十分**で、**入力ボックスの `❯ <入力文>` を会話エコーと誤認する**経路も潰す必要があった。送信直後（Claude がまだエコーしていない時点）はこれが原因で**ステータスバーだけが「応答」として保存**されていた（上表 cap-01, len=197）
- Issue の受入基準「1通 → assistant 1件」は**未達で 2件**。残る1件は #1268 で対象外と明記された「**起動バナーが assistant message として保存される**」で、ポーラーではなく送信時の `savePendingAssistantResponse`（#53/#54）が保存している。同じ層なので一度は直そうとしたが、`extractAssistantResponseBeforeLastPrompt` は「最後の `❯ <文>` の**手前**」を取る契約で、フッターを削ると入力ボックスではなく**前ターンのエコーが「最後」になり応答本文が丸ごと落ちる**（既存テストが落ちて判明）。alternate screen 上での #53/#54 の意味論を再設計する話になるため本Issueでは踏み込まず、**出血箇所（毎ポーリングの重複保存）のみを止めた**

## テスト: 静的モックでは本Issueを捕捉できない

**#1268 のユニットテストが green のまま通ってしまった理由がこれ。** #1268 のフィクスチャを実ペインに合わせて修正し（予約ヒント行と実際のステータスバー文言を追加）、**ヒント行がローテーションする経路**を追加した。

**欠陥注入**（`findClaudeChromeStart` を -1 固定）で修正前挙動を再現し:
- **新規7件が落ちる** ✅
- **#1268 の既存15件は落ちない** ← **静的フィクスチャでは本件を捕捉できないことの証明**

```
expected [ true, true, true, true ] to deeply equal [ true, false, false, false ]
```

長文応答で**エコーがペイン外へスクロールする経路**（実 1200 行応答で確認）もテストで固定した。「エコーが無ければ応答なし」としていたら **#1268 を再発させていた**ため。

## 🔬 実環境での検証（オーケストレーターが独立に再現）

隔離インスタンス（:3289 / 隔離 DB。**本番 :3000・本番 DB は不可触**）で、**修正前と全く同じ文面**を1通送信:

| | 修正前 | **修正後** |
|---|---|---|
| assistant メッセージ数 | **5**（バナー1 + 同一応答**4**） | ✅ **2**（バナー1 + 応答**1**） |
| 応答の len | 638（フッター混入） | ✅ **220**（クリーン） |
| 応答本体へのフッター混入 | あり | ✅ **0行** |

保存された応答本体:
```
⏺ CommandMate is a Git worktree management tool that integrates Claude CLI and tmux
  sessions, giving you a web UI plus a CLI to run and orchestrate multiple AI coding
  agents in parallel across branches.
✻ Worked for 2s
```

2ターン目も1件のみ保存され、**#1268 が直した「応答が History に届く」は退行なし**。

codex 経路は `cliToolId === 'claude'` ゲートにより `contentEnd === totalLines` で**不変**。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **568 files / 9,644 tests 全パス** |
| `npm run build` / `build:server` | ✅ exit 0 |

## 📌 残る課題（別Issueを起票）

**起動バナーが assistant message として保存される**（#53/#54 由来）。実環境で確認した内容には**個人情報が含まれる**:

```
▝▜█████▛▘  Opus 4.8 (1M context) with xhigh effort · Claude Max
  ▘▘ ▝▝    ~/cm-shots/CommandMate
 ⚠ 3 MCP servers need authentication · run /mcp
 ⚠ Your login expires in 5 days · run /login to renew
                                              ◉ xhigh · /effort
```

Closes #1289
