### PR TITLE
chore(deps): package-lock.json の engines を package.json に同期する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/tests/unit/cli/config/engines.test.ts
+++ b/tests/unit/cli/config/engines.test.ts
@@ -34,4 +34,17 @@ describe('package.json engines', () => {
     expect(preflightMin).toBeDefined();
     expect(packageJson.engines?.node).toBe(`>=${preflightMin}`);
   });
+
+  // npm mirrors engines into the lockfile's root package entry, so whoever runs
+  // `npm install` next silently rewrites the lockfile and dirties an unrelated
+  // branch. #1264 raised engines while #1271 had already baked the old value
+  // into the lock, and the two merged in that order — nothing failed, it just
+  // drifted. `npm ci` does not check this, so only a test will.
+  it('should match the engines recorded in package-lock.json', () => {
+    const lock: { packages?: Record<string, PackageJson> } = JSON.parse(
+      readFileSync(join(__dirname, '../../../../package-lock.json'), 'utf-8')
+    ) as { packages?: Record<string, PackageJson> };
+
+    expect(lock.packages?.['']?.engines?.node).toBe(packageJson.engines?.node);
+  });
 });


### PR DESCRIPTION
## 概要

`package-lock.json` の `engines` が `package.json` と食い違っているのを同期し、再発を防ぐガードを追加する。

```
package.json      engines.node = >=22.0.0
package-lock.json engines.node = >=20.0.0   ← ドリフト
```

## なぜ起きたか（#1264 と #1271 の相互作用）

npm は `engines` を**ロックファイルのルートエントリにも書き写す**。

1. **#1271** のワーカーが `@types/eslint` 追加のため `npm install` を実行 → その時点の `package.json`（`>=20.0.0`）が lock に焼き込まれた
2. **#1264** が `package.json` を `>=22.0.0` へ変更（**lock は触っていない**）
3. この順でマージ → **lock だけ古い値のまま**

**どちらの CI も 9/9 通過している。** `npm ci` は `engines` を検証しないため、**何も落ちずにドリフトだけが残った。**

## 実害

**`npm install` を叩いた人が、無関係なブランチでロックファイルを書き換えてしまう。**

実際に #1272 / #1289 の作業中、毎回 `package-lock.json` が `M` になり、都度 `git checkout` で戻す必要があった。コミットに混入すれば、レビュアーには「なぜこの PR が lock を触るのか」が分からない。

## 変更内容

- `package-lock.json`: `engines.node` を `>=22.0.0` へ同期（**差分は1行のみ**）
- `tests/unit/cli/config/engines.test.ts`: 両者の一致を強制するガードを追加

`npm install --package-lock-only` で生成しており、**依存の解決は不変**。

## 検証

| 項目 | 結果 |
|---|---|
| 差分 | ✅ **engines の1行のみ**（`1 file changed, 1 insertion(+), 1 deletion(-)`） |
| `npm ci` の整合性 | ✅ **exit 0**（`added 1078 packages in 6s`・クリーンな一時ディレクトリで検証） |

### ガードの実効性を欠陥注入で確認

| 手順 | 結果 |
|---|---|
| 同期後 | ✅ 4/4 パス |
| lock を `>=20.0.0` に戻す（＝**develop の現状**）／**置換1件を確認** | ✅ `AssertionError: expected '>=20.0.0' to be '>=22.0.0'` で失敗 |
| 復元 | ✅ 4/4 パス |

## 品質チェック

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **568 files / 9,634 tests 全パス** |
| `npm run build` | ✅ exit 0 |

## ガードの置き場所について

`engines.test.ts` には **#1264 が追加した「engines と CLI preflight の一致」ガード**が既にある。同じ「engines が複数箇所に宣言されている」問題なので、そこへ揃えた。

Refs #1264, #1271
