### PR TITLE
fix(security): isSystemDirectory をパス境界＋symlink 解決で判定する (#1285)

### DIFF
--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -21,7 +21,7 @@
 | `src/lib/db/db-migration-path.ts` | DBマイグレーション（migrateDbIfNeeded()、getLegacyDbPaths()） |
 | `src/lib/db/db-instance.ts` | DBインスタンス管理（getEnv().CM_DB_PATH使用、DB接続は openDatabaseWithAbiRecovery() 経由） |
 | `src/lib/db/abi-recovery.ts` | better-sqlite3 ABI mismatch 検知と自動 rebuild（Issue #1263: isAbiMismatchError()＝code `ERR_DLOPEN_FAILED` かつ message に `NODE_MODULE_VERSION` を含む二条件、rebuildBetterSqlite3()＝`npm rebuild better-sqlite3` を process.execPath を PATH 先頭に固定して実行、openDatabaseWithAbiRecovery()＝正常時ゼロオーバーヘッド・rebuild はプロセス毎1回・失敗時は sudo を促さない手順を提示） |
-| `src/config/system-directories.ts` | システムディレクトリ定数（SYSTEM_DIRECTORIES、isSystemDirectory()） |
+| `src/config/system-directories.ts` | システムディレクトリ定数（SYSTEM_DIRECTORIES、isSystemDirectory()、isPathWithin()）。Issue #1285: isSystemDirectory() は候補パスと SYSTEM_DIRECTORIES の**両方**を realpath 解決して境界一致で判定する（macOS の `/tmp`→`/private/tmp` 対策）。片側だけ解決すると素通しするため解決は呼び出し元でなく本関数に集約（I/O を伴う非純粋関数）。未作成パスは最近傍の実在祖先まで遡って解決 |
 | `src/config/status-colors.ts` | ステータス色の一元管理 |
 | `src/app/globals.css` | セマンティックデザイントークン（CSS変数）の定義・登録（Issue #1041）。Issue #1178 の Tailwind 4 CSS-first 移行で `tailwind.config.js` を廃止し `@theme inline` へ統合。詳細は [docs/design-system.md](./design-system.md) を参照 |
 | `src/lib/view-transitions/index.ts` | View Transitions APIガード（Issue #1122: supportsViewTransitions/prefersReducedMotion/startViewTransition。非対応・reduced-motion時は即時実行フォールバック、依存追加なしの薄いラッパでNext15/React19ネイティブへ移行容易）。ページ遷移クロスフェード基盤 |

--- a/src/config/system-directories.ts
+++ b/src/config/system-directories.ts
@@ -1,12 +1,16 @@
 /**
  * System Directories Configuration
  * Issue #135: DB path resolution logic fix
+ * Issue #1285: Path boundary matching and symlink resolution
  *
  * Centralized list of system directories that are not allowed for DB storage.
  * This supports security measures SEC-001, SEC-002, SEC-005.
  *
  * @module system-directories
  */
+
+import fs from 'fs';
+import path from 'path';
 
 /**
  * System directories that are not allowed for DB storage
@@ -28,11 +32,119 @@ export const SYSTEM_DIRECTORIES = [
 ] as const;
 
 /**
+ * POSIX separator. SYSTEM_DIRECTORIES are POSIX absolute paths and this guard
+ * protects POSIX platforms, so the boundary is always '/' rather than path.sep.
+ */
+const POSIX_SEP = '/';
+
+/**
+ * Check whether `target` is `dir` itself or lives underneath it.
+ *
+ * Issue #1285: A bare startsWith() has no path boundary, so '/tmp' matched
+ * '/tmpfoo' and '/var' matched '/variance'. Requiring an exact match or a
+ * separator after the prefix keeps unrelated siblings out of the match.
+ *
+ * @param target - Absolute path to test
+ * @param dir - Absolute directory path to test against
+ * @returns true if target is dir or is contained in dir
+ */
+export function isPathWithin(target: string, dir: string): boolean {
+  const normalizedDir = dir.endsWith(POSIX_SEP) ? dir.slice(0, -1) : dir;
+  return target === normalizedDir || target.startsWith(normalizedDir + POSIX_SEP);
+}
+
+/**
+ * SYSTEM_DIRECTORIES plus their physical locations.
+ *
+ * Issue #1285: On macOS '/tmp', '/var' and '/etc' are symlinks into '/private'.
+ * A resolved path such as '/private/tmp/x.db' therefore never matches the
+ * literal '/tmp' entry. Both sides of the comparison must be resolved, so the
+ * literal and physical forms are both kept as match candidates.
+ *
+ * Mount layout does not change while the process runs, so this is computed once.
+ */
+let resolvedSystemDirectoriesCache: string[] | null = null;
+
+function getSystemDirectoryCandidates(): string[] {
+  if (resolvedSystemDirectoriesCache !== null) {
+    return resolvedSystemDirectoriesCache;
+  }
+
+  const candidates = new Set<string>();
+  for (const dir of SYSTEM_DIRECTORIES) {
+    // Always keep the literal form: it must stay enforced even when the
+    // directory does not exist on this platform (e.g. /proc and /sys on macOS).
+    candidates.add(dir);
+    try {
+      candidates.add(fs.realpathSync(dir));
+    } catch {
+      // Not present on this platform; the literal form still applies.
+    }
+  }
+
+  resolvedSystemDirectoriesCache = Array.from(candidates);
+  return resolvedSystemDirectoriesCache;
+}
+
+/**
+ * Resolve symlinks in an absolute path, tolerating components that do not exist.
+ *
+ * Issue #1285: fs.realpathSync() throws on a missing path, but a DB file is
+ * validated *before* it is created, so "does not exist" is the normal case.
+ * The nearest existing ancestor is resolved and the remaining (not yet created)
+ * components are re-appended, which yields the physical location the path would
+ * occupy. Because the input is already lexically resolved it contains no '..',
+ * so the re-appended tail cannot escape the resolved ancestor.
+ *
+ * @param absolutePath - A lexically resolved absolute path
+ * @returns The physical path, or the input unchanged if nothing could be resolved
+ */
+function resolvePhysicalPath(absolutePath: string): string {
+  const pendingComponents: string[] = [];
+  let current = absolutePath;
+
+  for (;;) {
+    try {
+      const real = fs.realpathSync(current);
+      return pendingComponents.length > 0
+        ? path.join(real, ...pendingComponents)
+        : real;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        // Reached the root without resolving anything.
+        return absolutePath;
+      }
+      pendingComponents.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
  * Check if a path is within a system directory
  *
- * @param resolvedPath - The resolved absolute path to check
+ * Issue #1285: Resolution happens here rather than at each call site. The check
+ * is only correct when the candidate path *and* the system directory list are
+ * resolved consistently; resolving at a call site and comparing against the
+ * unresolved literals silently defeats the guard (that is what made the SEC-002
+ * call site in db-migration-path.ts miss '/tmp'). Centralizing keeps every
+ * caller correct by construction.
+ *
+ * The literal and physical forms are both matched, so a path is rejected if
+ * either form lands in a system directory. This fails closed: a symlink placed
+ * inside a system directory that points elsewhere is still rejected.
+ *
+ * This performs filesystem I/O and is therefore not a pure function.
+ *
+ * @param inputPath - The absolute path to check (relative paths are resolved against cwd)
  * @returns true if the path is within a system directory
  */
-export function isSystemDirectory(resolvedPath: string): boolean {
-  return SYSTEM_DIRECTORIES.some((dir) => resolvedPath.startsWith(dir));
+export function isSystemDirectory(inputPath: string): boolean {
+  const lexicalPath = path.resolve(inputPath);
+  const physicalPath = resolvePhysicalPath(lexicalPath);
+
+  return getSystemDirectoryCandidates().some(
+    (dir) => isPathWithin(lexicalPath, dir) || isPathWithin(physicalPath, dir)
+  );
 }

--- a/src/lib/db/db-path-resolver.ts
+++ b/src/lib/db/db-path-resolver.ts
@@ -12,7 +12,7 @@
 import path from 'path';
 import { homedir } from 'os';
 import { isGlobalInstall, getConfigDir } from '@/cli/utils/install-context';
-import { isSystemDirectory } from '@/config/system-directories';
+import { isPathWithin, isSystemDirectory } from '@/config/system-directories';
 
 /**
  * Get the default database path based on install type
@@ -81,8 +81,11 @@ export function validateDbPath(dbPath: string): string {
 
   if (isGlobalInstall()) {
     // Global install: DB path must be within home directory
+    // Issue #1285: startsWith() had no path boundary, so a sibling directory
+    // sharing the home prefix (e.g. /Users/alice-backup for /Users/alice) was
+    // accepted as "within home".
     const homeDir = homedir();
-    if (!resolvedPath.startsWith(homeDir)) {
+    if (!isPathWithin(resolvedPath, homeDir)) {
       throw new Error(
         `Security error: DB path must be within home directory: ${resolvedPath}`
       );

--- a/src/lib/db/db-repository.ts
+++ b/src/lib/db/db-repository.ts
@@ -389,7 +389,11 @@ export const MAX_DISABLED_REPOSITORIES = 1000;
  * All path normalization is centralized here to prevent inconsistencies.
  *
  * NOTE: path.resolve() removes trailing slashes and resolves relative paths
- * but does NOT resolve symlinks. For symlink resolution, use fs.realpathSync().
+ * but does NOT resolve symlinks, so the returned value is the lexical path the
+ * caller asked for. This is deliberate: the stored repository path stays the
+ * one the user supplied. Issue #1285: the system-directory guard no longer
+ * relies on this value being physical — isSystemDirectory() resolves symlinks
+ * itself, so a lexical path here is safe to hand it.
  * See design policy Section 7 for the symlink handling policy.
  *
  * SF-001: DRY - centralized path normalization

--- a/tests/unit/config/system-directories.test.ts
+++ b/tests/unit/config/system-directories.test.ts
@@ -1,13 +1,17 @@
 /**
  * System Directories Configuration Tests
  * Issue #135: DB path resolution logic fix
+ * Issue #1285: Path boundary matching and symlink resolution
  * Tests for system-directories.ts
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import {
   SYSTEM_DIRECTORIES,
   isSystemDirectory,
+  isPathWithin,
 } from '../../../src/config/system-directories';
 
 describe('system-directories', () => {
@@ -28,6 +32,30 @@ describe('system-directories', () => {
     });
   });
 
+  describe('isPathWithin', () => {
+    it('should match the directory itself', () => {
+      expect(isPathWithin('/etc', '/etc')).toBe(true);
+    });
+
+    it('should match paths under the directory', () => {
+      expect(isPathWithin('/etc/nginx/nginx.conf', '/etc')).toBe(true);
+    });
+
+    it('should not match a sibling that merely shares the prefix', () => {
+      expect(isPathWithin('/etcetera', '/etc')).toBe(false);
+      expect(isPathWithin('/etcetera/x.db', '/etc')).toBe(false);
+    });
+
+    it('should tolerate a trailing separator on the directory', () => {
+      expect(isPathWithin('/etc/nginx', '/etc/')).toBe(true);
+      expect(isPathWithin('/etcetera', '/etc/')).toBe(false);
+    });
+
+    it('should not match a parent of the directory', () => {
+      expect(isPathWithin('/etc', '/etc/nginx')).toBe(false);
+    });
+  });
+
   describe('isSystemDirectory', () => {
     describe('should return true for system directories', () => {
       const systemPaths = [
@@ -45,9 +73,9 @@ describe('system-directories', () => {
         '/proc/self/status',
       ];
 
-      for (const path of systemPaths) {
-        it(`should return true for ${path}`, () => {
-          expect(isSystemDirectory(path)).toBe(true);
+      for (const systemPath of systemPaths) {
+        it(`should return true for ${systemPath}`, () => {
+          expect(isSystemDirectory(systemPath)).toBe(true);
         });
       }
     });
@@ -62,9 +90,9 @@ describe('system-directories', () => {
         '/srv/www/data',
       ];
 
-      for (const path of safePaths) {
-        it(`should return false for ${path}`, () => {
-          expect(isSystemDirectory(path)).toBe(false);
+      for (const safePath of safePaths) {
+        it(`should return false for ${safePath}`, () => {
+          expect(isSystemDirectory(safePath)).toBe(false);
         });
       }
     });
@@ -83,10 +111,124 @@ describe('system-directories', () => {
         expect(isSystemDirectory('/usr/local')).toBe(true);
         expect(isSystemDirectory('/var/log')).toBe(true);
       });
+    });
 
-      // Note: Current implementation uses startsWith which may match
-      // paths like /etcetc. This is acceptable for security purposes
-      // as it's more restrictive rather than less restrictive.
+    /**
+     * Issue #1285: startsWith() had no path boundary, so every one of these
+     * unrelated top-level directories was rejected as a system directory.
+     */
+    describe('path boundary (Issue #1285)', () => {
+      const lookalikePaths = [
+        '/tmpfoo/x.db',
+        '/variance/x.db',
+        '/etcetera/x.db',
+        '/binary/x.db',
+        '/usrlocal/x.db',
+        '/sbinary/x.db',
+        '/devices/x.db',
+        '/systems/x.db',
+        '/procession/x.db',
+        '/username/x.db',
+      ];
+
+      for (const lookalikePath of lookalikePaths) {
+        it(`should return false for ${lookalikePath}`, () => {
+          expect(isSystemDirectory(lookalikePath)).toBe(false);
+        });
+      }
+    });
+
+    /**
+     * Issue #1285: The guard compares the candidate path against the system
+     * directory list. Both sides must be symlink-resolved, otherwise a path
+     * that reaches a system directory through a symlink slips past.
+     */
+    describe('symlink resolution (Issue #1285)', () => {
+      let workDir: string;
+
+      beforeAll(() => {
+        // The temp dir must NOT itself be inside a system directory, otherwise
+        // the assertions below would pass lexically and prove nothing.
+        // os.tmpdir() is /var/folders/... on macOS, so use the repo cwd.
+        workDir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-sysdir-test-'));
+      });
+
+      afterAll(() => {
+        fs.rmSync(workDir, { recursive: true, force: true });
+      });
+
+      it('the work dir itself is not a system directory (test precondition)', () => {
+        expect(isSystemDirectory(workDir)).toBe(false);
+      });
+
+      it('should reject a path reaching a system directory through a symlink', () => {
+        const link = path.join(workDir, 'etc-link');
+        fs.symlinkSync('/etc', link);
+
+        // Lexically this is under the repo cwd; only symlink resolution reveals /etc.
+        expect(isSystemDirectory(path.join(link, 'commandmate.db'))).toBe(true);
+      });
+
+      it('should reject a not-yet-created file under a symlinked system directory', () => {
+        const link = path.join(workDir, 'etc-link-2');
+        fs.symlinkSync('/etc', link);
+
+        // A DB file is validated before it is created, so realpathSync() throws
+        // on the leaf. The nearest existing ancestor must still be resolved.
+        const notCreated = path.join(link, 'nested', 'deeper', 'new.db');
+        expect(fs.existsSync(notCreated)).toBe(false);
+        expect(isSystemDirectory(notCreated)).toBe(true);
+      });
+
+      it('should reject a broken symlink placed under the work dir without crashing', () => {
+        const link = path.join(workDir, 'broken-link');
+        fs.symlinkSync(path.join(workDir, 'does-not-exist'), link);
+
+        expect(() => isSystemDirectory(path.join(link, 'x.db'))).not.toThrow();
+        expect(isSystemDirectory(path.join(link, 'x.db'))).toBe(false);
+      });
+
+      it('should not reject a symlink pointing at a safe directory', () => {
+        const target = path.join(workDir, 'safe-target');
+        fs.mkdirSync(target);
+        const link = path.join(workDir, 'safe-link');
+        fs.symlinkSync(target, link);
+
+        expect(isSystemDirectory(path.join(link, 'cm.db'))).toBe(false);
+      });
+
+      /**
+       * On macOS /tmp, /var and /etc are symlinks into /private, so the physical
+       * location of a system directory must be blocked too. On platforms where
+       * none of them are symlinks (Linux) this loop simply has nothing to check.
+       */
+      it('should reject the physical location of every symlinked system directory', () => {
+        const symlinked = SYSTEM_DIRECTORIES.filter((dir) => {
+          try {
+            return fs.realpathSync(dir) !== dir;
+          } catch {
+            return false;
+          }
+        });
+
+        for (const dir of symlinked) {
+          const physical = fs.realpathSync(dir);
+          expect(isSystemDirectory(physical)).toBe(true);
+          expect(isSystemDirectory(path.join(physical, 'cm.db'))).toBe(true);
+        }
+      });
+
+      it.runIf(process.platform === 'darwin')(
+        'should treat /private/tmp the same as /tmp on macOS',
+        () => {
+          expect(fs.realpathSync('/tmp')).toBe('/private/tmp');
+
+          expect(isSystemDirectory('/tmp/cm.db')).toBe(true);
+          expect(isSystemDirectory('/private/tmp/cm.db')).toBe(true);
+          expect(isSystemDirectory('/private/var/cm.db')).toBe(true);
+          expect(isSystemDirectory('/private/etc/cm.db')).toBe(true);
+        }
+      );
     });
   });
 });

--- a/tests/unit/db-path-resolver.test.ts
+++ b/tests/unit/db-path-resolver.test.ts
@@ -122,6 +122,22 @@ describe('db-path-resolver', () => {
 
         expect(() => validateDbPath(systemPath)).toThrow('Security error');
       });
+
+      it('should reject a sibling directory sharing the home prefix (Issue #1285)', () => {
+        mockIsGlobalInstall.mockReturnValue(true);
+
+        // startsWith() had no path boundary, so this was accepted as "within home".
+        const invalidPath = `${homedir()}-backup/data/cm.db`;
+
+        expect(() => validateDbPath(invalidPath)).toThrow('Security error');
+        expect(() => validateDbPath(invalidPath)).toThrow('home directory');
+      });
+
+      it('should accept the home directory itself for global install', () => {
+        mockIsGlobalInstall.mockReturnValue(true);
+
+        expect(validateDbPath(homedir())).toBe(homedir());
+      });
     });
 
     describe('local install - system directory protection (SEC-001)', () => {


### PR DESCRIPTION
## 概要

`isSystemDirectory()` が `startsWith` の前方一致で、**パス境界も symlink も見ていなかった**ため両方向に壊れていた。

- **素通し**: `/private/tmp` は `/tmp` と同一の場所だがブロックされない
- **誤検知**: `/tmpfoo` `/variance` `/etcetera` `/binary` が無関係なのに拒否される

## 🔴 Issue の前提が誤っており、指示どおりにやると悪化していた

**起票者（オーケストレーター）は `db-migration-path.ts:53` の SEC-002（`fs.realpathSync`）を「対策済み」とし、他の呼び出し元をこれに揃えるよう求めていた。**

実測の結果、**この前提は誤りで、SEC-002 の箇所こそ `/tmp` のブロックが完全に無効化されていた**:

```
realpathSync('/tmp/x.db')     -> '/private/tmp/x.db'
isSystemDirectory(上記)        -> false   ← '/tmp' リテラルに一致しない = 素通し
isSystemDirectory('/tmp/x.db') -> true    ← 解決しない方が正しく落ちる
```

**realpath 済みのパスを未解決のリテラル（`/tmp` `/var` `/etc`）と比較しているため、symlink を解決するほど判定が甘くなる。**

macOS では `/etc` `/var` `/tmp` の**3つとも `/private` 配下への symlink** であり、**SEC-002 経由ではこの3つすべてがすり抜けていた**。

### オーケストレーターによる独立検証（develop の現行実装で再現）

```
--- SEC-002 の経路（realpathSync してから判定）---
  realpathSync("/tmp") = "/private/tmp" → isSystemDirectory = false  ❌ 素通し
  realpathSync("/var") = "/private/var" → isSystemDirectory = false  ❌ 素通し
  realpathSync("/etc") = "/private/etc" → isSystemDirectory = false  ❌ 素通し
--- 他の経路（path.resolve のみ）---
  path.resolve("/tmp")  → isSystemDirectory = true  ✅ ブロック
  path.resolve("/var")  → isSystemDirectory = true  ✅ ブロック
  path.resolve("/etc")  → isSystemDirectory = true  ✅ ブロック
```

→ **Issue の指示どおり他の3箇所へ横展開していたら、`/tmp` `/var` `/etc` のブロックを全経路で無効化していた。**

**真因は「呼び出し元が realpath していない」ことではなく、比較の両側を揃えて解決していないことだった。**

## 設計判断: 解決は `isSystemDirectory` 内に集約する

Issue は「呼び出し元で解決する / `isSystemDirectory` 内で解決する」の二択を求めていた。**後者を選ぶ。** 純粋性は失われる（I/O が入る）が:

- 正しい判定には**候補パスと `SYSTEM_DIRECTORIES` の両側**の解決が必要。呼び出し元で片側だけ解決する設計は、上記のとおり guard を無効化する。全呼び出し元に「両側を解決せよ」を課すのは DRY に反し、**1箇所忘れれば破れる — 実際それが今回の不具合そのもの**
- **`/tmp` と `/private/tmp` が同一かはファイルシステムにしか答えられない。** 純粋な文字列関数はこの問いに原理的に正しく答えられず、**現状の「純粋な」実装は単に誤っている**。正確性を純粋性より優先する

結果、**呼び出し元は `path.resolve` のままで正しくなり（4箇所すべて）、今後の呼び出し元も構成上自動的に正しい。**

## 実装

- **`isPathWithin()`**: 完全一致または**区切り文字境界**での前方一致（誤検知の解消）
- `SYSTEM_DIRECTORIES` は**リテラル形と realpath 形の両方**を候補に持つ（`/proc` `/sys` のように当該 OS に存在しない場合も**リテラル形で防御を維持**）
- 候補パスは **lexical 形と physical 形の両方**を照合し、いずれかが該当すれば拒否する **fail closed** 設計（system dir 内から外を指す symlink も拒否）
- **未作成パスは `realpathSync` が throw する**ため（DB ファイルは作成前に検証されるのが正常系）、最近傍の実在祖先まで遡って解決し残りを再結合する

## 併せて修正（同一のパス境界バグ）

`validateDbPath()` の global install 判定 `startsWith(homeDir)` も境界が無く、**home と prefix を共有する兄弟ディレクトリ**（`/Users/alice` に対する `/Users/alice-backup`）を「home 配下」として通していた。`isPathWithin` に統一。

## 検証

### 受入基準の全ケースをオーケストレーターが実装で実測（11/11 一致）

| パス | 結果 |
|---|---|
| `/tmp/x.db` `/var/x.db` `/etc/x.db` | ✅ ブロック |
| **`/private/tmp/x.db` `/private/var/x.db` `/private/etc/x.db`** | ✅ **ブロック**（修正前は素通し） |
| `/usr/local/x.db` | ✅ ブロック |
| **`/tmpfoo/x.db` `/variance/x.db` `/etcetera/x.db` `/binary/x.db`** | ✅ **許可**（修正前は誤拒否） |

### その他

- `CM_DB_PATH` 経由の end-to-end で `/tmp` と `/private/tmp` が同じく throw することを確認。**#1267 の fail closed 挙動は維持**（`env.test.ts` 31/31 パス）
- **欠陥注入4種**（境界を `startsWith` に戻す / 入力の解決を外す / **`SYSTEM_DIRECTORIES` 側の解決を外す＝SEC-002 と同じ誤り** / home 境界を `startsWith` に戻す）で対応テストが落ちることを、**置換差分を確認したうえで**検証済み
- symlink テストは**実際の symlink を生成**して検証（macOS 固有パスのハードコードを避け **Linux CI でも有効**）。作業ディレクトリは system dir 配下だと lexical に一致して無意味になるため repo cwd 配下に作成

## セキュリティ判断は緩めていない

`/tmp` ブロック自体は #135 の判断。**本PRは判定の正確性を直すもので、ブロック範囲を緩めるものではない**（むしろ SEC-002 経由の素通しを塞いだぶん厳しくなっている）。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **568 files / 9,670 tests 全パス** |
| `npm run build` | ✅ exit 0 |

Refs #1267, #135
Closes #1285
