### PR TITLE
feat(i18n): ui/common/sidebar/external-apps の文言を移行し namespace 方針を確定する (#1273)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -71,5 +71,28 @@
   "confirmDialog": {
     "title": "Confirm",
     "confirm": "OK"
+  },
+  "language": "Language",
+  "loadingPage": "Loading page",
+  "closeNotification": "Close notification",
+  "status": {
+    "idle": "Idle",
+    "ready": "Ready",
+    "running": "Running",
+    "generating": "Generating",
+    "waiting": "Waiting for response",
+    "error": "Error",
+    "unknown": "Unknown"
+  },
+  "sort": {
+    "options": "Sort options",
+    "updatedAt": "Updated",
+    "repositoryName": "Repository",
+    "branchName": "Branch",
+    "status": "Status"
+  },
+  "branchItem": {
+    "cliToolStatus": "CLI tool status",
+    "hasUnread": "Has unread messages"
   }
 }

--- a/locales/en/externalApps.json
+++ b/locales/en/externalApps.json
@@ -1,0 +1,54 @@
+{
+  "status": {
+    "checking": "Checking...",
+    "running": "Running",
+    "stopped": "Stopped"
+  },
+  "card": {
+    "status": "Status",
+    "port": "Port",
+    "path": "Path",
+    "websocket": "WebSocket",
+    "enabled": "Enabled",
+    "disabledNotice": "This app is disabled",
+    "deleteConfirm": "Delete \"{name}\"?",
+    "delete": "Delete",
+    "open": "Open",
+    "settings": "Settings"
+  },
+  "manager": {
+    "addApp": "+ Add App",
+    "loading": "Loading apps...",
+    "loadError": "Failed to load external apps",
+    "empty": "No external apps registered yet.",
+    "emptyHelp": "Add an external app to proxy requests to other frontend applications.",
+    "addFirst": "Add Your First App"
+  },
+  "form": {
+    "editTitle": "Edit External App",
+    "addTitle": "Add External App",
+    "securityWarning": "Proxied apps run under the CommandMate origin and can access CommandMate APIs. Only register trusted applications.",
+    "displayName": "Display Name",
+    "displayNamePlaceholder": "My App",
+    "identifierName": "Identifier Name",
+    "identifierNamePlaceholder": "my-app",
+    "identifierNameHelp": "Alphanumeric and hyphens only. Cannot be changed later.",
+    "pathPrefix": "Path Prefix",
+    "pathPrefixPlaceholder": "app-name",
+    "pathPrefixHelp": "URL path for accessing this app. Cannot be changed later.",
+    "portNumber": "Port Number",
+    "portNumberPlaceholder": "5173",
+    "portNumberHelp": "Target port ({min}-{max})",
+    "appType": "App Type",
+    "appTypePlaceholder": "Select app type...",
+    "description": "Description",
+    "descriptionPlaceholder": "Optional description...",
+    "websocketLabel": "Enable WebSocket support",
+    "enabledLabel": "App is enabled",
+    "save": "Save Changes",
+    "add": "Add App",
+    "updateFailed": "Failed to update app",
+    "createFailed": "Failed to create app",
+    "genericError": "An error occurred"
+  }
+}

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -71,5 +71,28 @@
   "confirmDialog": {
     "title": "確認",
     "confirm": "OK"
+  },
+  "language": "言語",
+  "loadingPage": "ページを読み込み中",
+  "closeNotification": "通知を閉じる",
+  "status": {
+    "idle": "アイドル",
+    "ready": "準備完了",
+    "running": "実行中",
+    "generating": "生成中",
+    "waiting": "応答待ち",
+    "error": "エラー",
+    "unknown": "不明"
+  },
+  "sort": {
+    "options": "並び替えオプション",
+    "updatedAt": "更新日時",
+    "repositoryName": "リポジトリ",
+    "branchName": "ブランチ",
+    "status": "ステータス"
+  },
+  "branchItem": {
+    "cliToolStatus": "CLI ツールのステータス",
+    "hasUnread": "未読メッセージあり"
   }
 }

--- a/locales/ja/externalApps.json
+++ b/locales/ja/externalApps.json
@@ -1,0 +1,54 @@
+{
+  "status": {
+    "checking": "確認中...",
+    "running": "起動中",
+    "stopped": "停止中"
+  },
+  "card": {
+    "status": "ステータス",
+    "port": "ポート",
+    "path": "パス",
+    "websocket": "WebSocket 通信",
+    "enabled": "有効",
+    "disabledNotice": "このアプリは無効になっています",
+    "deleteConfirm": "「{name}」を削除しますか？",
+    "delete": "削除",
+    "open": "開く",
+    "settings": "設定"
+  },
+  "manager": {
+    "addApp": "+ アプリを追加",
+    "loading": "アプリを読み込み中...",
+    "loadError": "外部アプリの読み込みに失敗しました",
+    "empty": "外部アプリが登録されていません。",
+    "emptyHelp": "外部アプリを追加すると、他のフロントエンドアプリへリクエストをプロキシできます。",
+    "addFirst": "最初のアプリを追加"
+  },
+  "form": {
+    "editTitle": "外部アプリを編集",
+    "addTitle": "外部アプリを追加",
+    "securityWarning": "プロキシされたアプリは CommandMate と同一オリジンで動作し、CommandMate の API にアクセスできます。信頼できるアプリのみを登録してください。",
+    "displayName": "表示名",
+    "displayNamePlaceholder": "My App",
+    "identifierName": "識別名",
+    "identifierNamePlaceholder": "my-app",
+    "identifierNameHelp": "英数字とハイフンのみ使用できます。後から変更できません。",
+    "pathPrefix": "パスプレフィックス",
+    "pathPrefixPlaceholder": "app-name",
+    "pathPrefixHelp": "このアプリにアクセスする URL パスです。後から変更できません。",
+    "portNumber": "ポート番号",
+    "portNumberPlaceholder": "5173",
+    "portNumberHelp": "接続先ポート（{min}-{max}）",
+    "appType": "アプリ種別",
+    "appTypePlaceholder": "アプリ種別を選択...",
+    "description": "説明",
+    "descriptionPlaceholder": "説明（任意）...",
+    "websocketLabel": "WebSocket 通信を有効にする",
+    "enabledLabel": "アプリを有効にする",
+    "save": "変更を保存",
+    "add": "アプリを追加",
+    "updateFailed": "アプリの更新に失敗しました",
+    "createFailed": "アプリの作成に失敗しました",
+    "genericError": "エラーが発生しました"
+  }
+}

--- a/src/components/common/FullScreenModal.tsx
+++ b/src/components/common/FullScreenModal.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
 import { Z_INDEX } from '@/config/z-index';
 
@@ -37,6 +38,7 @@ export function FullScreenModal({
   footer,
   showCloseButton = true,
 }: FullScreenModalProps) {
+  const t = useTranslations('common');
   // Track the visual viewport so the sticky footer stays above the mobile keyboard.
   const [viewportHeight, setViewportHeight] = useState<number | null>(null);
 
@@ -104,7 +106,7 @@ export function FullScreenModal({
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close"
+            aria-label={t('close')}
             data-testid="full-screen-modal-close"
             className="flex-shrink-0 -mr-1 p-1 text-muted-foreground hover:text-foreground transition-colors"
           >

--- a/src/components/common/LocaleSwitcher.tsx
+++ b/src/components/common/LocaleSwitcher.tsx
@@ -18,6 +18,10 @@ export function LocaleSwitcher() {
     <select
       value={currentLocale}
       onChange={(e) => switchLocale(e.target.value)}
+      // Issue #1273: the aria-label is now translated, so it cannot double as a
+      // test selector — the e2e suite drives this control *after* switching to
+      // Japanese, where the label reads 言語.
+      data-testid="locale-switcher"
       aria-label={t('language')}
       className="
         w-full px-3 py-2 rounded-md

--- a/src/components/common/LocaleSwitcher.tsx
+++ b/src/components/common/LocaleSwitcher.tsx
@@ -6,17 +6,19 @@
  */
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { useLocaleSwitch } from '@/hooks/useLocaleSwitch';
 import { LOCALE_LABELS, SUPPORTED_LOCALES } from '@/config/i18n-config';
 
 export function LocaleSwitcher() {
   const { currentLocale, switchLocale } = useLocaleSwitch();
+  const t = useTranslations('common');
 
   return (
     <select
       value={currentLocale}
       onChange={(e) => switchLocale(e.target.value)}
-      aria-label="Language"
+      aria-label={t('language')}
       className="
         w-full px-3 py-2 rounded-md
         bg-sidebar text-sidebar-foreground

--- a/src/components/common/RouteLoading.tsx
+++ b/src/components/common/RouteLoading.tsx
@@ -22,6 +22,8 @@
  * which resets animation-duration/-delay — do not re-implement it here.
  */
 
+import { useTranslations } from 'next-intl';
+
 /**
  * Stagger for the indeterminate pulse. Whole literal class strings so the
  * Tailwind scanner picks them up.
@@ -33,11 +35,13 @@ const DOT_DELAYS = [
 ] as const;
 
 export function RouteLoading() {
+  const t = useTranslations('common');
+
   return (
     <div
       className="flex min-h-screen w-full items-center justify-center p-8"
       role="status"
-      aria-label="Loading page"
+      aria-label={t('loadingPage')}
       data-testid="route-loading"
     >
       <div className="flex items-center gap-2" aria-hidden="true">

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 import { CheckCircle, XCircle, Info, AlertTriangle, X } from 'lucide-react';
 import { Z_INDEX } from '@/config/z-index';
 import { EXIT_ANIMATION_DURATION_MS } from '@/config/ui-feedback-config';
@@ -137,6 +138,7 @@ export function Toast({
   onClose,
   duration = DEFAULT_DURATION,
 }: ToastProps) {
+  const t = useTranslations('common');
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const styles = getToastStyles(type);
 
@@ -205,7 +207,7 @@ export function Toast({
       <button
         data-testid="toast-close-button"
         onClick={handleClose}
-        aria-label="Close notification"
+        aria-label={t('closeNotification')}
         className={`
           ${styles.textColor}
           hover:opacity-70

--- a/src/components/external-apps/ExternalAppCard.tsx
+++ b/src/components/external-apps/ExternalAppCard.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { Card, Button, Badge } from '@/components/ui';
 import { ExternalAppStatus } from './ExternalAppStatus';
 import type { ExternalApp, ExternalAppType } from '@/types/external-apps';
@@ -60,6 +61,8 @@ function getAppTypeBadgeVariant(appType: ExternalAppType): 'success' | 'warning'
  * ```
  */
 export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps) {
+  const t = useTranslations('externalApps');
+  const tCommon = useTranslations('common');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -95,28 +98,28 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {/* Info */}
       <div className="space-y-2 mb-4">
         <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">Status</span>
+          <span className="text-sm text-muted-foreground">{t('card.status')}</span>
           <ExternalAppStatus appId={app.id} pollInterval={30000} />
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">Port</span>
+          <span className="text-sm text-muted-foreground">{t('card.port')}</span>
           <span className="text-sm font-mono text-foreground">:{app.targetPort}</span>
         </div>
         <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">Path</span>
+          <span className="text-sm text-muted-foreground">{t('card.path')}</span>
           <span className="text-sm font-mono text-foreground truncate max-w-[150px]">
             /proxy/{app.pathPrefix}/
           </span>
         </div>
         {app.websocketEnabled && (
           <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">WebSocket</span>
-            <Badge variant="info">Enabled</Badge>
+            <span className="text-sm text-muted-foreground">{t('card.websocket')}</span>
+            <Badge variant="info">{t('card.enabled')}</Badge>
           </div>
         )}
         {!app.enabled && (
           <div className="mt-2 py-1 px-2 bg-warning-subtle border border-warning-border rounded text-xs text-warning-foreground">
-            This app is disabled
+            {t('card.disabledNotice')}
           </div>
         )}
       </div>
@@ -125,7 +128,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
       {showDeleteConfirm ? (
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">
-            Delete &quot;{app.displayName}&quot;?
+            {t('card.deleteConfirm', { name: app.displayName })}
           </p>
           <div className="flex gap-2">
             <Button
@@ -135,7 +138,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
               disabled={isDeleting}
               loading={isDeleting}
             >
-              Delete
+              {t('card.delete')}
             </Button>
             <Button
               variant="ghost"
@@ -143,7 +146,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
               onClick={() => setShowDeleteConfirm(false)}
               disabled={isDeleting}
             >
-              Cancel
+              {tCommon('cancel')}
             </Button>
           </div>
         </div>
@@ -155,14 +158,14 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
             onClick={() => window.open(proxyUrl, '_blank')}
             disabled={!app.enabled}
           >
-            Open
+            {t('card.open')}
           </Button>
           <Button
             variant="secondary"
             size="sm"
             onClick={() => onEdit(app)}
           >
-            Settings
+            {t('card.settings')}
           </Button>
           <Button
             variant="ghost"
@@ -170,7 +173,7 @@ export function ExternalAppCard({ app, onEdit, onDelete }: ExternalAppCardProps)
             onClick={() => setShowDeleteConfirm(true)}
             className="text-danger-foreground hover:bg-danger-subtle"
           >
-            Delete
+            {t('card.delete')}
           </Button>
         </div>
       )}

--- a/src/components/external-apps/ExternalAppForm.tsx
+++ b/src/components/external-apps/ExternalAppForm.tsx
@@ -9,6 +9,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { Button, Input, Modal, Switch, Textarea, inputVariants } from '@/components/ui';
 import { cn } from '@/lib/utils/cn';
 import {
@@ -70,6 +71,8 @@ export function ExternalAppForm({
   editApp,
   onSave,
 }: ExternalAppFormProps) {
+  const t = useTranslations('externalApps');
+  const tCommon = useTranslations('common');
   const isEdit = !!editApp;
 
   // Form state
@@ -156,7 +159,7 @@ export function ExternalAppForm({
 
         if (!response.ok) {
           const data = await response.json();
-          throw new Error(data.error || 'Failed to update app');
+          throw new Error(data.error || t('form.updateFailed'));
         }
       } else {
         // Create new app
@@ -178,7 +181,7 @@ export function ExternalAppForm({
 
         if (!response.ok) {
           const data = await response.json();
-          throw new Error(data.error || 'Failed to create app');
+          throw new Error(data.error || t('form.createFailed'));
         }
       }
 
@@ -186,7 +189,7 @@ export function ExternalAppForm({
       onClose();
     } catch (error) {
       setSubmitError(
-        error instanceof Error ? error.message : 'An error occurred'
+        error instanceof Error ? error.message : t('form.genericError')
       );
     } finally {
       setIsSubmitting(false);
@@ -197,14 +200,14 @@ export function ExternalAppForm({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title={isEdit ? 'Edit External App' : 'Add External App'}
+      title={isEdit ? t('form.editTitle') : t('form.addTitle')}
       size="md"
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Issue #395: Security warning about same-origin proxy risks */}
         <div className="rounded-md bg-warning-subtle p-3 mb-4 border border-warning-border">
           <p className="text-sm text-warning-foreground">
-            Proxied apps run under the CommandMate origin and can access CommandMate APIs. Only register trusted applications.
+            {t('form.securityWarning')}
           </p>
         </div>
 
@@ -214,7 +217,7 @@ export function ExternalAppForm({
             htmlFor="displayName"
             className="block text-sm font-medium text-foreground mb-1"
           >
-            Display Name <span className="text-danger">*</span>
+            {t('form.displayName')} <span className="text-danger">*</span>
           </label>
           <Input
             id="displayName"
@@ -222,7 +225,7 @@ export function ExternalAppForm({
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             className={errors.displayName ? 'border-danger' : ''}
-            placeholder="My App"
+            placeholder={t('form.displayNamePlaceholder')}
             disabled={isSubmitting}
           />
           {errors.displayName && (
@@ -237,7 +240,7 @@ export function ExternalAppForm({
               htmlFor="name"
               className="block text-sm font-medium text-foreground mb-1"
             >
-              Identifier Name <span className="text-danger">*</span>
+              {t('form.identifierName')} <span className="text-danger">*</span>
             </label>
             <Input
               id="name"
@@ -245,11 +248,11 @@ export function ExternalAppForm({
               value={name}
               onChange={(e) => setName(e.target.value)}
               className={`font-mono ${errors.name ? 'border-danger' : ''}`}
-              placeholder="my-app"
+              placeholder={t('form.identifierNamePlaceholder')}
               disabled={isSubmitting}
             />
             <p className="mt-1 text-xs text-muted-foreground">
-              Alphanumeric and hyphens only. Cannot be changed later.
+              {t('form.identifierNameHelp')}
             </p>
             {errors.name && (
               <p className="mt-1 text-xs text-danger">{errors.name}</p>
@@ -264,7 +267,7 @@ export function ExternalAppForm({
               htmlFor="pathPrefix"
               className="block text-sm font-medium text-foreground mb-1"
             >
-              Path Prefix <span className="text-danger">*</span>
+              {t('form.pathPrefix')} <span className="text-danger">*</span>
             </label>
             <div className="flex items-center">
               <span className="text-sm text-muted-foreground mr-1">/proxy/</span>
@@ -274,13 +277,13 @@ export function ExternalAppForm({
                 value={pathPrefix}
                 onChange={(e) => setPathPrefix(e.target.value)}
                 className={`w-auto flex-1 font-mono ${errors.pathPrefix ? 'border-danger' : ''}`}
-                placeholder="app-name"
+                placeholder={t('form.pathPrefixPlaceholder')}
                 disabled={isSubmitting}
               />
               <span className="text-sm text-muted-foreground ml-1">/</span>
             </div>
             <p className="mt-1 text-xs text-muted-foreground">
-              URL path for accessing this app. Cannot be changed later.
+              {t('form.pathPrefixHelp')}
             </p>
             {errors.pathPrefix && (
               <p className="mt-1 text-xs text-danger">{errors.pathPrefix}</p>
@@ -294,7 +297,7 @@ export function ExternalAppForm({
             htmlFor="targetPort"
             className="block text-sm font-medium text-foreground mb-1"
           >
-            Port Number <span className="text-danger">*</span>
+            {t('form.portNumber')} <span className="text-danger">*</span>
           </label>
           <Input
             id="targetPort"
@@ -304,13 +307,16 @@ export function ExternalAppForm({
               setTargetPort(e.target.value ? parseInt(e.target.value, 10) : '')
             }
             className={`font-mono ${errors.targetPort ? 'border-danger' : ''}`}
-            placeholder="5173"
+            placeholder={t('form.portNumberPlaceholder')}
             min={PORT_CONSTRAINTS.MIN}
             max={PORT_CONSTRAINTS.MAX}
             disabled={isSubmitting}
           />
           <p className="mt-1 text-xs text-muted-foreground">
-            Target port ({PORT_CONSTRAINTS.MIN}-{PORT_CONSTRAINTS.MAX})
+            {t('form.portNumberHelp', {
+              min: PORT_CONSTRAINTS.MIN,
+              max: PORT_CONSTRAINTS.MAX,
+            })}
           </p>
           {errors.targetPort && (
             <p className="mt-1 text-xs text-danger">{errors.targetPort}</p>
@@ -324,7 +330,7 @@ export function ExternalAppForm({
               htmlFor="appType"
               className="block text-sm font-medium text-foreground mb-1"
             >
-              App Type <span className="text-danger">*</span>
+              {t('form.appType')} <span className="text-danger">*</span>
             </label>
             <select
               id="appType"
@@ -333,7 +339,7 @@ export function ExternalAppForm({
               className={cn(inputVariants(), errors.appType && 'border-danger')}
               disabled={isSubmitting}
             >
-              <option value="">Select app type...</option>
+              <option value="">{t('form.appTypePlaceholder')}</option>
               {appTypeOptions.map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
@@ -352,13 +358,13 @@ export function ExternalAppForm({
             htmlFor="description"
             className="block text-sm font-medium text-foreground mb-1"
           >
-            Description
+            {t('form.description')}
           </label>
           <Textarea
             id="description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="Optional description..."
+            placeholder={t('form.descriptionPlaceholder')}
             rows={2}
             disabled={isSubmitting}
           />
@@ -376,7 +382,7 @@ export function ExternalAppForm({
             htmlFor="websocketEnabled"
             className="text-sm text-foreground"
           >
-            Enable WebSocket support
+            {t('form.websocketLabel')}
           </label>
         </div>
 
@@ -390,7 +396,7 @@ export function ExternalAppForm({
               disabled={isSubmitting}
             />
             <label htmlFor="enabled" className="text-sm text-foreground">
-              App is enabled
+              {t('form.enabledLabel')}
             </label>
           </div>
         )}
@@ -410,10 +416,10 @@ export function ExternalAppForm({
             onClick={onClose}
             disabled={isSubmitting}
           >
-            Cancel
+            {tCommon('cancel')}
           </Button>
           <Button type="submit" variant="primary" loading={isSubmitting}>
-            {isEdit ? 'Save Changes' : 'Add App'}
+            {isEdit ? t('form.save') : t('form.add')}
           </Button>
         </div>
       </form>

--- a/src/components/external-apps/ExternalAppStatus.tsx
+++ b/src/components/external-apps/ExternalAppStatus.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
 import type { ExternalAppHealth } from '@/types/external-apps';
 
 export interface ExternalAppStatusProps {
@@ -35,6 +36,7 @@ export function ExternalAppStatus({
   showResponseTime = false,
   compact = false,
 }: ExternalAppStatusProps) {
+  const t = useTranslations('externalApps');
   const [health, setHealth] = useState<ExternalAppHealth | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -78,14 +80,14 @@ export function ExternalAppStatus({
     return (
       <div className="flex items-center gap-1.5">
         <span className="inline-block h-2.5 w-2.5 rounded-full bg-muted-foreground animate-pulse" />
-        {!compact && <span className="text-xs text-muted-foreground">Checking...</span>}
+        {!compact && <span className="text-xs text-muted-foreground">{t('status.checking')}</span>}
       </div>
     );
   }
 
   const isHealthy = health?.healthy ?? false;
   const statusColor = isHealthy ? 'bg-success' : 'bg-muted-foreground';
-  const statusText = isHealthy ? 'Running' : 'Stopped';
+  const statusText = isHealthy ? t('status.running') : t('status.stopped');
 
   if (compact) {
     return (

--- a/src/components/external-apps/ExternalAppsManager.tsx
+++ b/src/components/external-apps/ExternalAppsManager.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { Button, Card, Spinner } from '@/components/ui';
 import { ExternalAppCard } from './ExternalAppCard';
 import { ExternalAppForm } from './ExternalAppForm';
@@ -23,6 +24,8 @@ import { EXTERNAL_APPS_POLL_INTERVAL_MS } from '@/config/external-apps-config';
  * ```
  */
 export function ExternalAppsManager() {
+  const t = useTranslations('externalApps');
+  const tCommon = useTranslations('common');
   // Data state
   const [apps, setApps] = useState<ExternalApp[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -110,7 +113,7 @@ export function ExternalAppsManager() {
           provides the add-app action to avoid a duplicate "External Apps" title. */}
       <div className="flex items-center justify-end">
         <Button variant="primary" size="sm" onClick={handleAdd}>
-          + Add App
+          {t('manager.addApp')}
         </Button>
       </div>
 
@@ -119,15 +122,15 @@ export function ExternalAppsManager() {
         <Card padding="lg">
           <div className="flex items-center justify-center py-8">
             <Spinner size="xl" variant="accent" />
-            <span className="ml-3 text-muted-foreground">Loading apps...</span>
+            <span className="ml-3 text-muted-foreground">{t('manager.loading')}</span>
           </div>
         </Card>
       ) : error ? (
         <Card padding="lg">
           <div className="text-center py-8">
-            <p className="text-danger-foreground mb-4">Failed to load external apps</p>
+            <p className="text-danger-foreground mb-4">{t('manager.loadError')}</p>
             <Button variant="secondary" size="sm" onClick={fetchApps}>
-              Retry
+              {tCommon('retry')}
             </Button>
           </div>
         </Card>
@@ -135,14 +138,13 @@ export function ExternalAppsManager() {
         <Card padding="lg">
           <div className="text-center py-8">
             <p className="text-muted-foreground mb-4">
-              No external apps registered yet.
+              {t('manager.empty')}
             </p>
             <p className="text-sm text-muted-foreground mb-4">
-              Add an external app to proxy requests to other frontend
-              applications.
+              {t('manager.emptyHelp')}
             </p>
             <Button variant="primary" size="sm" onClick={handleAdd}>
-              Add Your First App
+              {t('manager.addFirst')}
             </Button>
           </div>
         </Card>

--- a/src/components/sidebar/BranchListItem.tsx
+++ b/src/components/sidebar/BranchListItem.tsx
@@ -9,6 +9,7 @@
 
 import React, { memo, useRef, useState, useEffect, useCallback } from 'react';
 import ReactDOM from 'react-dom';
+import { useTranslations } from 'next-intl';
 import type { SidebarBranchItem } from '@/types/sidebar';
 import { aggregateCliStatus, formatCliStatusBreakdown } from '@/types/sidebar';
 import { BranchStatusIndicator } from '@/components/sidebar/BranchStatusIndicator';
@@ -141,6 +142,7 @@ export const BranchListItem = memo(function BranchListItem({
   onClick,
   showRepositoryName = true,
 }: BranchListItemProps) {
+  const t = useTranslations('common');
   const tooltipId = `tooltip-${branch.id}`;
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
@@ -247,7 +249,7 @@ export const BranchListItem = memo(function BranchListItem({
           reveals the per-agent breakdown via the indicator's title/aria-label.
         */}
         {branch.cliStatus && Object.keys(branch.cliStatus).length > 0 && (
-          <div className="flex items-center justify-center flex-shrink-0 w-4" aria-label="CLI tool status">
+          <div className="flex items-center justify-center flex-shrink-0 w-4" aria-label={t('branchItem.cliToolStatus')}>
             <BranchStatusIndicator
               status={aggregateCliStatus(branch.cliStatus)}
               label={formatCliStatusBreakdown(branch.cliStatus, branch.cliStatusLabels)}
@@ -272,7 +274,7 @@ export const BranchListItem = memo(function BranchListItem({
           <span
             data-testid="unread-indicator"
             className="w-2 h-2 rounded-full bg-accent-500 flex-shrink-0"
-            aria-label="Has unread messages"
+            aria-label={t('branchItem.hasUnread')}
           />
         )}
       </div>

--- a/src/components/sidebar/SortSelector.tsx
+++ b/src/components/sidebar/SortSelector.tsx
@@ -9,11 +9,11 @@
 
 'use client';
 
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSidebarContext } from '@/contexts/SidebarContext';
 import { SortSelectorBase } from './SortSelectorBase';
-import type { SortOption } from './SortSelectorBase';
+import type { SortKey } from '@/lib/sidebar-utils';
 
 // ============================================================================
 // Constants
@@ -22,12 +22,17 @@ import type { SortOption } from './SortSelectorBase';
 /**
  * Sort options for sidebar (does NOT include lastSent) [CON-002]
  * lastSent is only available in Sessions page via SESSIONS_SORT_OPTIONS.
+ *
+ * Holds `common.sort.*` keys rather than labels: this is module scope, where
+ * t() cannot be called, so a literal would pin the dropdown to English
+ * (Issue #1271/#1273). SortSelectorBase still takes resolved `label` strings,
+ * so the Sessions page's own options are unaffected.
  */
-const SIDEBAR_SORT_OPTIONS: ReadonlyArray<SortOption> = [
-  { key: 'updatedAt', label: 'Updated' },
-  { key: 'repositoryName', label: 'Repository' },
-  { key: 'branchName', label: 'Branch' },
-  { key: 'status', label: 'Status' },
+const SIDEBAR_SORT_OPTIONS: ReadonlyArray<{ key: SortKey; labelKey: string }> = [
+  { key: 'updatedAt', labelKey: 'sort.updatedAt' },
+  { key: 'repositoryName', labelKey: 'sort.repositoryName' },
+  { key: 'branchName', labelKey: 'sort.branchName' },
+  { key: 'status', labelKey: 'sort.status' },
 ];
 
 /** Default directions for sidebar sort keys */
@@ -52,13 +57,18 @@ export const SortSelector = memo(function SortSelector() {
   const { sortKey, sortDirection, setSortKey, setSortDirection } = useSidebarContext();
   const t = useTranslations('common');
 
+  const options = useMemo(
+    () => SIDEBAR_SORT_OPTIONS.map(({ key, labelKey }) => ({ key, label: t(labelKey) })),
+    [t]
+  );
+
   return (
     <SortSelectorBase
       sortKey={sortKey}
       sortDirection={sortDirection}
       onSortKeyChange={setSortKey}
       onSortDirectionChange={setSortDirection}
-      options={SIDEBAR_SORT_OPTIONS}
+      options={options}
       defaultDirections={SIDEBAR_DEFAULT_DIRECTIONS}
       compact
       tooltip={t('tooltips.sort')}

--- a/src/components/sidebar/SortSelectorBase.tsx
+++ b/src/components/sidebar/SortSelectorBase.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import React, { memo, useState, useRef, useEffect, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
 import { Tooltip } from '@/components/common/Tooltip';
 import type { SortKey, SortDirection } from '@/lib/sidebar-utils';
 
@@ -76,6 +77,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
   tooltip,
   iconClassName = 'w-3 h-3',
 }: SortSelectorBaseProps) {
+  const t = useTranslations('common');
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -187,7 +189,7 @@ export const SortSelectorBase = memo(function SortSelectorBase({
       {isOpen && (
         <div
           role="listbox"
-          aria-label="Sort options"
+          aria-label={t('sort.options')}
           className="
             absolute right-0 top-full mt-1 z-50
             min-w-[140px] py-1 rounded-md shadow-lg

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useId } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
 import { cva } from 'class-variance-authority';
 import { Z_INDEX } from '@/config/z-index';
 import { EXIT_ANIMATION_DURATION_MS } from '@/config/ui-feedback-config';
@@ -63,6 +64,7 @@ export function Modal({
   showCloseButton = true,
   disableClose = false,
 }: ModalProps) {
+  const t = useTranslations('common');
   const titleId = useId();
 
   // [Issue #1127] Trap keyboard focus inside the dialog while it is open (Tab
@@ -150,7 +152,7 @@ export function Modal({
               {showCloseButton && (
                 <button
                   onClick={onClose}
-                  aria-label="Close"
+                  aria-label={t('close')}
                   className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 touch-manipulation"
                 >
                   <svg

--- a/src/components/ui/StatusDot.tsx
+++ b/src/components/ui/StatusDot.tsx
@@ -18,6 +18,7 @@
  */
 
 import React from 'react';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils/cn';
 
 export type StatusDotStatus =
@@ -36,13 +37,15 @@ interface StatusDotVisual {
   colorClass: string;
   /** Optional infinite animation utility. */
   animationClass?: string;
-  /** Default accessible label. */
-  label: string;
+  /** Key into the `common.status.*` dictionary for the default accessible
+   * label. A literal here would pin the label to English at module scope,
+   * where t() cannot be called (Issue #1271/#1273). */
+  labelKey: string;
 }
 
 const STATUS_DOT_CONFIG: Record<StatusDotStatus, StatusDotVisual> = {
-  idle: { colorClass: 'bg-muted-foreground', label: 'Idle' },
-  ready: { colorClass: 'bg-success', label: 'Ready' },
+  idle: { colorClass: 'bg-muted-foreground', labelKey: 'status.idle' },
+  ready: { colorClass: 'bg-success', labelKey: 'status.ready' },
   // running/generating add a static `ring` as a MOTION-INDEPENDENT
   // differentiator: the pulsing glow (animate-status-glow) sets box-shadow
   // directly and overrides the ring while animating, but when the pulse is
@@ -52,25 +55,25 @@ const STATUS_DOT_CONFIG: Record<StatusDotStatus, StatusDotVisual> = {
   running: {
     colorClass: 'bg-success text-success ring-2 ring-success/40',
     animationClass: 'animate-status-glow',
-    label: 'Running',
+    labelKey: 'status.running',
   },
   generating: {
     colorClass: 'bg-success text-success ring-2 ring-success/40',
     animationClass: 'animate-status-glow',
-    label: 'Generating',
+    labelKey: 'status.generating',
   },
   waiting: {
     colorClass: 'bg-warning',
     animationClass: 'animate-status-blink',
-    label: 'Waiting for response',
+    labelKey: 'status.waiting',
   },
-  error: { colorClass: 'bg-danger', label: 'Error' },
+  error: { colorClass: 'bg-danger', labelKey: 'status.error' },
 };
 
 /** Fallback for unrecognized state values (edge case: unknown status → gray). */
 const FALLBACK_VISUAL: StatusDotVisual = {
   colorClass: 'bg-muted-foreground',
-  label: 'Unknown',
+  labelKey: 'status.unknown',
 };
 
 const SIZE_CLASSES: Record<StatusDotSize, string> = {
@@ -105,8 +108,9 @@ export function StatusDot({
   className,
   ...rest
 }: StatusDotProps) {
+  const t = useTranslations('common');
   const visual = STATUS_DOT_CONFIG[status] ?? FALLBACK_VISUAL;
-  const accessibleLabel = label ?? visual.label;
+  const accessibleLabel = label ?? t(visual.labelKey);
 
   return (
     <span

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,7 +22,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   }
 
   // Load all namespace files and merge them
-  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette, home, review, pwa, notifications, keyboardShortcuts] = await Promise.all([
+  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette, home, review, pwa, notifications, keyboardShortcuts, externalApps] = await Promise.all([
     import(`../locales/${locale}/common.json`),
     import(`../locales/${locale}/worktree.json`),
     import(`../locales/${locale}/autoYes.json`),
@@ -36,6 +36,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
     import(`../locales/${locale}/pwa.json`),
     import(`../locales/${locale}/notifications.json`),
     import(`../locales/${locale}/keyboardShortcuts.json`),
+    import(`../locales/${locale}/externalApps.json`),
   ]);
 
   return {
@@ -56,6 +57,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
       pwa: pwa.default,
       notifications: notifications.default,
       keyboardShortcuts: keyboardShortcuts.default,
+      externalApps: externalApps.default,
     },
   };
 });

--- a/tests/e2e/locale-switcher.spec.ts
+++ b/tests/e2e/locale-switcher.spec.ts
@@ -20,7 +20,7 @@
  *      session subline (`home.running` / `home.waiting`), which are on this page
  *      and are translated.
  *
- * The `select[aria-label="Language"]` lives in the sidebar, which is a closed
+ * The `[data-testid="locale-switcher"]` lives in the sidebar, which is a closed
  * drawer on mobile — so only the desktop specs assert on it.
  */
 
@@ -35,7 +35,7 @@ test.describe('Locale Switcher', () => {
     await page.waitForLoadState('networkidle');
 
     // LocaleSwitcher select should exist with value "en"
-    const select = page.locator('select[aria-label="Language"]');
+    const select = page.locator('[data-testid="locale-switcher"]');
     await expect(select).toBeVisible();
     await expect(select).toHaveValue('en');
 
@@ -62,7 +62,7 @@ test.describe('Locale Switcher', () => {
     await expect(page.getByTestId('home-subline')).toContainText('待機中');
 
     // LocaleSwitcher should show "ja"
-    const select = page.locator('select[aria-label="Language"]');
+    const select = page.locator('[data-testid="locale-switcher"]');
     await expect(select).toHaveValue('ja');
   });
 
@@ -72,14 +72,14 @@ test.describe('Locale Switcher', () => {
 
     // Switch through the UI so the cookie under test is the one the app writes
     // (setLocaleCookie), not one the test planted. selectOption triggers a reload.
-    await page.locator('select[aria-label="Language"]').selectOption('ja');
+    await page.locator('[data-testid="locale-switcher"]').selectOption('ja');
     await expect(page.getByRole('heading', { name: '概要', level: 1 })).toBeVisible();
 
     // Reload and verify persistence
     await page.reload();
     await page.waitForLoadState('networkidle');
     await expect(page.getByRole('heading', { name: '概要', level: 1 })).toBeVisible();
-    await expect(page.locator('select[aria-label="Language"]')).toHaveValue('ja');
+    await expect(page.locator('[data-testid="locale-switcher"]')).toHaveValue('ja');
 
     // Verify the security flags setLocaleCookie promises
     const cookies = await context.cookies();
@@ -104,7 +104,7 @@ test.describe('Locale Switcher', () => {
     // Should fallback to English
     await expect(page.getByRole('heading', { name: 'Overview', level: 1 })).toBeVisible();
 
-    const select = page.locator('select[aria-label="Language"]');
+    const select = page.locator('[data-testid="locale-switcher"]');
     await expect(select).toHaveValue('en');
   });
 });

--- a/tests/integration/i18n-namespace-loading.test.ts
+++ b/tests/integration/i18n-namespace-loading.test.ts
@@ -23,8 +23,9 @@ const LOCALES_DIR = path.resolve(__dirname, '../../locales');
  * Issue #1124: Added 'pwa' namespace
  * Issue #1125: Added 'notifications' namespace
  * Issue #1130: Added 'keyboardShortcuts' namespace
+ * Issue #1273: Added 'externalApps' namespace
  */
-const EXPECTED_NAMESPACES = ['common', 'worktree', 'autoYes', 'error', 'prompt', 'auth', 'schedule', 'commandPalette', 'home', 'review', 'pwa', 'notifications', 'keyboardShortcuts'] as const;
+const EXPECTED_NAMESPACES = ['common', 'worktree', 'autoYes', 'error', 'prompt', 'auth', 'schedule', 'commandPalette', 'home', 'review', 'pwa', 'notifications', 'keyboardShortcuts', 'externalApps'] as const;
 
 describe('i18n Namespace Loading', () => {
   for (const locale of SUPPORTED_LOCALES) {

--- a/tests/unit/app/more/page.test.tsx
+++ b/tests/unit/app/more/page.test.tsx
@@ -10,6 +10,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
+// Issue #1273: the add-app action's wording now comes from
+// `externalApps.manager.addApp`. This test matches on the rendered wording, so
+// back it with the real dictionary — the global passthrough mock would echo the
+// key and the /add app/i match would depend on the key's spelling, not the copy.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // Mock AppShell to a passthrough so we don't pull in the full layout tree.
 vi.mock('@/components/layout', () => ({
   AppShell: ({ children }: { children: React.ReactNode }) =>

--- a/tests/unit/components/Toast.test.tsx
+++ b/tests/unit/components/Toast.test.tsx
@@ -11,6 +11,14 @@ import { Toast, ToastContainer, useToast } from '@/components/common/Toast';
 import { EXIT_ANIMATION_DURATION_MS } from '@/config/ui-feedback-config';
 import type { ToastType } from '@/types/markdown-editor';
 
+// Issue #1273: the close button's aria-label resolves through
+// `common.closeNotification`. Back it with the real dictionary so the English
+// assertion proves the key exists rather than echoing the global mock.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // Helper component to test useToast hook
 function TestComponent() {
   const { showToast, toasts, removeToast } = useToast();

--- a/tests/unit/components/common/LocaleSwitcher.test.tsx
+++ b/tests/unit/components/common/LocaleSwitcher.test.tsx
@@ -8,6 +8,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { LocaleSwitcher } from '@/components/common/LocaleSwitcher';
 
+// Issue #1273: the select's aria-label resolves through `common.language`.
+// Back it with the real dictionary so the English assertions prove the key
+// exists rather than echoing the global mock's passthrough.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // Mock useLocaleSwitch hook
 const mockSwitchLocale = vi.fn();
 vi.mock('@/hooks/useLocaleSwitch', () => ({

--- a/tests/unit/components/common/RouteLoading.test.tsx
+++ b/tests/unit/components/common/RouteLoading.test.tsx
@@ -6,9 +6,16 @@
  */
 
 import React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { RouteLoading } from '@/components/common/RouteLoading';
+
+// Issue #1273: the status label resolves through `common.loadingPage`. Back it
+// with the real dictionary so the English assertion proves the key exists.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
 
 afterEach(() => cleanup());
 

--- a/tests/unit/components/sidebar/BranchListItem.test.tsx
+++ b/tests/unit/components/sidebar/BranchListItem.test.tsx
@@ -11,6 +11,14 @@ import React from 'react';
 import { BranchListItem, __resetMouseEnterSuppression } from '@/components/sidebar/BranchListItem';
 import type { SidebarBranchItem } from '@/types/sidebar';
 
+// Issue #1273: the CLI-status wrapper and the nested StatusDot labels resolve
+// through `common.*`. Back them with the real dictionary so the English
+// assertions prove the keys exist rather than echoing the global mock.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 describe('BranchListItem', () => {
   const defaultBranch: SidebarBranchItem = {
     id: 'feature-test',

--- a/tests/unit/components/sidebar/BranchStatusIndicator.test.tsx
+++ b/tests/unit/components/sidebar/BranchStatusIndicator.test.tsx
@@ -11,6 +11,14 @@ import React from 'react';
 import { BranchStatusIndicator } from '@/components/sidebar/BranchStatusIndicator';
 import type { BranchStatus } from '@/types/sidebar';
 
+// Issue #1273: StatusDot's default labels resolve through `common.status.*`.
+// Back them with the real dictionary so the English assertions below prove the
+// keys exist rather than echoing the global mock's passthrough.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 describe('BranchStatusIndicator', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/unit/components/ui/StatusDot.test.tsx
+++ b/tests/unit/components/ui/StatusDot.test.tsx
@@ -5,10 +5,19 @@
  */
 
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { StatusDot } from '@/components/ui/StatusDot';
 import type { StatusDotStatus } from '@/components/ui/StatusDot';
+
+// Issue #1273: the default labels now resolve through `common.status.*`. The
+// global mock in tests/setup.ts would echo the key back, so the English
+// assertions below would pass against a dictionary that never had the entry —
+// back the component with the real dictionary instead.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
 
 describe('StatusDot', () => {
   describe('Rendering', () => {

--- a/tests/unit/i18n/common-keys.test.ts
+++ b/tests/unit/i18n/common-keys.test.ts
@@ -106,6 +106,41 @@ const EN_REPOSITORY_LABELS: Record<string, string> = {
 
 const REPOSITORY_KEYS = Object.keys(EN_REPOSITORY_LABELS);
 
+/**
+ * Issue #1273 migrated the shared chrome in components/{ui,common,sidebar} off
+ * hardcoded English. Same contract as the sections above: every value is the
+ * byte-exact pre-migration literal, lifted from `git show HEAD:<file>` rather
+ * than retyped, so a drift here is a user-visible regression.
+ *
+ * `status.*` is deliberately generic rather than StatusDot-specific: the same
+ * six words are still hardcoded in `src/config/status-colors.ts`, so that
+ * migration reuses these keys instead of forking a second set of translations.
+ */
+const EN_SHARED_CHROME: Record<string, string> = {
+  'status.idle': 'Idle',
+  'status.ready': 'Ready',
+  'status.running': 'Running',
+  'status.generating': 'Generating',
+  'status.waiting': 'Waiting for response',
+  'status.error': 'Error',
+  'status.unknown': 'Unknown',
+  'sort.options': 'Sort options',
+  'sort.updatedAt': 'Updated',
+  'sort.repositoryName': 'Repository',
+  'sort.branchName': 'Branch',
+  'sort.status': 'Status',
+  'branchItem.cliToolStatus': 'CLI tool status',
+  'branchItem.hasUnread': 'Has unread messages',
+  language: 'Language',
+  loadingPage: 'Loading page',
+  closeNotification: 'Close notification',
+  // Predates #1273; pinned because Modal / FullScreenModal now resolve their
+  // close button through it, so a change here silently retitles both.
+  close: 'Close',
+};
+
+const SHARED_CHROME_KEYS = Object.keys(EN_SHARED_CHROME);
+
 describe('common i18n keys (Issue #1197)', () => {
   it.each(['en', 'ja'])('%s/common.json has non-empty values for every leaf', (locale) => {
     const dict = loadCommon(locale);
@@ -243,6 +278,63 @@ describe('common i18n keys (Issue #1197)', () => {
           resolve(loadCommon(locale), 'repositories.localPathExample'),
           `${locale}: sample path must stay copy-pasteable`
         ).toContain('/Users/username/projects/my-repo');
+      }
+    });
+  });
+
+  describe('shared chrome copy (Issue #1273)', () => {
+    it('resolves every shared-chrome key in both locales', () => {
+      for (const locale of ['en', 'ja']) {
+        const dict = loadCommon(locale);
+        for (const key of SHARED_CHROME_KEYS) {
+          const value = resolve(dict, key);
+          expect(value, `${locale} missing ${key}`).toBeTruthy();
+          expect(typeof value, `${locale}: ${key} must be a string`).toBe('string');
+        }
+      }
+    });
+
+    it('never uses a raw key path as a shared-chrome label', () => {
+      for (const locale of ['en', 'ja']) {
+        const dict = loadCommon(locale);
+        for (const key of SHARED_CHROME_KEYS) {
+          expect(
+            resolve(dict, key) as string,
+            `${locale}: ${key} looks like a key passthrough`
+          ).not.toMatch(/^(common\.)?(status|sort|branchItem)\./);
+        }
+      }
+    });
+
+    it('translates shared-chrome labels rather than leaving them in English', () => {
+      const en = loadCommon('en');
+      const ja = loadCommon('ja');
+      for (const key of SHARED_CHROME_KEYS) {
+        expect(resolve(ja, key), `ja: ${key} is still the English string`).not.toBe(
+          resolve(en, key)
+        );
+      }
+    });
+
+    it('keeps every English shared-chrome label byte-identical to the pre-i18n markup', () => {
+      const en = loadCommon('en');
+      for (const [key, expected] of Object.entries(EN_SHARED_CHROME)) {
+        expect(resolve(en, key), `en: ${key} changed the rendered label`).toBe(expected);
+      }
+    });
+
+    /**
+     * Every status label must stay distinct: the dot's colour alone does not
+     * separate running from ready under prefers-reduced-motion, so the
+     * accessible label is the only cue a screen-reader user gets.
+     */
+    it('gives every status a distinct label in both locales', () => {
+      for (const locale of ['en', 'ja']) {
+        const dict = loadCommon(locale);
+        const labels = SHARED_CHROME_KEYS.filter((k) => k.startsWith('status.')).map((k) =>
+          resolve(dict, k)
+        );
+        expect(new Set(labels).size, `${locale}: two statuses share a label`).toBe(labels.length);
       }
     });
   });

--- a/tests/unit/i18n/external-apps-keys.test.ts
+++ b/tests/unit/i18n/external-apps-keys.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit-level i18n parity test for the `externalApps` namespace (Issue #1273).
+ *
+ * `src/i18n.ts` has no onError / getMessageFallback, so a missing key in one
+ * locale surfaces the raw key string in production. The global next-intl mock
+ * (tests/setup.ts) echoes the full key back, so a component test would stay
+ * green against a dictionary that never had the entry — mirroring
+ * common-keys / home-keys, this guard reads the real dictionary instead.
+ *
+ * Why a namespace of its own rather than a `common.externalApps.*` section:
+ * external apps are a feature domain (Issue #42 — own route, API, types and
+ * DB table), so their copy is owned by that domain the same way schedule /
+ * autoYes / commandPalette own theirs. `common` is reserved for strings with
+ * no single owning domain.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../../locales');
+
+function loadNamespace(locale: string): Record<string, unknown> {
+  const filePath = path.join(LOCALES_DIR, locale, 'externalApps.json');
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+/** Collect all dot-joined leaf key paths from a nested object. */
+function leafKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const full = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return leafKeys(value as Record<string, unknown>, full);
+    }
+    return [full];
+  });
+}
+
+function resolve(dict: Record<string, unknown>, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], dict);
+}
+
+/**
+ * The byte-exact pre-migration English, lifted from `git show HEAD:<file>` of
+ * the four external-apps components rather than retyped. English must stay
+ * display-neutral across this migration, so any drift here is a user-visible
+ * regression that the component tests' mocked t() could never catch.
+ */
+const EN_LABELS: Record<string, string> = {
+  'status.checking': 'Checking...',
+  'status.running': 'Running',
+  'status.stopped': 'Stopped',
+  'card.status': 'Status',
+  'card.port': 'Port',
+  'card.path': 'Path',
+  'card.websocket': 'WebSocket',
+  'card.enabled': 'Enabled',
+  'card.disabledNotice': 'This app is disabled',
+  'card.deleteConfirm': 'Delete "{name}"?',
+  'card.delete': 'Delete',
+  'card.open': 'Open',
+  'card.settings': 'Settings',
+  'manager.addApp': '+ Add App',
+  'manager.loading': 'Loading apps...',
+  'manager.loadError': 'Failed to load external apps',
+  'manager.empty': 'No external apps registered yet.',
+  'manager.emptyHelp':
+    'Add an external app to proxy requests to other frontend applications.',
+  'manager.addFirst': 'Add Your First App',
+  'form.editTitle': 'Edit External App',
+  'form.addTitle': 'Add External App',
+  'form.securityWarning':
+    'Proxied apps run under the CommandMate origin and can access CommandMate APIs. Only register trusted applications.',
+  'form.displayName': 'Display Name',
+  'form.displayNamePlaceholder': 'My App',
+  'form.identifierName': 'Identifier Name',
+  'form.identifierNamePlaceholder': 'my-app',
+  'form.identifierNameHelp': 'Alphanumeric and hyphens only. Cannot be changed later.',
+  'form.pathPrefix': 'Path Prefix',
+  'form.pathPrefixPlaceholder': 'app-name',
+  'form.pathPrefixHelp': 'URL path for accessing this app. Cannot be changed later.',
+  'form.portNumber': 'Port Number',
+  'form.portNumberPlaceholder': '5173',
+  'form.portNumberHelp': 'Target port ({min}-{max})',
+  'form.appType': 'App Type',
+  'form.appTypePlaceholder': 'Select app type...',
+  'form.description': 'Description',
+  'form.descriptionPlaceholder': 'Optional description...',
+  'form.websocketLabel': 'Enable WebSocket support',
+  'form.enabledLabel': 'App is enabled',
+  'form.save': 'Save Changes',
+  'form.add': 'Add App',
+  'form.updateFailed': 'Failed to update app',
+  'form.createFailed': 'Failed to create app',
+  'form.genericError': 'An error occurred',
+};
+
+const ALL_KEYS = Object.keys(EN_LABELS);
+
+/**
+ * Sample inputs the user copies or types back. Translating a placeholder would
+ * make the example wrong rather than localized (`my-app` must stay a legal
+ * identifier, `5173` a port), so these are exempt from the "ja must differ
+ * from en" rule rather than being an oversight.
+ */
+const LOCALE_INVARIANT_KEYS = new Set([
+  'form.displayNamePlaceholder',
+  'form.identifierNamePlaceholder',
+  'form.pathPrefixPlaceholder',
+  'form.portNumberPlaceholder',
+]);
+
+describe('externalApps i18n keys (Issue #1273)', () => {
+  it.each(['en', 'ja'])('%s/externalApps.json has non-empty values for every leaf', (locale) => {
+    const dict = loadNamespace(locale);
+    const keys = leafKeys(dict);
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(resolve(dict, key), `${locale}: ${key}`).toBeTruthy();
+    }
+  });
+
+  it('en and ja expose the identical set of keys (parity)', () => {
+    const en = leafKeys(loadNamespace('en')).sort();
+    const ja = leafKeys(loadNamespace('ja')).sort();
+    expect(en).toEqual(ja);
+  });
+
+  it('resolves every key the components request at runtime, in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadNamespace(locale);
+      for (const key of ALL_KEYS) {
+        const value = resolve(dict, key);
+        expect(value, `${locale} missing ${key}`).toBeTruthy();
+        expect(typeof value, `${locale}: ${key} must be a string`).toBe('string');
+      }
+    }
+  });
+
+  it('never uses a raw key path as a label', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadNamespace(locale);
+      for (const key of ALL_KEYS) {
+        expect(
+          resolve(dict, key) as string,
+          `${locale}: ${key} looks like a key passthrough`
+        ).not.toMatch(/^(externalApps\.)?(status|card|manager|form)\./);
+      }
+    }
+  });
+
+  it('translates labels rather than leaving them in English', () => {
+    const en = loadNamespace('en');
+    const ja = loadNamespace('ja');
+    for (const key of ALL_KEYS) {
+      if (LOCALE_INVARIANT_KEYS.has(key)) continue;
+      expect(resolve(ja, key), `ja: ${key} is still the English string`).not.toBe(
+        resolve(en, key)
+      );
+    }
+  });
+
+  it('keeps every English label byte-identical to the pre-i18n markup', () => {
+    const en = loadNamespace('en');
+    for (const [key, expected] of Object.entries(EN_LABELS)) {
+      expect(resolve(en, key), `en: ${key} changed the rendered label`).toBe(expected);
+    }
+  });
+
+  it('keeps sample placeholders verbatim in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadNamespace(locale);
+      for (const key of LOCALE_INVARIANT_KEYS) {
+        expect(resolve(dict, key), `${locale}: ${key} must stay verbatim`).toBe(EN_LABELS[key]);
+      }
+    }
+  });
+
+  /**
+   * The two interpolated strings must keep their ICU placeholders in every
+   * locale: a translator dropping `{name}` / `{min}` silently renders a delete
+   * prompt with no app name, or a port hint with no range.
+   */
+  it('preserves ICU placeholders in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadNamespace(locale);
+      expect(resolve(dict, 'card.deleteConfirm'), `${locale}: lost {name}`).toContain('{name}');
+      const portHelp = resolve(dict, 'form.portNumberHelp') as string;
+      expect(portHelp, `${locale}: lost {min}`).toContain('{min}');
+      expect(portHelp, `${locale}: lost {max}`).toContain('{max}');
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1273 の対応。**#1270 系の namespace 方針を確定**し、`ui/` `common/` `sidebar/` `external-apps/` を i18n 化する。

**#1274 / #1275 / #1276 / #1277 がこの決定を参照する。**

## 🔴 namespace 方針（確定）

**namespace は「文言を所有する feature domain」で決める。`common` は「単一の所有ドメインを持たない文言」（画面横断の chrome・共有プリミティブ）専用。**

| 領域 | 方針 |
|---|---|
| `ui/` `common/` `sidebar/` | **`common` に集約**（新規 namespace を作らない） |
| `external-apps/` | **新規 `externalApps` namespace** |

### `ui/` を `common` に寄せる理由

#1197（nav）/ #1219（repositories）の踏襲であると同時に、**既に repo 内で確定済みの状態**でもある:

- `ui/ConfirmDialog` は既に `useTranslations('common')` を呼び `common.confirmDialog.*` を引いている
- `sidebar/SortSelector` も `common.tooltips.sort` を引いている

→ **ここで `ui.json` / `sidebar.json` を新設すると、両ディレクトリが2つの namespace に分裂して現状より悪化する。**

「`ui/` は画面に属さない汎用プリミティブ」という論点は妥当だが、**`common` は「画面」ではなく「所有ドメインなし」の置き場なので矛盾しない**。

### `external-apps/` で方針が分岐する理由

**これは feature domain だから。** Issue #42 の専用 route（`/proxy`）/ API / types / DB を持ち、文言は**約45件**ある。

`common.json`（**2,187 bytes**）に投入すると**約3倍に膨らみ common が junk drawer 化する**。既存の `schedule` / `autoYes` / `commandPalette` / `home` / `review` と同じ扱いにした。

## ⚠️ 起票時の grep 実数が両方向に誤っていた（起票者の手法の欠陥）

**Issue の「32ユニーク」は信用できない。**

| 領域 | 起票時の grep | 実測 |
|---|---|---|
| `ui/` | 15 | **実文言は 1件のみ**（`Modal.tsx:153` の `aria-label="Close"`）。**13件は JSDoc `@example`**（`* <Badge variant="success">Active</Badge>` 等）、1件は正規表現の誤マッチ（`=> Promise<boolean>` が `>...<` に一致） |
| `external-apps/` | 9 | **約45件**（`ExternalAppCard` 単体で grep 3件に対し**実際12件**） |

**起票者の grep は JSDoc を数え、JSX テキストの大半を取りこぼす**（`[A-Z][A-Za-z][...]{3,}` が**5文字以上を要求**するため `Port` `Path` のような短い語を落とす）。

→ 完了判定には**コメント行を除外した grep** を使い、担当領域の実文言 **0件**を確認した（残1件は `=> Promise<boolean>;` の誤マッチで文字列ではない）。

### その他の訂正

- 「大半が aria-label」も `ui/` `common/` `sidebar/` に限れば正しいが、**`external-apps/` はほぼ全てが表示テキスト**。領域全体では**表示テキストが多数派**
- **#1271 のルールは JSX 属性を検出しない**（モジュールスコープ const の `label`/`title`/`description`/`placeholder`/`ariaLabel`/`tooltip`/`subtitle`/`heading` のみ）。担当領域の11件は `ui/StatusDot` 7 + `sidebar/SortSelector` 4 で、`common/` と `external-apps/` には**元から1件も無かった**

## #1271 警告の削減実績

**124件 → 113件（-11）**。内訳: `components/ui` 7→0、`components/sidebar` 4→0。`common/` `external-apps/` は元から0件。

残113件は担当外（`lib/standard-commands` 45、`components/worktree` 26、`config/status-colors` 15 等）。

## status ラベルの共有

`common.status.*` は `StatusDot` 専用ではなく**汎用キー**として定義した。**同じ6語が `src/config/status-colors.ts`（担当外・#1271 警告15件）にも直書き**されており、そちらの移行時にキーを再利用させ**翻訳の二重管理を防ぐ**ため。

## テストの実効性（欠陥注入で検証）

**EN はバイト一致。** 検証は `git show HEAD:<file>` から抽出した移行前原文と辞書値を突き合わせる方式（**自作期待値同士の照合を回避**）で **65/65 一致**。EN 文言を1箇所ドリフトさせると検出されることも確認。

**6パターンの欠陥注入**（注入の適用を置換件数 > 0 で毎回検証）で全ケース期待通り失敗することを確認: EN ドリフト / ja キー欠落 / ja 未翻訳 / ICU プレースホルダ欠落 / キーパス素通し / 存在しないキーの参照。

### 🔬 real-intl バックが load-bearing であることを実証

wording を検証するコンポーネントテストを #1206 の real-intl バックに切り替えた。**`en/common.json` から status ブロックを削除すると:**

| 構成 | 結果 |
|---|---|
| **real-intl バック** | ✅ **25件が失敗** |
| グローバルモック（`tests/setup.ts` の素通し） | ❌ **26件すべて green のまま通過** |

**#1197 と同じ盲点が実際に再現することを確認した上での切り替え。**

## 積み残し（意図的なスコープ外）

`APP_TYPE_LABELS`（SvelteKit / Streamlit / Next.js / Other）は未移行。**4件中3件がブランド名**で、テーブルの実体は `lib/external-apps/validation.ts` にあり**本Issueの components 配下スコープ外**。`"Other"` 1語のみが翻訳対象。

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0（警告 113件・CI 無影響） |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **569 files / 9,660 tests 全パス** |
| `npm run build` | ✅ exit 0 |
| EN/JA キーパリティ（`externalApps`） | ✅ **差分0** |

Refs #1193, #1270, #1271
Closes #1273
