### PR TITLE
fix(i18n): worktree/ ファイル閲覧・編集系の文言を worktree namespace へ移行する (#1275)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -61,7 +61,20 @@
       "showSize": "File size",
       "showCreated": "Created date",
       "showModified": "Modified date"
-    }
+    },
+    "loading": "Loading files",
+    "empty": "No files found",
+    "newFile": "New File",
+    "newDirectory": "New Directory",
+    "noResultsMatching": "No files matching \"{query}\"",
+    "noResultsContaining": "No files containing \"{query}\"",
+    "label": "File tree",
+    "refreshing": "Refreshing files",
+    "refreshLabel": "Refresh file tree",
+    "resetViewLabel": "Reset file tree view",
+    "loadError": "Failed to load files",
+    "loadDirectoryError": "Failed to load directory: {status}",
+    "itemCount": "{count} items"
   },
   "update": {
     "available": "A new version is available",
@@ -135,10 +148,137 @@
     "reorderError": "Failed to reorder todos"
   },
   "htmlPreview": {
-    "interactiveModeConfirm": "Interactive mode executes scripts in the HTML file. Use Safe mode for untrusted HTML files."
+    "interactiveModeConfirm": "Interactive mode executes scripts in the HTML file. Use Safe mode for untrusted HTML files.",
+    "title": "HTML Preview: {path}",
+    "modeSource": "Source",
+    "modePreview": "Preview",
+    "modeSplit": "Split",
+    "sandboxSafe": "Safe",
+    "sandboxInteractive": "Interactive"
   },
   "editor": {
     "saveFailedCloseConfirm": "Save failed. Close anyway?",
-    "unsavedCloseConfirm": "You have unsaved changes. Are you sure you want to close?"
+    "unsavedCloseConfirm": "You have unsaved changes. Are you sure you want to close?",
+    "loading": "Loading...",
+    "placeholder": "Start typing...",
+    "placeholderMarkdown": "Start typing markdown...",
+    "saveSuccess": "File saved successfully",
+    "saveError": "Failed to save file",
+    "loadError": "Failed to load file",
+    "sessionExpired": "Session expired. Please re-login.",
+    "autoSaveFailed": "Auto-save failed. Switched to manual save.",
+    "unsaved": "Unsaved",
+    "auto": "Auto",
+    "splitView": "Split view",
+    "editorOnly": "Editor only",
+    "previewOnly": "Preview only",
+    "enterFullscreen": "Enter fullscreen (Ctrl+Shift+F)",
+    "exitFullscreen": "Exit fullscreen (ESC)"
+  },
+  "actions": {
+    "copyPath": "Copy path",
+    "copyContent": "Copy content",
+    "copyFilePath": "Copy file path",
+    "copyFileContent": "Copy file content",
+    "search": "Search",
+    "searchInFile": "Search in file",
+    "edit": "Edit",
+    "editFile": "Edit file",
+    "download": "Download",
+    "downloadFile": "Download file",
+    "close": "Close",
+    "save": "Save",
+    "saving": "Saving...",
+    "saved": "Saved",
+    "prev": "Prev",
+    "next": "Next",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "minimize": "Minimize",
+    "maximize": "Maximize",
+    "retry": "Retry",
+    "refresh": "Refresh",
+    "resetView": "Reset view"
+  },
+  "fileSearch": {
+    "placeholder": "Search...",
+    "prevMatch": "Previous match",
+    "nextMatch": "Next match",
+    "close": "Close search"
+  },
+  "fileViewer": {
+    "loading": "Loading file...",
+    "loadError": "Failed to load file",
+    "tabSource": "Source",
+    "tabPreview": "Preview",
+    "sandboxSafe": "Safe",
+    "sandboxInteractive": "Interactive",
+    "slideTitle": "{name} - Slide {number}",
+    "noSlides": "No slides found in {fileName}",
+    "slides": "Slides",
+    "editor": "Editor"
+  },
+  "fileTabs": {
+    "unsavedChanges": "Unsaved changes",
+    "closeTab": "Close {name}"
+  },
+  "markdownPreview": {
+    "loadingImage": "[loading image...]",
+    "editor": "Editor",
+    "preview": "Preview",
+    "exitFullscreenHint": "Press ESC to exit fullscreen",
+    "exitFullscreenHintSwipe": "(or swipe down)",
+    "largeFileWarning": "Large file: Performance may be affected."
+  },
+  "mermaid": {
+    "rendering": "Rendering diagram...",
+    "loading": "Loading diagram...",
+    "errorTitle": "Diagram Error",
+    "emptyCode": "Diagram code is empty",
+    "renderError": "Failed to render diagram"
+  },
+  "imageViewer": {
+    "loadError": "Failed to load image"
+  },
+  "videoViewer": {
+    "loadError": "Failed to load video",
+    "loading": "Loading video...",
+    "unsupported": "Your browser does not support the video tag."
+  },
+  "logViewer": {
+    "title": "Log Files",
+    "all": "All ({count})",
+    "toolCount": "{tool} ({count})",
+    "empty": "No log files found",
+    "emptyFiltered": "No {tool} log files found",
+    "copyTitle": "Copy sanitized log to clipboard",
+    "export": "Export",
+    "exporting": "Exporting...",
+    "copied": "Log copied to clipboard (sanitized)",
+    "exportError": "Failed to export log: {error}",
+    "searchPlaceholder": "Search in log file...",
+    "prevMatch": "Previous match (Shift+Enter)",
+    "nextMatch": "Next match (Enter)",
+    "noMatches": "No matches found for \"{query}\""
+  },
+  "pdfPreview": {
+    "title": "PDF Preview: {path}",
+    "loadError": "Could not load the PDF preview.",
+    "openInNewTab": "Open PDF in a new tab",
+    "download": "Download",
+    "downloadPdf": "Download PDF"
+  },
+  "diffViewer": {
+    "badge": "DIFF",
+    "close": "Close diff view"
+  },
+  "search": {
+    "searching": "Searching...",
+    "placeholder": "Search files...",
+    "label": "Search files",
+    "clear": "Clear search",
+    "mode": "Mode:",
+    "modeName": "Name",
+    "modeContent": "Content"
   }
 }

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -61,7 +61,20 @@
       "showSize": "ファイルサイズ",
       "showCreated": "作成日時",
       "showModified": "更新日時"
-    }
+    },
+    "loading": "ファイルを読み込み中",
+    "empty": "ファイルが見つかりません",
+    "newFile": "新規ファイル",
+    "newDirectory": "新規ディレクトリ",
+    "noResultsMatching": "「{query}」に一致するファイルはありません",
+    "noResultsContaining": "「{query}」を含むファイルはありません",
+    "label": "ファイルツリー",
+    "refreshing": "ファイルを更新中",
+    "refreshLabel": "ファイルツリーを更新",
+    "resetViewLabel": "ファイルツリーの表示をリセット",
+    "loadError": "ファイルの読み込みに失敗しました",
+    "loadDirectoryError": "ディレクトリの読み込みに失敗しました: {status}",
+    "itemCount": "{count} 項目"
   },
   "update": {
     "available": "新しいバージョンが利用可能です",
@@ -135,10 +148,137 @@
     "reorderError": "ToDoの並び替えに失敗しました"
   },
   "htmlPreview": {
-    "interactiveModeConfirm": "Interactiveモードではスクリプトが実行されます。信頼できないHTMLファイルではSafeモードを使用してください。"
+    "interactiveModeConfirm": "Interactiveモードではスクリプトが実行されます。信頼できないHTMLファイルではSafeモードを使用してください。",
+    "title": "HTML プレビュー: {path}",
+    "modeSource": "ソース",
+    "modePreview": "プレビュー",
+    "modeSplit": "分割",
+    "sandboxSafe": "セーフ",
+    "sandboxInteractive": "インタラクティブ"
   },
   "editor": {
     "saveFailedCloseConfirm": "保存に失敗しました。このまま閉じますか？",
-    "unsavedCloseConfirm": "未保存の変更があります。閉じてもよろしいですか？"
+    "unsavedCloseConfirm": "未保存の変更があります。閉じてもよろしいですか？",
+    "loading": "読み込み中...",
+    "placeholder": "入力を開始...",
+    "placeholderMarkdown": "Markdown の入力を開始...",
+    "saveSuccess": "ファイルを保存しました",
+    "saveError": "ファイルの保存に失敗しました",
+    "loadError": "ファイルの読み込みに失敗しました",
+    "sessionExpired": "セッションの有効期限が切れました。再ログインしてください。",
+    "autoSaveFailed": "自動保存に失敗しました。手動保存に切り替えます。",
+    "unsaved": "未保存",
+    "auto": "自動",
+    "splitView": "分割表示",
+    "editorOnly": "エディタのみ",
+    "previewOnly": "プレビューのみ",
+    "enterFullscreen": "全画面にする (Ctrl+Shift+F)",
+    "exitFullscreen": "全画面を終了 (ESC)"
+  },
+  "actions": {
+    "copyPath": "パスをコピー",
+    "copyContent": "内容をコピー",
+    "copyFilePath": "ファイルパスをコピー",
+    "copyFileContent": "ファイルの内容をコピー",
+    "search": "検索",
+    "searchInFile": "ファイル内を検索",
+    "edit": "編集",
+    "editFile": "ファイルを編集",
+    "download": "ダウンロード",
+    "downloadFile": "ファイルをダウンロード",
+    "close": "閉じる",
+    "save": "保存",
+    "saving": "保存中...",
+    "saved": "保存済み",
+    "prev": "前へ",
+    "next": "次へ",
+    "fullscreen": "全画面",
+    "exitFullscreen": "全画面を終了",
+    "minimize": "最小化",
+    "maximize": "最大化",
+    "retry": "再試行",
+    "refresh": "更新",
+    "resetView": "表示をリセット"
+  },
+  "fileSearch": {
+    "placeholder": "検索...",
+    "prevMatch": "前の結果",
+    "nextMatch": "次の結果",
+    "close": "検索を閉じる"
+  },
+  "fileViewer": {
+    "loading": "ファイルを読み込み中...",
+    "loadError": "ファイルの読み込みに失敗しました",
+    "tabSource": "ソース",
+    "tabPreview": "プレビュー",
+    "sandboxSafe": "セーフ",
+    "sandboxInteractive": "インタラクティブ",
+    "slideTitle": "{name} - スライド {number}",
+    "noSlides": "{fileName} にスライドが見つかりません",
+    "slides": "スライド",
+    "editor": "エディタ"
+  },
+  "fileTabs": {
+    "unsavedChanges": "未保存の変更",
+    "closeTab": "{name} を閉じる"
+  },
+  "markdownPreview": {
+    "loadingImage": "[画像を読み込み中...]",
+    "editor": "エディタ",
+    "preview": "プレビュー",
+    "exitFullscreenHint": "ESC キーで全画面を終了",
+    "exitFullscreenHintSwipe": "(または下にスワイプ)",
+    "largeFileWarning": "大きなファイル: パフォーマンスに影響する場合があります。"
+  },
+  "mermaid": {
+    "rendering": "図を描画中...",
+    "loading": "図を読み込み中...",
+    "errorTitle": "図のエラー",
+    "emptyCode": "図のコードが空です",
+    "renderError": "図の描画に失敗しました"
+  },
+  "imageViewer": {
+    "loadError": "画像の読み込みに失敗しました"
+  },
+  "videoViewer": {
+    "loadError": "動画の読み込みに失敗しました",
+    "loading": "動画を読み込み中...",
+    "unsupported": "お使いのブラウザは video タグに対応していません。"
+  },
+  "logViewer": {
+    "title": "ログファイル",
+    "all": "すべて ({count})",
+    "toolCount": "{tool} ({count})",
+    "empty": "ログファイルが見つかりません",
+    "emptyFiltered": "{tool} のログファイルが見つかりません",
+    "copyTitle": "サニタイズしたログをクリップボードにコピー",
+    "export": "エクスポート",
+    "exporting": "エクスポート中...",
+    "copied": "ログをクリップボードにコピーしました (サニタイズ済み)",
+    "exportError": "ログのエクスポートに失敗しました: {error}",
+    "searchPlaceholder": "ログファイル内を検索...",
+    "prevMatch": "前の一致 (Shift+Enter)",
+    "nextMatch": "次の一致 (Enter)",
+    "noMatches": "「{query}」に一致するものはありません"
+  },
+  "pdfPreview": {
+    "title": "PDF プレビュー: {path}",
+    "loadError": "PDFプレビューを読み込めませんでした。",
+    "openInNewTab": "PDFを新しいタブで開く",
+    "download": "ダウンロード",
+    "downloadPdf": "PDF をダウンロード"
+  },
+  "diffViewer": {
+    "badge": "DIFF",
+    "close": "差分表示を閉じる"
+  },
+  "search": {
+    "searching": "検索中...",
+    "placeholder": "ファイルを検索...",
+    "label": "ファイルを検索",
+    "clear": "検索をクリア",
+    "mode": "モード:",
+    "modeName": "名前",
+    "modeContent": "内容"
   }
 }

--- a/src/components/worktree/DiffViewer.tsx
+++ b/src/components/worktree/DiffViewer.tsx
@@ -9,6 +9,7 @@
 'use client';
 
 import React, { memo } from 'react';
+import { useTranslations } from 'next-intl';
 
 // ============================================================================
 // Types
@@ -54,13 +55,15 @@ export const DiffViewer = memo(function DiffViewer({
   filePath,
   onClose,
 }: DiffViewerProps) {
+  const t = useTranslations('worktree');
+
   return (
     <div className="h-full flex flex-col bg-surface">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-xs font-medium text-accent-600 dark:text-accent-400 shrink-0">
-            DIFF
+            {t('diffViewer.badge')}
           </span>
           <span className="text-xs font-mono text-muted-foreground truncate">
             {filePath}
@@ -70,7 +73,7 @@ export const DiffViewer = memo(function DiffViewer({
           type="button"
           onClick={onClose}
           className="p-1 text-muted-foreground hover:text-foreground rounded shrink-0"
-          aria-label="Close diff view"
+          aria-label={t('diffViewer.close')}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/src/components/worktree/FilePanelContent.tsx
+++ b/src/components/worktree/FilePanelContent.tsx
@@ -12,6 +12,7 @@
 
 import React, { useEffect, useRef, memo, useState, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
 import { Maximize2, Minimize2, ClipboardCopy, Check, Copy, Search } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { FileTab } from '@/hooks/useFileTabs';
@@ -119,10 +120,11 @@ const MARP_FRONTMATTER_REGEX = /^---\s*\nmarp:\s*true/;
 
 /** Loading spinner */
 function LoadingSpinner() {
+  const t = useTranslations('worktree');
   return (
     <div className="flex items-center justify-center py-12">
       <Spinner size="xl" variant="accent" />
-      <p className="ml-3 text-muted-foreground">Loading file...</p>
+      <p className="ml-3 text-muted-foreground">{t('fileViewer.loading')}</p>
     </div>
   );
 }
@@ -153,6 +155,7 @@ function ErrorDisplay({ error }: { error: string }) {
 
 /** Toolbar with path copy, content copy, search, and maximize/minimize buttons */
 function FileToolbar({ filePath, isMaximized, onToggleMaximize, copyableContent, onSearch }: { filePath: string; isMaximized: boolean; onToggleMaximize: () => void; copyableContent?: string; onSearch?: () => void }) {
+  const t = useTranslations('worktree');
   const [pathCopied, setPathCopied] = useState(false);
   const [contentCopied, setContentCopied] = useState(false);
   const pathTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -196,8 +199,8 @@ function FileToolbar({ filePath, isMaximized, onToggleMaximize, copyableContent,
           type="button"
           onClick={handleCopyPath}
           className="flex-shrink-0 p-1 rounded-md hover:bg-muted text-muted-foreground transition-colors"
-          aria-label="Copy file path"
-          title="Copy path"
+          aria-label={t('actions.copyFilePath')}
+          title={t('actions.copyPath')}
         >
           {pathCopied ? <Check className="w-3.5 h-3.5 text-success" /> : <ClipboardCopy className="w-3.5 h-3.5" />}
         </button>
@@ -211,8 +214,8 @@ function FileToolbar({ filePath, isMaximized, onToggleMaximize, copyableContent,
             type="button"
             onClick={onSearch}
             className="flex-shrink-0 p-1 rounded-md hover:bg-muted text-muted-foreground transition-colors"
-            aria-label="Search in file"
-            title="Search"
+            aria-label={t('actions.searchInFile')}
+            title={t('actions.search')}
           >
             <Search className="w-3.5 h-3.5" />
           </button>
@@ -222,8 +225,8 @@ function FileToolbar({ filePath, isMaximized, onToggleMaximize, copyableContent,
             type="button"
             onClick={handleCopyContent}
             className="flex-shrink-0 p-1 rounded-md hover:bg-muted text-muted-foreground transition-colors"
-            aria-label="Copy file content"
-            title="Copy content"
+            aria-label={t('actions.copyFileContent')}
+            title={t('actions.copyContent')}
           >
             {contentCopied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
           </button>
@@ -232,8 +235,8 @@ function FileToolbar({ filePath, isMaximized, onToggleMaximize, copyableContent,
           type="button"
           onClick={onToggleMaximize}
           className="flex-shrink-0 p-1.5 rounded-md hover:bg-muted text-muted-foreground transition-colors"
-          aria-label={isMaximized ? 'Minimize' : 'Maximize'}
-          title={isMaximized ? 'Minimize' : 'Maximize'}
+          aria-label={isMaximized ? t('actions.minimize') : t('actions.maximize')}
+          title={isMaximized ? t('actions.minimize') : t('actions.maximize')}
         >
           {isMaximized ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
         </button>
@@ -497,6 +500,7 @@ function MarpPreview({
   slides: string[];
   fileName: string;
 }) {
+  const t = useTranslations('worktree');
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const handlePrev = () => {
@@ -508,7 +512,7 @@ function MarpPreview({
   };
 
   if (slides.length === 0) {
-    return <div className="p-4 text-muted-foreground">No slides found in {fileName}</div>;
+    return <div className="p-4 text-muted-foreground">{t('fileViewer.noSlides', { fileName })}</div>;
   }
 
   return (
@@ -520,7 +524,7 @@ function MarpPreview({
           disabled={currentSlide === 0}
           className="px-3 py-1 text-sm rounded-md bg-muted disabled:opacity-50 hover:bg-muted/80 transition-colors"
         >
-          Prev
+          {t('actions.prev')}
         </button>
         <span className="text-sm text-muted-foreground">
           {currentSlide + 1} / {slides.length}
@@ -531,14 +535,14 @@ function MarpPreview({
           disabled={currentSlide === slides.length - 1}
           className="px-3 py-1 text-sm rounded-md bg-muted disabled:opacity-50 hover:bg-muted/80 transition-colors"
         >
-          Next
+          {t('actions.next')}
         </button>
       </div>
       <div className="flex-1 overflow-hidden">
         <iframe
           srcDoc={slides[currentSlide]}
           sandbox=""
-          title={`${fileName} - Slide ${currentSlide + 1}`}
+          title={t('fileViewer.slideTitle', { name: fileName, number: currentSlide + 1 })}
           className="w-full h-full border-0"
         />
       </div>
@@ -571,6 +575,7 @@ function MarpEditorWithSlides({
   onDirtyChange?: (isDirty: boolean) => void;
   onOpenFile?: (path: string) => void;
 }) {
+  const t = useTranslations('worktree');
   const [marpViewMode, setMarpViewMode] = useState<'slides' | 'editor'>('slides');
 
   return (
@@ -586,7 +591,7 @@ function MarpEditorWithSlides({
                 : 'text-muted-foreground hover:bg-muted'
             }`}
           >
-            Slides
+            {t('fileViewer.slides')}
           </button>
           <button
             type="button"
@@ -597,7 +602,7 @@ function MarpEditorWithSlides({
                 : 'text-muted-foreground hover:bg-muted'
             }`}
           >
-            Editor
+            {t('fileViewer.editor')}
           </button>
         </div>
         <FileToolbar filePath={filePath} isMaximized={isMaximized} onToggleMaximize={onToggleMaximize} copyableContent={contentText} />
@@ -787,6 +792,12 @@ export const FilePanelContent = memo(function FilePanelContent({
   onDirtyChange,
   onOpenFile,
 }: FilePanelContentProps) {
+  const t = useTranslations('worktree');
+  // [Issue #1275] `t` is a fresh closure on every render, so listing it in the
+  // auto-fetch effect's deps would re-run that effect on every render. Read it
+  // via a ref to keep the effect keyed on the tab/worktree inputs alone.
+  const tRef = useRef(t);
+  tRef.current = t;
   const fetchingRef = useRef(false);
   const [marpSlides, setMarpSlides] = useState<string[] | null>(null);
   const [isMaximized, setIsMaximized] = useState(false);
@@ -839,7 +850,7 @@ export const FilePanelContent = memo(function FilePanelContent({
           const errorData = await response.json();
           const errMsg = typeof errorData.error === 'string'
             ? errorData.error
-            : errorData.error?.message || 'Failed to load file';
+            : errorData.error?.message || tRef.current('fileViewer.loadError');
           onLoadError(tab.path, errMsg);
           return;
         }
@@ -849,7 +860,7 @@ export const FilePanelContent = memo(function FilePanelContent({
       } catch (err: unknown) {
         onLoadError(
           tab.path,
-          err instanceof Error ? err.message : 'Failed to load file',
+          err instanceof Error ? err.message : tRef.current('fileViewer.loadError'),
         );
       } finally {
         fetchingRef.current = false;

--- a/src/components/worktree/FilePanelTabs.tsx
+++ b/src/components/worktree/FilePanelTabs.tsx
@@ -12,6 +12,7 @@
 'use client';
 
 import React, { memo, useCallback, useState, useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 import { X, ChevronDown } from 'lucide-react';
 import { FilePanelContent } from './FilePanelContent';
 import type { FileTab } from '@/hooks/useFileTabs';
@@ -70,6 +71,8 @@ const TabButton = memo(function TabButton({
   onActivate: (path: string) => void;
   onClose: (path: string) => void;
 }) {
+  const t = useTranslations('worktree');
+
   const handleClick = useCallback(() => {
     if (!isActive) {
       onActivate(tab.path);
@@ -103,14 +106,14 @@ const TabButton = memo(function TabButton({
         <span
           data-testid={`file-tab-dirty-${tab.path}`}
           className="w-2 h-2 rounded-full bg-warning flex-shrink-0"
-          title="Unsaved changes"
+          title={t('fileTabs.unsavedChanges')}
         />
       )}
       <button
         type="button"
         onClick={handleClose}
         className="ml-1 p-0.5 rounded-sm hover:bg-muted transition-colors"
-        aria-label={`Close ${tab.name}`}
+        aria-label={t('fileTabs.closeTab', { name: tab.name })}
       >
         <X className="w-3 h-3" />
       </button>

--- a/src/components/worktree/FileSearchBar.tsx
+++ b/src/components/worktree/FileSearchBar.tsx
@@ -11,6 +11,7 @@
 'use client';
 
 import React, { memo } from 'react';
+import { useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui';
 
@@ -51,6 +52,8 @@ export const FileSearchBar = memo(function FileSearchBar({
   onPrevMatch,
   onClose,
 }: FileSearchBarProps) {
+  const t = useTranslations('worktree');
+
   return (
     <div className="flex items-center gap-1 px-2 py-1 bg-muted border-b border-input flex-shrink-0">
       <input
@@ -62,7 +65,7 @@ export const FileSearchBar = memo(function FileSearchBar({
           if (e.key === 'Escape') { onClose(); }
           if (e.key === 'Enter') { if (e.shiftKey) { onPrevMatch(); } else { onNextMatch(); } }
         }}
-        placeholder="検索..."
+        placeholder={t('fileSearch.placeholder')}
         className="flex-1 min-w-0 px-2 py-0.5 text-sm bg-surface dark:text-foreground border border-input rounded outline-none focus:ring-1 focus:ring-ring"
         autoComplete="off"
         autoCorrect="off"
@@ -72,9 +75,9 @@ export const FileSearchBar = memo(function FileSearchBar({
       <span className="text-xs text-muted-foreground min-w-[3rem] text-right">
         {matchCount > 0 ? `${currentIdx + 1}/${matchCount}` : '0/0'}
       </span>
-      <Button variant="ghost" type="button" onClick={onPrevMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50" aria-label="前の結果">▲</Button>
-      <Button variant="ghost" type="button" onClick={onNextMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50" aria-label="次の結果">▼</Button>
-      <Button variant="ghost" type="button" onClick={onClose} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white" aria-label="検索を閉じる"><X className="w-4 h-4" /></Button>
+      <Button variant="ghost" type="button" onClick={onPrevMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50" aria-label={t('fileSearch.prevMatch')}>▲</Button>
+      <Button variant="ghost" type="button" onClick={onNextMatch} disabled={matchCount === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white disabled:text-muted-foreground/50" aria-label={t('fileSearch.nextMatch')}>▼</Button>
+      <Button variant="ghost" type="button" onClick={onClose} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground dark:hover:text-white" aria-label={t('fileSearch.close')}><X className="w-4 h-4" /></Button>
     </div>
   );
 });

--- a/src/components/worktree/FileTreeView.tsx
+++ b/src/components/worktree/FileTreeView.tsx
@@ -29,7 +29,7 @@ import { useFilePolling } from '@/hooks/useFilePolling';
 import { useFileMetadataDisplay } from '@/hooks/useFileMetadataDisplay';
 import { FILE_TREE_POLL_INTERVAL_MS } from '@/config/file-polling-config';
 import { useFileTreeExpandedState } from '@/hooks/useFileTreeExpandedState';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { FilePlus, FolderPlus, AlertCircle, RefreshCw, RotateCcw } from 'lucide-react';
 import { Button, Skeleton } from '@/components/ui';
 
@@ -125,6 +125,7 @@ export const FileTreeView = memo(function FileTreeView({
 }: FileTreeViewProps) {
   // [Issue #162] Get locale for date formatting
   const locale = useLocale();
+  const t = useTranslations('worktree');
   // [Issue #969] Inline metadata column visibility (size / created / modified),
   // localStorage-persisted and synced across hook instances.
   const { settings: metadataDisplay, toggle: toggleMetadata } =
@@ -146,6 +147,13 @@ export const FileTreeView = memo(function FileTreeView({
   const expandedRef = useRef(expanded);
   expandedRef.current = expanded;
 
+  // [Issue #1275] `t` is a fresh closure on every render, so listing it in the
+  // dep arrays below would rebuild fetchDirectory -> reloadTreeWithExpandedDirs
+  // on every render and re-fire the reload effect in a loop. Read it via a ref
+  // to keep the "stable as long as worktreeId is unchanged" invariant intact.
+  const tRef = useRef(t);
+  tRef.current = t;
+
   // [Issue #164] Ref to track in-progress fetches and prevent duplicate requests
   const loadingPathsRef = useRef<Set<string>>(new Set());
 
@@ -165,7 +173,7 @@ export const FileTreeView = memo(function FileTreeView({
         const response = await fetch(url);
 
         if (!response.ok) {
-          throw new Error(`Failed to load directory: ${response.status}`);
+          throw new Error(tRef.current('fileTree.loadDirectoryError', { status: response.status }));
         }
 
         return await response.json();
@@ -255,7 +263,7 @@ export const FileTreeView = memo(function FileTreeView({
       }
     } catch (err) {
       if (mountedRef.current) {
-        setError(err instanceof Error ? err.message : 'Failed to load files');
+        setError(err instanceof Error ? err.message : tRef.current('fileTree.loadError'));
       }
     } finally {
       if (mountedRef.current) {
@@ -525,7 +533,7 @@ export const FileTreeView = memo(function FileTreeView({
         data-testid="file-tree-loading"
         className={`p-2 ${className}`}
         role="status"
-        aria-label="Loading files"
+        aria-label={t('fileTree.loading')}
       >
         {[0, 8, 16, 8, 0, 8].map((indent, i) => (
           <div
@@ -567,7 +575,7 @@ export const FileTreeView = memo(function FileTreeView({
         data-testid="file-tree-empty"
         className={`p-4 text-center text-muted-foreground ${className}`}
       >
-        <p className="text-sm">No files found</p>
+        <p className="text-sm">{t('fileTree.empty')}</p>
         {/* Action buttons for empty state - only show when callbacks are provided */}
         {(onNewFile || onNewDirectory) && (
           <div className="flex flex-col gap-2 mt-4">
@@ -579,7 +587,7 @@ export const FileTreeView = memo(function FileTreeView({
                 className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-foreground bg-surface border border-input rounded-md hover:bg-muted transition-colors"
               >
                 <FilePlus className="w-4 h-4" aria-hidden="true" />
-                <span>New File</span>
+                <span>{t('fileTree.newFile')}</span>
               </Button>
             )}
             {onNewDirectory && (
@@ -590,7 +598,7 @@ export const FileTreeView = memo(function FileTreeView({
                 className="flex items-center justify-center gap-2 px-3 py-2 text-sm text-foreground bg-surface border border-input rounded-md hover:bg-muted transition-colors"
               >
                 <FolderPlus className="w-4 h-4" aria-hidden="true" />
-                <span>New Directory</span>
+                <span>{t('fileTree.newDirectory')}</span>
               </Button>
             )}
           </div>
@@ -607,7 +615,9 @@ export const FileTreeView = memo(function FileTreeView({
         className={`p-4 text-center text-muted-foreground ${className}`}
       >
         <p className="text-sm">
-          No {searchMode === 'content' ? 'files containing' : 'files matching'} &quot;{searchQuery}&quot;
+          {searchMode === 'content'
+            ? t('fileTree.noResultsContaining', { query: searchQuery })
+            : t('fileTree.noResultsMatching', { query: searchQuery })}
         </p>
       </div>
     );
@@ -618,7 +628,7 @@ export const FileTreeView = memo(function FileTreeView({
       ref={scrollContainerRef}
       data-testid="file-tree-view"
       role="tree"
-      aria-label="File tree"
+      aria-label={t('fileTree.label')}
       className={`overflow-auto bg-surface ${className}`}
     >
       {/* [Issue #300/#888] Toolbar: root-level create actions + manual refresh.
@@ -636,7 +646,7 @@ export const FileTreeView = memo(function FileTreeView({
             className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors"
           >
             <FilePlus className="w-4 h-4" aria-hidden="true" />
-            <span>New File</span>
+            <span>{t('fileTree.newFile')}</span>
           </button>
         )}
         {onNewDirectory && (
@@ -647,7 +657,7 @@ export const FileTreeView = memo(function FileTreeView({
             className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors"
           >
             <FolderPlus className="w-4 h-4" aria-hidden="true" />
-            <span>New Directory</span>
+            <span>{t('fileTree.newDirectory')}</span>
           </button>
         )}
         {/* Right-aligned group: metadata toggle + refetch indicator + manual refresh button. */}
@@ -667,7 +677,7 @@ export const FileTreeView = memo(function FileTreeView({
                 aria-hidden="true"
                 className="w-3 h-3 border-2 border-input border-t-cyan-500 rounded-full animate-spin"
               />
-              <span className="sr-only">Refreshing files</span>
+              <span className="sr-only">{t('fileTree.refreshing')}</span>
             </div>
           )}
           {/* [Issue #888] Manual refresh: re-fetch the root + all expanded
@@ -680,8 +690,8 @@ export const FileTreeView = memo(function FileTreeView({
               void reloadTreeWithExpandedDirs();
             }}
             disabled={isRefetching}
-            aria-label="Refresh file tree"
-            title="更新"
+            aria-label={t('fileTree.refreshLabel')}
+            title={t('actions.refresh')}
             className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <RefreshCw
@@ -699,8 +709,8 @@ export const FileTreeView = memo(function FileTreeView({
             data-testid="file-tree-reset-button"
             type="button"
             onClick={handleResetView}
-            aria-label="Reset file tree view"
-            title="表示をリセット"
+            aria-label={t('fileTree.resetViewLabel')}
+            title={t('actions.resetView')}
             className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:bg-muted rounded transition-colors"
           >
             <RotateCcw className="w-4 h-4" aria-hidden="true" />
@@ -726,7 +736,7 @@ export const FileTreeView = memo(function FileTreeView({
             }}
             className="px-2 py-0.5 text-xs rounded border border-danger-border hover:bg-danger-subtle transition-colors"
           >
-            再試行
+            {t('actions.retry')}
           </Button>
         </div>
       )}

--- a/src/components/worktree/FileViewer.tsx
+++ b/src/components/worktree/FileViewer.tsx
@@ -67,6 +67,8 @@ function FileViewerSearchBar({
   onNext: () => void;
   onClose: () => void;
 }) {
+  const t = useTranslations('worktree');
+
   return (
     <div className="flex items-center gap-1 px-2 py-1 bg-muted border-b border-border">
       <input
@@ -78,7 +80,7 @@ function FileViewerSearchBar({
           if (e.key === 'Escape') { onClose(); }
           if (e.key === 'Enter') { if (e.shiftKey) { onPrev(); } else { onNext(); } }
         }}
-        placeholder="検索..."
+        placeholder={t('fileSearch.placeholder')}
         className="flex-1 min-w-0 px-2 py-0.5 text-sm bg-surface dark:bg-surface-2 text-foreground border border-input rounded outline-none focus:ring-1 focus:ring-ring"
         autoComplete="off"
         autoCorrect="off"
@@ -88,9 +90,9 @@ function FileViewerSearchBar({
       <span className="text-xs text-muted-foreground min-w-[3rem] text-right">
         {searchMatches.length > 0 ? `${searchCurrentIdx + 1}/${searchMatches.length}` : '0/0'}
       </span>
-      <button onClick={onPrev} disabled={searchMatches.length === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground disabled:text-muted-foreground" aria-label="前の結果">▲</button>
-      <button onClick={onNext} disabled={searchMatches.length === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground disabled:text-muted-foreground" aria-label="次の結果">▼</button>
-      <button onClick={onClose} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground" aria-label="検索を閉じる"><X className="w-4 h-4" /></button>
+      <button onClick={onPrev} disabled={searchMatches.length === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground disabled:text-muted-foreground" aria-label={t('fileSearch.prevMatch')}>▲</button>
+      <button onClick={onNext} disabled={searchMatches.length === 0} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground disabled:text-muted-foreground" aria-label={t('fileSearch.nextMatch')}>▼</button>
+      <button onClick={onClose} className="min-w-[32px] min-h-[32px] flex items-center justify-center text-muted-foreground hover:text-foreground" aria-label={t('fileSearch.close')}><X className="w-4 h-4" /></button>
     </div>
   );
 }
@@ -204,7 +206,7 @@ function HtmlPreviewMobile({
                   : 'text-muted-foreground hover:bg-muted'
               }`}
             >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              {tab === 'source' ? tWorktree('fileViewer.tabSource') : tWorktree('fileViewer.tabPreview')}
             </button>
           ))}
         </div>
@@ -222,7 +224,7 @@ function HtmlPreviewMobile({
                   : 'text-muted-foreground hover:bg-muted'
               }`}
             >
-              {level.charAt(0).toUpperCase() + level.slice(1)}
+              {level === 'safe' ? tWorktree('fileViewer.sandboxSafe') : tWorktree('fileViewer.sandboxInteractive')}
             </button>
           ))}
         </div>
@@ -257,7 +259,7 @@ function HtmlPreviewMobile({
             key={`${filePath}-${sandboxLevel}`}
             srcDoc={iframeSrcDoc}
             sandbox={SANDBOX_ATTRIBUTES[sandboxLevel]}
-            title={`HTML Preview: ${filePath}`}
+            title={tWorktree('htmlPreview.title', { path: filePath })}
             className="w-full h-full border-0 bg-white"
           />
         )}
@@ -298,6 +300,7 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
   const [marpCurrentSlide, setMarpCurrentSlide] = useState(0);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const codeContainerRef = useRef<HTMLDivElement>(null);
+  const t = useTranslations('worktree');
 
   // [Issue #723] Unified search hook (replaces previously inlined logic at
   // L242-318). Provides debounced (300ms, SEARCH_DEBOUNCE_MS) + minimum-2-char
@@ -395,14 +398,14 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
           const errorData = await response.json();
           const errMsg = typeof errorData.error === 'string'
             ? errorData.error
-            : errorData.error?.message || 'Failed to load file';
+            : errorData.error?.message || t('fileViewer.loadError');
           throw new Error(errMsg);
         }
 
         const data = await response.json();
         setContent(data);
       } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : 'Failed to load file');
+        setError(err instanceof Error ? err.message : t('fileViewer.loadError'));
       } finally {
         setLoading(false);
       }
@@ -522,7 +525,7 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
               disabled={marpCurrentSlide === 0}
               className="px-3 py-1 text-sm rounded-md bg-muted disabled:opacity-50 hover:bg-muted/80 transition-colors"
             >
-              Prev
+              {t('actions.prev')}
             </button>
             <span className="text-sm text-muted-foreground">
               {marpCurrentSlide + 1} / {marpSlides.length}
@@ -533,13 +536,13 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
               disabled={marpCurrentSlide === marpSlides.length - 1}
               className="px-3 py-1 text-sm rounded-md bg-muted disabled:opacity-50 hover:bg-muted/80 transition-colors"
             >
-              Next
+              {t('actions.next')}
             </button>
           </div>
           <iframe
             srcDoc={marpSlides[marpCurrentSlide]}
             sandbox=""
-            title={`${filePath} - Slide ${marpCurrentSlide + 1}`}
+            title={t('fileViewer.slideTitle', { name: filePath, number: marpCurrentSlide + 1 })}
             className="w-full border-0"
             style={{ height: isFullscreen ? 'calc(100vh - 100px)' : '50vh' }}
           />
@@ -591,9 +594,7 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
    * fetch above, plus `?download=1` so the server streams the RAW bytes as an
    * attachment (bypassing base64 preview size limits). Rendered independently
    * of `canCopy`/preview success so it is reachable in EVERY state (success,
-   * error, oversize FILE_TOO_LARGE, unsupported/binary). Labels are hardcoded
-   * because FileViewer does not use next-intl (consistent with the other
-   * toolbar buttons).
+   * error, oversize FILE_TOO_LARGE, unsupported/binary).
    */
   const downloadUrl = `/api/worktrees/${worktreeId}/files/${encodePathForUrl(filePath)}?download=1`;
   const downloadName = filePath ? filePath.split('/').pop() || filePath : '';
@@ -604,11 +605,11 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
       href={downloadUrl}
       download={downloadName}
       className={className}
-      aria-label="Download file"
-      title="Download"
+      aria-label={t('actions.downloadFile')}
+      title={t('actions.download')}
     >
       <Download className="w-3.5 h-3.5" />
-      {showLabel && <span>Download</span>}
+      {showLabel && <span>{t('actions.download')}</span>}
     </a>
   );
 
@@ -619,8 +620,8 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
         <button
           onClick={handleCopyPath}
           className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-          aria-label="Copy file path"
-          title="Copy path"
+          aria-label={t('actions.copyFilePath')}
+          title={t('actions.copyPath')}
         >
           {pathCopied ? (
             <Check className="w-3.5 h-3.5 text-success" />
@@ -638,8 +639,8 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
           <button
             onClick={openSearch}
             className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-            aria-label="Search in file"
-            title="Search"
+            aria-label={t('actions.searchInFile')}
+            title={t('actions.search')}
           >
             <Search className="w-3.5 h-3.5" />
           </button>
@@ -648,8 +649,8 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
           <button
             onClick={handleEditMarkdown}
             className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-            aria-label="Edit file"
-            title="Edit"
+            aria-label={t('actions.editFile')}
+            title={t('actions.edit')}
           >
             <Pencil className="w-3.5 h-3.5" />
           </button>
@@ -659,8 +660,8 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
             data-testid="copy-content-button"
             onClick={handleCopy}
             className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-            aria-label="Copy file content"
-            title="Copy content"
+            aria-label={t('actions.copyFileContent')}
+            title={t('actions.copyContent')}
           >
             {copied ? (
               <Check className="w-3.5 h-3.5 text-success" />
@@ -676,8 +677,8 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
         <button
           onClick={toggleFullscreen}
           className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-          aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-          title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+          aria-label={isFullscreen ? t('actions.exitFullscreen') : t('actions.fullscreen')}
+          title={isFullscreen ? t('actions.exitFullscreen') : t('actions.fullscreen')}
         >
           {isFullscreen ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
         </button>
@@ -724,7 +725,7 @@ export const FileViewer = memo(function FileViewer({ isOpen, onClose, worktreeId
         {loading && (
           <div className="flex items-center justify-center py-12">
             <Spinner size="xl" variant="accent" />
-            <p className="ml-3 text-muted-foreground">Loading file...</p>
+            <p className="ml-3 text-muted-foreground">{t('fileViewer.loading')}</p>
           </div>
         )}
 

--- a/src/components/worktree/HtmlPreview.tsx
+++ b/src/components/worktree/HtmlPreview.tsx
@@ -58,6 +58,13 @@ document.addEventListener('click', function(e) {
 
 export type HtmlViewMode = 'source' | 'preview' | 'split';
 
+/** i18n key for each view mode label */
+const VIEW_MODE_LABEL_KEYS: Record<HtmlViewMode, string> = {
+  source: 'htmlPreview.modeSource',
+  preview: 'htmlPreview.modePreview',
+  split: 'htmlPreview.modeSplit',
+};
+
 export interface HtmlPreviewProps {
   worktreeId: string;
   filePath: string;
@@ -126,12 +133,14 @@ function HtmlIframePreview({
   sandboxLevel: SandboxLevel;
   filePath: string;
 }) {
+  const tWorktree = useTranslations('worktree');
+
   return (
     <iframe
       key={`${filePath}-${sandboxLevel}`}
       srcDoc={htmlContent}
       sandbox={SANDBOX_ATTRIBUTES[sandboxLevel]}
-      title={`HTML Preview: ${filePath}`}
+      title={tWorktree('htmlPreview.title', { path: filePath })}
       className="w-full h-full border-0 bg-white"
       data-testid="html-iframe-preview"
     />
@@ -264,7 +273,7 @@ export function HtmlPreview({
                   : 'text-muted-foreground hover:bg-muted'
               }`}
             >
-              {mode.charAt(0).toUpperCase() + mode.slice(1)}
+              {tWorktree(VIEW_MODE_LABEL_KEYS[mode])}
             </button>
           ))}
         </div>
@@ -284,7 +293,7 @@ export function HtmlPreview({
                   : 'text-muted-foreground hover:bg-muted'
               }`}
             >
-              {level.charAt(0).toUpperCase() + level.slice(1)}
+              {level === 'safe' ? tWorktree('htmlPreview.sandboxSafe') : tWorktree('htmlPreview.sandboxInteractive')}
             </button>
           ))}
         </div>

--- a/src/components/worktree/ImageViewer.tsx
+++ b/src/components/worktree/ImageViewer.tsx
@@ -14,6 +14,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslations } from 'next-intl';
 
 export interface ImageViewerProps {
   /** Image source (Base64 data URI) */
@@ -40,6 +41,7 @@ export interface ImageViewerProps {
  * ```
  */
 export function ImageViewer({ src, alt, onError }: ImageViewerProps) {
+  const t = useTranslations('worktree');
   const [hasError, setHasError] = useState(false);
 
   const handleError = () => {
@@ -63,7 +65,7 @@ export function ImageViewer({ src, alt, onError }: ImageViewerProps) {
             d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
           />
         </svg>
-        <p className="text-sm">Failed to load image</p>
+        <p className="text-sm">{t('imageViewer.loadError')}</p>
         <p className="text-xs text-muted-foreground mt-1">{alt}</p>
       </div>
     );

--- a/src/components/worktree/LogViewer.tsx
+++ b/src/components/worktree/LogViewer.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
 import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Input, Spinner } from '@/components/ui';
 import { ToastContainer, useToast } from '@/components/common/Toast';
 import { worktreeApi, handleApiError } from '@/lib/api-client';
@@ -36,6 +37,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
   const [cliToolFilter, setCliToolFilter] = useState<'all' | 'claude' | 'codex' | 'gemini' | 'antigravity'>('all');
   const [exporting, setExporting] = useState(false);
   const { toasts, showToast, removeToast } = useToast();
+  const t = useTranslations('worktree');
 
   /**
    * Fetch log files list
@@ -101,13 +103,13 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
       setExporting(true);
       const data = await worktreeApi.getLogFile(worktreeId, selectedFile, { sanitize: true });
       await copyToClipboard(data.content);
-      showToast('Log copied to clipboard (sanitized)', 'success');
+      showToast(t('logViewer.copied'), 'success');
     } catch (err) {
-      showToast(`Failed to export log: ${handleApiError(err)}`, 'error');
+      showToast(t('logViewer.exportError', { error: handleApiError(err) }), 'error');
     } finally {
       setExporting(false);
     }
-  }, [worktreeId, selectedFile, showToast]);
+  }, [worktreeId, selectedFile, showToast, t]);
 
   /**
    * Find all matches in content
@@ -219,7 +221,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
         <CardHeader>
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <CardTitle>Log Files</CardTitle>
+              <CardTitle>{t('logViewer.title')}</CardTitle>
               <Badge variant="gray">{filteredLogFiles.length}</Badge>
             </div>
 
@@ -230,35 +232,35 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
                 size="sm"
                 onClick={() => setCliToolFilter('all')}
               >
-                All ({logFiles.length})
+                {t('logViewer.all', { count: logFiles.length })}
               </Button>
               <Button
                 variant={cliToolFilter === 'claude' ? 'primary' : 'ghost'}
                 size="sm"
                 onClick={() => setCliToolFilter('claude')}
               >
-                Claude ({logFiles.filter(f => f.toLowerCase().includes('claude')).length})
+                {t('logViewer.toolCount', { tool: 'Claude', count: logFiles.filter(f => f.toLowerCase().includes('claude')).length })}
               </Button>
               <Button
                 variant={cliToolFilter === 'codex' ? 'primary' : 'ghost'}
                 size="sm"
                 onClick={() => setCliToolFilter('codex')}
               >
-                Codex ({logFiles.filter(f => f.toLowerCase().includes('codex')).length})
+                {t('logViewer.toolCount', { tool: 'Codex', count: logFiles.filter(f => f.toLowerCase().includes('codex')).length })}
               </Button>
               <Button
                 variant={cliToolFilter === 'gemini' ? 'primary' : 'ghost'}
                 size="sm"
                 onClick={() => setCliToolFilter('gemini')}
               >
-                Gemini ({logFiles.filter(f => f.toLowerCase().includes('gemini')).length})
+                {t('logViewer.toolCount', { tool: 'Gemini', count: logFiles.filter(f => f.toLowerCase().includes('gemini')).length })}
               </Button>
               <Button
                 variant={cliToolFilter === 'antigravity' ? 'primary' : 'ghost'}
                 size="sm"
                 onClick={() => setCliToolFilter('antigravity')}
               >
-                Antigravity ({logFiles.filter(f => f.toLowerCase().includes('antigravity')).length})
+                {t('logViewer.toolCount', { tool: 'Antigravity', count: logFiles.filter(f => f.toLowerCase().includes('antigravity')).length })}
               </Button>
             </div>
           </div>
@@ -278,7 +280,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
 
           {!loading && filteredLogFiles.length === 0 && !error && (
             <p className="text-sm text-muted-foreground text-center py-4">
-              {cliToolFilter === 'all' ? 'No log files found' : `No ${cliToolFilter} log files found`}
+              {cliToolFilter === 'all' ? t('logViewer.empty') : t('logViewer.emptyFiltered', { tool: cliToolFilter })}
             </p>
           )}
 
@@ -315,9 +317,9 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
                     size="sm"
                     onClick={handleExport}
                     disabled={!selectedFile || exporting}
-                    title="Copy sanitized log to clipboard"
+                    title={t('logViewer.copyTitle')}
                   >
-                    {exporting ? 'Exporting...' : 'Export'}
+                    {exporting ? t('logViewer.exporting') : t('logViewer.export')}
                   </Button>
                   <Button
                     variant="ghost"
@@ -329,7 +331,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
                       setCurrentMatchIndex(0);
                     }}
                   >
-                    Close
+                    {t('actions.close')}
                   </Button>
                 </div>
               </div>
@@ -342,7 +344,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     onKeyDown={handleSearchKeyDown}
-                    placeholder="Search in log file..."
+                    placeholder={t('logViewer.searchPlaceholder')}
                     className="w-full pr-20"
                   />
                   {matches.length > 0 && (
@@ -360,7 +362,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
                       size="sm"
                       onClick={goToPrevMatch}
                       disabled={matches.length === 0}
-                      title="Previous match (Shift+Enter)"
+                      title={t('logViewer.prevMatch')}
                     >
                       ↑
                     </Button>
@@ -369,7 +371,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
                       size="sm"
                       onClick={goToNextMatch}
                       disabled={matches.length === 0}
-                      title="Next match (Enter)"
+                      title={t('logViewer.nextMatch')}
                     >
                       ↓
                     </Button>
@@ -400,7 +402,7 @@ export function LogViewer({ worktreeId }: LogViewerProps) {
 
             {!loading && searchQuery && matches.length === 0 && fileContent && (
               <div className="text-center py-4 text-sm text-muted-foreground">
-                No matches found for &quot;{searchQuery}&quot;
+                {t('logViewer.noMatches', { query: searchQuery })}
               </div>
             )}
           </CardContent>

--- a/src/components/worktree/MarkdownEditor.tsx
+++ b/src/components/worktree/MarkdownEditor.tsx
@@ -395,7 +395,7 @@ export const MarkdownEditor = memo(function MarkdownEditor({
       const data = await response.json();
 
       if (!response.ok || !data.success) {
-        throw new Error(data.error?.message || 'Failed to load file');
+        throw new Error(data.error?.message || tWorktree('editor.loadError'));
       }
 
       const fileContent = data.content || '';
@@ -409,12 +409,15 @@ export const MarkdownEditor = memo(function MarkdownEditor({
         setShowLargeFileWarning(true);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load file';
+      const message = err instanceof Error ? err.message : tWorktree('editor.loadError');
       setError(message);
     } finally {
       setIsLoading(false);
     }
-  }, [worktreeId, filePath]);
+    // tWorktree is intentionally omitted: it is only used for the fallback error
+    // message, and re-creating loadContent would re-fetch the file on every
+    // locale change (and loop under a non-memoized t).
+  }, [worktreeId, filePath]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
    * API save function shared by manual and auto-save.
@@ -433,15 +436,15 @@ export const MarkdownEditor = memo(function MarkdownEditor({
       );
       // Session expiry detection before JSON parsing
       if (response.status === 401 || response.redirected) {
-        throw new Error('Session expired. Please re-login.');
+        throw new Error(tWorktree('editor.sessionExpired'));
       }
       const data = await response.json();
       if (!response.ok || !data.success) {
-        throw new Error(data.error?.message || 'Failed to save file');
+        throw new Error(data.error?.message || tWorktree('editor.saveError'));
       }
       setOriginalContent(valueToSave);
     },
-    [worktreeId, filePath]
+    [worktreeId, filePath, tWorktree]
   );
 
   // Auto-save integration (dirty state reset is handled inside saveToApi)
@@ -479,18 +482,18 @@ export const MarkdownEditor = memo(function MarkdownEditor({
 
     try {
       await saveToApi(content);
-      showToast('File saved successfully', 'success');
+      showToast(tWorktree('editor.saveSuccess'), 'success');
 
       if (onSave) {
         onSave(filePath);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to save file';
+      const message = err instanceof Error ? err.message : tWorktree('editor.saveError');
       showToast(message, 'error');
     } finally {
       setIsSaving(false);
     }
-  }, [saveToApi, content, isDirty, isSaving, onSave, filePath, showToast]);
+  }, [saveToApi, content, isDirty, isSaving, onSave, filePath, showToast, tWorktree]);
 
   /** Line count for line number gutter */
   const lineCount = content.split('\n').length;
@@ -648,11 +651,11 @@ export const MarkdownEditor = memo(function MarkdownEditor({
         onKeyDown={handleKeyDown}
         onScroll={handleEditorScroll}
         className={`flex-1 py-4 pr-4 pl-3 font-mono text-sm resize-none bg-surface text-foreground focus:outline-none leading-[1.5rem]${showFocusRing ? ' focus:ring-2 focus:ring-ring focus:ring-inset' : ''}`}
-        placeholder={isTextMode ? 'Start typing...' : 'Start typing markdown...'}
+        placeholder={isTextMode ? tWorktree('editor.placeholder') : tWorktree('editor.placeholderMarkdown')}
         spellCheck={false}
       />
     </>
-  ), [lineCount, content, handleContentChange, handleKeyDown, handleEditorScroll, isTextMode]);
+  ), [lineCount, content, handleContentChange, handleKeyDown, handleEditorScroll, isTextMode, tWorktree]);
 
   // Global ESC key handler for maximized mode
   useEffect(() => {
@@ -748,9 +751,9 @@ export const MarkdownEditor = memo(function MarkdownEditor({
   useEffect(() => {
     if (autoSaveError && isAutoSaveEnabled) {
       setAutoSaveEnabled(false);
-      showToast('Auto-save failed. Switched to manual save.', 'error');
+      showToast(tWorktree('editor.autoSaveFailed'), 'error');
     }
-  }, [autoSaveError, isAutoSaveEnabled, setAutoSaveEnabled, showToast]);
+  }, [autoSaveError, isAutoSaveEnabled, setAutoSaveEnabled, showToast, tWorktree]);
 
   // Calculate container classes for maximized state
   const containerClasses = useMemo(() => {
@@ -805,7 +808,7 @@ export const MarkdownEditor = memo(function MarkdownEditor({
       >
         <div className="text-center">
           <Spinner size="xl" variant="accent" className="inline-block" />
-          <p className="mt-4 text-muted-foreground">Loading...</p>
+          <p className="mt-4 text-muted-foreground">{tWorktree('editor.loading')}</p>
         </div>
       </div>
     );
@@ -826,7 +829,7 @@ export const MarkdownEditor = memo(function MarkdownEditor({
               onClick={onClose}
               className="mt-4 px-4 py-2 bg-muted hover:bg-muted/80 rounded-lg text-foreground"
             >
-              Close
+              {tWorktree('actions.close')}
             </button>
           )}
         </div>

--- a/src/components/worktree/MarkdownPreview.tsx
+++ b/src/components/worktree/MarkdownPreview.tsx
@@ -21,6 +21,7 @@
 'use client';
 
 import React, { memo, useMemo, useCallback, useRef, useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -93,6 +94,7 @@ function isMermaidPreChild(children: React.ReactNode): boolean {
  * The file API returns JSON with a Base64 data URI in the `content` field.
  */
 function WorktreeImage({ apiUrl, alt, width, height }: { apiUrl: string; alt: string; width?: string; height?: string }) {
+  const t = useTranslations('worktree');
   const [dataUri, setDataUri] = useState<string | null>(null);
 
   useEffect(() => {
@@ -108,7 +110,7 @@ function WorktreeImage({ apiUrl, alt, width, height }: { apiUrl: string; alt: st
     return () => { cancelled = true; };
   }, [apiUrl]);
 
-  if (!dataUri) return <span style={{ color: '#999' }}>[loading image...]</span>;
+  if (!dataUri) return <span style={{ color: '#999' }}>{t('markdownPreview.loadingImage')}</span>;
   // eslint-disable-next-line @next/next/no-img-element
   return <img src={dataUri} alt={alt} width={width} height={height} style={{ maxWidth: width || '100%' }} />;
 }
@@ -265,6 +267,7 @@ export const MobileTabBar = memo(function MobileTabBar({
   mobileTab,
   onTabChange,
 }: MobileTabBarProps) {
+  const t = useTranslations('worktree');
   return (
     <div className="flex border-b border-border">
       <button
@@ -277,7 +280,7 @@ export const MobileTabBar = memo(function MobileTabBar({
         }`}
       >
         <FileText className="h-4 w-4 inline-block mr-1" />
-        Editor
+        {t('markdownPreview.editor')}
       </button>
       <button
         data-testid="mobile-tab-preview"
@@ -289,7 +292,7 @@ export const MobileTabBar = memo(function MobileTabBar({
         }`}
       >
         <Eye className="h-4 w-4 inline-block mr-1" />
-        Preview
+        {t('markdownPreview.preview')}
       </button>
     </div>
   );
@@ -305,12 +308,13 @@ export const MobileTabBar = memo(function MobileTabBar({
 export const MaximizeHint = memo(function MaximizeHint({
   isMobile,
 }: MaximizeHintProps) {
+  const t = useTranslations('worktree');
   return (
     <div
       data-testid="maximize-hint"
       className="flex items-center justify-center px-4 py-1 bg-muted text-muted-foreground text-xs"
     >
-      Press ESC to exit fullscreen {isMobile && '(or swipe down)'}
+      {t('markdownPreview.exitFullscreenHint')} {isMobile && t('markdownPreview.exitFullscreenHintSwipe')}
     </div>
   );
 });
@@ -325,13 +329,14 @@ export const MaximizeHint = memo(function MaximizeHint({
 export const LargeFileWarning = memo(function LargeFileWarning({
   onDismiss,
 }: LargeFileWarningProps) {
+  const t = useTranslations('worktree');
   return (
     <div
       data-testid="large-file-warning"
       className="flex items-center gap-2 px-4 py-2 bg-warning-subtle border-b border-warning-border text-warning-foreground text-sm"
     >
       <AlertTriangle className="h-4 w-4" />
-      Large file: Performance may be affected.
+      {t('markdownPreview.largeFileWarning')}
       <button
         onClick={onDismiss}
         className="ml-auto text-warning hover:text-warning"

--- a/src/components/worktree/MarkdownToolbar.tsx
+++ b/src/components/worktree/MarkdownToolbar.tsx
@@ -15,6 +15,7 @@
 'use client';
 
 import React, { memo } from 'react';
+import { useTranslations } from 'next-intl';
 import {
   Save,
   X,
@@ -90,6 +91,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
   onClose,
   hideViewModeToggle,
 }: MarkdownToolbarProps) {
+  const t = useTranslations('worktree');
   return (
     <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-muted">
       {/* File path and dirty indicator */}
@@ -101,7 +103,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
             data-testid="dirty-indicator"
             className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-warning-subtle text-warning-foreground flex-shrink-0"
           >
-            Unsaved
+            {t('editor.unsaved')}
           </span>
         )}
       </div>
@@ -121,7 +123,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
                   ? 'bg-white dark:bg-input shadow-sm text-accent-600 dark:text-accent-400'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
-              title="Split view"
+              title={t('editor.splitView')}
             >
               <Columns className="h-4 w-4" />
             </button>
@@ -135,7 +137,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
                   ? 'bg-white dark:bg-input shadow-sm text-accent-600 dark:text-accent-400'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
-              title="Editor only"
+              title={t('editor.editorOnly')}
             >
               <FileText className="h-4 w-4" />
             </button>
@@ -149,7 +151,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
                   ? 'bg-white dark:bg-input shadow-sm text-accent-600 dark:text-accent-400'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
-              title="Preview only"
+              title={t('editor.previewOnly')}
             >
               <Eye className="h-4 w-4" />
             </button>
@@ -164,7 +166,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
           className={`p-1.5 hover:bg-muted rounded ${
             copied ? 'text-success' : 'text-muted-foreground hover:text-foreground'
           }`}
-          title="Copy content"
+          title={t('actions.copyContent')}
         >
           {copied ? (
             <Check className="h-4 w-4" />
@@ -179,7 +181,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
           data-testid="maximize-button"
           onClick={onToggleFullscreen}
           className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
-          title={isMaximized ? 'Exit fullscreen (ESC)' : 'Enter fullscreen (Ctrl+Shift+F)'}
+          title={isMaximized ? t('editor.exitFullscreen') : t('editor.enterFullscreen')}
           aria-pressed={isMaximized}
         >
           {isMaximized ? (
@@ -191,7 +193,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
 
         {/* Auto-save toggle */}
         <div className="flex items-center gap-1.5">
-          <span className="text-xs text-muted-foreground">Auto</span>
+          <span className="text-xs text-muted-foreground">{t('editor.auto')}</span>
           {/* Issue #1061: role=switch aria-checked トグルトラック（knob 描画）— 残置 */}
           <button
             data-testid="auto-save-toggle"
@@ -211,7 +213,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
         {/* Save button OR auto-save indicator */}
         {isAutoSaveEnabled ? (
           <span data-testid="auto-save-indicator" className="text-sm text-muted-foreground">
-            {isAutoSaving ? 'Saving...' : isDirty ? '' : 'Saved'}
+            {isAutoSaving ? t('actions.saving') : isDirty ? '' : t('actions.saved')}
           </span>
         ) : (
           <Button
@@ -226,7 +228,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
             }`}
           >
             <Save className="h-4 w-4" />
-            {isSaving ? 'Saving...' : 'Save'}
+            {isSaving ? t('actions.saving') : t('actions.save')}
           </Button>
         )}
 
@@ -237,7 +239,7 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
             data-testid="close-button"
             onClick={onClose}
             className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
-            title="Close"
+            title={t('actions.close')}
           >
             <X className="h-4 w-4" />
           </Button>

--- a/src/components/worktree/MermaidCodeBlock.tsx
+++ b/src/components/worktree/MermaidCodeBlock.tsx
@@ -11,6 +11,7 @@
 
 import React from 'react';
 import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
 import { Spinner } from '@/components/ui/Spinner';
 
 /**
@@ -24,12 +25,15 @@ const MermaidDiagram = dynamic(
     })),
   {
     ssr: false,
-    loading: () => (
-      <div className="mermaid-loading flex items-center gap-2 text-muted-foreground p-4">
-        <Spinner size="sm" />
-        <span>Loading diagram...</span>
-      </div>
-    ),
+    loading: function MermaidDiagramLoading() {
+      const t = useTranslations('worktree');
+      return (
+        <div className="mermaid-loading flex items-center gap-2 text-muted-foreground p-4">
+          <Spinner size="sm" />
+          <span>{t('mermaid.loading')}</span>
+        </div>
+      );
+    },
   }
 );
 

--- a/src/components/worktree/MermaidDiagram.tsx
+++ b/src/components/worktree/MermaidDiagram.tsx
@@ -13,6 +13,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef, useId } from 'react';
+import { useTranslations } from 'next-intl';
 import mermaid from 'mermaid';
 import { MERMAID_CONFIG } from '@/config/mermaid-config';
 import { Spinner } from '@/components/ui/Spinner';
@@ -72,10 +73,17 @@ export function MermaidDiagram({
   code,
   id: providedId,
 }: MermaidDiagramProps): React.JSX.Element {
+  const t = useTranslations('worktree');
   const [svg, setSvg] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // [Issue #1275] `t` is a fresh closure on every render, so listing it in the
+  // render effect's deps would re-run mermaid.render on every render. Read it
+  // via a ref to keep the effect keyed on `code`/`diagramId` alone.
+  const tRef = useRef(t);
+  tRef.current = t;
 
   // Generate unique ID if not provided
   const reactId = useId();
@@ -94,7 +102,7 @@ export function MermaidDiagram({
       const trimmedCode = code?.trim() || '';
       if (!trimmedCode) {
         if (isMounted) {
-          setError('Diagram code is empty');
+          setError(tRef.current('mermaid.emptyCode'));
           setIsLoading(false);
         }
         return;
@@ -117,7 +125,7 @@ export function MermaidDiagram({
       } catch (err) {
         if (isMounted) {
           const message =
-            err instanceof Error ? err.message : 'Failed to render diagram';
+            err instanceof Error ? err.message : tRef.current('mermaid.renderError');
           setError(message);
           setIsLoading(false);
         }
@@ -140,7 +148,7 @@ export function MermaidDiagram({
       >
         <div className="flex items-center gap-2">
           <Spinner size="sm" variant="accent" />
-          <span>Rendering diagram...</span>
+          <span>{t('mermaid.rendering')}</span>
         </div>
       </div>
     );
@@ -153,7 +161,7 @@ export function MermaidDiagram({
         data-testid="mermaid-error"
         className="bg-danger-subtle border border-danger-border p-4 rounded"
       >
-        <p className="text-danger font-medium">Diagram Error</p>
+        <p className="text-danger font-medium">{t('mermaid.errorTitle')}</p>
         <pre className="text-sm text-danger mt-2 whitespace-pre-wrap break-words bg-danger-subtle">
           {error}
         </pre>

--- a/src/components/worktree/PdfPreview.tsx
+++ b/src/components/worktree/PdfPreview.tsx
@@ -27,6 +27,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { PDF_IFRAME_SANDBOX } from '@/config/pdf-extensions';
 import { Spinner } from '@/components/ui/Spinner';
 
@@ -52,6 +53,7 @@ export interface PdfPreviewProps {
 export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreviewProps): React.JSX.Element {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const [hasError, setHasError] = useState(false);
+  const t = useTranslations('worktree');
 
   useEffect(() => {
     let cancelled = false;
@@ -91,7 +93,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
         data-testid="pdf-preview-error"
       >
         <p className="text-sm text-danger-foreground">
-          PDFプレビューを読み込めませんでした。
+          {t('pdfPreview.loadError')}
         </p>
         <a
           href={dataUri}
@@ -99,7 +101,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
           className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-input text-sm text-foreground hover:bg-muted"
           rel="noopener"
         >
-          Download PDF
+          {t('pdfPreview.downloadPdf')}
         </a>
       </div>
     );
@@ -147,14 +149,14 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
             rel="noopener noreferrer"
             className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-accent-600 hover:bg-accent-700 active:bg-accent-800 text-white text-sm font-medium transition-colors"
           >
-            PDFを新しいタブで開く
+            {t('pdfPreview.openInNewTab')}
           </a>
           <a
             href={blobUrl}
             download={fileName}
             className="inline-flex items-center justify-center gap-2 px-6 py-2 rounded-lg border border-input text-sm text-foreground hover:bg-muted transition-colors"
           >
-            ダウンロード
+            {t('pdfPreview.download')}
           </a>
         </div>
       </div>
@@ -165,7 +167,7 @@ export function PdfPreview({ dataUri, filePath, variant = 'iframe' }: PdfPreview
     <iframe
       src={blobUrl}
       sandbox={PDF_IFRAME_SANDBOX}
-      title={`PDF Preview: ${filePath}`}
+      title={t('pdfPreview.title', { path: filePath })}
       className="w-full h-full border-0 bg-white"
       data-testid="pdf-preview-iframe"
     />

--- a/src/components/worktree/SearchBar.tsx
+++ b/src/components/worktree/SearchBar.tsx
@@ -12,6 +12,7 @@
 'use client';
 
 import React, { memo, useCallback, useRef, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { MOBILE_BREAKPOINT } from '@/hooks/useIsMobile';
 import type { SearchMode } from '@/types/models';
 import { Spinner } from '@/components/ui/Spinner';
@@ -84,6 +85,8 @@ const ClearIcon = memo(function ClearIcon() {
 });
 
 const LoadingSpinner = memo(function LoadingSpinner() {
+  const t = useTranslations('worktree');
+
   return (
     <Spinner
       size="sm"
@@ -91,7 +94,7 @@ const LoadingSpinner = memo(function LoadingSpinner() {
       data-testid="search-loading"
       role="status"
       aria-hidden={false}
-      aria-label="Searching..."
+      aria-label={t('search.searching')}
     />
   );
 });
@@ -123,10 +126,11 @@ export const SearchBar = memo(function SearchBar({
   onQueryChange,
   onModeChange,
   onClear,
-  placeholder = 'Search files...',
+  placeholder,
   className = '',
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const t = useTranslations('worktree');
 
   // Handle input change
   const handleInputChange = useCallback(
@@ -189,9 +193,9 @@ export const SearchBar = memo(function SearchBar({
           value={query}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
-          placeholder={placeholder}
+          placeholder={placeholder ?? t('search.placeholder')}
           className="flex-1 min-w-0 px-2 py-1 text-sm bg-muted text-foreground border border-input rounded focus:outline-none focus:ring-1 focus:ring-ring focus:border-accent-500"
-          aria-label="Search files"
+          aria-label={t('search.label')}
           aria-busy={isSearching}
         />
 
@@ -205,7 +209,7 @@ export const SearchBar = memo(function SearchBar({
               data-testid="search-clear"
               onClick={handleClear}
               className="p-1 text-muted-foreground hover:text-foreground rounded transition-colors"
-              aria-label="Clear search"
+              aria-label={t('search.clear')}
             >
               <ClearIcon />
             </button>
@@ -215,7 +219,7 @@ export const SearchBar = memo(function SearchBar({
 
       {/* Mode Toggle Row */}
       <div className="flex items-center gap-1">
-        <span className="text-xs text-muted-foreground mr-1">Mode:</span>
+        <span className="text-xs text-muted-foreground mr-1">{t('search.mode')}</span>
         <button
           type="button"
           data-testid="mode-name"
@@ -227,7 +231,7 @@ export const SearchBar = memo(function SearchBar({
           }`}
           aria-pressed={mode === 'name'}
         >
-          Name
+          {t('search.modeName')}
         </button>
         <button
           type="button"
@@ -240,7 +244,7 @@ export const SearchBar = memo(function SearchBar({
           }`}
           aria-pressed={mode === 'content'}
         >
-          Content
+          {t('search.modeContent')}
         </button>
       </div>
 

--- a/src/components/worktree/TreeNode.tsx
+++ b/src/components/worktree/TreeNode.tsx
@@ -435,7 +435,7 @@ export const TreeNode = memo(function TreeNode({
             className="text-xs text-muted-foreground flex-shrink-0"
           >
             {isDirectory
-              ? item.itemCount !== undefined && `${item.itemCount} items`
+              ? item.itemCount !== undefined && t('fileTree.itemCount', { count: item.itemCount })
               : formatFileSize(item.size)}
           </span>
         )}

--- a/src/components/worktree/VideoViewer.tsx
+++ b/src/components/worktree/VideoViewer.tsx
@@ -18,6 +18,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { Spinner } from '@/components/ui/Spinner';
 
 export interface VideoViewerProps {
@@ -42,6 +43,7 @@ export interface VideoViewerProps {
  * ```
  */
 export function VideoViewer({ src, onError }: VideoViewerProps) {
+  const t = useTranslations('worktree');
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
 
@@ -71,7 +73,7 @@ export function VideoViewer({ src, onError }: VideoViewerProps) {
             d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
           />
         </svg>
-        <p className="text-sm">Failed to load video</p>
+        <p className="text-sm">{t('videoViewer.loadError')}</p>
       </div>
     );
   }
@@ -81,7 +83,7 @@ export function VideoViewer({ src, onError }: VideoViewerProps) {
       {isLoading && (
         <div className="flex items-center justify-center py-8">
           <Spinner size="xl" variant="accent" />
-          <p className="ml-3 text-muted-foreground">Loading video...</p>
+          <p className="ml-3 text-muted-foreground">{t('videoViewer.loading')}</p>
         </div>
       )}
       {/* [KISS] src on <video> is sufficient; <source> would be redundant for a single format */}
@@ -97,7 +99,7 @@ export function VideoViewer({ src, onError }: VideoViewerProps) {
         }}
         className="rounded-lg shadow-sm"
       >
-        Your browser does not support the video tag.
+        {t('videoViewer.unsupported')}
       </video>
     </div>
   );

--- a/tests/unit/components/FilePanelContent.test.tsx
+++ b/tests/unit/components/FilePanelContent.test.tsx
@@ -13,6 +13,15 @@ import { FilePanelContent } from '@/components/worktree/FilePanelContent';
 import type { FileTab } from '@/hooks/useFileTabs';
 import type { FileContent } from '@/types/models';
 
+// Issue #1275: this file asserts rendered wording ("Loading file...", the
+// "Maximize" toolbar label), so it must resolve keys through the real
+// dictionary. The global mock in tests/setup.ts echoes `worktree.<key>` back
+// and would keep these assertions green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // Mock ImageViewer
 vi.mock('@/components/worktree/ImageViewer', () => ({
   ImageViewer: ({ src, alt }: { src: string; alt: string }) => (

--- a/tests/unit/components/FilePanelTabs.test.tsx
+++ b/tests/unit/components/FilePanelTabs.test.tsx
@@ -12,6 +12,15 @@ import { FilePanelTabs } from '@/components/worktree/FilePanelTabs';
 import type { FileTab } from '@/hooks/useFileTabs';
 import type { FileContent } from '@/types/models';
 
+// Issue #1275: this file asserts rendered wording (the per-tab close label), so
+// it must resolve keys through the real dictionary. The global mock in
+// tests/setup.ts echoes `worktree.<key>` back — it does not even interpolate
+// {name} — and would keep these assertions green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // Mock FilePanelContent [DR3-006]
 vi.mock('@/components/worktree/FilePanelContent', () => ({
   FilePanelContent: ({ tab, onOpenFile }: { tab: FileTab; onOpenFile?: (path: string) => void }) => (

--- a/tests/unit/components/HtmlPreview.test.tsx
+++ b/tests/unit/components/HtmlPreview.test.tsx
@@ -12,6 +12,15 @@ import { render, screen, act, cleanup, fireEvent, waitFor } from '@testing-libra
 import { HtmlPreview } from '@/components/worktree/HtmlPreview';
 import { ConfirmProvider } from '@/components/ui/ConfirmDialog';
 
+// Issue #1275: this file drives the UI by rendered wording ("Interactive" mode
+// button) and asserts the iframe title, so it must resolve keys through the
+// real dictionary. The global mock in tests/setup.ts echoes `worktree.<key>`
+// back and would keep these assertions green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 describe('HtmlPreview - postMessage link handling', () => {
   const defaultProps = {
     worktreeId: 'test-wt',

--- a/tests/unit/components/MarkdownEditor.test.tsx
+++ b/tests/unit/components/MarkdownEditor.test.tsx
@@ -24,6 +24,15 @@ import {
   AUTO_SAVE_DEBOUNCE_MS,
 } from '@/types/markdown-editor';
 
+// Issue #1275: this file asserts rendered wording (the save toast, the ESC
+// hint), so it must resolve keys through the real dictionary. The global mock
+// in tests/setup.ts echoes `worktree.<key>` back and would keep these
+// assertions green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // Mock fetch API
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/tests/unit/components/PdfPreview.test.tsx
+++ b/tests/unit/components/PdfPreview.test.tsx
@@ -10,6 +10,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import { PdfPreview } from '@/components/worktree/PdfPreview';
 
+// Issue #1275: this file asserts the rendered iframe title, so it must resolve
+// keys through the real dictionary. The global mock in tests/setup.ts echoes
+// `worktree.<key>` back and would keep the assertion green even if the key did
+// not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // ----------------------------------------------------------------------------
 // Test doubles for URL.createObjectURL / revokeObjectURL
 // ----------------------------------------------------------------------------

--- a/tests/unit/components/worktree/FileViewer.test.tsx
+++ b/tests/unit/components/worktree/FileViewer.test.tsx
@@ -17,6 +17,15 @@ import { render, screen, cleanup } from '@testing-library/react';
 import { FileViewer } from '@/components/worktree/FileViewer';
 import { encodePathForUrl } from '@/lib/url-path-encoder';
 
+// Issue #1275: this file asserts the download anchor's rendered aria-label, so
+// it must resolve keys through the real dictionary. The global mock in
+// tests/setup.ts echoes `worktree.<key>` back and would keep the assertion
+// green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 // ----------------------------------------------------------------------------
 // fetch stubs
 // ----------------------------------------------------------------------------

--- a/tests/unit/components/worktree/SearchBar.test.tsx
+++ b/tests/unit/components/worktree/SearchBar.test.tsx
@@ -9,6 +9,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SearchBar } from '@/components/worktree/SearchBar';
 
+// Issue #1275: this file asserts rendered wording (aria-labels, the default
+// placeholder), so it must resolve keys through the real dictionary. The global
+// mock in tests/setup.ts echoes `worktree.<key>` back and would keep these
+// assertions green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 describe('SearchBar', () => {
   const defaultProps = {
     query: '',

--- a/tests/unit/components/worktree/TreeNode.test.tsx
+++ b/tests/unit/components/worktree/TreeNode.test.tsx
@@ -14,6 +14,15 @@ import { TRUNCATION_TOOLTIP_DELAY_MS } from '@/components/common/TruncationToolt
 import type { TreeItem } from '@/types/models';
 import type { FileMetadataDisplaySettings } from '@/hooks/useFileMetadataDisplay';
 
+// Issue #1275: this file asserts rendered wording (the directory item count),
+// so it must resolve keys through the real dictionary. The global mock in
+// tests/setup.ts echoes `worktree.<key>` back and would keep the assertion
+// green even if the key did not exist.
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock('en');
+});
+
 const FILE: TreeItem = {
   name: 'app.ts',
   type: 'file',
@@ -98,10 +107,12 @@ describe('TreeNode metadata display [Issue #969]', () => {
       expect(tooltip).toHaveTextContent('app.ts');
       // Size line (formatFileSize(2048) === '2.0 KB')
       expect(tooltip).toHaveTextContent('2.0 KB');
-      // Localized labels resolve via the mocked useTranslations (key passthrough)
-      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.size');
-      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.created');
-      expect(tooltip).toHaveTextContent('worktree.fileTree.metadata.modified');
+      // Issue #1275: these now resolve through the real dictionary, so assert
+      // the wording a user actually sees rather than the mock's key echo — a
+      // key-echo assertion passes even when the key is missing from locales/.
+      expect(tooltip).toHaveTextContent('Size:');
+      expect(tooltip).toHaveTextContent('Created:');
+      expect(tooltip).toHaveTextContent('Modified:');
     });
 
     it('does not show a metadata tooltip on directory rows', () => {

--- a/tests/unit/i18n/worktree-file-viewer-keys.test.ts
+++ b/tests/unit/i18n/worktree-file-viewer-keys.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit-level i18n guard for the worktree file viewer/editor keys (Issue #1275).
+ *
+ * The global next-intl mock (tests/setup.ts) echoes `namespace.key` back, so a
+ * component test asserting a label stays green even when the real dictionary
+ * has no such entry — the blind spot #1197 found and #1273 re-proved. These
+ * checks read locales/<locale>/worktree.json directly so a one-sided locale
+ * edit or a dropped key fails the required `npm run test:unit` gate.
+ *
+ * The en/ja parity check for the whole namespace lives in an integration test
+ * that the unit gate does not run, hence the section-scoped duplicate here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../../locales');
+
+function loadWorktree(locale: string): Record<string, unknown> {
+  const filePath = path.join(LOCALES_DIR, locale, 'worktree.json');
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+function leafKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const full = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return leafKeys(value as Record<string, unknown>, full);
+    }
+    return [full];
+  });
+}
+
+function resolve(dict: Record<string, unknown>, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], dict);
+}
+
+/** Sections Issue #1275 introduced or extended for the file viewer/editor surface. */
+const SECTIONS = [
+  'actions',
+  'fileSearch',
+  'fileTree',
+  'fileViewer',
+  'fileTabs',
+  'editor',
+  'markdownPreview',
+  'mermaid',
+  'imageViewer',
+  'videoViewer',
+  'logViewer',
+  'pdfPreview',
+  'htmlPreview',
+  'diffViewer',
+  'search',
+] as const;
+
+/**
+ * English wording pinned byte-for-byte against the pre-migration markup.
+ *
+ * Issue #1275 migrated these from hardcoded JSX to `worktree.*`. The migration
+ * must be display-neutral in English, so any drift here is a user-visible
+ * regression rather than an intended copy change — exactly what the mocked
+ * `t()` in component tests can never catch.
+ */
+const EN_PINNED: Record<string, string> = {
+  'actions.copyPath': 'Copy path',
+  'actions.copyContent': 'Copy content',
+  'actions.copyFilePath': 'Copy file path',
+  'actions.copyFileContent': 'Copy file content',
+  'actions.search': 'Search',
+  'actions.searchInFile': 'Search in file',
+  'actions.edit': 'Edit',
+  'actions.editFile': 'Edit file',
+  'actions.download': 'Download',
+  'actions.downloadFile': 'Download file',
+  'actions.close': 'Close',
+  'actions.save': 'Save',
+  'actions.saving': 'Saving...',
+  'actions.saved': 'Saved',
+  'actions.prev': 'Prev',
+  'actions.next': 'Next',
+  'actions.fullscreen': 'Fullscreen',
+  'actions.exitFullscreen': 'Exit fullscreen',
+  'actions.minimize': 'Minimize',
+  'actions.maximize': 'Maximize',
+  'fileTree.loading': 'Loading files',
+  'fileTree.empty': 'No files found',
+  'fileTree.newFile': 'New File',
+  'fileTree.newDirectory': 'New Directory',
+  'fileTree.noResultsMatching': 'No files matching "{query}"',
+  'fileTree.noResultsContaining': 'No files containing "{query}"',
+  'fileTree.label': 'File tree',
+  'fileTree.refreshing': 'Refreshing files',
+  'fileTree.refreshLabel': 'Refresh file tree',
+  'fileTree.resetViewLabel': 'Reset file tree view',
+  'fileTree.loadError': 'Failed to load files',
+  'fileTree.itemCount': '{count} items',
+  'fileViewer.loading': 'Loading file...',
+  'fileViewer.loadError': 'Failed to load file',
+  'fileViewer.tabSource': 'Source',
+  'fileViewer.tabPreview': 'Preview',
+  'fileViewer.sandboxSafe': 'Safe',
+  'fileViewer.sandboxInteractive': 'Interactive',
+  'fileViewer.noSlides': 'No slides found in {fileName}',
+  'fileViewer.slides': 'Slides',
+  'fileViewer.editor': 'Editor',
+  'fileTabs.unsavedChanges': 'Unsaved changes',
+  'editor.loading': 'Loading...',
+  'editor.placeholder': 'Start typing...',
+  'editor.placeholderMarkdown': 'Start typing markdown...',
+  'editor.saveSuccess': 'File saved successfully',
+  'editor.saveError': 'Failed to save file',
+  'editor.loadError': 'Failed to load file',
+  'editor.sessionExpired': 'Session expired. Please re-login.',
+  'editor.autoSaveFailed': 'Auto-save failed. Switched to manual save.',
+  'editor.unsaved': 'Unsaved',
+  'editor.auto': 'Auto',
+  'editor.splitView': 'Split view',
+  'editor.editorOnly': 'Editor only',
+  'editor.previewOnly': 'Preview only',
+  'editor.enterFullscreen': 'Enter fullscreen (Ctrl+Shift+F)',
+  'editor.exitFullscreen': 'Exit fullscreen (ESC)',
+  'markdownPreview.loadingImage': '[loading image...]',
+  'markdownPreview.editor': 'Editor',
+  'markdownPreview.preview': 'Preview',
+  'markdownPreview.exitFullscreenHint': 'Press ESC to exit fullscreen',
+  'markdownPreview.exitFullscreenHintSwipe': '(or swipe down)',
+  'markdownPreview.largeFileWarning': 'Large file: Performance may be affected.',
+  'mermaid.rendering': 'Rendering diagram...',
+  'mermaid.loading': 'Loading diagram...',
+  'mermaid.errorTitle': 'Diagram Error',
+  'mermaid.emptyCode': 'Diagram code is empty',
+  'mermaid.renderError': 'Failed to render diagram',
+  'imageViewer.loadError': 'Failed to load image',
+  'videoViewer.loadError': 'Failed to load video',
+  'videoViewer.loading': 'Loading video...',
+  'videoViewer.unsupported': 'Your browser does not support the video tag.',
+  'logViewer.title': 'Log Files',
+  'logViewer.empty': 'No log files found',
+  'logViewer.copyTitle': 'Copy sanitized log to clipboard',
+  'logViewer.export': 'Export',
+  'logViewer.exporting': 'Exporting...',
+  'logViewer.copied': 'Log copied to clipboard (sanitized)',
+  'logViewer.searchPlaceholder': 'Search in log file...',
+  'logViewer.prevMatch': 'Previous match (Shift+Enter)',
+  'logViewer.nextMatch': 'Next match (Enter)',
+  'logViewer.noMatches': 'No matches found for "{query}"',
+  'pdfPreview.downloadPdf': 'Download PDF',
+  'htmlPreview.modeSource': 'Source',
+  'htmlPreview.modePreview': 'Preview',
+  'htmlPreview.modeSplit': 'Split',
+  'htmlPreview.sandboxSafe': 'Safe',
+  'htmlPreview.sandboxInteractive': 'Interactive',
+  'diffViewer.badge': 'DIFF',
+  'diffViewer.close': 'Close diff view',
+  'search.searching': 'Searching...',
+  'search.placeholder': 'Search files...',
+  'search.label': 'Search files',
+  'search.clear': 'Clear search',
+  'search.mode': 'Mode:',
+  'search.modeName': 'Name',
+  'search.modeContent': 'Content',
+};
+
+/**
+ * Strings that were hardcoded *Japanese* before this Issue, so English users
+ * were shown Japanese. There is no pre-migration English to stay faithful to —
+ * these EN values are new by necessity, and ja must keep the original wording
+ * byte-for-byte instead.
+ */
+const JA_PINNED: Record<string, string> = {
+  'actions.retry': '再試行',
+  'actions.refresh': '更新',
+  'actions.resetView': '表示をリセット',
+  'fileSearch.placeholder': '検索...',
+  'fileSearch.prevMatch': '前の結果',
+  'fileSearch.nextMatch': '次の結果',
+  'fileSearch.close': '検索を閉じる',
+  'pdfPreview.loadError': 'PDFプレビューを読み込めませんでした。',
+  'pdfPreview.openInNewTab': 'PDFを新しいタブで開く',
+  'pdfPreview.download': 'ダウンロード',
+};
+
+describe('worktree file viewer i18n keys (Issue #1275)', () => {
+  it.each(['en', 'ja'])('%s/worktree.json defines every guarded section', (locale) => {
+    const dict = loadWorktree(locale);
+    for (const section of SECTIONS) {
+      expect(dict[section], `${locale}: missing section "${section}"`).toBeDefined();
+    }
+  });
+
+  it.each(['en', 'ja'])('%s/worktree.json has a non-empty string at every leaf', (locale) => {
+    const dict = loadWorktree(locale);
+    for (const section of SECTIONS) {
+      const sub = dict[section] as Record<string, unknown>;
+      for (const key of leafKeys(sub)) {
+        const value = resolve(sub, key);
+        expect(typeof value, `${locale}: ${section}.${key} is not a string`).toBe('string');
+        expect((value as string).trim(), `${locale}: ${section}.${key} is empty`).not.toBe('');
+      }
+    }
+  });
+
+  it('en and ja expose the same key set for every guarded section (parity)', () => {
+    const en = loadWorktree('en');
+    const ja = loadWorktree('ja');
+    for (const section of SECTIONS) {
+      const enKeys = leafKeys(en[section] as Record<string, unknown>).sort();
+      const jaKeys = leafKeys(ja[section] as Record<string, unknown>).sort();
+      expect(jaKeys, `parity mismatch in section "${section}"`).toEqual(enKeys);
+    }
+  });
+
+  it('en wording stays byte-identical to the pre-migration markup', () => {
+    const en = loadWorktree('en');
+    for (const [key, expected] of Object.entries(EN_PINNED)) {
+      expect(resolve(en, key), `en drift at ${key}`).toBe(expected);
+    }
+  });
+
+  it('ja keeps the wording that was hardcoded in Japanese before the migration', () => {
+    const ja = loadWorktree('ja');
+    for (const [key, expected] of Object.entries(JA_PINNED)) {
+      expect(resolve(ja, key), `ja drift at ${key}`).toBe(expected);
+    }
+  });
+
+  it('ja is actually translated, not an English copy', () => {
+    const en = loadWorktree('en');
+    const ja = loadWorktree('ja');
+    // Product nouns and format-only values legitimately match across locales.
+    const ALLOWED_IDENTICAL = new Set([
+      'diffViewer.badge',
+      'logViewer.toolCount',
+      'editor.enterFullscreen',
+      'editor.exitFullscreen',
+    ]);
+    const identical: string[] = [];
+    for (const section of SECTIONS) {
+      for (const key of leafKeys(en[section] as Record<string, unknown>)) {
+        const full = `${section}.${key}`;
+        if (ALLOWED_IDENTICAL.has(full)) continue;
+        if (resolve(en, full) === resolve(ja, full)) identical.push(full);
+      }
+    }
+    expect(identical, 'ja values identical to en (untranslated)').toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1275 の対応。`worktree/` のファイル閲覧・編集系（`FileTreeView` / `FileViewer` / `FilePanel*` / `Markdown*` / `Mermaid*` / 各ビューア / `TreeNode` / `SearchBar`）の直書き文言を `worktree.*` へ移行する。

**重複文言は `worktree.actions.*` に寄せ、同一文言に別キーを振らない。**

親Issue: #1270（さらに上位: #1193）

## 🔴 起票者の grep 実数は約40%しか捉えていなかった

**実数は 53 ではなく約 133 箇所。**

Issue の grep は**属性と JSX テキストしか見ておらず**、以下を取りこぼしていた:
- 三項演算子
- テンプレートリテラル
- toast
- エラーメッセージ

（#1276 も独立に同じ結論に達している）

## 🔴 直書き「日本語」が4ファイルに存在した

**Issue の grep は `[A-Z]` 始まりの英語しか探しておらず、構造的に不可視だった。**

| ファイル | 日本語の行数（オーケストレーターが develop で実数確認） |
|---|---|
| `FileTreeView.tsx` | **8** |
| `PdfPreview.tsx` | **4** |
| `MarkdownToolbar.tsx` | **4** |
| `FileSearchBar.tsx` | **4** |

実例: `title="更新"` / `placeholder="検索..."` / `PDFプレビューを読み込めませんでした。`

→ **en 表示が日本語のままだった不具合。** en に英語訳を入れる。「**EN はバイト一致**」の**対象外**（一致させると en 辞書が日本語になる）。

## 🔬 `t` を dep 配列に入れると壊れる（#1219 の教訓を実数で再現）

`tests/setup.ts` の next-intl モックは**毎レンダー新しい `t` を返す**ため、`t` を dep に入れると:

| コンポーネント | 症状 |
|---|---|
| `FileTreeView` | **fetch ループ（1テストで 3,124 fetch）** |
| `MermaidDiagram` | render が **2回 → 5回**に増えて落ちる |

→ **I/O を伴う effect は `tRef` 経由で読み、dep を元の不変条件のまま保つ。**

## 📌 #1277 への申し送り

- **`TreeContextMenu.tsx` は `ContextMenu` の再エクスポートのみ**で文言を持たない。**実体の `ContextMenu.tsx` は #1277 の担当**のため触っていない
- **E2E の修正は本Issueでは不要だった**（変更対象の文言を引くセレクタは存在せず、`dirty-indicator` は `data-testid` 経由）。ただし **`New File` / `New Directory` の menuitem セレクタは #1277 の `ContextMenu.tsx` を見ている** → **#1277 がそこを i18n 化すると E2E が壊れる**（#1273 の locale switcher と同じ構造）

## テストの実効性

キー素通しモックは実辞書にキーが無くても green のままになるため、文言を検証するテストは **`tests/helpers/real-intl.ts`（実辞書バック）へ切り替えた**。

`worktree-file-viewer-keys.test.ts` は **en/ja パリティ・EN 文言ドリフト・ja 未翻訳**を実辞書から検出する。いずれも**欠陥注入で「壊すと落ちる」ことを確認済み**。

## 検証

| 項目 | 結果 |
|---|---|
| 担当領域の未 i18n 文字列 | ✅ **実測0件（英語・日本語とも）** |
| **EN バイト一致** | ✅ `git show HEAD:` から抽出した英語リテラル **54/54** が辞書に一致 |

## 品質チェック（オーケストレーターが自前で再検証）

| チェック項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `CI=true npm run test:unit` | ✅ **570 files / 9,692 tests 全パス** |
| `CI=true npm run test:integration` | ✅ **50 files / 686 tests 全パス** |
| `npm run build` | ✅ exit 0 |

`MarkdownEditor` は #1216 で CI 限定フレーク（`fireResize` の黙った no-op）を修正済み。**退行していない**ことを上記で確認。

Refs #1270, #1273, #1219, #1206
Closes #1275
