### PR TITLE
fix(i18n): status-colors.ts のラベルを辞書キーへ移行する (#1304)

### DIFF
--- a/docs/features/sidebar-status-indicator.md
+++ b/docs/features/sidebar-status-indicator.md
@@ -31,21 +31,23 @@
 > OS の「視差効果を減らす」設定時は `globals.css`（Issue #1050）が全アニメを無効化し、
 > 静的ドットへフォールバックする（このとき `running` はリングで `ready` と識別できる）。
 
-### 表示の適用範囲と既知の不整合（Issue #1051 時点）
+### 表示の適用範囲（Issue #1078 で統一済み）
 
-Issue #1051 の StatusDot 化は **サイドバー / Home / Sessions のみ**。以下は今回移行しておらず、
-**従来の `src/config/status-colors.ts`（`MOBILE_STATUS_CONFIG` / `DESKTOP_STATUS_CONFIG`）** のままで、
-今後の追随対象。全面的な表示統一はまだ達成していない点に注意。
+Issue #1051 の StatusDot 化は当初 **サイドバー / Home / Sessions のみ**で、worktree詳細と
+`MobileHeader` は独自の色設定（青スピナー / `bg-yellow-500`）のまま併存していた。
+Issue #1078 で両者とも `<StatusDot>` へ移行し、この不整合は解消済み。
 
-| 箇所 | `running` / `generating` | `waiting` |
-|------|--------------------------|-----------|
-| サイドバー / Home / Sessions（StatusDot） | 緑グロー + パルス（発光ドット） | amber（`bg-warning`）・弱点滅 |
-| worktree詳細（`WorktreeDetailRefactored` 等）・`MobileHeader` | 青スピナー（`border-info`, `animate-spin`） | 黄（`bg-yellow-500`）・静的 |
+`src/config/status-colors.ts` に残るのは以下の2つ:
 
-- **`running` の色/表現差**: StatusDot 側は緑の発光ドット、worktree詳細/MobileHeader 側は青スピナーのまま。
-- **`waiting` の色差**: StatusDot は amber（`bg-warning`）、worktree詳細/MobileHeader は `bg-yellow-500`。
-  さらに `Terminal.tsx` / `MobileTabBar.tsx` は `bg-yellow-500` をハードコードしている。
-  完全統一には `status-colors.ts` とこれらのハードコード双方の変更が必要なため、追随作業まで保留。
+| export | 用途 |
+|--------|------|
+| `SIDEBAR_STATUS_CONFIG` | `ReviewTab` / Sessions のエージェント status dot（色・dot/spinner・`labelKey`） |
+| `DESKTOP_STATUS_LABEL_KEYS` | worktree詳細 DesktopHeader の長文ラベル（`worktree.detailStatus.*`）のみ |
+
+- **ラベルは辞書キー**: モジュールスコープでは `t()` を呼べないため、config はキーだけを持ち
+  描画側が解決する（Issue #1271 / #1304）。汎用6語は `common.status.*`（Issue #1273）を再利用する。
+- **`waiting` の色**: `src/components/Terminal.tsx` は今も `bg-yellow-500` をハードコードしており、
+  トークン（`bg-warning`）への統一は未着手（`MobileTabBar.tsx` は解消済み）。
 
 ## ブランチ左の集約ステータスアイコン（Issue #867）
 

--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -606,5 +606,11 @@
     "statusPill": "{label}: {status}",
     "subTabMessage": "Message",
     "subTabGit": "Git"
+  },
+  "detailStatus": {
+    "idle": "Idle - No active session",
+    "ready": "Ready - Waiting for input",
+    "running": "Running - Processing",
+    "waiting": "Waiting - User input required"
   }
 }

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -606,5 +606,11 @@
     "statusPill": "{label}: {status}",
     "subTabMessage": "メッセージ",
     "subTabGit": "Git"
+  },
+  "detailStatus": {
+    "idle": "アイドル - セッションなし",
+    "ready": "準備完了 - 入力待ち",
+    "running": "実行中 - 処理しています",
+    "waiting": "待機中 - ユーザー入力が必要です"
   }
 }

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -79,7 +79,8 @@ const DEFAULT_STATUS_PRIORITY = 4;
 
 /** Small CLI status dot for Sessions list (Issue #1051: shared StatusDot). */
 function CliDot({ status, label }: { status: BranchStatus; label: string }) {
-  const title = `${label}: ${SIDEBAR_STATUS_CONFIG[status].label}`;
+  const tCommon = useTranslations('common');
+  const title = `${label}: ${tCommon(SIDEBAR_STATUS_CONFIG[status].labelKey)}`;
   return <StatusDot status={status} size="md" label={title} />;
 }
 

--- a/src/components/review/ReviewTab.tsx
+++ b/src/components/review/ReviewTab.tsx
@@ -46,8 +46,9 @@ const FILTER_PREDICATES: Record<ReviewFilter, (wt: Worktree) => boolean> = {
 
 /** Small CLI status dot */
 function CliDot({ status, label }: { status: BranchStatus; label: string }) {
+  const tCommon = useTranslations('common');
   const config = SIDEBAR_STATUS_CONFIG[status];
-  const title = `${label}: ${config.label}`;
+  const title = `${label}: ${tCommon(config.labelKey)}`;
   const base = 'w-2.5 h-2.5 rounded-full flex-shrink-0';
 
   if (config.type === 'spinner') {

--- a/src/components/worktree/WorktreeDetailRefactored.tsx
+++ b/src/components/worktree/WorktreeDetailRefactored.tsx
@@ -510,8 +510,8 @@ export const WorktreeDetailRefactored = memo(function WorktreeDetailRefactored({
                 worktree?.sessionStatusByInstance?.[inst.id] ?? worktree?.sessionStatusByCli?.[inst.cliTool]
               );
               // Issue #1277: the status wording comes from the generic
-              // `common.status.*` keys (#1273), not the hardcoded English
-              // `.label` on SIDEBAR_STATUS_CONFIG — one source of truth.
+              // `common.status.*` keys (#1273) — one source of truth, shared
+              // with SIDEBAR_STATUS_CONFIG's labelKey (#1304).
               const statusLabel = tCommon(`status.${toolStatus}`);
               const isActive = activeInstanceId === inst.id;
               return (

--- a/src/components/worktree/WorktreeDetailSubComponents.tsx
+++ b/src/components/worktree/WorktreeDetailSubComponents.tsx
@@ -14,7 +14,7 @@
 import React, { useEffect, useCallback, useState, memo, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { type WorktreeStatus } from '@/components/mobile/MobileHeader';
-import { DESKTOP_STATUS_CONFIG } from '@/config/status-colors';
+import { DESKTOP_STATUS_LABEL_KEYS } from '@/config/status-colors';
 import { StatusDot } from '@/components/ui/StatusDot';
 import { Tooltip } from '@/components/common/Tooltip';
 import {
@@ -546,11 +546,15 @@ export const DesktopHeader = memo(function DesktopHeader({
 }: DesktopHeaderProps) {
   const tWorktree = useTranslations('worktree');
   // Issue #1277: agent-instance status labels resolve through the generic
-  // `common.status.*` keys (defined by #1273) rather than the hardcoded English
-  // `.label` on SIDEBAR_STATUS_CONFIG, so the wording has a single source of
-  // truth. The config keeps owning the colour/type mapping.
+  // `common.status.*` keys (defined by #1273), so the wording has a single
+  // source of truth. The config keeps owning the color/type mapping.
   const tCommon = useTranslations('common');
-  const statusConfig = DESKTOP_STATUS_CONFIG[status];
+  // Issue #1304: the worktree-level dot shows a long-form description
+  // ("Idle - No active session"). `error` has no entry — its label is the
+  // generic `common.status.error`, which StatusDot resolves itself when `label`
+  // is omitted, so we pass undefined rather than duplicating that wording.
+  const statusLabelKey = DESKTOP_STATUS_LABEL_KEYS[status];
+  const statusLabel = statusLabelKey ? tWorktree(statusLabelKey) : undefined;
   // Issue #111: DRY - Use shared truncateString utility
   const DESKTOP_BRANCH_MAX_LENGTH = 30;
   const DESCRIPTION_MAX_LENGTH = 50;
@@ -632,7 +636,7 @@ export const DesktopHeader = memo(function DesktopHeader({
           data-testid="desktop-status-indicator"
           status={status}
           size="lg"
-          label={statusConfig.label}
+          label={statusLabel}
         />
         {/* Worktree name, memo, and repository */}
         <div className="flex flex-col min-w-0">

--- a/src/config/status-colors.ts
+++ b/src/config/status-colors.ts
@@ -1,12 +1,16 @@
 /**
  * Centralized Status Color Configuration
  *
- * SF1: Consolidates color settings that were duplicated across:
- * - BranchStatusIndicator.tsx
- * - MobileHeader.tsx
- * - WorktreeDetailRefactored.tsx
+ * SF1: Consolidates color settings that were duplicated across the status
+ * surfaces. Consumers today are `ReviewTab` and Sessions (SIDEBAR_STATUS_CONFIG)
+ * plus the worktree-detail DesktopHeader (DESKTOP_STATUS_LABEL_KEYS);
+ * BranchStatusIndicator and MobileHeader now render <StatusDot> directly.
  *
  * G1: waiting status uses the warning token to distinguish from ready (success token)
+ *
+ * Issue #1304: labels are stored as dictionary *keys*, never literals. This is a
+ * module-scope config imported by many components, so t() cannot be called here
+ * (Issue #1271) — the render site resolves the key.
  */
 
 // ============================================================================
@@ -33,8 +37,12 @@ export type StatusDisplayType = 'dot' | 'spinner';
 export interface StatusConfig {
   /** Tailwind CSS class for the color */
   className: string;
-  /** Accessible label for the status */
-  label: string;
+  /**
+   * Key into the `common.status.*` dictionary for the accessible label
+   * (Issue #1273 defined these generic keys; #1304 reuses them here). A literal
+   * would pin the label to English at module scope, where t() cannot run.
+   */
+  labelKey: string;
   /** Display type: 'dot' for static circle, 'spinner' for animated */
   type: StatusDisplayType;
 }
@@ -68,97 +76,59 @@ export const STATUS_COLORS = {
 // ============================================================================
 
 /**
- * Base status configuration for sidebar components
- * Used by: BranchStatusIndicator
+ * Base status configuration for the agent status dots.
+ * Used by: ReviewTab, Sessions page.
+ *
+ * Every label here is one of the generic `common.status.*` words, so the keys
+ * are reused verbatim rather than re-declared (Issue #1304).
  */
 export const SIDEBAR_STATUS_CONFIG: Record<SidebarStatusType, StatusConfig> = {
   idle: {
     className: STATUS_COLORS.idle,
-    label: 'Idle',
+    labelKey: 'status.idle',
     type: 'dot',
   },
   ready: {
     className: STATUS_COLORS.ready,
-    label: 'Ready',
+    labelKey: 'status.ready',
     type: 'dot',
   },
   running: {
     className: STATUS_COLORS.spinner,
-    label: 'Running',
+    labelKey: 'status.running',
     type: 'spinner',
   },
   waiting: {
     className: STATUS_COLORS.waiting,
-    label: 'Waiting for response',
+    labelKey: 'status.waiting',
     type: 'dot',
   },
   generating: {
     className: STATUS_COLORS.spinner,
-    label: 'Generating',
+    labelKey: 'status.generating',
     type: 'spinner',
   },
 };
 
 /**
- * Status configuration for mobile header
- * Used by: MobileHeader
+ * Long-form status descriptions for the worktree-detail desktop header
+ * (Issue #1304). Keys are relative to the `worktree` namespace.
+ *
+ * Unlike SIDEBAR_STATUS_CONFIG these are *not* the generic `common.status.*`
+ * words ("Idle - No active session" vs. "Idle"), so they need their own entries.
+ *
+ * `error` is intentionally absent: its label is exactly the generic
+ * `common.status.error` that <StatusDot> already resolves when no `label` is
+ * passed, so re-declaring it here would duplicate the wording that #1273
+ * centralised. The map is Partial for that reason — an absent key means
+ * "let StatusDot use its generic default".
+ *
+ * Only the label varies per status here; the dot's color/motion comes from
+ * <StatusDot> itself, which is why this is a key map rather than a StatusConfig.
  */
-export const MOBILE_STATUS_CONFIG: Record<WorktreeStatusType, StatusConfig> = {
-  idle: {
-    className: STATUS_COLORS.idle,
-    label: 'Idle',
-    type: 'dot',
-  },
-  ready: {
-    className: STATUS_COLORS.ready,
-    label: 'Ready',
-    type: 'dot',
-  },
-  running: {
-    className: STATUS_COLORS.spinner,
-    label: 'Running',
-    type: 'spinner',
-  },
-  waiting: {
-    className: STATUS_COLORS.waiting,
-    label: 'Waiting for response',
-    type: 'dot',
-  },
-  error: {
-    className: STATUS_COLORS.error,
-    label: 'Error',
-    type: 'dot',
-  },
-};
-
-/**
- * Status configuration for desktop header in worktree detail
- * Used by: WorktreeDetailRefactored (DesktopHeader)
- */
-export const DESKTOP_STATUS_CONFIG: Record<WorktreeStatusType, StatusConfig> = {
-  idle: {
-    className: STATUS_COLORS.idle,
-    label: 'Idle - No active session',
-    type: 'dot',
-  },
-  ready: {
-    className: STATUS_COLORS.ready,
-    label: 'Ready - Waiting for input',
-    type: 'dot',
-  },
-  running: {
-    className: STATUS_COLORS.spinner,
-    label: 'Running - Processing',
-    type: 'spinner',
-  },
-  waiting: {
-    className: STATUS_COLORS.waiting,
-    label: 'Waiting - User input required',
-    type: 'dot',
-  },
-  error: {
-    className: STATUS_COLORS.error,
-    label: 'Error',
-    type: 'dot',
-  },
+export const DESKTOP_STATUS_LABEL_KEYS: Partial<Record<WorktreeStatusType, string>> = {
+  idle: 'detailStatus.idle',
+  ready: 'detailStatus.ready',
+  running: 'detailStatus.running',
+  waiting: 'detailStatus.waiting',
 };

--- a/tests/unit/SessionsPage.test.tsx
+++ b/tests/unit/SessionsPage.test.tsx
@@ -29,14 +29,16 @@ vi.mock('@/components/layout', () => ({
     React.createElement('div', { 'data-testid': 'app-shell' }, children),
 }));
 
-// Mock status-colors
+// Mock status-colors (Issue #1304: labels are `common.status.*` keys, resolved
+// at render — this suite asserts layout/behaviour, not wording, so the keys are
+// echoed by the global next-intl mock. Wording is covered by status-colors-keys.)
 vi.mock('@/config/status-colors', () => ({
   SIDEBAR_STATUS_CONFIG: {
-    idle: { type: 'dot', className: 'bg-gray-400', label: 'Idle' },
-    ready: { type: 'dot', className: 'bg-accent-500', label: 'Ready' },
-    running: { type: 'spinner', className: 'border-green-500', label: 'Running' },
-    waiting: { type: 'dot', className: 'bg-yellow-500', label: 'Waiting' },
-    generating: { type: 'spinner', className: 'border-info', label: 'Generating' },
+    idle: { type: 'dot', className: 'bg-gray-400', labelKey: 'status.idle' },
+    ready: { type: 'dot', className: 'bg-accent-500', labelKey: 'status.ready' },
+    running: { type: 'spinner', className: 'border-green-500', labelKey: 'status.running' },
+    waiting: { type: 'dot', className: 'bg-yellow-500', labelKey: 'status.waiting' },
+    generating: { type: 'spinner', className: 'border-info', labelKey: 'status.generating' },
   },
 }));
 

--- a/tests/unit/components/review/ReviewPage-stalled.test.tsx
+++ b/tests/unit/components/review/ReviewPage-stalled.test.tsx
@@ -45,14 +45,15 @@ vi.mock('@/config/review-config', () => ({
   MAX_USER_INSTRUCTION_LENGTH: 1000,
 }));
 
-// Mock status-colors
+// Mock status-colors (Issue #1304: labels are `common.status.*` keys, resolved
+// at render — this suite asserts stalled-filter behaviour, not wording.)
 vi.mock('@/config/status-colors', () => ({
   SIDEBAR_STATUS_CONFIG: {
-    idle: { type: 'dot', className: 'bg-gray-400', label: 'Idle' },
-    ready: { type: 'dot', className: 'bg-accent-500', label: 'Ready' },
-    running: { type: 'spinner', className: 'border-green-500', label: 'Running' },
-    waiting: { type: 'dot', className: 'bg-yellow-500', label: 'Waiting' },
-    generating: { type: 'spinner', className: 'border-info', label: 'Generating' },
+    idle: { type: 'dot', className: 'bg-gray-400', labelKey: 'status.idle' },
+    ready: { type: 'dot', className: 'bg-accent-500', labelKey: 'status.ready' },
+    running: { type: 'spinner', className: 'border-green-500', labelKey: 'status.running' },
+    waiting: { type: 'dot', className: 'bg-yellow-500', labelKey: 'status.waiting' },
+    generating: { type: 'spinner', className: 'border-info', labelKey: 'status.generating' },
   },
 }));
 

--- a/tests/unit/components/worktree/DesktopHeader-status-label.test.tsx
+++ b/tests/unit/components/worktree/DesktopHeader-status-label.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1304: the worktree-level status dot in DesktopHeader used to read its
+ * accessible label from a hardcoded English `label` on DESKTOP_STATUS_CONFIG.
+ * It now resolves `DESKTOP_STATUS_LABEL_KEYS[status]` through the dictionary,
+ * and `error` falls through to <StatusDot>'s own `common.status.error`.
+ *
+ * Backed by the REAL dictionary (tests/helpers/real-intl) rather than the global
+ * echo mock: with the echo mock these assertions would pass against keys that do
+ * not exist (#1197). Both locales are exercised, because the bug this migration
+ * fixes is "English shown to a Japanese user".
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DesktopHeader } from '@/components/worktree/WorktreeDetailSubComponents';
+import type { WorktreeStatusType } from '@/config/status-colors';
+
+const locale = vi.hoisted(() => ({ current: 'en' }));
+
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock(() => locale.current);
+});
+
+const baseProps = {
+  worktreeName: 'feature/1304-status-colors',
+  repositoryName: 'CommandMate',
+  onBackClick: vi.fn(),
+  onInfoClick: vi.fn(),
+};
+
+/** Renders fresh each call so a test may sweep every status in one body. */
+function statusLabel(status: WorktreeStatusType): string {
+  cleanup();
+  render(<DesktopHeader {...baseProps} status={status} />);
+  return screen.getByTestId('desktop-status-indicator').getAttribute('aria-label') ?? '';
+}
+
+/** EN values are the pre-#1304 literals — the byte-identity bar. */
+const EN: Record<WorktreeStatusType, string> = {
+  idle: 'Idle - No active session',
+  ready: 'Ready - Waiting for input',
+  running: 'Running - Processing',
+  waiting: 'Waiting - User input required',
+  error: 'Error',
+};
+
+const JA: Record<WorktreeStatusType, string> = {
+  idle: 'アイドル - セッションなし',
+  ready: '準備完了 - 入力待ち',
+  running: '実行中 - 処理しています',
+  waiting: '待機中 - ユーザー入力が必要です',
+  error: 'エラー',
+};
+
+describe('DesktopHeader worktree status label (Issue #1304)', () => {
+  describe('en — byte-identical to the pre-migration hardcoded labels', () => {
+    for (const [status, expected] of Object.entries(EN)) {
+      it(`renders "${expected}" for ${status}`, () => {
+        locale.current = 'en';
+        expect(statusLabel(status as WorktreeStatusType)).toBe(expected);
+      });
+    }
+  });
+
+  describe('ja — the wording a Japanese user actually sees', () => {
+    for (const [status, expected] of Object.entries(JA)) {
+      it(`renders "${expected}" for ${status}`, () => {
+        locale.current = 'ja';
+        expect(statusLabel(status as WorktreeStatusType)).toBe(expected);
+      });
+    }
+
+    it('shows no English for any status (the #1275/#1276/#1277 failure mode)', () => {
+      locale.current = 'ja';
+      for (const status of Object.keys(EN) as WorktreeStatusType[]) {
+        expect(statusLabel(status)).not.toMatch(/[A-Za-z]/);
+      }
+    });
+  });
+});

--- a/tests/unit/i18n/status-colors-keys.test.ts
+++ b/tests/unit/i18n/status-colors-keys.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Real-dictionary guard for `src/config/status-colors.ts` (Issue #1304).
+ *
+ * The config is module scope, so it stores dictionary KEYS and the render site
+ * resolves them (Issue #1271). The global next-intl mock in tests/setup.ts
+ * echoes `namespace.key` back, so a component test would stay green even if the
+ * key had no dictionary entry — this suite reads locales/<locale>/*.json off
+ * disk instead, so a missing/renamed key fails here (#1197 blind spot).
+ *
+ * It also pins the EN wording to what shipped BEFORE the migration: the values
+ * below were lifted from the pre-#1304 `label:` literals, so a drift in either
+ * direction (dictionary edited, or config re-pointed at a different key) fails.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { SIDEBAR_STATUS_CONFIG, DESKTOP_STATUS_LABEL_KEYS } from '@/config/status-colors';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../../locales');
+const LOCALES = ['en', 'ja'] as const;
+
+function load(locale: string, namespace: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(LOCALES_DIR, locale, `${namespace}.json`), 'utf-8')
+  );
+}
+
+function resolve(dict: Record<string, unknown>, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], dict);
+}
+
+/**
+ * EN wording as it shipped before #1304 (git HEAD's `label:` literals). The
+ * acceptance bar is byte-identity, so these are the ORIGINALS, not values
+ * copied back out of the dictionary (which would be circular).
+ */
+const PRE_MIGRATION_EN = {
+  sidebar: {
+    idle: 'Idle',
+    ready: 'Ready',
+    running: 'Running',
+    waiting: 'Waiting for response',
+    generating: 'Generating',
+  },
+  desktop: {
+    idle: 'Idle - No active session',
+    ready: 'Ready - Waiting for input',
+    running: 'Running - Processing',
+    waiting: 'Waiting - User input required',
+    // `error` is deliberately not in DESKTOP_STATUS_LABEL_KEYS — see below.
+    error: 'Error',
+  },
+} as const;
+
+describe('status-colors.ts i18n keys (Issue #1304)', () => {
+  describe('SIDEBAR_STATUS_CONFIG reuses common.status.* (no new keys)', () => {
+    for (const locale of LOCALES) {
+      it(`every labelKey resolves to a string in ${locale}/common.json`, () => {
+        const common = load(locale, 'common');
+        for (const [status, config] of Object.entries(SIDEBAR_STATUS_CONFIG)) {
+          expect(
+            resolve(common, config.labelKey),
+            `${locale}/common.json has no string at "${config.labelKey}" (status: ${status})`
+          ).toBeTypeOf('string');
+        }
+      });
+    }
+
+    it('points every status at the generic status.* key, not a bespoke one', () => {
+      for (const [status, config] of Object.entries(SIDEBAR_STATUS_CONFIG)) {
+        expect(config.labelKey, `status "${status}" should reuse common.status.*`).toBe(
+          `status.${status}`
+        );
+      }
+    });
+
+    it('EN wording is byte-identical to the pre-migration labels', () => {
+      const common = load('en', 'common');
+      for (const [status, expected] of Object.entries(PRE_MIGRATION_EN.sidebar)) {
+        const key = SIDEBAR_STATUS_CONFIG[status as keyof typeof SIDEBAR_STATUS_CONFIG].labelKey;
+        expect(resolve(common, key)).toBe(expected);
+      }
+    });
+  });
+
+  describe('DESKTOP_STATUS_LABEL_KEYS long-form descriptions', () => {
+    for (const locale of LOCALES) {
+      it(`every labelKey resolves to a string in ${locale}/worktree.json`, () => {
+        const worktree = load(locale, 'worktree');
+        for (const [status, key] of Object.entries(DESKTOP_STATUS_LABEL_KEYS)) {
+          expect(
+            resolve(worktree, key as string),
+            `${locale}/worktree.json has no string at "${key}" (status: ${status})`
+          ).toBeTypeOf('string');
+        }
+      });
+    }
+
+    it('EN wording is byte-identical to the pre-migration labels', () => {
+      const worktree = load('en', 'worktree');
+      for (const [status, key] of Object.entries(DESKTOP_STATUS_LABEL_KEYS)) {
+        const expected = PRE_MIGRATION_EN.desktop[status as keyof typeof PRE_MIGRATION_EN.desktop];
+        expect(resolve(worktree, key as string)).toBe(expected);
+      }
+    });
+
+    it('JA wording is actually translated (not an English passthrough)', () => {
+      const en = load('en', 'worktree');
+      const ja = load('ja', 'worktree');
+      for (const key of Object.values(DESKTOP_STATUS_LABEL_KEYS)) {
+        const jaValue = resolve(ja, key as string) as string;
+        expect(jaValue).not.toBe(resolve(en, key as string));
+        expect(jaValue, `${key} should contain Japanese`).toMatch(
+          /[぀-ゟ゠-ヿ一-鿿]/
+        );
+      }
+    });
+
+    /**
+     * The reuse invariant #1273 asked for: the desktop `error` label is exactly
+     * the generic word, so it has NO entry here — <StatusDot> falls back to
+     * common.status.error when no label is passed. If someone adds an `error`
+     * key to this map they have re-duplicated the wording.
+     */
+    it('omits `error` so the generic common.status.error stays the single source', () => {
+      expect(DESKTOP_STATUS_LABEL_KEYS).not.toHaveProperty('error');
+      for (const locale of LOCALES) {
+        expect(resolve(load(locale, 'common'), 'status.error')).toBeTypeOf('string');
+      }
+      // ...and that generic word is what the desktop header showed pre-#1304.
+      expect(resolve(load('en', 'common'), 'status.error')).toBe(PRE_MIGRATION_EN.desktop.error);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
`src/config/status-colors.ts` の直書きラベルを i18n 辞書キーへ移行する（#1302 系 / #1304）。

## 主な変更
- `DESKTOP_STATUS_CONFIG` のラベルを辞書キー参照へ。`common.status.*` で表現できるものは再利用。
- ただし `Idle - No active session` など `common.status.*` に存在しない長文ラベル4件は EN byte-identity を優先し `worktree.detailStatus.*` を新設（当初 Issue の「キー再利用のみ・新規キーゼロ」前提は成立しなかったため）。
- `Error` は `common.status.error` と一致するため新規キー化せず再利用。
- 参照元が無い dead code `MOBILE_STATUS_CONFIG`（#1078 以降未使用）を削除。
- 関連: `src/app/sessions/page.tsx` / `ReviewTab.tsx` / `WorktreeDetail*` の表示側を辞書キー参照へ。

## テスト
- lint / tsc / test:unit / test:integration / build いずれもローカルで green（CI で最終確認）。

Refs #1304