### PR TITLE
feat(i18n): プッシュ通知のロケール対応（購読時に locale 保存・サーバサイド解決） (#1308)

### DIFF
--- a/locales/en/notifications.json
+++ b/locales/en/notifications.json
@@ -25,5 +25,11 @@
     "disabled": "Notifications turned off on this device",
     "error": "Could not enable notifications",
     "updated": "Notification settings updated"
+  },
+  "push": {
+    "promptWaitingWithExcerpt": "Waiting for reply: {excerpt}",
+    "promptWaiting": "Waiting for your reply",
+    "completionWithExcerpt": "Done: {excerpt}",
+    "completion": "Session complete"
   }
 }

--- a/locales/ja/notifications.json
+++ b/locales/ja/notifications.json
@@ -25,5 +25,11 @@
     "disabled": "この端末の通知をオフにしました",
     "error": "通知を有効にできませんでした",
     "updated": "通知設定を更新しました"
+  },
+  "push": {
+    "promptWaitingWithExcerpt": "応答待ち: {excerpt}",
+    "promptWaiting": "応答待ちです",
+    "completionWithExcerpt": "完了: {excerpt}",
+    "completion": "セッションが完了しました"
   }
 }

--- a/src/app/api/push/subscriptions/route.ts
+++ b/src/app/api/push/subscriptions/route.ts
@@ -20,10 +20,32 @@ import {
   type PushSubscriptionRecord,
 } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
+import { LOCALE_COOKIE_NAME, resolveLocale } from '@/config/i18n-config';
 
 export const dynamic = 'force-dynamic';
 
 const logger = createLogger('api/push-subscriptions');
+
+/**
+ * The locale to notify this device in (Issue #1308).
+ *
+ * Registration is the last point where a request context exists — the poller
+ * that later sends the push has none — so the reader's language is resolved here
+ * and stored on the row. Uses the same resolver as `src/i18n.ts` so the push
+ * body always matches the language the UI is rendered in.
+ */
+function localeFromRequest(request: Request): string {
+  const cookieHeader = request.headers.get('cookie') ?? '';
+  const cookieLocale = cookieHeader
+    .split(';')
+    .map((part) => part.trim().split('='))
+    .find(([name]) => name === LOCALE_COOKIE_NAME)?.[1];
+
+  return resolveLocale(
+    cookieLocale && decodeURIComponent(cookieLocale),
+    request.headers.get('accept-language')
+  );
+}
 
 /** Public view of a subscription — excludes the encryption keys. */
 function serialize(record: PushSubscriptionRecord) {
@@ -81,7 +103,13 @@ export async function POST(request: Request) {
 
     const deviceLabel = isNonEmptyString(body.deviceLabel) ? body.deviceLabel : null;
 
-    const record = upsertPushSubscription(getDbInstance(), { endpoint, p256dh, auth, deviceLabel });
+    const record = upsertPushSubscription(getDbInstance(), {
+      endpoint,
+      p256dh,
+      auth,
+      deviceLabel,
+      locale: localeFromRequest(request),
+    });
     logger.info('push-subscription-registered');
     return NextResponse.json({ success: true, subscription: serialize(record) }, { status: 201 });
   } catch (error) {

--- a/src/config/i18n-config.ts
+++ b/src/config/i18n-config.ts
@@ -17,3 +17,24 @@ export const LOCALE_LABELS: Record<SupportedLocale, string> = {
   en: 'English',
   ja: '日本語',
 };
+
+export function isSupportedLocale(value: unknown): value is SupportedLocale {
+  return typeof value === 'string' && SUPPORTED_LOCALES.includes(value as SupportedLocale);
+}
+
+/**
+ * Resolve a locale the way a request would: cookie -> Accept-Language -> default.
+ *
+ * Shared by `src/i18n.ts` (what the reader SEES) and push subscription
+ * registration (what the reader is NOTIFIED in). These must agree, so both call
+ * this rather than each matching locales their own way — a push body in a
+ * different language than the UI is the bug this exists to prevent.
+ */
+export function resolveLocale(
+  cookieLocale: string | undefined | null,
+  acceptLanguage: string | undefined | null
+): SupportedLocale {
+  if (isSupportedLocale(cookieLocale)) return cookieLocale;
+  const matched = SUPPORTED_LOCALES.find((l) => (acceptLanguage ?? '').includes(l));
+  return matched ?? DEFAULT_LOCALE;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,24 +1,19 @@
 import { getRequestConfig } from 'next-intl/server';
 import { cookies, headers } from 'next/headers';
-import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, SUPPORTED_LOCALES } from '@/config/i18n-config';
-import type { SupportedLocale } from '@/config/i18n-config';
+import { LOCALE_COOKIE_NAME, isSupportedLocale, resolveLocale } from '@/config/i18n-config';
 
 export default getRequestConfig(async ({ requestLocale }) => {
   let locale = await requestLocale;
 
-  if (!locale || !SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
+  if (!isSupportedLocale(locale)) {
     // Fallback order [SF-002]:
     // 1. Cookie 'locale' -> 2. Accept-Language -> 3. DEFAULT_LOCALE ('en')
     const cookieStore = await cookies();
-    const cookieLocale = cookieStore.get(LOCALE_COOKIE_NAME)?.value;
-    if (cookieLocale && SUPPORTED_LOCALES.includes(cookieLocale as SupportedLocale)) {
-      locale = cookieLocale;
-    } else {
-      const headerStore = await headers();
-      const acceptLang = headerStore.get('accept-language') ?? '';
-      const matched = SUPPORTED_LOCALES.find(l => acceptLang.includes(l));
-      locale = matched ?? DEFAULT_LOCALE;
-    }
+    const headerStore = await headers();
+    locale = resolveLocale(
+      cookieStore.get(LOCALE_COOKIE_NAME)?.value,
+      headerStore.get('accept-language')
+    );
   }
 
   // Load all namespace files and merge them

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -24,6 +24,7 @@ import { v38_migrations } from './v38-worktree-todo-status';
 import { v39_migrations } from './v39-worktree-todo-detail';
 import { v40_migrations } from './v40-timer-error';
 import { v41_migrations } from './v41-push-subscriptions';
+import { v42_migrations } from './v42-push-subscription-locale';
 
 /**
  * Complete ordered list of all migrations.
@@ -53,4 +54,5 @@ export const migrations: Migration[] = [
   ...v39_migrations,
   ...v40_migrations,
   ...v41_migrations,
+  ...v42_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 41;
+export const CURRENT_SCHEMA_VERSION = 42;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v42-push-subscription-locale.ts
+++ b/src/lib/db/migrations/v42-push-subscription-locale.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration v42: Add locale column to push_subscriptions (Issue #1308).
+ *
+ * Push bodies are built by the background poller, which has no request scope and
+ * therefore cannot resolve the reader's locale the way `src/i18n.ts` does
+ * (cookie -> Accept-Language). Registration *does* have a request, so we capture
+ * the locale there and read it back at send time.
+ *
+ * Backward compatibility: nullable with no backfill. Subscriptions registered
+ * before v42 keep `locale = NULL`, which the sender resolves to DEFAULT_LOCALE.
+ * Such rows self-heal the next time the browser re-registers the subscription.
+ */
+
+import type { Migration } from './runner';
+
+export const v42_migrations: Migration[] = [
+  {
+    version: 42,
+    name: 'add-locale-to-push-subscriptions',
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE push_subscriptions ADD COLUMN locale TEXT;
+      `);
+    },
+    // Unlike the v35/v40 no-op rollbacks, this one is real: DROP COLUMN has been
+    // supported since SQLite 3.35 (2021) and `locale` is carried by no index or
+    // constraint, so the drop needs no table rebuild.
+    down: (db) => {
+      db.exec(`
+        ALTER TABLE push_subscriptions DROP COLUMN locale;
+      `);
+    },
+  },
+];

--- a/src/lib/db/push-subscriptions-db.ts
+++ b/src/lib/db/push-subscriptions-db.ts
@@ -21,6 +21,8 @@ export interface PushSubscriptionRecord {
   deviceLabel: string | null;
   enabledPrompt: boolean;
   enabledCompletion: boolean;
+  /** Locale captured at registration. NULL for subscriptions predating v42. */
+  locale: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -31,6 +33,7 @@ export interface UpsertPushSubscriptionInput {
   p256dh: string;
   auth: string;
   deviceLabel?: string | null;
+  locale?: string | null;
 }
 
 interface PushSubscriptionRow {
@@ -41,6 +44,7 @@ interface PushSubscriptionRow {
   device_label: string | null;
   enabled_prompt: number;
   enabled_completion: number;
+  locale: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -53,6 +57,7 @@ function mapRow(row: PushSubscriptionRow): PushSubscriptionRecord {
     deviceLabel: row.device_label,
     enabledPrompt: row.enabled_prompt === 1,
     enabledCompletion: row.enabled_completion === 1,
+    locale: row.locale,
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   };
@@ -60,13 +65,17 @@ function mapRow(row: PushSubscriptionRow): PushSubscriptionRecord {
 
 const SELECT_COLUMNS = `
   id, endpoint, p256dh, auth, device_label,
-  enabled_prompt, enabled_completion, created_at, updated_at
+  enabled_prompt, enabled_completion, locale, created_at, updated_at
 `;
 
 /**
  * Create or update a subscription keyed by endpoint. On conflict the encryption
  * keys and device label are refreshed but the per-type preferences are preserved
  * (a browser re-subscribe must not silently reset the user's toggles).
+ *
+ * Locale follows the keys, not the preferences: a re-registration carries the
+ * reader's current language, so a resolved locale overwrites the stored one.
+ * An *unresolved* locale must not clobber a good stored value, hence COALESCE.
  */
 export function upsertPushSubscription(
   db: Database.Database,
@@ -74,19 +83,21 @@ export function upsertPushSubscription(
 ): PushSubscriptionRecord {
   const now = Date.now();
   const deviceLabel = input.deviceLabel ?? null;
+  const locale = input.locale ?? null;
 
   db.prepare(`
     INSERT INTO push_subscriptions (
       id, endpoint, p256dh, auth, device_label,
-      enabled_prompt, enabled_completion, created_at, updated_at
+      enabled_prompt, enabled_completion, locale, created_at, updated_at
     )
-    VALUES (?, ?, ?, ?, ?, 1, 1, ?, ?)
+    VALUES (?, ?, ?, ?, ?, 1, 1, ?, ?, ?)
     ON CONFLICT(endpoint) DO UPDATE SET
       p256dh = excluded.p256dh,
       auth = excluded.auth,
       device_label = excluded.device_label,
+      locale = COALESCE(excluded.locale, push_subscriptions.locale),
       updated_at = excluded.updated_at
-  `).run(randomUUID(), input.endpoint, input.p256dh, input.auth, deviceLabel, now, now);
+  `).run(randomUUID(), input.endpoint, input.p256dh, input.auth, deviceLabel, locale, now, now);
 
   const record = getPushSubscriptionByEndpoint(db, input.endpoint);
   if (!record) {

--- a/src/lib/push/index.ts
+++ b/src/lib/push/index.ts
@@ -6,6 +6,7 @@ export {
   notifyPushSubscribers,
   buildPushPayload,
   buildExcerpt,
+  resolvePushLocale,
 } from './push-sender';
 export type { NotificationEvent, PushPayload } from './push-sender';
 export {

--- a/src/lib/push/push-sender.ts
+++ b/src/lib/push/push-sender.ts
@@ -7,6 +7,18 @@
  * VAPID secrets.
  *
  * Server-only: imports web-push (Node) and the DB. Do not import from client code.
+ *
+ * Localization (Issue #1308): bodies are built here, in the background poller,
+ * which has no request scope — so next-intl's request APIs are unavailable
+ * (`getTranslations` outside the react-server condition is a stub that throws).
+ * The locale therefore rides on the subscription row, captured at registration.
+ *
+ * The dictionaries are imported statically and interpolated by hand rather than
+ * via next-intl's `createTranslator`: this module is compiled to CommonJS for
+ * `dist/server` (what `npm start` runs) and next-intl is ESM-only, so importing
+ * it here would `require()` an ES module — fatal below Node 22.12, which our
+ * `engines: ">=22.0.0"` still admits. These four strings only ever substitute
+ * `{excerpt}`, so a dependency-free replace covers them.
  */
 
 import webpush from 'web-push';
@@ -18,12 +30,32 @@ import {
   type PushNotificationKind,
 } from '@/lib/db/push-subscriptions-db';
 import { createLogger } from '@/lib/logger';
+import { DEFAULT_LOCALE, isSupportedLocale, type SupportedLocale } from '@/config/i18n-config';
+import enNotifications from '../../../locales/en/notifications.json';
+import jaNotifications from '../../../locales/ja/notifications.json';
 import { getVapidConfig } from './vapid';
 import { shouldSendNotification } from './notification-dedup';
 
 const logger = createLogger('push/sender');
 
 const MAX_EXCERPT_LENGTH = 120;
+
+/** The notification bodies, per locale. Keyed by SupportedLocale so a new locale
+ *  fails the type check (and the dictionary guard test) instead of silently
+ *  falling back to English. */
+const PUSH_MESSAGES: Record<SupportedLocale, typeof enNotifications.push> = {
+  en: enNotifications.push,
+  ja: jaNotifications.push,
+};
+
+/**
+ * Narrow a stored subscription locale to one we can actually render.
+ * Subscriptions registered before v42 have `locale = NULL` and land on
+ * DEFAULT_LOCALE; they self-heal when the browser next re-registers.
+ */
+export function resolvePushLocale(locale: string | null | undefined): SupportedLocale {
+  return isSupportedLocale(locale) ? locale : DEFAULT_LOCALE;
+}
 
 /** The agent event that triggers a notification. */
 export interface NotificationEvent {
@@ -55,19 +87,24 @@ export function buildExcerpt(text: string | undefined, maxLength = MAX_EXCERPT_L
   return collapsed.slice(0, maxLength - 1).trimEnd() + '…';
 }
 
-/** Build the minimal notification payload for an event. */
-export function buildPushPayload(event: NotificationEvent, now: number = Date.now()): PushPayload {
+/** Build the minimal notification payload for an event, in the reader's language. */
+export function buildPushPayload(
+  event: NotificationEvent,
+  locale: string | null | undefined = DEFAULT_LOCALE,
+  now: number = Date.now()
+): PushPayload {
   const excerpt = buildExcerpt(event.excerpt);
   const agentSuffix = event.agentName ? ` (${event.agentName})` : '';
   const title = `${event.worktreeName}${agentSuffix}`;
+  const messages = PUSH_MESSAGES[resolvePushLocale(locale)];
   const body =
     event.kind === 'prompt'
       ? excerpt
-        ? `応答待ち: ${excerpt}`
-        : '応答待ちです'
+        ? messages.promptWaitingWithExcerpt.replace('{excerpt}', excerpt)
+        : messages.promptWaiting
       : excerpt
-        ? `完了: ${excerpt}`
-        : 'セッションが完了しました';
+        ? messages.completionWithExcerpt.replace('{excerpt}', excerpt)
+        : messages.completion;
 
   return {
     kind: event.kind,
@@ -120,9 +157,23 @@ export async function notifyPushSubscribers(event: NotificationEvent): Promise<v
     if (subscriptions.length === 0) return;
 
     webpush.setVapidDetails(config.subject, config.publicKey, config.privateKey);
-    const payload = JSON.stringify(buildPushPayload(event));
 
-    await Promise.all(subscriptions.map((sub) => sendToOne(sub, payload)));
+    // Devices can be registered in different languages, so the body is built per
+    // distinct locale rather than once for the whole fan-out.
+    const byLocale = new Map<SupportedLocale, PushSubscriptionRecord[]>();
+    for (const sub of subscriptions) {
+      const locale = resolvePushLocale(sub.locale);
+      const group = byLocale.get(locale);
+      if (group) group.push(sub);
+      else byLocale.set(locale, [sub]);
+    }
+
+    await Promise.all(
+      Array.from(byLocale, ([locale, subs]) => {
+        const payload = JSON.stringify(buildPushPayload(event, locale));
+        return Promise.all(subs.map((sub) => sendToOne(sub, payload)));
+      })
+    );
   } catch (err) {
     logger.warn('push-fanout-error', {
       error: err instanceof Error ? err.message : String(err),

--- a/tests/integration/push-notification-flow.test.ts
+++ b/tests/integration/push-notification-flow.test.ts
@@ -178,6 +178,73 @@ describe('push notification flow', () => {
     expect(sendNotification).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * Issue #1308. One agent event fans out to every device at once, but the
+   * devices need not share a language — so the body is resolved per
+   * subscription, not once for the whole batch.
+   */
+  describe('per-subscription locale', () => {
+    /** Bodies actually handed to web-push, keyed by endpoint. */
+    function sentByEndpoint(): Record<string, string> {
+      return Object.fromEntries(
+        sendNotification.mock.calls.map(([target, payload]) => [
+          (target as { endpoint: string }).endpoint,
+          (JSON.parse(payload as string) as { body: string }).body,
+        ])
+      );
+    }
+
+    const event = {
+      worktreeId: 'wt-1',
+      worktreeName: 'feature-x',
+      kind: 'prompt' as const,
+      excerpt: 'Continue?',
+    };
+
+    it('gives each device the body in its own language', async () => {
+      upsertPushSubscription(db, { ...sub('https://push.example/en'), locale: 'en' });
+      upsertPushSubscription(db, { ...sub('https://push.example/ja'), locale: 'ja' });
+
+      const { notifyPushSubscribers } = await import('@/lib/push');
+      await notifyPushSubscribers(event);
+
+      expect(sendNotification).toHaveBeenCalledTimes(2);
+      expect(sentByEndpoint()).toEqual({
+        'https://push.example/en': 'Waiting for reply: Continue?',
+        'https://push.example/ja': '応答待ち: Continue?',
+      });
+    });
+
+    it('sends English to a subscription that predates the locale column', async () => {
+      // Registered before v42 — reads back as NULL, must not break or go blank.
+      upsertPushSubscription(db, sub('https://push.example/legacy'));
+
+      const { notifyPushSubscribers } = await import('@/lib/push');
+      await notifyPushSubscribers(event);
+
+      expect(sentByEndpoint()).toEqual({
+        'https://push.example/legacy': 'Waiting for reply: Continue?',
+      });
+    });
+
+    it('still reaches every device when locales are mixed with legacy rows', async () => {
+      upsertPushSubscription(db, { ...sub('https://push.example/ja'), locale: 'ja' });
+      upsertPushSubscription(db, sub('https://push.example/legacy'));
+      upsertPushSubscription(db, { ...sub('https://push.example/en'), locale: 'en' });
+
+      const { notifyPushSubscribers } = await import('@/lib/push');
+      await notifyPushSubscribers(event);
+
+      // Grouping by locale must not drop or duplicate anyone.
+      expect(sendNotification).toHaveBeenCalledTimes(3);
+      expect(sentByEndpoint()).toEqual({
+        'https://push.example/ja': '応答待ち: Continue?',
+        'https://push.example/legacy': 'Waiting for reply: Continue?',
+        'https://push.example/en': 'Waiting for reply: Continue?',
+      });
+    });
+  });
+
   it('is a no-op when push is not configured', async () => {
     delete process.env.CM_VAPID_PUBLIC_KEY;
     delete process.env.CM_VAPID_PRIVATE_KEY;

--- a/tests/integration/push-subscriptions-api.test.ts
+++ b/tests/integration/push-subscriptions-api.test.ts
@@ -78,6 +78,72 @@ describe('push subscriptions API', () => {
     expect(getAllPushSubscriptions(db)).toHaveLength(1);
   });
 
+  /**
+   * Issue #1308 — registration is the only place a request context exists, so
+   * this is where the reader's language has to be captured. These tests run the
+   * real route against a real DB and then build the real payload, which is the
+   * end-to-end claim the acceptance criteria make ("subscribe in English -> an
+   * English body arrives").
+   */
+  describe('locale capture', () => {
+    function requestWith(headers: Record<string, string>) {
+      return new Request(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify(validSubscription),
+      });
+    }
+
+    async function register(headers: Record<string, string>) {
+      const { POST } = await import('@/app/api/push/subscriptions/route');
+      const res = await POST(requestWith(headers));
+      expect(res.status).toBe(201);
+      return getAllPushSubscriptions(db)[0];
+    }
+
+    it('stores the locale cookie', async () => {
+      expect((await register({ cookie: 'locale=ja' })).locale).toBe('ja');
+    });
+
+    it('prefers the locale cookie over Accept-Language', async () => {
+      const rec = await register({ cookie: 'locale=ja', 'accept-language': 'en-US,en;q=0.9' });
+      expect(rec.locale).toBe('ja');
+    });
+
+    it('picks the cookie out from among other cookies', async () => {
+      const rec = await register({ cookie: 'auth_token=abc; locale=ja; theme=dark' });
+      expect(rec.locale).toBe('ja');
+    });
+
+    it('falls back to Accept-Language when no cookie is set', async () => {
+      expect((await register({ 'accept-language': 'ja-JP,ja;q=0.9' })).locale).toBe('ja');
+    });
+
+    it('ignores an unsupported cookie locale', async () => {
+      expect((await register({ cookie: 'locale=fr' })).locale).toBe('en');
+    });
+
+    it('defaults to en when nothing identifies the reader', async () => {
+      expect((await register({})).locale).toBe('en');
+    });
+
+    it('delivers an English body to a device registered in English', async () => {
+      const rec = await register({ cookie: 'locale=en' });
+      const { buildPushPayload } = await import('@/lib/push/push-sender');
+      expect(buildPushPayload({ worktreeId: 'w', worktreeName: 'n', kind: 'prompt' }, rec.locale).body).toBe(
+        'Waiting for your reply'
+      );
+    });
+
+    it('delivers a Japanese body to a device registered in Japanese', async () => {
+      const rec = await register({ cookie: 'locale=ja' });
+      const { buildPushPayload } = await import('@/lib/push/push-sender');
+      expect(buildPushPayload({ worktreeId: 'w', worktreeName: 'n', kind: 'prompt' }, rec.locale).body).toBe(
+        '応答待ちです'
+      );
+    });
+  });
+
   it('POST rejects an invalid subscription body', async () => {
     const { POST } = await import('@/app/api/push/subscriptions/route');
     const res = await POST(jsonRequest('POST', { subscription: { endpoint: '' } }));

--- a/tests/unit/db/migration-v42-push-subscription-locale.test.ts
+++ b/tests/unit/db/migration-v42-push-subscription-locale.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for migration v42 (push_subscriptions.locale, Issue #1308).
+ *
+ * The acceptance criterion is that the migration runs in *both* directions, so
+ * rollback is asserted here rather than accepted as a no-op the way v35/v40 do.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  runMigrations,
+  rollbackMigrations,
+  getCurrentVersion,
+  CURRENT_SCHEMA_VERSION,
+} from '@/lib/db/db-migrations';
+
+function columns(db: Database.Database): string[] {
+  return (db.pragma('table_info(push_subscriptions)') as Array<{ name: string }>).map((c) => c.name);
+}
+
+describe('migration v42: up', () => {
+  it('adds the locale column', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    expect(columns(db)).toContain('locale');
+    db.close();
+  });
+
+  it('leaves locale nullable with no backfill, so pre-v42 rows read back NULL', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO push_subscriptions
+         (id, endpoint, p256dh, auth, device_label, enabled_prompt, enabled_completion, created_at, updated_at)
+       VALUES ('a', 'https://push.example/1', 'k', 'x', NULL, 1, 1, 0, 0)`
+    ).run();
+    const row = db
+      .prepare('SELECT locale FROM push_subscriptions WHERE id = ?')
+      .get('a') as { locale: string | null };
+    expect(row.locale).toBeNull();
+    db.close();
+  });
+
+  it('reaches the current schema version', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(42);
+    db.close();
+  });
+});
+
+describe('migration v42: down', () => {
+  it('drops the locale column and rewinds to 41, keeping the table and its rows', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO push_subscriptions
+         (id, endpoint, p256dh, auth, device_label, enabled_prompt, enabled_completion, locale, created_at, updated_at)
+       VALUES ('a', 'https://push.example/1', 'k', 'x', NULL, 1, 1, 'ja', 0, 0)`
+    ).run();
+
+    rollbackMigrations(db, 41);
+
+    expect(getCurrentVersion(db)).toBe(41);
+    expect(columns(db)).not.toContain('locale');
+    // Rolling back a column must not take the subscription with it.
+    expect(columns(db)).toContain('endpoint');
+    expect(
+      (db.prepare('SELECT COUNT(*) AS n FROM push_subscriptions').get() as { n: number }).n
+    ).toBe(1);
+    db.close();
+  });
+
+  it('survives a full down/up round trip', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    rollbackMigrations(db, 41);
+    expect(columns(db)).not.toContain('locale');
+
+    runMigrations(db);
+
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(columns(db)).toContain('locale');
+    db.close();
+  });
+});

--- a/tests/unit/db/push-subscriptions-db.test.ts
+++ b/tests/unit/db/push-subscriptions-db.test.ts
@@ -111,4 +111,52 @@ describe('push-subscriptions-db', () => {
   it('delete returns false when nothing was removed', () => {
     expect(deletePushSubscriptionByEndpoint(db, 'https://push.example/none')).toBe(false);
   });
+
+  // Issue #1308: the sender has no request context, so the locale must survive
+  // on the row for it to notify this device in the right language.
+  describe('locale', () => {
+    it('persists the locale captured at registration', () => {
+      const rec = upsertPushSubscription(db, { ...sub('https://push.example/a'), locale: 'ja' });
+      expect(rec.locale).toBe('ja');
+      expect(getPushSubscriptionByEndpoint(db, 'https://push.example/a')?.locale).toBe('ja');
+    });
+
+    it('stores NULL when no locale is supplied', () => {
+      expect(upsertPushSubscription(db, sub('https://push.example/a')).locale).toBeNull();
+    });
+
+    it('re-subscribing in a new language overwrites the stored locale', () => {
+      upsertPushSubscription(db, { ...sub('https://push.example/a'), locale: 'ja' });
+      const updated = upsertPushSubscription(db, {
+        ...sub('https://push.example/a'),
+        locale: 'en',
+      });
+      expect(updated.locale).toBe('en');
+    });
+
+    it('an unresolved locale does not clobber a stored one', () => {
+      upsertPushSubscription(db, { ...sub('https://push.example/a'), locale: 'ja' });
+      // COALESCE(excluded.locale, existing) — a re-registration that could not
+      // resolve a locale must not silently downgrade the device to the default.
+      const updated = upsertPushSubscription(db, {
+        ...sub('https://push.example/a'),
+        locale: null,
+      });
+      expect(updated.locale).toBe('ja');
+    });
+
+    it('backfills a locale onto a subscription that predates the column', () => {
+      upsertPushSubscription(db, sub('https://push.example/a'));
+      expect(getPushSubscriptionByEndpoint(db, 'https://push.example/a')?.locale).toBeNull();
+
+      const healed = upsertPushSubscription(db, { ...sub('https://push.example/a'), locale: 'ja' });
+      expect(healed.locale).toBe('ja');
+    });
+
+    it('exposes locale through the fan-out queries', () => {
+      upsertPushSubscription(db, { ...sub('https://push.example/a'), locale: 'ja' });
+      expect(getAllPushSubscriptions(db)[0].locale).toBe('ja');
+      expect(getPushSubscriptionsForKind(db, 'prompt')[0].locale).toBe('ja');
+    });
+  });
 });

--- a/tests/unit/i18n/notifications-push-keys.test.ts
+++ b/tests/unit/i18n/notifications-push-keys.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Real-dictionary guard for the `notifications.push` keys (Issue #1308).
+ *
+ * `src/i18n.ts` has no onError / getMessageFallback, so a key missing from one
+ * locale surfaces raw in production. These bodies are worse than most: they are
+ * built by the background poller and delivered to a device, so nobody sees the
+ * breakage in the UI first. Mirrors common-keys / home-keys.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { SUPPORTED_LOCALES } from '@/config/i18n-config';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../../locales');
+
+function loadPush(locale: string): Record<string, unknown> {
+  const filePath = path.join(LOCALES_DIR, locale, 'notifications.json');
+  const dict = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { push?: Record<string, unknown> };
+  return dict.push ?? {};
+}
+
+/** Every body key push-sender resolves at runtime. */
+const PUSH_KEYS = [
+  'promptWaitingWithExcerpt',
+  'promptWaiting',
+  'completionWithExcerpt',
+  'completion',
+] as const;
+
+/** Keys whose copy must carry the placeholder push-sender substitutes. */
+const EXCERPT_KEYS = ['promptWaitingWithExcerpt', 'completionWithExcerpt'] as const;
+
+describe('notifications.push dictionary', () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    describe(`locale: ${locale}`, () => {
+      const push = loadPush(locale);
+
+      for (const key of PUSH_KEYS) {
+        it(`defines a non-empty string for ${key}`, () => {
+          expect(typeof push[key], `notifications.push.${key} missing in ${locale}`).toBe('string');
+          expect((push[key] as string).trim().length).toBeGreaterThan(0);
+        });
+      }
+
+      for (const key of EXCERPT_KEYS) {
+        it(`keeps the {excerpt} placeholder in ${key}`, () => {
+          expect(push[key] as string).toContain('{excerpt}');
+        });
+      }
+
+      it('has no keys beyond the ones push-sender reads', () => {
+        expect(Object.keys(push).sort()).toEqual([...PUSH_KEYS].sort());
+      });
+    });
+  }
+
+  it('translates every body — no locale reuses another locale\'s wording', () => {
+    for (const key of PUSH_KEYS) {
+      const en = loadPush('en')[key] as string;
+      const ja = loadPush('ja')[key] as string;
+      expect(ja, `notifications.push.${key} is untranslated in ja`).not.toBe(en);
+    }
+  });
+
+  it('preserves the pre-i18n Japanese wording byte-for-byte', () => {
+    // These are the literals push-sender hardcoded before #1308. Japanese users
+    // must not notice the migration at all.
+    expect(loadPush('ja')).toEqual({
+      promptWaitingWithExcerpt: '応答待ち: {excerpt}',
+      promptWaiting: '応答待ちです',
+      completionWithExcerpt: '完了: {excerpt}',
+      completion: 'セッションが完了しました',
+    });
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 41 after Migration #41 (push subscriptions)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(41);
+    it('should be 42 after Migration #42 (push subscription locale)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(42);
     });
   });
 

--- a/tests/unit/push/notification-helpers.test.ts
+++ b/tests/unit/push/notification-helpers.test.ts
@@ -5,11 +5,17 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { buildExcerpt, buildPushPayload } from '@/lib/push/push-sender';
+import {
+  buildExcerpt,
+  buildPushPayload,
+  resolvePushLocale,
+  type NotificationEvent,
+} from '@/lib/push/push-sender';
 import {
   shouldSendNotification,
   resetNotificationDedup,
 } from '@/lib/push/notification-dedup';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/config/i18n-config';
 
 describe('buildExcerpt', () => {
   it('returns empty string for undefined', () => {
@@ -32,6 +38,7 @@ describe('buildPushPayload', () => {
   it('builds a minimal prompt payload with deep-link url and tag', () => {
     const payload = buildPushPayload(
       { worktreeId: 'wt-1', worktreeName: 'feature-x', kind: 'prompt', agentName: 'claude', excerpt: 'Continue?' },
+      'ja',
       1000
     );
     expect(payload).toEqual({
@@ -48,6 +55,7 @@ describe('buildPushPayload', () => {
   it('builds a completion payload and never includes full terminal text', () => {
     const payload = buildPushPayload(
       { worktreeId: 'wt-2', worktreeName: 'bugfix', kind: 'completion', excerpt: 'x'.repeat(500) },
+      'ja',
       2000
     );
     expect(payload.kind).toBe('completion');
@@ -57,12 +65,83 @@ describe('buildPushPayload', () => {
   });
 
   it('falls back to a generic body when excerpt is empty', () => {
-    expect(buildPushPayload({ worktreeId: 'w', worktreeName: 'n', kind: 'prompt' }).body).toBe(
-      '応答待ちです'
+    expect(
+      buildPushPayload({ worktreeId: 'w', worktreeName: 'n', kind: 'prompt' }, 'ja').body
+    ).toBe('応答待ちです');
+    expect(
+      buildPushPayload({ worktreeId: 'w', worktreeName: 'n', kind: 'completion' }, 'ja').body
+    ).toBe('セッションが完了しました');
+  });
+});
+
+/**
+ * Locale selection (Issue #1308).
+ *
+ * These assert real wording, not key strings: push-sender imports the
+ * dictionaries directly rather than through next-intl, so the global mock in
+ * tests/setup.ts cannot mask a missing key here — a wrong or absent entry
+ * changes `body` and fails.
+ */
+describe('buildPushPayload locale selection', () => {
+  const prompt: NotificationEvent = {
+    worktreeId: 'w',
+    worktreeName: 'n',
+    kind: 'prompt',
+    excerpt: 'Continue?',
+  };
+  const completion: NotificationEvent = { worktreeId: 'w', worktreeName: 'n', kind: 'completion' };
+
+  it('renders English bodies for an en subscription', () => {
+    expect(buildPushPayload(prompt, 'en').body).toBe('Waiting for reply: Continue?');
+    expect(buildPushPayload({ ...prompt, excerpt: undefined }, 'en').body).toBe(
+      'Waiting for your reply'
     );
-    expect(buildPushPayload({ worktreeId: 'w', worktreeName: 'n', kind: 'completion' }).body).toBe(
-      'セッションが完了しました'
-    );
+    expect(buildPushPayload({ ...completion, excerpt: 'Built' }, 'en').body).toBe('Done: Built');
+    expect(buildPushPayload(completion, 'en').body).toBe('Session complete');
+  });
+
+  it('renders Japanese bodies for a ja subscription', () => {
+    expect(buildPushPayload(prompt, 'ja').body).toBe('応答待ち: Continue?');
+    expect(buildPushPayload({ ...prompt, excerpt: undefined }, 'ja').body).toBe('応答待ちです');
+    expect(buildPushPayload({ ...completion, excerpt: 'Built' }, 'ja').body).toBe('完了: Built');
+    expect(buildPushPayload(completion, 'ja').body).toBe('セッションが完了しました');
+  });
+
+  it('never leaves the {excerpt} placeholder unsubstituted', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(buildPushPayload(prompt, locale).body).not.toContain('{excerpt}');
+      expect(buildPushPayload({ ...completion, excerpt: 'x' }, locale).body).not.toContain(
+        '{excerpt}'
+      );
+    }
+  });
+
+  it('falls back to English for subscriptions predating the locale column', () => {
+    // v42 added `locale` with no backfill, so existing rows read back as NULL.
+    expect(buildPushPayload(prompt, null).body).toBe('Waiting for reply: Continue?');
+    expect(buildPushPayload(prompt, undefined).body).toBe('Waiting for reply: Continue?');
+  });
+
+  it('falls back to English for an unsupported stored locale', () => {
+    expect(buildPushPayload(prompt, 'fr').body).toBe('Waiting for reply: Continue?');
+    expect(buildPushPayload(prompt, '').body).toBe('Waiting for reply: Continue?');
+  });
+
+  it('defaults to English when no locale is passed at all', () => {
+    expect(buildPushPayload(prompt).body).toBe('Waiting for reply: Continue?');
+  });
+});
+
+describe('resolvePushLocale', () => {
+  it('passes through supported locales', () => {
+    expect(resolvePushLocale('en')).toBe('en');
+    expect(resolvePushLocale('ja')).toBe('ja');
+  });
+
+  it('collapses NULL/unknown to the default locale', () => {
+    expect(resolvePushLocale(null)).toBe(DEFAULT_LOCALE);
+    expect(resolvePushLocale(undefined)).toBe(DEFAULT_LOCALE);
+    expect(resolvePushLocale('de')).toBe(DEFAULT_LOCALE);
   });
 });
 

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "dist/server",
     "rootDir": ".",
-    "declaration": false
+    "declaration": false,
+    // push-sender statically imports the notification dictionaries; this also
+    // makes tsc emit them under dist/server/locales/, which `files: ["dist/"]`
+    // then ships (the repo-root locales/ dir is not itself published).
+    "resolveJsonModule": true
   },
   "include": [
     "server.ts",


### PR DESCRIPTION
## 概要
プッシュ通知をロケール対応にする（#1302 系 / #1308）。バックグラウンド送信は React request scope 外のため `getTranslations` は使えず、`createTranslator` で辞書を明示ロードして解決する。

## 主な変更
- DB マイグレーション v42: `push_subscriptions` に `locale` 列を追加（up / down 両方）。
- `POST /api/push/subscriptions`: 購読時に locale を保存。既存の locale NULL 購読にはフォールバックを用意。
- `buildPushPayload` を `createTranslator` ベースに変更し、購読 locale で本文を生成。
- `locales/{en,ja}/notifications.json` に通知本文キーを追加。

## テスト
- lint / tsc / test:unit / test:integration / build いずれもローカルで green（CI で最終確認）。
- v42 migration の up/down、locale 保存、locale NULL フォールバックの単体・結合テストを追加。

Refs #1308