### PR TITLE
fix(i18n): src/app（sessions/review/layout/offline）の文言を移行する (#1305)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,7 +1,19 @@
 {
   "sessions": {
     "idleAgents": "{count} idle",
-    "activeAgents": "{count} active"
+    "activeAgents": "{count} active",
+    "title": "Sessions",
+    "description": "All worktree sessions across repositories.",
+    "filterPlaceholder": "Filter by name or repository...",
+    "filterAriaLabel": "Filter sessions by name or repository",
+    "sortByAriaLabel": "Sort by",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "loadingAriaLabel": "Loading sessions",
+    "refreshError": "Failed to refresh sessions: {message}",
+    "loadError": "Failed to load sessions: {message}",
+    "noMatching": "No matching sessions found.",
+    "empty": "No sessions yet."
   },
   "nav": {
     "home": "Home",
@@ -105,7 +117,8 @@
     "updatedAt": "Updated",
     "repositoryName": "Repository",
     "branchName": "Branch",
-    "status": "Status"
+    "status": "Status",
+    "lastSent": "Last Sent"
   },
   "branchItem": {
     "cliToolStatus": "CLI tool status",
@@ -116,5 +129,8 @@
     "offline": "Offline",
     "reconnectingTooltip": "Re-establishing the live connection (running on polling)",
     "offlineTooltip": "No live connection (running on polling)"
+  },
+  "meta": {
+    "description": "Git worktree management with Claude CLI and tmux sessions"
   }
 }

--- a/locales/en/pwa.json
+++ b/locales/en/pwa.json
@@ -1,5 +1,6 @@
 {
   "offline": {
+    "metaTitle": "Offline",
     "title": "You're offline",
     "description": "CommandMate can't reach the server right now. Check your connection and try again.",
     "reconnect": "Reconnect"

--- a/locales/en/review.json
+++ b/locales/en/review.json
@@ -1,4 +1,13 @@
 {
+  "page": {
+    "title": "Review",
+    "description": "Worktrees that need your attention."
+  },
+  "tabs": {
+    "review": "Review",
+    "report": "Report",
+    "template": "Template"
+  },
   "status": {
     "done": "Done",
     "inReview": "In Review",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -1,7 +1,19 @@
 {
   "sessions": {
     "idleAgents": "アイドル {count} 件",
-    "activeAgents": "稼働 {count} 件"
+    "activeAgents": "稼働 {count} 件",
+    "title": "セッション",
+    "description": "全リポジトリの worktree セッション。",
+    "filterPlaceholder": "名前またはリポジトリで絞り込み...",
+    "filterAriaLabel": "名前またはリポジトリでセッションを絞り込む",
+    "sortByAriaLabel": "並び替え",
+    "sortAscending": "昇順に並び替え",
+    "sortDescending": "降順に並び替え",
+    "loadingAriaLabel": "セッションを読み込み中",
+    "refreshError": "セッションの更新に失敗しました: {message}",
+    "loadError": "セッションの読み込みに失敗しました: {message}",
+    "noMatching": "一致するセッションがありません。",
+    "empty": "セッションがまだありません。"
   },
   "nav": {
     "home": "ホーム",
@@ -105,7 +117,8 @@
     "updatedAt": "更新日時",
     "repositoryName": "リポジトリ",
     "branchName": "ブランチ",
-    "status": "ステータス"
+    "status": "ステータス",
+    "lastSent": "最終送信"
   },
   "branchItem": {
     "cliToolStatus": "CLI ツールのステータス",
@@ -116,5 +129,8 @@
     "offline": "オフライン",
     "reconnectingTooltip": "ライブ接続を再確立しています（ポーリングで動作中）",
     "offlineTooltip": "ライブ接続なし（ポーリングで動作中）"
+  },
+  "meta": {
+    "description": "Claude CLI と tmux セッションによる Git worktree 管理"
   }
 }

--- a/locales/ja/pwa.json
+++ b/locales/ja/pwa.json
@@ -1,5 +1,6 @@
 {
   "offline": {
+    "metaTitle": "オフライン",
     "title": "オフラインです",
     "description": "サーバーに接続できません。接続を確認して再試行してください。",
     "reconnect": "再接続"

--- a/locales/ja/review.json
+++ b/locales/ja/review.json
@@ -1,4 +1,13 @@
 {
+  "page": {
+    "title": "レビュー",
+    "description": "対応が必要な worktree。"
+  },
+  "tabs": {
+    "review": "レビュー",
+    "report": "レポート",
+    "template": "テンプレート"
+  },
   "status": {
     "done": "完了",
     "inReview": "レビュー中",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,27 +1,34 @@
 import type { Metadata, Viewport } from 'next';
-import { getLocale, getMessages, getTimeZone } from 'next-intl/server';
+import { getLocale, getMessages, getTimeZone, getTranslations } from 'next-intl/server';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
 import { AppProviders } from '@/components/providers/AppProviders';
 import './globals.css';
 
-export const metadata: Metadata = {
-  // [Issue #1082] Title template: per-page `title` renders as "<page> | CommandMate";
-  // pages without their own title fall back to `default`.
-  title: {
-    default: 'CommandMate',
-    template: '%s | CommandMate',
-  },
-  description: 'Git worktree management with Claude CLI and tmux sessions',
-  // [Issue #1124] iOS PWA: Safari ignores the Web App Manifest for standalone
-  // launch, so these emit apple-mobile-web-app-* meta tags for home-screen
-  // installs (Android/desktop rely on manifest.ts).
-  appleWebApp: {
-    capable: true,
-    title: 'CommandMate',
-    statusBarStyle: 'default',
-  },
-};
+// [Issue #1305] `description` is locale-dependent, and t() cannot be called at
+// module scope, so the static `metadata` export became `generateMetadata`.
+// "CommandMate" stays a literal on purpose: it is the product name, not copy.
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common');
+
+  return {
+    // [Issue #1082] Title template: per-page `title` renders as "<page> | CommandMate";
+    // pages without their own title fall back to `default`.
+    title: {
+      default: 'CommandMate',
+      template: '%s | CommandMate',
+    },
+    description: t('meta.description'),
+    // [Issue #1124] iOS PWA: Safari ignores the Web App Manifest for standalone
+    // launch, so these emit apple-mobile-web-app-* meta tags for home-screen
+    // installs (Android/desktop rely on manifest.ts).
+    appleWebApp: {
+      capable: true,
+      title: 'CommandMate',
+      statusBarStyle: 'default',
+    },
+  };
+}
 
 // [Issue #1082] themeColor follows the light/dark --background token so the
 // browser chrome (mobile address bar / PWA) matches the active theme.

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { OfflineReconnectButton } from '@/components/pwa/OfflineReconnectButton';
 
-export const metadata: Metadata = {
-  title: 'Offline',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('pwa');
+  return { title: t('offline.metaTitle') };
+}
 
 /**
  * Offline fallback page (Issue #1124).

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -12,6 +12,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { AppShell } from '@/components/layout';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui';
 import ReviewTab from '@/components/review/ReviewTab';
@@ -20,22 +21,25 @@ import TemplateTab from '@/components/review/TemplateTab';
 
 type PageTab = 'review' | 'report' | 'template';
 
-const PAGE_TABS: Array<{ value: PageTab; label: string }> = [
-  { value: 'review', label: 'Review' },
-  { value: 'report', label: 'Report' },
-  { value: 'template', label: 'Template' },
+// Holds `review.tabs.*` keys rather than labels: t() cannot be called at module
+// scope, so a literal would pin the tabs to English (Issue #1271/#1305).
+const PAGE_TABS: Array<{ value: PageTab; labelKey: string }> = [
+  { value: 'review', labelKey: 'tabs.review' },
+  { value: 'report', labelKey: 'tabs.report' },
+  { value: 'template', labelKey: 'tabs.template' },
 ];
 
 export default function ReviewPage() {
+  const t = useTranslations('review');
   const [pageTab, setPageTab] = useState<PageTab>('review');
 
   return (
     <AppShell>
       <div className="container-custom py-8 overflow-auto h-full">
         <div className="mb-6">
-          <h1 className="text-2xl font-bold text-foreground mb-2">Review</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-2">{t('page.title')}</h1>
           <p className="text-sm text-muted-foreground">
-            Worktrees that need your attention.
+            {t('page.description')}
           </p>
         </div>
 
@@ -51,7 +55,7 @@ export default function ReviewPage() {
                 value={tab.value}
                 data-testid={`page-tab-${tab.value}`}
               >
-                {tab.label}
+                {t(tab.labelKey)}
               </TabsTrigger>
             ))}
           </TabsList>

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -24,7 +24,6 @@ import { useWorktreesCacheContext } from '@/components/providers/WorktreesCacheP
 import { deriveCliStatus } from '@/types/sidebar';
 import { isWorkingStatus } from '@/lib/agent-status-display';
 import { getCliToolDisplayName } from '@/lib/cli-tools/types';
-import { SIDEBAR_STATUS_CONFIG } from '@/config/status-colors';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
 import {
   Input,
@@ -49,11 +48,17 @@ import type { BranchStatus } from '@/types/sidebar';
 // Constants
 // ============================================================================
 
-/** Sort options for Sessions page (includes lastSent, no branchName/updatedAt) [CON-002] */
-const SESSIONS_SORT_OPTIONS: ReadonlyArray<{ key: SortKey; label: string }> = [
-  { key: 'repositoryName', label: 'Repository' },
-  { key: 'status', label: 'Status' },
-  { key: 'lastSent', label: 'Last Sent' },
+/**
+ * Sort options for Sessions page (includes lastSent, no branchName/updatedAt) [CON-002]
+ *
+ * Holds `common.sort.*` keys rather than labels, mirroring SIDEBAR_SORT_OPTIONS:
+ * this is module scope, where t() cannot be called, so a literal would pin the
+ * dropdown to English (Issue #1271/#1305).
+ */
+const SESSIONS_SORT_OPTIONS: ReadonlyArray<{ key: SortKey; labelKey: string }> = [
+  { key: 'repositoryName', labelKey: 'sort.repositoryName' },
+  { key: 'status', labelKey: 'sort.status' },
+  { key: 'lastSent', labelKey: 'sort.lastSent' },
 ];
 
 /** Default directions for Sessions sort keys */
@@ -77,10 +82,18 @@ const DEFAULT_STATUS_PRIORITY = 4;
 // Helpers
 // ============================================================================
 
-/** Small CLI status dot for Sessions list (Issue #1051: shared StatusDot). */
+/**
+ * Small CLI status dot for Sessions list (Issue #1051: shared StatusDot).
+ *
+ * The status half of the title comes from `common.status.*` — the same
+ * dictionary StatusDot resolves internally — rather than the English literals
+ * in status-colors.ts, so the tooltip translates without a second source of
+ * truth for these labels (Issue #1305, following #1277). `label` is the CLI
+ * tool's display name (e.g. "Claude"), a proper noun that is not translated.
+ */
 function CliDot({ status, label }: { status: BranchStatus; label: string }) {
   const tCommon = useTranslations('common');
-  const title = `${label}: ${tCommon(SIDEBAR_STATUS_CONFIG[status].labelKey)}`;
+  const title = `${label}: ${tCommon(`status.${status}`)}`;
   return <StatusDot status={status} size="md" label={title} />;
 }
 
@@ -92,18 +105,28 @@ function isWorktreeActive(wt: Worktree, agents: readonly CLIToolType[]): boolean
   });
 }
 
-/** Status display labels */
-const STATUS_LABELS: Record<string, string> = {
-  ready: 'Ready',
-  in_progress: 'In Progress',
-  in_review: 'In Review',
-  done: 'Done',
+/**
+ * Worktree lifecycle status -> `worktree.worktreeStatus.*` keys.
+ *
+ * Reuses the dictionary WorktreeCard/WorktreeDetail already own instead of
+ * duplicating the labels here (Issue #1305, following #1277). Module scope, so
+ * keys rather than literals (Issue #1271).
+ */
+const STATUS_LABEL_KEYS: Record<string, string> = {
+  ready: 'worktreeStatus.ready',
+  in_progress: 'worktreeStatus.inProgress',
+  in_review: 'worktreeStatus.inReview',
+  done: 'worktreeStatus.done',
 };
 
-/** Format status display label */
-function formatStatus(status: string | null | undefined): string {
+/** Format status display label. Unknown values fall back to the raw status. */
+function formatStatus(
+  status: string | null | undefined,
+  tWorktree: (key: string) => string
+): string {
   if (!status) return '';
-  return STATUS_LABELS[status] ?? status;
+  const labelKey = STATUS_LABEL_KEYS[status];
+  return labelKey ? tWorktree(labelKey) : status;
 }
 
 /** Status badge CSS classes keyed by status value */
@@ -121,6 +144,7 @@ const DEFAULT_BADGE_CLASS = 'bg-muted text-muted-foreground';
 
 export default function SessionsPage() {
   const tCommon = useTranslations('common');
+  const tWorktree = useTranslations('worktree');
   const isMobile = useIsMobile();
   const { worktrees, isLoading, error, refresh } = useWorktreesCacheContext();
   // [Issue #1050] Whether we have any data to keep mounted. Based on the raw
@@ -219,9 +243,9 @@ export default function SessionsPage() {
         className="container-custom py-8 h-full"
       >
         <div className="mb-6">
-          <h1 className="text-2xl font-bold text-foreground mb-2">Sessions</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-2">{tCommon('sessions.title')}</h1>
           <p className="text-sm text-muted-foreground">
-            All worktree sessions across repositories.
+            {tCommon('sessions.description')}
           </p>
         </div>
 
@@ -229,12 +253,12 @@ export default function SessionsPage() {
         <div className="mb-6 flex items-center gap-3">
           <Input
             type="text"
-            placeholder="Filter by name or repository..."
+            placeholder={tCommon('sessions.filterPlaceholder')}
             value={filterText}
             onChange={handleFilterChange}
             className="max-w-md flex-1"
             data-testid="sessions-filter"
-            aria-label="Filter sessions by name or repository"
+            aria-label={tCommon('sessions.filterAriaLabel')}
             // Issue #1128: surface the search keyboard + "search" enter key on mobile.
             inputMode="search"
             enterKeyHint="search"
@@ -243,14 +267,14 @@ export default function SessionsPage() {
             <SelectTrigger
               className="w-40"
               data-testid="sessions-sort-select"
-              aria-label="Sort by"
+              aria-label={tCommon('sessions.sortByAriaLabel')}
             >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {SESSIONS_SORT_OPTIONS.map((opt) => (
                 <SelectItem key={opt.key} value={opt.key}>
-                  {opt.label}
+                  {tCommon(opt.labelKey)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -259,7 +283,11 @@ export default function SessionsPage() {
             type="button"
             onClick={toggleSortDirection}
             data-testid="sessions-sort-direction"
-            aria-label={sortDirection === 'asc' ? 'Sort ascending' : 'Sort descending'}
+            aria-label={
+              sortDirection === 'asc'
+                ? tCommon('sessions.sortAscending')
+                : tCommon('sessions.sortDescending')
+            }
             className="rounded-md border border-input bg-surface p-2 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {sortDirection === 'asc' ? (
@@ -289,13 +317,13 @@ export default function SessionsPage() {
                 role="status"
                 data-testid="sessions-error-banner"
               >
-                Failed to refresh sessions: {error.message}
+                {tCommon('sessions.refreshError', { message: error.message })}
               </div>
             )}
             <div className="space-y-2" data-testid="sessions-list">
               {filteredAndSorted.length === 0 ? (
                 <div className="text-muted-foreground py-8 text-center" data-testid="sessions-empty">
-                  No matching sessions found.
+                  {tCommon('sessions.noMatching')}
                 </div>
               ) : (
                 filteredAndSorted.map((wt: Worktree, index: number) => {
@@ -383,7 +411,7 @@ export default function SessionsPage() {
                         <span className={`px-2 py-0.5 text-xs font-medium rounded ${
                           STATUS_BADGE_CLASSES[wt.status ?? ''] ?? DEFAULT_BADGE_CLASS
                         }`}>
-                          {formatStatus(wt.status)}
+                          {formatStatus(wt.status, tWorktree)}
                         </span>
                       </div>
                     )}
@@ -427,7 +455,7 @@ export default function SessionsPage() {
                 className="space-y-2"
                 data-testid="sessions-loading"
                 role="status"
-                aria-label="Loading sessions"
+                aria-label={tCommon('sessions.loadingAriaLabel')}
               >
                 {[0, 1, 2].map((i) => (
                   <div
@@ -451,12 +479,12 @@ export default function SessionsPage() {
             )}
             {!isLoading && error && (
               <div className="text-danger-foreground" data-testid="sessions-error">
-                Failed to load sessions: {error.message}
+                {tCommon('sessions.loadError', { message: error.message })}
               </div>
             )}
             {!isLoading && !error && (
               <div className="text-muted-foreground py-8 text-center" data-testid="sessions-empty">
-                {filterText ? 'No matching sessions found.' : 'No sessions yet.'}
+                {filterText ? tCommon('sessions.noMatching') : tCommon('sessions.empty')}
               </div>
             )}
           </>

--- a/tests/unit/app/metadata-i18n.test.ts
+++ b/tests/unit/app/metadata-i18n.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Real-dictionary i18n tests for the `generateMetadata` exports — Issue #1305.
+ *
+ * `src/app/layout.tsx` and `src/app/offline/page.tsx` moved from a static
+ * `metadata` const to `generateMetadata()` because t() cannot be called at
+ * module scope. These tests read the real dictionaries so a missing key fails
+ * rather than echoing (Issue #1197/#1273), and pin the two literals that must
+ * NOT be translated: "CommandMate" is the product name, not copy.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const locale = vi.hoisted(() => ({ current: 'en' }));
+
+vi.mock('next-intl/server', () => ({
+  getLocale: vi.fn(),
+  getMessages: vi.fn(),
+  getTimeZone: vi.fn(),
+  getTranslations: async (namespace: string) => {
+    const file = path.resolve(__dirname, `../../../locales/${locale.current}/${namespace}.json`);
+    const dict = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    return (key: string): string => {
+      const value = key
+        .split('.')
+        .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], dict);
+      if (typeof value !== 'string') {
+        throw new Error(`no string at "${namespace}.${key}" for ${locale.current}`);
+      }
+      return value;
+    };
+  },
+}));
+
+vi.mock('geist/font/sans', () => ({ GeistSans: { variable: 'font-sans' } }));
+vi.mock('geist/font/mono', () => ({ GeistMono: { variable: 'font-mono' } }));
+vi.mock('@/components/providers/AppProviders', () => ({ AppProviders: () => null }));
+vi.mock('@/components/pwa/OfflineReconnectButton', () => ({
+  OfflineReconnectButton: () => null,
+}));
+
+import { generateMetadata as generateLayoutMetadata } from '@/app/layout';
+import { generateMetadata as generateOfflineMetadata } from '@/app/offline/page';
+
+beforeEach(() => {
+  locale.current = 'en';
+});
+
+describe('root layout metadata (Issue #1305)', () => {
+  it('resolves the description from common.meta.description (en byte-match)', async () => {
+    const metadata = await generateLayoutMetadata();
+
+    expect(metadata.description).toBe(
+      'Git worktree management with Claude CLI and tmux sessions'
+    );
+  });
+
+  it('translates the description for ja', async () => {
+    locale.current = 'ja';
+    const metadata = await generateLayoutMetadata();
+
+    expect(metadata.description).toBe('Claude CLI と tmux セッションによる Git worktree 管理');
+  });
+
+  it('keeps the product name untranslated in both locales', async () => {
+    for (const loc of ['en', 'ja']) {
+      locale.current = loc;
+      const metadata = await generateLayoutMetadata();
+
+      expect(metadata.title).toEqual({
+        default: 'CommandMate',
+        template: '%s | CommandMate',
+      });
+      expect(metadata.appleWebApp).toEqual({
+        capable: true,
+        title: 'CommandMate',
+        statusBarStyle: 'default',
+      });
+    }
+  });
+});
+
+describe('offline page metadata (Issue #1305)', () => {
+  it('resolves the title from pwa.offline.metaTitle (en byte-match)', async () => {
+    const metadata = await generateOfflineMetadata();
+
+    expect(metadata.title).toBe('Offline');
+  });
+
+  it('translates the title for ja', async () => {
+    locale.current = 'ja';
+    const metadata = await generateOfflineMetadata();
+
+    expect(metadata.title).toBe('オフライン');
+  });
+});

--- a/tests/unit/app/review/page-i18n.test.tsx
+++ b/tests/unit/app/review/page-i18n.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Real-dictionary i18n tests for the Review page (/review) — Issue #1305.
+ *
+ * Backed by the real dictionaries (not the global passthrough mock in
+ * tests/setup.ts) so that deleting a key from locales/<locale>/review.json fails
+ * these tests rather than silently echoing the key (Issue #1197/#1273).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+const locale = vi.hoisted(() => ({ current: 'en' }));
+
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock(() => locale.current);
+});
+
+vi.mock('@/components/layout', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'app-shell' }, children),
+}));
+
+// The tab bodies own their own data fetching; this page-level shell test only
+// covers the heading and the tab triggers.
+vi.mock('@/components/review/ReviewTab', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'review-tab-body' }),
+}));
+vi.mock('@/components/review/ReportTab', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'report-tab-body' }),
+}));
+vi.mock('@/components/review/TemplateTab', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'template-tab-body' }),
+}));
+
+import ReviewPage from '@/app/review/page';
+
+beforeEach(() => {
+  locale.current = 'en';
+  vi.clearAllMocks();
+});
+
+describe('Review page i18n (Issue #1305)', () => {
+  describe('en — wording matches the pre-migration literals byte-for-byte', () => {
+    it('renders the heading and description from the dictionary', () => {
+      render(<ReviewPage />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Review');
+      expect(screen.getByText('Worktrees that need your attention.')).toBeInTheDocument();
+    });
+
+    it('renders all three tab labels', () => {
+      render(<ReviewPage />);
+
+      expect(screen.getByTestId('page-tab-review')).toHaveTextContent('Review');
+      expect(screen.getByTestId('page-tab-report')).toHaveTextContent('Report');
+      expect(screen.getByTestId('page-tab-template')).toHaveTextContent('Template');
+    });
+  });
+
+  describe('ja — copy is translated, not pinned to English', () => {
+    beforeEach(() => {
+      locale.current = 'ja';
+    });
+
+    it('translates the heading and description', () => {
+      render(<ReviewPage />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('レビュー');
+      expect(screen.queryByText('Worktrees that need your attention.')).toBeNull();
+    });
+
+    it('translates the tab labels', () => {
+      render(<ReviewPage />);
+
+      expect(screen.getByTestId('page-tab-review')).toHaveTextContent('レビュー');
+      expect(screen.getByTestId('page-tab-report')).toHaveTextContent('レポート');
+      expect(screen.getByTestId('page-tab-template')).toHaveTextContent('テンプレート');
+    });
+  });
+});

--- a/tests/unit/app/sessions/page-i18n.test.tsx
+++ b/tests/unit/app/sessions/page-i18n.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Real-dictionary i18n tests for the Sessions page (/sessions) — Issue #1305.
+ *
+ * The existing SessionsPage.test.tsx asserts on data-testid only and runs under
+ * the global passthrough mock from tests/setup.ts, so it stayed green both
+ * before and after this migration — it cannot see whether a label resolves to
+ * real copy. These tests back next-intl with the real dictionaries so that
+ * deleting a key from locales/<locale>/*.json fails them (Issue #1197/#1273).
+ *
+ * Both locales are exercised: `en` proves the migrated wording is byte-identical
+ * to the pre-migration literals, `ja` proves an English user's copy is not
+ * pinned into the Japanese UI (and vice versa).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+const locale = vi.hoisted(() => ({ current: 'en' }));
+
+vi.mock('next-intl', async () => {
+  const { createRealIntlMock } = await import('@tests/helpers/real-intl');
+  return createRealIntlMock(() => locale.current);
+});
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/sessions',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) =>
+    React.createElement('a', { href, ...props }, children),
+}));
+
+vi.mock('@/components/layout', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'app-shell' }, children),
+}));
+
+vi.mock('@/lib/date-utils', () => ({
+  formatRelativeTime: () => '2 hours ago',
+  formatRelativeTimeShort: () => '2h ago',
+}));
+
+let mockWorktrees: Array<Record<string, unknown>> = [];
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+vi.mock('@/components/providers/WorktreesCacheProvider', () => ({
+  useWorktreesCacheContext: () => ({
+    worktrees: mockWorktrees,
+    repositories: [],
+    isLoading: mockIsLoading,
+    error: mockError,
+    refresh: vi.fn(),
+  }),
+}));
+
+import SessionsPage from '@/app/sessions/page';
+
+function createWorktree(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wt-1',
+    name: 'feature/test',
+    path: '/path/to/wt',
+    repositoryPath: '/path/to/repo',
+    repositoryName: 'MyRepo',
+    selectedAgents: ['claude'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  locale.current = 'en';
+  mockWorktrees = [];
+  mockIsLoading = false;
+  mockError = null;
+  vi.clearAllMocks();
+});
+
+describe('Sessions page i18n (Issue #1305)', () => {
+  describe('en — wording matches the pre-migration literals byte-for-byte', () => {
+    it('renders the page heading and description from the dictionary', () => {
+      render(<SessionsPage />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Sessions');
+      expect(screen.getByText('All worktree sessions across repositories.')).toBeInTheDocument();
+    });
+
+    it('renders the filter placeholder and aria-label', () => {
+      render(<SessionsPage />);
+
+      const filter = screen.getByTestId('sessions-filter');
+      expect(filter).toHaveAttribute('placeholder', 'Filter by name or repository...');
+      expect(filter).toHaveAttribute('aria-label', 'Filter sessions by name or repository');
+    });
+
+    it('renders the sort control labels', () => {
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-sort-select')).toHaveAttribute('aria-label', 'Sort by');
+      // Default sort is `lastSent`, whose trigger renders the selected label.
+      expect(screen.getByTestId('sessions-sort-direction')).toHaveAttribute(
+        'aria-label',
+        'Sort descending'
+      );
+    });
+
+    it('renders the empty state', () => {
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-empty')).toHaveTextContent('No sessions yet.');
+    });
+
+    it('renders the loading aria-label', () => {
+      mockIsLoading = true;
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-loading')).toHaveAttribute(
+        'aria-label',
+        'Loading sessions'
+      );
+    });
+
+    it('interpolates the blocking load error', () => {
+      mockError = new Error('boom');
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-error')).toHaveTextContent(
+        'Failed to load sessions: boom'
+      );
+    });
+
+    it('interpolates the non-blocking refresh error banner', () => {
+      mockWorktrees = [createWorktree()];
+      mockError = new Error('boom');
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-error-banner')).toHaveTextContent(
+        'Failed to refresh sessions: boom'
+      );
+    });
+
+    it('renders the worktree lifecycle status badge from worktree.worktreeStatus.*', () => {
+      mockWorktrees = [createWorktree({ id: 'wt-st', status: 'in_progress' })];
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('session-item-wt-st')).toHaveTextContent('In Progress');
+    });
+  });
+
+  describe('ja — copy is translated, not pinned to English', () => {
+    beforeEach(() => {
+      locale.current = 'ja';
+    });
+
+    it('translates the page heading and description', () => {
+      render(<SessionsPage />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('セッション');
+      expect(screen.queryByText('All worktree sessions across repositories.')).toBeNull();
+    });
+
+    it('translates the filter placeholder and empty state', () => {
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-filter')).toHaveAttribute(
+        'placeholder',
+        '名前またはリポジトリで絞り込み...'
+      );
+      expect(screen.getByTestId('sessions-empty')).toHaveTextContent('セッションがまだありません。');
+    });
+
+    it('translates the lifecycle status badge', () => {
+      mockWorktrees = [createWorktree({ id: 'wt-st', status: 'in_progress' })];
+      render(<SessionsPage />);
+
+      const item = screen.getByTestId('session-item-wt-st');
+      expect(item).toHaveTextContent('作業中');
+      expect(item).not.toHaveTextContent('In Progress');
+    });
+
+    it('translates the interpolated load error while keeping the raw message', () => {
+      mockError = new Error('boom');
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('sessions-error')).toHaveTextContent(
+        'セッションの読み込みに失敗しました: boom'
+      );
+    });
+  });
+
+  describe('unknown lifecycle status falls back to the raw value', () => {
+    it('does not throw on a status with no dictionary key', () => {
+      mockWorktrees = [createWorktree({ id: 'wt-unk', status: 'archived' })];
+      render(<SessionsPage />);
+
+      expect(screen.getByTestId('session-item-wt-unk')).toHaveTextContent('archived');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
`src/app` 配下（sessions / review / layout / offline）の直書き文言を i18n 辞書キーへ移行する（#1302 系 / #1305）。

## 主な変更
- `sessions/page.tsx`: 見出し・プレースホルダ・aria-label・ソートオプション・ステータスラベルを辞書キーへ。module scope の定数は `labelKey` パターンで保持（t() を呼べないため）。
- `review/page.tsx` / `layout.tsx`（metadata）/ `offline/page.tsx` を辞書キーへ。
- `locales/{en,ja}/{common,review,pwa}.json` にキー追加（EN は移行前の文言と byte-identical）。

## #1304 とのリベース解決
`sessions/page.tsx` の `CliDot` で #1304 と衝突。#1304 の `SIDEBAR_STATUS_CONFIG[status].labelKey` は全ステータスで `status.<value>` と一致するため、import を除去した本 PR の `tCommon(\`status.${status}\`)` は**同一キーを解決**する。import 除去と整合する #1305 側を採用。

## テスト
- CI で lint / tsc / test:unit / test:integration / E2E / build を確認。

Refs #1305