### PR TITLE
feat(website): quick start を2トラック化し npx を @latest に統一する (#1317)

### DIFF
--- a/tests/unit/website/landing-page.test.ts
+++ b/tests/unit/website/landing-page.test.ts
@@ -56,6 +56,21 @@ function extractRefs(html: string): string[] {
 const isExternal = (ref: string) =>
   /^(https?:)?\/\//.test(ref) || ref.startsWith('mailto:') || ref.startsWith('#');
 
+/**
+ * The shell commands the page offers a working copy button for, as command text.
+ * A command box only counts if a `.copy-btn` actually targets its id — markup
+ * that renders a command without wiring the button is what this catches.
+ */
+function copyableCommands(html: string): string[] {
+  const targeted = new Set(
+    Array.from(html.matchAll(/data-copy-target="([^"]+)"/g), (match) => match[1]),
+  );
+
+  return Array.from(html.matchAll(/<code class="install-cmd" id="([^"]+)">([^<]+)<\/code>/g))
+    .filter(([, id]) => targeted.has(id))
+    .map(([, , command]) => command.trim());
+}
+
 describe('Issue #1200: landing page structure', () => {
   it('has an index.html at the website root', () => {
     expect(fs.existsSync(INDEX_HTML)).toBe(true);
@@ -217,6 +232,43 @@ describe('Issue #1272: the LP ships no demo media', () => {
     expect(heroFigure![0]).not.toMatch(/loading="lazy"/);
     expect(heroFigure![0]).toMatch(/width="\d+"/);
     expect(heroFigure![0]).toMatch(/height="\d+"/);
+  });
+});
+
+/**
+ * Issue #1316 — a bare `npx commandmate` runs an already-installed global bin
+ * without consulting the registry at all, so a reader following the LP on a
+ * machine that once installed CommandMate silently gets whatever version is
+ * already there (0.3.5 against a current 0.10.0, as measured). `@latest` is what
+ * forces the resolve, and the LP advertises npx in three places, so the pin has
+ * to hold in all of them rather than in whichever one was edited last.
+ *
+ * Issue #1317 — the quick start is two tracks, and Track B only earns its place
+ * by being copy-pasteable: it exists so a long-running daemon is launched from a
+ * stable global install rather than from npm's `_npx` cache, which a later npx
+ * run replaces underneath the running server.
+ */
+describe('Issue #1316/#1317: quick start tracks', () => {
+  it('pins every npx invocation to @latest', () => {
+    const invocations = readIndexHtml().match(/npx commandmate[^\s<]*/g) ?? [];
+
+    expect(invocations.length).toBeGreaterThan(0);
+    expect([...new Set(invocations)]).toEqual(['npx commandmate@latest']);
+  });
+
+  it('gives every Track B command its own copy button', () => {
+    const copyable = copyableCommands(readIndexHtml());
+
+    for (const command of ['npm install -g commandmate', 'commandmate init', 'commandmate start --daemon']) {
+      expect(copyable).toContain(command);
+    }
+  });
+
+  it('tells the reader how to stop the server both tracks leave running', () => {
+    const html = readIndexHtml();
+
+    expect(html).toMatch(/commandmate stop/);
+    expect(html).toMatch(/commandmate status/);
   });
 });
 

--- a/website/index.html
+++ b/website/index.html
@@ -53,8 +53,8 @@
           <h1>Orchestrate your agent CLIs,<br />not your terminal tabs.</h1>
           <p class="lede">CommandMate is a local control plane for agent CLIs.</p>
 
-          <div class="install" data-copy-root>
-            <code class="install-cmd" id="install-cmd">npx commandmate</code>
+          <div class="install">
+            <code class="install-cmd" id="install-cmd">npx commandmate@latest</code>
             <button type="button" class="copy-btn" data-copy-target="install-cmd">
               <span data-copy-label>Copy</span>
             </button>
@@ -121,32 +121,75 @@
       <!-- 3. 60-second quick start -->
       <section class="section" id="quick-start" aria-labelledby="quick-start-h">
         <h2 id="quick-start-h">Quick start, in 60 seconds</h2>
-        <ol class="steps">
-          <li>
-            <h3>Install and start</h3>
-            <p>One command. It checks your dependencies and starts the server.</p>
-            <div class="install install-sm" data-copy-root>
-              <code class="install-cmd" id="step-install">npx commandmate</code>
-              <button type="button" class="copy-btn" data-copy-target="step-install">
+        <p class="section-lede">
+          Two ways in. Take Track A to see it working, Track B once you keep coming back.
+        </p>
+
+        <div class="tracks">
+          <article class="track" aria-labelledby="track-try-h">
+            <p class="track-tag">Track A</p>
+            <h3 id="track-try-h">Just try it</h3>
+            <p class="track-lede">
+              One command, nothing installed first. It checks your dependencies, walks you through
+              setup, starts the server, and opens your browser.
+            </p>
+            <div class="install install-sm">
+              <code class="install-cmd" id="try-cmd">npx commandmate@latest</code>
+              <button type="button" class="copy-btn" data-copy-target="try-cmd">
                 <span data-copy-label>Copy</span>
               </button>
             </div>
-          </li>
-          <li>
-            <h3>Answer the setup questions</h3>
-            <p>
-              First run only, and skipped entirely if you already have a <code>.env</code>. Installing
-              globally instead? Run <code>commandmate init</code>.
+            <p class="track-note">
+              The questions are first-run only. Run it again later and it goes straight to the UI at
+              <code>http://localhost:3000</code>.
             </p>
-          </li>
-          <li>
-            <h3>Open the UI</h3>
-            <p>
-              Your browser opens automatically at <code>http://localhost:3000</code>. Run it again
-              later and it skips straight to the UI.
+          </article>
+
+          <article class="track" aria-labelledby="track-daily-h">
+            <p class="track-tag">Track B</p>
+            <h3 id="track-daily-h">Install it for daily use</h3>
+            <p class="track-lede">
+              Track A runs the server out of npm's cache, where a later <code>npx</code> can swap the
+              files under it. A global install gives a long-running server somewhere stable to live.
             </p>
-          </li>
-        </ol>
+            <ol class="steps steps-stack">
+              <li>
+                <h4>Install globally</h4>
+                <div class="install install-sm">
+                  <code class="install-cmd" id="install-global-cmd">npm install -g commandmate</code>
+                  <button type="button" class="copy-btn" data-copy-target="install-global-cmd">
+                    <span data-copy-label>Copy</span>
+                  </button>
+                </div>
+              </li>
+              <li>
+                <h4>Answer the setup questions</h4>
+                <p>First run only, and skipped entirely if you already have a <code>.env</code>.</p>
+                <div class="install install-sm">
+                  <code class="install-cmd" id="init-cmd">commandmate init</code>
+                  <button type="button" class="copy-btn" data-copy-target="init-cmd">
+                    <span data-copy-label>Copy</span>
+                  </button>
+                </div>
+              </li>
+              <li>
+                <h4>Start in the background</h4>
+                <p>Keeps serving after you close the terminal.</p>
+                <div class="install install-sm">
+                  <code class="install-cmd" id="start-cmd">commandmate start --daemon</code>
+                  <button type="button" class="copy-btn" data-copy-target="start-cmd">
+                    <span data-copy-label>Copy</span>
+                  </button>
+                </div>
+              </li>
+            </ol>
+          </article>
+        </div>
+
+        <p class="note">
+          Either track leaves a server running in the background. <code>commandmate status</code>
+          tells you whether one is up, and <code>commandmate stop</code> shuts it down.
+        </p>
       </section>
 
       <!-- 4. Screenshot gallery -->
@@ -268,8 +311,8 @@
       <!-- Closing CTA -->
       <section class="section closing">
         <h2>Start in one command</h2>
-        <div class="install install-lg" data-copy-root>
-          <code class="install-cmd" id="closing-cmd">npx commandmate</code>
+        <div class="install install-lg">
+          <code class="install-cmd" id="closing-cmd">npx commandmate@latest</code>
           <button type="button" class="copy-btn" data-copy-target="closing-cmd">
             <span data-copy-label>Copy</span>
           </button>

--- a/website/main.js
+++ b/website/main.js
@@ -42,23 +42,30 @@
     var idleLabel = label.textContent;
     var timer = null;
 
-    button.addEventListener('click', function () {
-      copyText(source.textContent.trim()).then(
-        function () {
-          label.textContent = 'Copied';
-          button.setAttribute('data-copied', 'true');
-        },
-        function () {
-          // Never claim success we did not get: tell the user to copy by hand.
-          label.textContent = 'Press Ctrl+C';
-        },
-      );
-
+    // Only ever armed once the label has actually changed, so the countdown
+    // measures how long the user saw the feedback rather than how long the
+    // clipboard took to answer.
+    function scheduleReset() {
       window.clearTimeout(timer);
       timer = window.setTimeout(function () {
         label.textContent = idleLabel;
         button.removeAttribute('data-copied');
       }, COPIED_MS);
+    }
+
+    button.addEventListener('click', function () {
+      copyText(source.textContent.trim()).then(
+        function () {
+          label.textContent = 'Copied';
+          button.setAttribute('data-copied', 'true');
+          scheduleReset();
+        },
+        function () {
+          // Never claim success we did not get: tell the user to copy by hand.
+          label.textContent = 'Press Ctrl+C';
+          scheduleReset();
+        },
+      );
     });
   });
 })();

--- a/website/styles.css
+++ b/website/styles.css
@@ -220,6 +220,9 @@ a {
   color: var(--fg);
   overflow-x: auto;
   white-space: nowrap;
+  /* Without this the nowrap text sets an unshrinkable min-content floor, so a
+     long command widens the whole page on a phone instead of scrolling here. */
+  min-width: 0;
 }
 
 .install-cmd::before {
@@ -332,7 +335,6 @@ a {
 }
 
 .section > h2 + .cards,
-.section > h2 + .steps,
 .section > h2 + .table-scroll {
   margin-top: 2rem;
 }
@@ -371,6 +373,58 @@ a {
   font-size: 0.9rem;
 }
 
+/* ---------- quick start tracks ---------- */
+
+.tracks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.track {
+  padding: 1.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.track-tag {
+  margin: 0 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.track h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.track-lede {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.94rem;
+}
+
+.track-note {
+  margin: 0.9rem 0 0;
+  color: var(--fg-muted);
+  font-size: 0.88rem;
+}
+
+/* Inline code only: .install-cmd sits inside a box that already frames it. */
+.track code:not(.install-cmd),
+.note code {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 0.1rem 0.35rem;
+}
+
 /* ---------- steps ---------- */
 
 .steps {
@@ -405,7 +459,26 @@ a {
   font-weight: 700;
 }
 
-.steps h3 {
+/* One column, badge beside the content rather than above it. Must stay after
+   the `.steps > li` rules above: same specificity, so order decides. */
+.steps-stack {
+  /* minmax(0, …) rather than 1fr: a grid item's auto minimum would otherwise
+     let a wide command box stretch the column past the card. */
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.1rem;
+  margin-top: 1.25rem;
+}
+
+.steps-stack > li {
+  padding-top: 0;
+  padding-left: 2.75rem;
+}
+
+.steps-stack > li::before {
+  top: 0.1rem;
+}
+
+.steps h4 {
   margin: 0 0 0.4rem;
   font-size: 1.02rem;
   font-weight: 700;
@@ -417,11 +490,31 @@ a {
   font-size: 0.92rem;
 }
 
-.steps code {
-  background: var(--bg-subtle);
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  padding: 0.1rem 0.35rem;
+/* A command box the card can't show in full is worse than no button at all. */
+.track .install {
+  max-width: none;
+}
+
+/* On a phone the button and the command cannot share a line without the command
+   scrolling out of sight — which defeats a section that exists to be read and
+   copied. Give the command the width and let the button sit under it. */
+@media (max-width: 30rem) {
+  .track {
+    padding: 1.25rem;
+  }
+
+  .steps-stack > li {
+    padding-left: 2.25rem;
+  }
+
+  .install {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .install-cmd {
+    flex: 1 0 100%;
+  }
 }
 
 /* ---------- gallery ---------- */


### PR DESCRIPTION
ランディングページの改修3件をまとめて実装します。`website/index.html` の同じ3ブロック（隣接行）を触るため、直列3サイクルではなく1PRに束ねました。

対応 Issue: #1316 / #1317 / #1320

## #1316: npx を @latest に統一

hero / quick start / closing CTA の3箇所を `npx commandmate@latest` に変更。

**根拠（実測）**: グローバル導入済みの環境では bare `npx commandmate` が**古い global bin を実行し、レジストリを一切参照しません**。開発機で実際に 0.3.5 が実行されました（最新は 0.10.0、7リリース遅れ）。隔離した `NPM_CONFIG_CACHE` / `NPM_CONFIG_PREFIX` での検証結果:

| ケース | `npx commandmate` | `npx commandmate@latest` |
|---|---|---|
| グローバル導入済み | **0.3.5**（古い global を実行） | **0.10.0** |
| クリーンな新規マシン | 0.10.0 | 0.10.0 |
| 新バージョン公開後の再実行 | 再解決する | 再解決する（0.9.1 → 0.10.0 を確認） |

npx キャッシュは古くなりません。唯一の差は**グローバル導入による shadowing の回避**です。

## #1317: quick start を2トラック化

- **Track A「Just try it」**: `npx commandmate@latest` の1コマンド
- **Track B「Install it for daily use」**: `npm install -g commandmate` → `commandmate init` → `commandmate start --daemon` を**それぞれ copy 可能**に

`npx commandmate` は init（`quickstart.ts:90-92`）も daemon 起動（`quickstart.ts:122`）も自動実行するため、旧 step 2 の `commandmate init` は「グローバル導入派向けの分岐」にすぎませんでした。単に copy ボタンを足すと npx 派の誤実行を招くため、トラックを分けて各コマンドが正しい文脈に収まる形にしています。

**daemon を Track B に置く理由**: npx 実行時の daemon は npm キャッシュ配下（`~/.npm/_npx/<hash>/...`）から起動するため、npx 再実行で足元の `.next/` が差し替わり壊れます（`daemon.ts:126-134` が `cwd: getPackageRoot()` で detached spawn）。

**停止方法を追記**: 従来 LP には `commandmate stop` が一切書かれておらず、daemon を残すのに止め方が不明でした。

## #1320: copy ボタンの粗さ修正

- `main.js` の `setTimeout` を `scheduleReset()` として各 `.then` コールバック内へ移動（従来は click 時に同期スケジュールされ、clipboard promise 解決前にカウント開始）
- 参照されていない `data-copy-root` 属性を削除

## テスト

`landing-page.test.ts` に3つのガードを追加:
- npx 呼び出しが全て `@latest` に固定されていること
- Track B の各コマンドに copy ボタンが**実際に結線**されていること（コマンド描画のみでボタン未結線を捕捉）
- stop / status が記載されていること

## 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass (580 files / 9872 tests) |
| npm run build | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
