### PR TITLE
fix(cli): npx 実行時の update を検出して誤動作を防ぐ (#1319)

### DIFF
--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -389,7 +389,7 @@
 | `src/cli/commands/start.ts` | startコマンド（前景/デーモン、--issue対応 Issue #136）。runStart()はexitせずStartResultを返す（Issue #1195） |
 | `src/cli/commands/stop.ts` | stopコマンド（サーバー停止、--issue対応 Issue #136） |
 | `src/cli/commands/status.ts` | statusコマンド（状態確認、--issue/--all対応 Issue #136）。statusコマンド（--all対応） |
-| `src/cli/commands/update.ts` | updateコマンド（停止→npm install -g→再起動、--check/--yes）（Issue #1194） |
+| `src/cli/commands/update.ts` | updateコマンド（停止→npm install -g→再起動、--check/--yes。npx実行時は何もせず案内して正常終了）（Issue #1194, #1319） |
 | `src/cli/utils/preflight.ts` | システム依存関係チェック（compareVersionsはsemver.tsへ移譲、Issue #1194） |
 | `src/cli/utils/semver.ts` | semver 3方向比較（compareVersions/isComparableVersion）（Issue #1194） |
 | `src/cli/utils/npm-runner.ts` | npm実行ラッパ（viewLatestVersion/installGlobalLatest）（Issue #1194） |
@@ -403,7 +403,7 @@
 | `src/cli/utils/prompt.ts` | 対話形式プロンプトユーティリティ（Issue #119） |
 | `src/cli/utils/server-ready.ts` | サーバ起動完了待ち（waitForServer: TCPポーリング、throwしない）（Issue #1195） |
 | `src/cli/utils/browser.ts` | ブラウザ自動オープン（open/xdg-open、CI・SSH・DISPLAY判定、依存追加なし）（Issue #1195） |
-| `src/cli/utils/install-context.ts` | インストールコンテキスト検出（isGlobalInstall, getConfigDir。npxは global 扱い）（Issue #136, #1195） |
+| `src/cli/utils/install-context.ts` | インストールコンテキスト検出（isGlobalInstall, getConfigDir。npxは global 扱い。isNpxExecutionでnpx実行を別途判定）（Issue #136, #1195, #1319） |
 | `src/cli/utils/input-validators.ts` | 入力検証（Issue番号、ブランチ名）（Issue #136） |
 | `src/cli/utils/resource-resolvers.ts` | リソースパス解決（DB、PID、Log）（Issue #136） |
 | `src/cli/utils/port-allocator.ts` | ポート自動割り当て（MAX_WORKTREES=10制限）（Issue #136） |

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -22,7 +22,7 @@ import { readFileSync } from 'fs';
 import { ExitCode, getErrorMessage, type UpdateOptions } from '../types';
 import { CLILogger } from '../utils/logger';
 import { getPackageJsonPath } from '../utils/paths';
-import { isGlobalInstall } from '../utils/install-context';
+import { isGlobalInstall, isNpxExecution } from '../utils/install-context';
 import { getEnvPath } from '../utils/env-setup';
 import { getDaemonManagerFactory } from '../utils/daemon-factory';
 import { viewLatestVersion, installGlobalLatest } from '../utils/npm-runner';
@@ -44,6 +44,19 @@ const PACKAGE_NAME = 'commandmate';
  */
 export async function updateCommand(options: UpdateOptions = {}): Promise<void> {
   try {
+    // --- Step 0: npx gate (Issue #1319) -------------------------------------
+    // `npx commandmate` runs from the npx cache, which isGlobalInstall() reports
+    // as global (Issue #1195). Without this gate step 1 lets a throwaway process
+    // rewrite the user's global install, and step 8 then fails its own check by
+    // re-reading the npx cache's package.json instead of the new global one.
+    // The gate covers --check too: "current version" under npx is whatever npx
+    // happened to cache, which says nothing about the user's install.
+    if (isNpxExecution()) {
+      printNpxGuidance();
+      process.exit(ExitCode.SUCCESS);
+      return;
+    }
+
     // --- Step 1: install type gate -----------------------------------------
     // Known limitation (D-17 / S3-009): isGlobalInstall() also returns true for
     // a project-local `npm install commandmate`. Step 8 catches that case.
@@ -305,6 +318,26 @@ function tryReadInstalledVersion(): string {
  */
 function stripV(version: string): string {
   return version.replace(/^v/, '');
+}
+
+/**
+ * Guidance for an `npx commandmate update` run (Issue #1319).
+ *
+ * Nothing is changed: npx already fetched the requested version, and updating
+ * the user's global install from here would be a side effect they never asked
+ * this throwaway process to perform.
+ */
+function printNpxGuidance(): void {
+  console.log('');
+  console.log(`This is an npx run, so "${PACKAGE_NAME} update" will not change anything.`);
+  console.log('npx fetches the requested version every time, so it has nothing to update.');
+  console.log('');
+  console.log(`To update a globally installed ${PACKAGE_NAME}, run:`);
+  console.log(`  npm install -g ${PACKAGE_NAME}@latest`);
+  console.log('');
+  console.log(`Once it is installed globally, "${PACKAGE_NAME} update" handles this for you`);
+  console.log('(stop the server -> install -> restart).');
+  console.log('');
 }
 
 /**

--- a/src/cli/utils/install-context.ts
+++ b/src/cli/utils/install-context.ts
@@ -45,6 +45,30 @@ export function isGlobalInstall(): boolean {
 }
 
 /**
+ * Check if the running code was resolved from the npx cache
+ * Issue #1319: `npx commandmate` must not be treated as an installed CLI
+ *
+ * npm resolves `npx <pkg>` under `<npm-cache>/_npx/<hash>/node_modules/<pkg>`,
+ * which isGlobalInstall() reports as global on purpose (Issue #1195: config and
+ * db must still land in ~/.commandmate). This answers a narrower question that
+ * isGlobalInstall() cannot: is this process a throwaway npx run rather than the
+ * user's own install? Callers that would mutate the installation need both.
+ *
+ * @returns true if running from the npx cache
+ *
+ * @example
+ * ```typescript
+ * if (isNpxExecution()) {
+ *   // Do not modify the user's install from a throwaway process
+ * }
+ * ```
+ */
+export function isNpxExecution(): boolean {
+  const currentPath = dirname(__dirname);
+  return currentPath.includes('/_npx/') || currentPath.includes('\\_npx\\');
+}
+
+/**
  * Get the config directory path
  * Issue #119: Returns ~/.commandmate for global, cwd for local
  * Issue #125: Added symlink resolution for security (path traversal protection)

--- a/tests/unit/cli/commands/update.test.ts
+++ b/tests/unit/cli/commands/update.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../../../src/cli/utils/paths', () => ({
 }));
 vi.mock('../../../../src/cli/utils/install-context', () => ({
   isGlobalInstall: vi.fn(() => true),
+  isNpxExecution: vi.fn(() => false),
 }));
 vi.mock('../../../../src/cli/utils/env-setup', () => ({
   getEnvPath: vi.fn(() => '/mock/home/.commandmate/.env'),
@@ -41,7 +42,7 @@ vi.mock('../../../../src/cli/utils/prompt', () => ({
 // Import after mocking
 import { updateCommand } from '../../../../src/cli/commands/update';
 import { ExitCode, type UpdateOptions } from '../../../../src/cli/types';
-import { isGlobalInstall } from '../../../../src/cli/utils/install-context';
+import { isGlobalInstall, isNpxExecution } from '../../../../src/cli/utils/install-context';
 import { getDaemonManagerFactory } from '../../../../src/cli/utils/daemon-factory';
 import { getEnvPath } from '../../../../src/cli/utils/env-setup';
 import { listRunningWorktreeServers } from '../../../../src/cli/utils/worktree-servers';
@@ -195,6 +196,7 @@ describe('updateCommand', () => {
     } as unknown as ReturnType<typeof getDaemonManagerFactory>);
 
     vi.mocked(isGlobalInstall).mockReturnValue(true);
+    vi.mocked(isNpxExecution).mockReturnValue(false);
     vi.mocked(isInteractive).mockReturnValue(true);
     vi.mocked(confirm).mockResolvedValue(true);
     vi.mocked(listRunningWorktreeServers).mockResolvedValue([]);
@@ -211,6 +213,67 @@ describe('updateCommand', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     delete process.env.CM_AUTH_TOKEN;
+  });
+
+  // Issue #1319: `npx commandmate update` reached the global branch because the npx
+  // cache satisfies isGlobalInstall() (Issue #1195 pins that). It rewrote the user's
+  // global install and then reported UPDATE_FAILED, because the post-install check
+  // re-read the npx cache's package.json (still the old version) rather than the new
+  // global one. The npx gate runs before every other step.
+  describe('npx execution (Issue #1319)', () => {
+    beforeEach(() => {
+      vi.mocked(isNpxExecution).mockReturnValue(true);
+      // The npx cache reports the version npx happened to fetch, and the registry
+      // has a newer one: without the gate this is the "update available" path.
+      mockPackageJson('0.9.0', '0.9.0');
+      mockNpm({ latest: '1.0.0' });
+    });
+
+    it('should not run npm install -g', async () => {
+      await updateCommand({ yes: true });
+
+      expect(installCalls()).toHaveLength(0);
+    });
+
+    it('should not stop or start the server', async () => {
+      await updateCommand({ yes: true });
+
+      expect(daemon.stop).not.toHaveBeenCalled();
+      expect(daemon.start).not.toHaveBeenCalled();
+    });
+
+    it('should exit SUCCESS instead of UPDATE_FAILED', async () => {
+      await updateCommand({ yes: true });
+
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+      expect(mockExit).not.toHaveBeenCalledWith(ExitCode.UPDATE_FAILED);
+      expect(output()).not.toContain('npm install は成功したが');
+    });
+
+    it('should explain that npx needs no update and how to update a global install', async () => {
+      await updateCommand({ yes: true });
+
+      expect(output()).toContain('npx');
+      expect(output()).toContain('npm install -g commandmate@latest');
+    });
+
+    it('should gate --check as well, since the npx cache version is not the install', async () => {
+      await updateCommand({ check: true });
+
+      expect(output()).not.toContain('Current: v0.9.0');
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+      expect(installCalls()).toHaveLength(0);
+    });
+
+    it('should not prompt for confirmation in a non-interactive npx run', async () => {
+      vi.mocked(isInteractive).mockReturnValue(false);
+
+      await updateCommand({});
+
+      expect(confirm).not.toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+      expect(mockExit).not.toHaveBeenCalledWith(ExitCode.CONFIG_ERROR);
+    });
   });
 
   describe('--check (D-7)', () => {

--- a/tests/unit/cli/utils/install-context.test.ts
+++ b/tests/unit/cli/utils/install-context.test.ts
@@ -20,6 +20,7 @@ vi.mock('path', async () => {
 
 // Import will happen after mock setup
 let isGlobalInstall: () => boolean;
+let isNpxExecution: () => boolean;
 let getConfigDir: () => string;
 
 describe('install-context', () => {
@@ -30,6 +31,7 @@ describe('install-context', () => {
     // Dynamic import to pick up mocks
     const module = await import('../../../../src/cli/utils/install-context');
     isGlobalInstall = module.isGlobalInstall;
+    isNpxExecution = module.isNpxExecution;
     getConfigDir = module.getConfigDir;
   });
 
@@ -55,6 +57,50 @@ describe('install-context', () => {
       const result = isGlobalInstall();
       // Just verify it returns without error and is boolean
       expect(typeof result).toBe('boolean');
+    });
+  });
+
+  // Issue #1319: a separate detector so `update` can refuse to rewrite the user's
+  // install from a throwaway npx process. isGlobalInstall() must keep answering
+  // true for the npx cache (Issue #1195), so it cannot carry this distinction.
+  describe('isNpxExecution (Issue #1319)', () => {
+    it('should detect the npx cache path', () => {
+      vi.mocked(path.dirname).mockReturnValue(
+        '/Users/tester/.npm/_npx/a1b2c3d4e5f6a7b8/node_modules/commandmate/dist/cli'
+      );
+
+      expect(isNpxExecution()).toBe(true);
+    });
+
+    it('should detect the npx cache path on Windows', () => {
+      vi.mocked(path.dirname).mockReturnValue(
+        'C:\\Users\\tester\\AppData\\Local\\npm-cache\\_npx\\a1b2c3d4\\node_modules\\commandmate\\dist\\cli'
+      );
+
+      expect(isNpxExecution()).toBe(true);
+    });
+
+    it('should not treat a global install as an npx execution', () => {
+      vi.mocked(path.dirname).mockReturnValue(
+        '/usr/local/lib/node_modules/commandmate/dist/cli'
+      );
+
+      expect(isNpxExecution()).toBe(false);
+      expect(isGlobalInstall()).toBe(true);
+    });
+
+    it('should not treat a development checkout as an npx execution', () => {
+      vi.mocked(path.dirname).mockReturnValue('/Users/tester/src/commandmate/src/cli');
+
+      expect(isNpxExecution()).toBe(false);
+    });
+
+    it('should not match a directory that merely contains "npx"', () => {
+      vi.mocked(path.dirname).mockReturnValue(
+        '/Users/tester/projects/npx-playground/node_modules/commandmate/dist/cli'
+      );
+
+      expect(isNpxExecution()).toBe(false);
     });
   });
 
@@ -119,6 +165,12 @@ describe('install-context', () => {
 
     it('should detect a global install when running from the npx cache', () => {
       expect(isGlobalInstall()).toBe(true);
+    });
+
+    // Issue #1319: isNpxExecution() answers the question isGlobalInstall() cannot,
+    // for callers that would mutate the installation (commands/update.ts).
+    it('should also report an npx execution for the same path', () => {
+      expect(isNpxExecution()).toBe(true);
     });
 
     it('should place .env under ~/.commandmate when run via npx', () => {


### PR DESCRIPTION
対応 Issue: #1319

Issue は「要検証（未再現・コード読解ベース）」で起票されていましたが、**再現を確認した上で修正**しています。

## 再現確認: 再現した

完全隔離環境（`HOME` / `NPM_CONFIG_PREFIX` / `NPM_CONFIG_CACHE` を全てテンポラリ配下へ）で、ビルド済み CLI を npx キャッシュと同形のパスに配置し version を 0.9.1 に偽装、隔離 prefix に `commandmate@0.9.1` をグローバル導入して実行:

```
→ [ERROR] npm install は成功したがバージョンを確認できませんでした
    Expected: v0.10.0
    Found:    v0.9.1
→ EXIT CODE: 5 (UPDATE_FAILED)
→ しかし隔離グローバル側は 0.9.1 → 0.10.0 に更新済み
```

Issue の推定3点が全て裏取りできました。npx パスで `isGlobalInstall()` は true、`getPackageJsonPath()` は npx キャッシュ側を指したまま、そして**使い捨ての npx プロセスがユーザーのグローバル導入を実際に書き換えていました**。

### Issue 記載の再現手順は誤りでした（訂正）

`npx commandmate@latest update --yes` では**再現しません**。`@latest` だと npx キャッシュに latest が入るため `currentVersion === latestVersion` となり「Already up to date」で `exit 0` し、グローバル書き換えにも到達しないためです。

再現条件は「**npx が解決した版が registry latest より古いとき**」（`npx commandmate@0.9.1 update` 等）。詳細は https://github.com/Kewton/CommandMate/issues/1319#issuecomment-4993862136

## 修正

- **`isGlobalInstall()` は一切変更していません**。`tests/unit/cli/utils/install-context.test.ts:101-104` が固定する #1195 の前提（config/DB が `~/.commandmate` に置かれること）を維持するため
- 代わりに **`isNpxExecution()` を別関数として追加**（`/_npx/` および Windows の `\_npx\` を判定）し、`update` の先頭で gate
- npx 検出時は何も変更せず案内して `exit 0`
- `--check` も gate 対象。npx 配下の "current version" は npx がたまたま取得した版であって利用者の導入状況を表さないため、報告すること自体が誤誘導になる

修正後、同一の隔離環境で再検証済み。

## 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass (580 files / 9881 tests) |
| npm run build | Pass |
| npm run build:cli | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
