### PR TITLE
fix: 公開パッケージから .next/cache (633MB) を除外する (#1315)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bin/",
     "dist/",
     ".next/",
+    "!.next/cache",
     "public/",
     ".env.example"
   ],

--- a/tests/unit/config/npm-package-files.test.ts
+++ b/tests/unit/config/npm-package-files.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the published package's `files` whitelist (Issue #1315).
+ *
+ * `files` whitelists `.next/`, which pulled in `.next/cache` — Next.js's webpack
+ * build cache, needed only to make the *next* build faster and never read at
+ * runtime. It was 633MB of a 656MB package, so every `npx commandmate@latest`
+ * unpacked it: measured 656.3MB unpacked / 89.8MB downloaded before, 22.8MB /
+ * 5.3MB after. `.npmignore` cannot fix this — a `files` whitelist wins over it,
+ * so the exclusion has to live here.
+ *
+ * Nothing else guards this. `npm pack` is only exercised on release, so a
+ * regression would ship silently and only show up as a slow install.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+const files: string[] = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+).files;
+
+describe('Issue #1315: the published package excludes the Next.js build cache', () => {
+  it('negates .next/cache', () => {
+    expect(files).toContain('!.next/cache');
+  });
+
+  it('negates it after .next/, which is the only order npm honours', () => {
+    // npm applies `files` in order and lets later patterns override earlier
+    // ones. Sorting this array alphabetically, or moving the negation above
+    // `.next/`, silently re-includes 633MB — with every other assertion here
+    // still green, which is exactly why this one exists.
+    const included = files.indexOf('.next/');
+    const negated = files.indexOf('!.next/cache');
+
+    expect(included).toBeGreaterThanOrEqual(0);
+    expect(negated).toBeGreaterThan(included);
+  });
+
+  it('still ships everything the server needs at runtime', () => {
+    // Verified by installing the packed tarball into an isolated prefix and
+    // booting it: /, /sessions, /repositories, /more, /api/worktrees and
+    // /api/repositories all returned 200 without `.next/cache` present. Dropping
+    // any of these entries instead of the cache would break that.
+    for (const entry of ['bin/', 'dist/', '.next/', 'public/', '.env.example']) {
+      expect(files).toContain(entry);
+    }
+  });
+
+  it('excludes nothing under .next/ beyond the cache', () => {
+    // `.next/server`, `.next/static` and `.next/BUILD_ID` are load-bearing. A
+    // broader negation (e.g. `!.next/s*`) would pack clean and fail at boot.
+    const overreaching = files.filter(
+      (entry) => entry.startsWith('!.next/') && entry !== '!.next/cache',
+    );
+
+    expect(overreaching).toEqual([]);
+  });
+});


### PR DESCRIPTION
対応 Issue: #1315

`package.json` の `files` が `.next/` を whitelist しているため、**Next.js の webpack ビルドキャッシュ `.next/cache` が丸ごと publish されていました**。実行時には一切読まれず、次回ビルドを速くするためだけのものです。

`npx commandmate@latest` を実行する全ユーザーが毎回これを展開していました。

## 効果（`npm pack --dry-run` 実測）

| | 修正前 | 修正後 | 削減 |
|---|---|---|---|
| unpacked | 656.3 MB | **22.8 MB** | −96.5% |
| **packed（実際のDL量）** | 89.8 MB | **5.3 MB** | **−94%** |
| files | 1124 | 1115 | −9 |

## 変更

```diff
   "files": [
     "bin/",
     "dist/",
     ".next/",
+    "!.next/cache",
     "public/",
     ".env.example"
   ],
```

`.npmignore` では防げません（`files` の whitelist が優先されるため）。除外は `files` 側に置く必要があります。

## 検証: 実起動まで確認済み

`.next/server` / `.next/static` / `.next/BUILD_ID` は実行に必要なため、**除外しすぎていないことを実機で確認**しました。packed tarball を**隔離した `HOME` / `NPM_CONFIG_PREFIX` / `NPM_CONFIG_CACHE`** へグローバル導入し、隔離ポートで起動:

| ルート | 結果 |
|---|---|
| `/` `/sessions` `/repositories` `/more` | **HTTP 200** |
| `/api/worktrees` `/api/repositories` | **HTTP 200** |
| SSR | `<title>CommandMate</title>` と `_next/static` 参照を確認 |

導入されたパッケージに `.next/cache` は存在せず、それでも全ルートが正常応答しました。実行時に Next が cache を必要としないことが実証されています。

> 検証は本番環境を汚さないよう完全隔離しています（シェルに `CM_PORT=3000` と本番 `CM_DB_PATH` が export されているため、`env -u` で遮断した上で隔離ポート 3915 を使用）。検証後にサーバー停止・環境削除済み、本番 3000 は無傷を確認。

## テスト

`tests/unit/config/npm-package-files.test.ts` を追加（4件）。`npm pack` はリリース時しか実行されないため、回帰しても静かに publish されてしまう点を CI で塞ぎます。

**特に重要なのが順序ガード**です。npm は `files` を順序で解決し後勝ちで上書きするため、`'!.next/cache'` は `'.next/'` より後ろでなければ効きません。実測で確認済み:

| `files` の順序 | unpacked |
|---|---|
| `['.next/', '!.next/cache']` | 22.8 MB |
| `['!.next/cache', '.next/']` | **656.3 MB**（cache が復活） |

配列をアルファベット順にソートするような善意の変更で **633MB が無言で戻ります**。そのためガードを入れ、意図的に壊して落ちること・復元で通ることを確認しました。

## 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass (581 files / 9888 tests) |
| npm run build | Pass |
| npm run build:all | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
