### PR TITLE
docs: リリース手順を実態に合わせて更新する

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: "git worktree + commandmatedev でリリースを自動実行"
+description: "develop → main の PR 経由でリリースを実行する（版上げ・CHANGELOG・タグ・GitHub Release・マージバック）"
 disable-model-invocation: true
 allowed-tools: "Bash, Read, Edit, Write"
 argument-hint: "[version-type] (major|minor|patch) or [version] (e.g., 1.2.3)"
@@ -8,239 +8,287 @@ argument-hint: "[version-type] (major|minor|patch) or [version] (e.g., 1.2.3)"
 
 # リリーススキル
 
-git worktree 環境を作成し、commandmatedev 経由でエージェントにリリース準備を委譲、完了後にマージ・タグ・push を実行してリリースを完了するスキルです。
+`develop` でバージョンを上げ、`develop → main` の PR 経由で main へ反映し、タグ・GitHub Release・develop へのマージバックまでを実行するスキルです。
+
+> **npm publish は行いません。** `.github/workflows/publish.yml` が GitHub Release の `published` を契機に OIDC（npm Trusted Publishers）で自動 publish します。ローカルには publish 用の認証が無いため、`npm publish` を手元で実行してはいけません。
 
 ## 使用方法
 
 ```bash
-/release patch      # パッチバージョンアップ (0.4.9 → 0.4.10)
-/release minor      # マイナーバージョンアップ (0.4.9 → 0.5.0)
-/release major      # メジャーバージョンアップ (0.4.9 → 1.0.0)
+/release patch      # パッチバージョンアップ (0.10.0 → 0.10.1)
+/release minor      # マイナーバージョンアップ (0.10.0 → 0.11.0)
+/release major      # メジャーバージョンアップ (0.10.0 → 1.0.0)
 /release 1.0.0      # 直接バージョン指定
 ```
 
 ## 前提条件
 
-- `main` ブランチが最新であること
-- commandmatedev サーバが起動していること
-- `npm run lint && npx tsc --noEmit && npm run test:unit && npm run build` が通る状態であること
+- **`develop` ブランチ**が最新で、`origin/develop` と同期していること（リリースは develop 基点。main 基点ではない）
+- 作業ツリーがクリーンであること
+- `npm run lint && npx tsc --noEmit && npm run test:unit && npm run build` が通ること
 
-## 実行内容
+## この手順が「なぜこの形か」
 
-あなたはリリースマネージャーです。以下の3フェーズでリリースを実行してください。
+| 事実 | 理由 |
+|---|---|
+| main へ直接 push しない | `.git/hooks/pre-push` が `protected_branch='main'` で拒否する。**PR 経由が唯一の経路** |
+| PR は `develop → main` | v0.10.0 以降の実績（#1314 / #1325）。`release/vX.Y.Z` ブランチを切る旧手順（#1202）は使わない |
+| squash マージ | 上記 PR は squash される。その結果 **develop の祖先が切れる**ため、マージバックが必須になる |
+| マージバックは `-s ours` | squash 後は main の tree が develop と同一なので、内容ではなく**祖先関係だけを復元**する |
+| Release ノートは CHANGELOG 転記 | v0.10.0 以降の実績。`--generate-notes` は v0.9.1 までの形式 |
+| npm publish しない | `publish.yml` が Release 契機で自動実行する（OIDC / provenance 付き） |
 
 ---
 
-### Phase 1: worktree 作成 & 登録確認
+## Phase 1: 事前確認
 
-#### 1-1. commandmatedev サーバ疎通確認
+### 1-1. develop を最新化し、クリーンか確認
 
 ```bash
-commandmatedev ls 2>&1
+git checkout develop
+git pull origin develop
+git status --porcelain          # 空であること
+git rev-list --left-right --count develop...origin/develop   # 0  0 であること
 ```
 
-失敗した場合はエラーメッセージを表示して中断：
-```
-Error: commandmatedev server is not running.
-Run `commandmatedev start --daemon` first.
-```
-
-#### 1-2. 現在バージョンの取得 & 次バージョン計算
+### 1-2. 次バージョンの計算
 
 ```bash
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 ```
 
-引数（patch/minor/major）に応じて次バージョンを計算する。
+引数（patch/minor/major）に応じて `NEXT_VERSION` を計算する。
 
-セマンティックバージョニングのルール：
-- `patch`: `0.4.9` → `0.4.10`
-- `minor`: `0.4.9` → `0.5.0`
-- `major`: `0.4.9` → `1.0.0`
+- `patch`: `0.10.0` → `0.10.1`
+- `minor`: `0.10.0` → `0.11.0`
+- `major`: `0.10.0` → `1.0.0`
 
-計算結果を `NEXT_VERSION` 変数に格納する。
-
-#### 1-3. main ブランチを最新化
+### 1-3. 安全ガード
 
 ```bash
-git checkout main
-git pull origin main
+# タグが既に存在したら中断
+git fetch origin --tags
+git tag -l "v${NEXT_VERSION}"   # 空であること。あればエラー表示して中断
 ```
 
-#### 1-4. release ブランチ & worktree 作成
+以下を確認し、満たさなければ中断する:
 
-```bash
-RELEASE_BRANCH="release/v${NEXT_VERSION}"
-WORKTREE_DIR="../commandmate-release-v${NEXT_VERSION}"
-git worktree add -b "$RELEASE_BRANCH" "$WORKTREE_DIR" main
-```
+- 現在のブランチが `develop` であること
+- `main` に未反映の変更が実際に存在すること（`git diff --stat origin/main..origin/develop` が空でない）
 
-worktree内で依存関係をインストール:
-
-```bash
-cd "$WORKTREE_DIR" && npm install
-```
-
-#### 1-5. worktree 登録確認
-
-worktree が commandmatedev に認識されるまで待つ。認識されない場合はリポジトリ同期を実行する。
-
-```bash
-# 同期を試行
-curl -s -X POST http://localhost:3000/api/repositories/sync
-
-# 登録確認
-commandmatedev ls --branch "release/v${NEXT_VERSION}" --quiet
-```
-
-WT ID を取得できない場合は、ユーザーに commandmatedev のブラウザ UI で worktree を確認するよう案内する。
+> **注意**: `git log origin/main..origin/develop` は squash の影響で実態より遥かに多くのコミットを表示する。**tree 差分（`git diff`）が正**。
 
 ---
 
-### Phase 2: エージェントによるリリース準備
+## Phase 2: バージョン更新（develop 上で直接）
 
-#### 2-1. リリースタスクをエージェントに送信
-
-```bash
-WT=$(commandmatedev ls --branch "release/v${NEXT_VERSION}" --quiet)
-```
-
-以下のプロンプトを送信する：
+### 2-1. package.json / package-lock.json
 
 ```bash
-commandmatedev send "$WT" "v${NEXT_VERSION} のリリース準備を実行してください。
-
-以下の手順を順番に実行してください：
-
-1. package.json の version を \"${NEXT_VERSION}\" に更新
-2. npm install --package-lock-only で package-lock.json を更新
-3. git log でmainの直近の変更内容を確認し、CHANGELOG.md に v${NEXT_VERSION} のエントリを追加
-   - feat, fix, refactor, docs 等のカテゴリ別に整理
-   - 既存のCHANGELOGのフォーマットに合わせる
-4. 以下の品質チェックを実行し、全てパスすることを確認：
-   - npm run lint
-   - npx tsc --noEmit
-   - npm run test:unit
-   - npm run build
-5. 全パスしたら以下でコミット：
-   git add package.json package-lock.json CHANGELOG.md
-   git commit -m 'chore: release v${NEXT_VERSION}'
-6. 失敗した場合は修正してリトライ
-
-完了したら「リリース準備完了」と報告してください。" \
-  --auto-yes --duration 1h
+npm version "${NEXT_VERSION}" --no-git-tag-version
 ```
 
-#### 2-2. 完了待ち
+`npm version` は package.json と package-lock.json の**2箇所（root と `packages[""]`）を同時に整合**させる。手で書き換えないこと。
+
+### 2-2. CHANGELOG.md
+
+`## [Unreleased]` の直後に新セクションを挿入する。
+
+```markdown
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+> **Highlight**: このリリースの中心を2〜4文で。何が問題で、何を変えたか。可能なら実測値を入れる。
+
+### Added
+- feat(scope): **要点**。詳細説明 (#Issue番号)
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+## [前のバージョン] - ...
+```
+
+規約:
+
+- **リンク参照（`[X.Y.Z]: https://github.com/...compare/...`）は追加しない**。0.5.2 で止まっており、近年のリリースでは付けていない
+- 日付は JST 基準
+- 該当が無いカテゴリの見出しは書かない
+- 各項目末尾に Issue 番号を `(#1234)` 形式で入れる
+
+`templates/changelog-entry.md` も参照。
+
+### 2-3. 品質ゲート
+
+全て通ること。1つでも落ちたら修正してから進む。
 
 ```bash
-commandmatedev wait "$WT" --timeout 600 --on-prompt agent
+npm run lint
+npx tsc --noEmit
+npm run test:unit
+npm run build
 ```
 
-**exit code による分岐:**
-
-| exit code | 状況 | 対応 |
-|---|---|---|
-| `0` | 完了 | Phase 3 に進む |
-| `10` | プロンプト検知 | `commandmatedev capture "$WT" --json` で内容確認し、ユーザーに判断を委ねる |
-| `124` | タイムアウト | `commandmatedev capture "$WT"` で状況確認し、ユーザーに報告 |
-
-#### 2-3. 結果確認
+### 2-4. コミット & push
 
 ```bash
-commandmatedev capture "$WT"
+git add package.json package-lock.json CHANGELOG.md
+git commit -m "chore: release v${NEXT_VERSION}"
+git push origin develop
 ```
 
-出力を確認し、コミットが完了しているか検証する。コミットが確認できない場合はユーザーに報告して中断する。
+変更は**この3ファイルのみ**であること（`git diff --stat` で確認）。
 
 ---
 
-### Phase 3: マージ & タグ & push
+## Phase 3: リリース PR
 
-#### 3-1. main にマージ
+### 3-1. PR 作成
 
 ```bash
-git checkout main
-git merge "release/v${NEXT_VERSION}" --no-ff -m "release: v${NEXT_VERSION}"
+gh pr create --repo Kewton/CommandMate --base main --head develop \
+  --title "release: v${NEXT_VERSION}" \
+  --body-file <(...)
 ```
 
-#### 3-2. タグ打ち
+PR 本文に含める要素:
+
+- **リリース概要**: 何のためのリリースか
+- **バージョン**: `X.Y.Z → X.Y.Z+1`（patch/minor/major の別）
+- **DB マイグレーション**: 有無（有る場合は `CURRENT_SCHEMA_VERSION` の遷移）
+- **実差分**: `git diff --stat origin/main..origin/develop` の実数。「squash 履歴のため `main..develop` のコミット数は実態より多く表示される」旨を注記
+- **対応 Issue** 一覧
+- **主な変更**: Added / Changed / Fixed
+- **品質チェック**結果
+
+### 3-2. CI 通過を確認
 
 ```bash
-git tag -a "v${NEXT_VERSION}" -m "v${NEXT_VERSION}"
+gh pr checks <PR番号> --repo Kewton/CommandMate --watch
 ```
 
-#### 3-3. push（main + タグ）
+### 3-3. マージはユーザーに委ねる
+
+**main 向け PR はレビュー1名以上の承認が必須**（CLAUDE.md のルール）。スキルからマージしてはいけない。CI 通過を報告し、ユーザーの承認・マージを待つ。
+
+---
+
+## Phase 4: マージ後（タグ・Release・マージバック）
+
+> ここから先は**ユーザーが PR をマージした後**に実行する。
+
+### 4-1. マージ確認と tree 一致検証
 
 ```bash
-git push origin main
+git fetch origin --tags
+MERGE_SHA=$(gh pr view <PR番号> --repo Kewton/CommandMate --json mergeCommit -q '.mergeCommit.oid')
+
+# main と develop の tree が一致していること（内容ドリフトが無いことの証明）
+[ "$(git rev-parse origin/main^{tree})" = "$(git rev-parse origin/develop^{tree})" ] \
+  && echo "tree 一致 OK" || echo "tree 不一致 — 調査すること"
+```
+
+### 4-2. annotated タグを main の squash コミットに作成
+
+```bash
+git tag -a "v${NEXT_VERSION}" "$MERGE_SHA" -m "v${NEXT_VERSION}"
 git push origin "v${NEXT_VERSION}"
 ```
 
-#### 3-4. develop に逆マージ
+lightweight ではなく **annotated**（`-a`）であること。過去タグは全て annotated。
+
+### 4-3. GitHub Release 作成 → **これが npm publish のトリガー**
+
+ノートは CHANGELOG の該当セクションを転記する（`--generate-notes` は使わない）。
+
+```bash
+awk '/^## \['"${NEXT_VERSION}"'\]/{f=1} /^## \['"${CURRENT_VERSION}"'\]/{f=0} f' CHANGELOG.md > /tmp/release-notes.md
+
+gh release create "v${NEXT_VERSION}" --repo Kewton/CommandMate \
+  --title "v${NEXT_VERSION}" \
+  --notes-file /tmp/release-notes.md
+```
+
+> ⚠️ **この時点で `publish.yml` が発火し npm publish が始まる。** Release 作成は「npm への公開を実行する」ことと等価。**ユーザーの明示的な合意なしに Release を作成してはいけない。**
+
+### 4-4. publish ワークフローの完走を確認
+
+```bash
+gh run list --repo Kewton/CommandMate --workflow=publish.yml --limit 1
+# status=completed conclusion=success になるまで待つ
+npm view commandmate version    # NEXT_VERSION になること
+```
+
+失敗した場合はユーザーに報告する。**`npm publish` を手元で実行して回避しようとしないこと**（OIDC は CI 内でしか成立せず、provenance も付かない）。
+
+### 4-5. main を develop へマージバック（祖先復元）
+
+**必須。** squash により main のコミットは develop の祖先ではなくなっており、放置すると次回の develop → main PR で幻コンフリクトが出る。
 
 ```bash
 git checkout develop
 git pull origin develop
-git merge main --no-ff -m "chore: merge release v${NEXT_VERSION} to develop"
+git merge -s ours origin/main -m "chore: merge release v${NEXT_VERSION} to develop (restore ancestry)"
+
+# tree が壊れていないことを検証（-s ours は develop の tree を保持する）
+[ "$(git rev-parse origin/main^{tree})" = "$(git rev-parse develop^{tree})" ] \
+  && echo "tree 一致 OK" || echo "tree が壊れた — push しないこと"
+
 git push origin develop
 ```
 
-#### 3-5. GitHub Releases 作成
+### 4-6. 効果検証
 
 ```bash
-gh release create "v${NEXT_VERSION}" --title "v${NEXT_VERSION}" --generate-notes
-```
-
-#### 3-6. worktree クリーンアップ
-
-```bash
-git worktree remove "$WORKTREE_DIR"
-git branch -d "$RELEASE_BRANCH"
-```
-
-#### 3-7. CommandMate 同期
-
-```bash
-curl -s -X POST http://localhost:3000/api/repositories/sync
+git fetch origin
+git merge-base --is-ancestor origin/main origin/develop \
+  && echo "祖先切れ解消 OK" || echo "まだ切れている"
 ```
 
 ---
 
 ## 完了報告
 
-以下の形式で報告する：
-
 ```
 Release v${NEXT_VERSION} completed!
 
-  Tag:      v${NEXT_VERSION}
+  Tag:      v${NEXT_VERSION} → <squash SHA>
   Release:  https://github.com/Kewton/CommandMate/releases/tag/v${NEXT_VERSION}
+  npm:      <npm view commandmate version の実測値>
 
-  Worktree: cleaned up
-  Branches: main ✓, develop ✓ (synced)
+  Branches: main ✓, develop ✓ (ancestry restored, tree一致検証済み)
 ```
 
 ## エラー時の対応
 
 | エラー | 対応 |
 |---|---|
-| commandmatedev サーバ未起動 | `commandmatedev start --daemon` を案内して中断 |
-| worktree が登録されない | ブラウザ UI での確認を案内 |
-| エージェントがタイムアウト | `commandmatedev capture` で状況確認し報告 |
-| 品質チェック失敗 | エージェントが自動修正を試みる。3回失敗で中断 |
-| マージコンフリクト | ユーザーに手動解消を依頼 |
-| タグが既に存在する | エラー表示し、別バージョンの指定を促す |
+| `develop` 以外で実行 | 中断。develop に切り替えてもらう |
+| 作業ツリーが汚れている | 中断。**stash しない**（他エージェント稼働中だと破損の恐れ） |
+| タグが既に存在 | 中断。別バージョンの指定を促す |
+| `main..develop` の tree 差分が空 | リリースする変更が無い。中断 |
+| 品質ゲート失敗 | 修正してリトライ。3回失敗で中断 |
+| main へ push しようとして hook に拒否された | **手順の誤り**。PR 経由に戻る |
+| publish ワークフロー失敗 | ユーザーに報告。ローカル `npm publish` で回避しない |
+| マージバック後に tree 不一致 | push せずユーザーに報告 |
 
 ## 安全ガード
 
-- main ブランチ以外からのリリースは拒否
-- worktree 作成前に既存の同名 worktree がないか確認
+- **main 直 push は行わない**（hook が拒否する。PR が唯一の経路）
+- **PR のマージはユーザーに委ねる**（main 向けは承認必須）
+- **GitHub Release の作成 = npm publish の実行**。ユーザーの明示的合意を得てから行う
+- **`npm publish` をローカル実行しない**（OIDC / provenance が CI 前提）
 - タグが既に存在する場合は中断
-- Phase 3 に進む前にエージェントのコミットを検証
+- マージバック後は必ず tree 一致を検証してから push
 
 ## 参考
 
-- [リリースガイド](../../docs/release-guide.md)
+- [リリースガイド](../../../docs/release-guide.md)
+- `.github/workflows/publish.yml` — Release 契機の自動 publish（OIDC）
+- `.git/hooks/pre-push` — main 直 push の拒否
 - [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/)
 - [Semantic Versioning](https://semver.org/lang/ja/)

--- a/.claude/skills/release/examples/release-example.md
+++ b/.claude/skills/release/examples/release-example.md
@@ -1,162 +1,144 @@
 # リリース実行例
 
-このドキュメントでは、`/release` スキルの実行例を示します。
+`/release` スキルの実行例です。**v0.10.1 の実際のリリース記録**を題材にしています（2026-07-17 実施）。
 
-## 例1: パッチリリース (v0.1.0 → v0.1.1)
+## 例: パッチリリース (v0.10.0 → v0.10.1)
 
 ### コマンド
+
 ```
 /release patch
 ```
 
-### 実行結果
-```
-🚀 リリーススキルを開始します
+### Phase 1: 事前確認
 
+```
 📋 事前チェック
-  ✅ mainブランチで実行中
+  ✅ develop ブランチで実行中
   ✅ 未コミットの変更なし
-  ✅ リモートと同期済み
+  ✅ origin/develop と同期済み (0  0)
+  ✅ main..develop に tree 差分あり (15 files, +559 -92)
 
 📊 バージョン情報
-  現在: 0.1.0
-  新規: 0.1.1
+  現在: 0.10.0
+  新規: 0.10.1
   種別: patch
 
 🏷️ タグチェック
-  ✅ v0.1.1 は存在しません
+  ✅ v0.10.1 は存在しません
+```
 
+> `git log origin/main..origin/develop` は squash の影響で 136 件と表示されるが、**tree 差分（15 files）が正**。コミット数で判断しないこと。
+
+### Phase 2: バージョン更新（develop 上）
+
+```
 📝 ファイル更新
-  ✅ package.json を更新 (0.1.0 → 0.1.1)
-  ✅ package-lock.json を更新
-  ✅ CHANGELOG.md を更新
+  ✅ npm version 0.10.1 --no-git-tag-version
+       package.json      0.10.0 → 0.10.1
+       package-lock.json root と packages[""] の2箇所を同時更新
+  ✅ CHANGELOG.md に [0.10.1] セクションを追加
+       （比較リンクは追加しない）
 
-📤 コミット & プッシュ
-  ✅ コミット作成: chore: release v0.1.1
-  ✅ mainブランチをプッシュ
-  ✅ タグ v0.1.1 を作成・プッシュ
+✅ 品質ゲート
+  lint  PASS
+  tsc   PASS
+  test  PASS (581 files / 9888 tests)
+  build PASS
 
-🎉 GitHub Releases
-  ✅ リリース作成完了
-  🔗 https://github.com/Kewton/CommandMate/releases/tag/v0.1.1
-
-✨ リリース完了！
-
-確認コマンド:
-  git tag -l                    # タグ一覧
-  git describe --tags --abbrev=0  # 最新タグ
-  gh release view v0.1.1        # リリース詳細
+📤 コミット & push
+  ✅ chore: release v0.10.1  (1873dcf1)
+  ✅ 変更は3ファイルのみ (CHANGELOG.md / package.json / package-lock.json)
+  ✅ git push origin develop
 ```
 
----
+### Phase 3: リリース PR
 
-## 例2: マイナーリリース (v0.1.1 → v0.2.0)
-
-### コマンド
 ```
-/release minor
-```
+🔀 PR 作成
+  ✅ release: v0.10.1  (develop → main)
+     https://github.com/Kewton/CommandMate/pull/1325
 
-### 実行結果
-```
-🚀 リリーススキルを開始します
+⏳ CI
+  ✅ 全9チェック通過
 
-📋 事前チェック
-  ✅ mainブランチで実行中
-  ✅ 未コミットの変更なし
-  ✅ リモートと同期済み
-
-📊 バージョン情報
-  現在: 0.1.1
-  新規: 0.2.0
-  種別: minor
-
-...（以下同様）
-
-✨ リリース完了！
+⚠️ main 向け PR はレビュー承認が必須です。
+   マージはユーザーが行ってください。CI 通過を報告してここで待機します。
 ```
 
----
+### Phase 4: マージ後
 
-## 例3: メジャーリリース (v0.2.0 → v1.0.0)
-
-### コマンド
 ```
-/release major
-```
+✅ マージ確認
+  7edcb567 release: v0.10.1 (#1325)   ← squash (parents=1)
+  main package.json = 0.10.1
+  tree 一致検証: main == develop ✅
 
-### 実行結果
-```
-🚀 リリーススキルを開始します
+🏷️ タグ
+  ✅ git tag -a v0.10.1 7edcb567 -m "v0.10.1"
+  ✅ git push origin v0.10.1
 
-📋 事前チェック
-  ✅ mainブランチで実行中
-  ✅ 未コミットの変更なし
-  ✅ リモートと同期済み
+🎉 GitHub Release
+  ✅ CHANGELOG の [0.10.1] セクションを転記して作成
+     https://github.com/Kewton/CommandMate/releases/tag/v0.10.1
 
-📊 バージョン情報
-  現在: 0.2.0
-  新規: 1.0.0
-  種別: major
+  ⚠️ この時点で publish.yml が発火 → npm publish が自動で始まる
 
-⚠️ メジャーバージョンアップです。破壊的変更が含まれていることを確認してください。
-続行しますか？ (y/n): y
+📦 publish ワークフロー
+  ✅ run 29546342769  conclusion=success
+  ✅ npm view commandmate version → 0.10.1
+     unpackedSize 20.1 MB / tarball 5.2 MB / provenance あり
 
-...（以下同様）
-
-✨ リリース完了！
-```
-
----
-
-## 例4: 直接バージョン指定 (→ v2.0.0)
-
-### コマンド
-```
-/release 2.0.0
+🔄 マージバック（祖先復元）
+  ✅ git merge -s ours origin/main -m "chore: merge release v0.10.1 to develop (restore ancestry)"
+  ✅ tree 一致検証 OK
+  ✅ git push origin develop  (0d4398c8)
+  ✅ merge-base --is-ancestor origin/main origin/develop → 祖先切れ解消
 ```
 
-### 実行結果
+### 完了報告
+
 ```
-🚀 リリーススキルを開始します
+Release v0.10.1 completed!
 
-📋 事前チェック
-  ✅ mainブランチで実行中
-  ✅ 未コミットの変更なし
-  ✅ リモートと同期済み
+  Tag:      v0.10.1 → 7edcb567
+  Release:  https://github.com/Kewton/CommandMate/releases/tag/v0.10.1
+  npm:      0.10.1 (tarball 5.2 MB, provenance あり)
 
-📊 バージョン情報
-  現在: 1.0.0
-  新規: 2.0.0
-  種別: direct
-
-...（以下同様）
-
-✨ リリース完了！
+  Branches: main ✓, develop ✓ (ancestry restored, tree一致検証済み)
 ```
 
 ---
 
 ## エラー例
 
+### develop 以外で実行した場合
+
+```
+📋 事前チェック
+  ❌ 現在のブランチ: main
+
+リリースは develop 基点です。develop に切り替えてください:
+  git checkout develop && git pull origin develop
+
+リリースを中断しました。
+```
+
 ### 未コミットの変更がある場合
 
 ```
-/release patch
-
-🚀 リリーススキルを開始します
-
 📋 事前チェック
   ❌ 未コミットの変更があります
 
-以下のファイルに変更があります:
   M src/lib/env.ts
   ?? new-file.ts
 
 対処方法:
   1. 変更をコミット: git add . && git commit -m "..."
-  2. 変更をスタッシュ: git stash
-  3. 変更を破棄: git checkout .
+  2. 変更を破棄: git checkout .
+
+⚠️ git stash は避けてください。他のエージェントが同じ作業ツリーで
+   稼働している場合、作業内容を破損させます。
 
 リリースを中断しました。
 ```
@@ -164,48 +146,48 @@
 ### タグが既に存在する場合
 
 ```
-/release patch
-
-🚀 リリーススキルを開始します
-
-📋 事前チェック
-  ✅ mainブランチで実行中
-  ✅ 未コミットの変更なし
-  ✅ リモートと同期済み
-
-📊 バージョン情報
-  現在: 0.1.0
-  新規: 0.1.1
-
 🏷️ タグチェック
-  ❌ タグ v0.1.1 は既に存在します
+  ❌ タグ v0.10.1 は既に存在します
 
 対処方法:
-  1. 別のバージョンを指定: /release 0.1.2
-  2. 既存タグを削除（非推奨）: git tag -d v0.1.1 && git push origin :refs/tags/v0.1.1
+  1. 別のバージョンを指定: /release 0.10.2
+  2. 既存タグを削除（非推奨・publish 済みなら不可）:
+     git tag -d v0.10.1 && git push origin :refs/tags/v0.10.1
 
 リリースを中断しました。
 ```
 
-### [Unreleased]セクションが空の場合
+### main へ push しようとした場合
 
 ```
-/release patch
+$ git push origin main
 
-🚀 リリーススキルを開始します
+❌ Error: Direct push to 'main' is not allowed.
+   Please create a Pull Request instead.
+```
 
+これは `.git/hooks/pre-push` による正しい拒否です。**`--no-verify` で回避しないでください。**
+PR 経由（Phase 3）に戻ってください。
+
+### publish ワークフローが失敗した場合
+
+```
+📦 publish ワークフロー
+  ❌ run 29546342769  conclusion=failure
+     失敗ステップ: Security audit
+
+ユーザーに報告して指示を仰いでください。
+
+⚠️ npm publish をローカル実行して回避しないこと。
+   この構成は OIDC (npm Trusted Publishers) で CI からのみ publish します。
+   ローカルには認証が無く、provenance も付きません。
+```
+
+### main..develop に差分が無い場合
+
+```
 📋 事前チェック
-  ✅ mainブランチで実行中
-  ✅ 未コミットの変更なし
-  ✅ リモートと同期済み
+  ❌ main..develop の tree 差分が空です
 
-📊 バージョン情報
-  現在: 0.1.0
-  新規: 0.1.1
-
-📝 CHANGELOG確認
-  ⚠️ [Unreleased]セクションが空です
-  リリースノートがない状態でリリースしますか？ (y/n): n
-
-リリースを中断しました。
+リリースする変更がありません。リリースを中断しました。
 ```

--- a/.claude/skills/release/templates/changelog-entry.md
+++ b/.claude/skills/release/templates/changelog-entry.md
@@ -1,82 +1,87 @@
 # CHANGELOGエントリテンプレート
 
-このテンプレートは、リリース時にCHANGELOG.mdを更新する際の形式を示します。
+リリース時に `CHANGELOG.md` を更新する際の形式です。**実際の直近リリース（v0.10.0 / v0.10.1）の書式に準拠**しています。
 
 ## バージョンセクションの形式
+
+`## [Unreleased]` の直後に挿入します。
 
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD
 
+> **Highlight**: このリリースの中心を2〜4文で。何が問題で、何を変えたか。**実測値があれば必ず入れる**。
+
 ### Added
-- 新機能の説明 (Issue #XX)
+
+- feat(scope): **要点を太字で**。補足説明 (#1234)
 
 ### Changed
-- 変更内容の説明 (Issue #XX)
 
-### Deprecated
-- 非推奨になった機能の説明
-
-### Removed
-- 削除された機能の説明
+- fix(docs): **要点**。補足説明 (#1234)
 
 ### Fixed
-- バグ修正の説明 (Issue #XX)
 
-### Security
-- セキュリティ関連の修正
+- fix(cli): **要点**。補足説明 (#1234)
 ```
 
-## セクションの説明
+- 日付は **JST 基準**
+- 該当が無いカテゴリの見出しは**書かない**
+- 各カテゴリ見出しの後は**空行を1行**入れる
 
-| セクション | 内容 |
-|-----------|------|
-| **Added** | 新機能 |
-| **Changed** | 既存機能の変更 |
-| **Deprecated** | 将来削除予定の機能 |
-| **Removed** | 削除された機能 |
-| **Fixed** | バグ修正 |
-| **Security** | セキュリティ関連の修正 |
+## セクション
+
+| セクション | 内容 | 使用実績 |
+|---|---|---|
+| **Added** | 新機能 | 頻繁 |
+| **Changed** | 既存機能の変更 | 頻繁 |
+| **Fixed** | バグ修正 | 頻繁 |
+| **Security** | セキュリティ関連の修正 | 6回 |
+| **Removed** | 削除された機能 | 3回 |
+| **Deprecated** | 将来削除予定の機能 | 1回 |
 
 ## 記載ルール
 
-1. **過去形で記載**: 「追加した」「修正した」ではなく「追加」「修正」
-2. **Issue番号を併記**: 可能な限り関連Issue番号を記載
-3. **ユーザー視点で記載**: 技術的な詳細ではなく、ユーザーへの影響を記載
-4. **BREAKING CHANGEの明示**: 破壊的変更は `**BREAKING**:` プレフィックスを付与
+1. **conventional prefix を付ける**: `feat(scope):` / `fix(scope):` / `chore(scope):` / `docs:` / `refactor(scope):` 等。直近3バージョンの全29項目が prefix 付き
+2. **Issue 番号は `(#1234)` 形式**: `(Issue #1234)` は v0.9.1 以前の旧表記。**新規では使わない**
+3. **要点を `**太字**` で**: 項目の冒頭に結論を置き、詳細はその後ろに続ける
+4. **ユーザー視点＋根拠**: 「何が起きていたか」「何がどう変わるか」を書く。実測値・計測結果があれば入れる
+5. **BREAKING CHANGE の明示**: 破壊的変更は `**BREAKING**:` プレフィックスを付与
+
+## 比較リンクは追加しない
+
+ファイル末尾の比較リンク（`[X.Y.Z]: https://github.com/.../compare/...`）は **`0.5.2` で止まっており、以降のリリースでは付けていません**。新規リリースでも**追加しないでください**（既存の古いリンクはそのまま残す）。
 
 ## 例
 
-### 良い例
+### 良い例（実際の v0.10.1 より）
 
 ```markdown
-### Added
-- リリーススキル `/release` を追加 (Issue #86)
-- 環境変数フォールバック機能を追加 (Issue #76)
-
-### Changed
-- **BREAKING**: 環境変数名を `MCBD_*` から `CM_*` に変更 (Issue #77)
-
 ### Fixed
-- サイドバーのステータス表示が更新されない問題を修正 (Issue #31)
+
+- fix: **公開パッケージから `.next/cache` を除外**。`files` が `.next/` を whitelist していたため Next.js の webpack ビルドキャッシュ（実行時には読まれない）が丸ごと publish され、`npx` 利用者が毎回 633MB を展開していた。`npm pack` 実測で 656.3MB → 22.8MB（unpacked）／89.8MB → 5.3MB（packed） (#1315)
 ```
+
+要点が太字、prefix あり、**実測値が入っている**、`(#1315)` 形式。
 
 ### 悪い例
 
 ```markdown
 ### Added
-- release skill added  <!-- 英語/小文字始まり -->
-- src/lib/env.ts に getEnvWithFallback() を追加  <!-- 技術的すぎる -->
+- release skill added                          <!-- 英語・prefix なし -->
+- src/lib/env.ts に getEnvWithFallback() を追加   <!-- 技術詳細のみでユーザー影響が不明 -->
 
 ### Fixed
-- バグを修正  <!-- 具体性がない -->
+- バグを修正 (Issue #31)                        <!-- 具体性なし・旧 Issue 表記 -->
 ```
 
-## 比較リンクの形式
+## Highlight の書き方
 
-ファイル末尾に以下の形式で比較リンクを追加：
+リリース全体の要約です。GitHub Release ノートにもそのまま転記されるため、**そのリリースを一言で説明する文**にします。
 
-```markdown
-[unreleased]: https://github.com/Kewton/CommandMate/compare/vX.Y.Z...HEAD
-[X.Y.Z]: https://github.com/Kewton/CommandMate/compare/vA.B.C...vX.Y.Z
-[A.B.C]: https://github.com/Kewton/CommandMate/releases/tag/vA.B.C
-```
+実例（v0.10.1）:
+
+> **Highlight**: **`npx` 導線の実効性を回復するパッチリリース**。v0.10.0 で新設したランディングページと README が案内していた `npx commandmate` は、**グローバル導入済みの環境では既存の binary を実行しレジストリを一切参照しない**ため、利用者が気づかないまま旧版を使い続けていた（実測: 最新 0.10.0 に対し 0.3.5 が実行された）。全案内を `npx commandmate@latest` に統一した。…
+
+- 中心テーマを冒頭に置く
+- **問題 → 変更**の順で書く
+- DB マイグレーションがあれば必ず記載（`CURRENT_SCHEMA_VERSION` の遷移も）

--- a/docs/en/release-guide.md
+++ b/docs/en/release-guide.md
@@ -14,26 +14,50 @@ This project follows [Semantic Versioning](https://semver.org/).
 MAJOR.MINOR.PATCH
 ```
 
-| Type | When to Update | Example |
-|------|---------------|---------|
-| **MAJOR** | Breaking changes (backward-incompatible changes) | v1.0.0 → v2.0.0 |
+| Type | When to bump | Example |
+|------|--------------|---------|
+| **MAJOR** | Breaking changes (backward-incompatible) | v1.0.0 → v2.0.0 |
 | **MINOR** | Backward-compatible feature additions | v1.0.0 → v1.1.0 |
 | **PATCH** | Backward-compatible bug fixes | v1.0.0 → v1.0.1 |
 
 ### Version Decision Criteria
 
-| Change | Version Type |
-|--------|-------------|
-| API removal/modification | MAJOR |
-| Configuration file format changes | MAJOR |
-| Environment variable name changes (without fallback) | MAJOR |
-| New feature additions | MINOR |
-| New API additions | MINOR |
-| New configuration options | MINOR |
-| Bug fixes | PATCH |
-| Documentation fixes | PATCH |
-| Refactoring (no behavior change) | PATCH |
-| Dependency updates (no behavior change) | PATCH |
+| Change | Version type |
+|--------|--------------|
+| Removing or changing an API | MAJOR |
+| Changing a config file format | MAJOR |
+| Renaming an environment variable (without fallback) | MAJOR |
+| Adding a feature | MINOR |
+| Adding an API | MINOR |
+| Adding a config option | MINOR |
+| Bug fix | PATCH |
+| Documentation fix | PATCH |
+| Refactoring (no behaviour change) | PATCH |
+| Dependency update (no behaviour change) | PATCH |
+
+---
+
+## Release Flow Overview
+
+```
+Bump version on develop (package.json / package-lock.json / CHANGELOG.md)
+   ↓  chore: release vX.Y.Z
+PR "release: vX.Y.Z" (develop → main)  -- review approval required
+   ↓  squash merge
+Tag vX.Y.Z on main (annotated)
+   ↓
+Create GitHub Release  --->  publish.yml fires  --->  npm publish (automatic, OIDC)
+   ↓
+Merge main back into develop (-s ours, restores ancestry)
+```
+
+### Three premises to internalise
+
+| Premise | Why |
+|---|---|
+| **You cannot push to main directly** | `.git/hooks/pre-push` rejects it via `protected_branch='main'`. A PR is the only path |
+| **Creating a GitHub Release publishes to npm** | `.github/workflows/publish.yml` fires on `release: [published]` and runs `npm publish`. Creating the Release *is* publishing |
+| **The back-merge is mandatory** | The develop → main PR is squashed, which severs develop's ancestry. Skip it and the next PR shows phantom conflicts |
 
 ---
 
@@ -41,212 +65,303 @@ MAJOR.MINOR.PATCH
 
 ### Preparation
 
-1. **Verify all PRs are merged into main**
+1. **Bring `develop` up to date** (releases are cut from develop, not main)
+
    ```bash
-   git checkout main
-   git pull origin main
-   git status
+   git checkout develop
+   git pull origin develop
+   git rev-list --left-right --count develop...origin/develop   # must be 0  0
    ```
 
-2. **Verify no uncommitted changes**
+2. **Confirm there are no uncommitted changes**
+
    ```bash
-   git status
-   # Verify "nothing to commit, working tree clean"
+   git status --porcelain    # must be empty
    ```
 
-3. **Verify all tests pass**
+   > Avoid `git stash`. If another agent is working in the same tree, it will corrupt their work.
+
+3. **Confirm all quality checks pass**
+
    ```bash
    npm run lint
+   npx tsc --noEmit
    npm run test:unit
    npm run build
    ```
 
+4. **Confirm there are actually changes not yet on main**
+
+   ```bash
+   git fetch origin
+   git diff --stat origin/main..origin/develop
+   ```
+
+   > **Note**: `git log origin/main..origin/develop` reports far more commits than reality because of squashing (e.g. 136 commits for a 15-file diff). **The tree diff (`git diff`) is authoritative.**
+
 ### Step 1: Determine Version
 
-Check the current version and decide on the new version.
-
 ```bash
-# Check current version
-cat package.json | grep '"version"'
+node -p "require('./package.json').version"
 ```
 
-### Step 2: Update package.json
+Pick the next version using the criteria above.
+
+### Step 2: Update package.json / package-lock.json
 
 ```bash
-# Update the version in package.json
-# Example: 0.1.0 → 0.2.0
+npm version 0.10.1 --no-git-tag-version
 ```
 
-### Step 3: Update package-lock.json
+`npm version` keeps package.json and **both places in package-lock.json (root and `packages[""]`)** consistent. Do not hand-edit them.
 
-```bash
-npm install --package-lock-only
-```
+`--no-git-tag-version` is required — without it npm creates a tag, which collides with the PR flow below.
 
-### Step 4: Update CHANGELOG.md
+### Step 3: Update CHANGELOG.md
 
-1. Move content from the `[Unreleased]` section to a new version section
-2. Add release date (YYYY-MM-DD format)
-3. Add comparison links
+Insert a new section directly below `## [Unreleased]`.
 
-**Before:**
 ```markdown
 ## [Unreleased]
 
-### Added
-- New feature description
+## [0.10.1] - 2026-07-17
 
-### Fixed
-- Bug fix description
-```
-
-**After:**
-```markdown
-## [Unreleased]
-
-## [0.2.0] - 2026-01-30
+> **Highlight**: Two to four sentences on what this release is about -- what was wrong and what changed. Include measured numbers where you have them.
 
 ### Added
-- New feature description
+
+- feat(scope): **Bold the point**. Supporting detail (#1234)
+
+### Changed
+
+- fix(docs): **The point**. Supporting detail (#1234)
 
 ### Fixed
-- Bug fix description
+
+- fix(cli): **The point**. Supporting detail (#1234)
+
+## [0.10.0] - 2026-07-16
 ```
 
-**Adding comparison links (at end of file):**
-```markdown
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/Kewton/CommandMate/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/Kewton/CommandMate/releases/tag/v0.1.0
-```
+Conventions:
 
-### Step 5: Create Commit
+- **Do not add compare links** (`[X.Y.Z]: https://github.com/.../compare/...`). They stop at `0.5.2` and have not been added since (leave the existing old ones in place)
+- Issue references use the **`(#1234)` form**. `(Issue #1234)` is the pre-v0.9.1 style
+- Prefix each entry with a conventional-commit scope (`feat(scope):`, `fix(scope):`, ...)
+- Dates are JST-based
+- Omit category headings that have no entries
+
+See [`templates/changelog-entry.md`](../../.claude/skills/release/templates/changelog-entry.md) for details.
+
+### Step 4: Commit & push
 
 ```bash
 git add package.json package-lock.json CHANGELOG.md
-git commit -m "chore: release v0.2.0"
+git commit -m "chore: release v0.10.1"
+git push origin develop
 ```
 
-### Step 6: Create and Push Tag
+Verify with `git diff --stat` that **only these three files** changed.
+
+### Step 5: Release PR (develop → main)
 
 ```bash
-# Create tag
-git tag v0.2.0
-
-# Push main branch and tag
-git push origin main
-git push origin v0.2.0
+gh pr create --repo Kewton/CommandMate --base main --head develop \
+  --title "release: v0.10.1" \
+  --body-file <(...)
 ```
 
-### Step 7: Create GitHub Release
+The PR body should cover:
+
+- **Summary**: what this release is for
+- **Version**: `0.10.0 → 0.10.1` (patch/minor/major)
+- **DB migration**: whether there is one (and the `CURRENT_SCHEMA_VERSION` transition if so)
+- **Actual diff**: the real numbers from `git diff --stat origin/main..origin/develop`, with a note that the commit count in `main..develop` is inflated by squash history
+- **Issues covered**
+- **Main changes**: Added / Changed / Fixed
+- **Quality check** results
+
+Then watch CI:
 
 ```bash
-# Auto-generate release notes
-gh release create v0.2.0 --title "v0.2.0" --generate-notes
+gh pr checks <PR-number> --repo Kewton/CommandMate --watch
+```
 
-# Or use CHANGELOG.md content
-gh release create v0.2.0 --title "v0.2.0" --notes "$(sed -n '/## \[0.2.0\]/,/## \[0.1.0\]/p' CHANGELOG.md | head -n -1)"
+> **PRs targeting main require at least one review approval** (see [CLAUDE.md](../../CLAUDE.md)). Merge with **squash** once approved.
+
+### Step 6: Create and push the tag
+
+Run this after the merge.
+
+```bash
+git fetch origin --tags
+MERGE_SHA=$(gh pr view <PR-number> --repo Kewton/CommandMate --json mergeCommit -q '.mergeCommit.oid')
+
+# main and develop must have identical trees (proves there is no content drift)
+[ "$(git rev-parse origin/main^{tree})" = "$(git rev-parse origin/develop^{tree})" ] && echo "trees match"
+
+git tag -a "v0.10.1" "$MERGE_SHA" -m "v0.10.1"
+git push origin "v0.10.1"
+```
+
+The tag must be **annotated** (`-a`) -- every existing tag is.
+
+### Step 7: Create the GitHub Release -- this triggers npm publish
+
+Release notes are the **CHANGELOG section, transcribed verbatim** (`--generate-notes` is the pre-v0.10.0 style).
+
+```bash
+awk '/^## \[0\.10\.1\]/{f=1} /^## \[0\.10\.0\]/{f=0} f' CHANGELOG.md > /tmp/release-notes.md
+
+gh release create "v0.10.1" --repo Kewton/CommandMate \
+  --title "v0.10.1" \
+  --notes-file /tmp/release-notes.md
+```
+
+> ⚠️ **`publish.yml` fires at this moment and npm publish begins.** Creating the Release *is* publishing to npm. It cannot be undone (see below).
+
+### Step 8: Confirm the publish workflow completed
+
+```bash
+gh run list --repo Kewton/CommandMate --workflow=publish.yml --limit 1
+# wait for status=completed conclusion=success
+
+npm view commandmate version    # should be the new version
+```
+
+### Step 9: Merge main back into develop (restore ancestry)
+
+**Mandatory.** Squashing means main's commit is no longer an ancestor of develop. Skip this and the next develop → main PR will show phantom conflicts.
+
+```bash
+git checkout develop
+git pull origin develop
+git merge -s ours origin/main -m "chore: merge release v0.10.1 to develop (restore ancestry)"
+
+# verify the tree survived (-s ours keeps develop's tree)
+[ "$(git rev-parse origin/main^{tree})" = "$(git rev-parse develop^{tree})" ] && echo "trees match"
+
+git push origin develop
+```
+
+Confirm it worked:
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/main origin/develop && echo "ancestry restored"
 ```
 
 ---
 
-## Post-Release Verification
+## About publishing to npm
 
-```bash
-# List all tags
-git tag -l
+**Do not run `npm publish` locally.**
 
-# Check latest tag
-git describe --tags --abbrev=0
+`.github/workflows/publish.yml` runs `npm publish --provenance --access public` via npm Trusted Publishers (OIDC authentication), triggered by the GitHub Release `published` event.
 
-# Check GitHub Releases
-gh release list
+- There are no publish credentials locally
+- OIDC only works inside a GitHub Actions run
+- A local publish would ship without provenance
 
-# View specific release details
-gh release view v0.2.0
-```
+If the workflow fails, fix the cause -- do not work around it with a local publish.
 
----
+### What the workflow does
 
-## Release Using Claude Code Skill
-
-The `/release` skill can automate the above procedure.
-
-```bash
-# Patch version bump (0.1.0 → 0.1.1)
-/release patch
-
-# Minor version bump (0.1.0 → 0.2.0)
-/release minor
-
-# Major version bump (0.1.0 → 1.0.0)
-/release major
-
-# Direct version specification
-/release 1.0.0
-```
+`npm ci` → `npm audit --audit-level=critical` → `npm run test:unit` → `npm run build` → `npm run build:cli` → `npm run build:server` → package size check → `npm publish --provenance --access public`
 
 ---
 
-## npm version Command (Optional)
-
-The `npm version` command can perform version updates and tag creation in one step.
+## Post-release verification
 
 ```bash
-# Patch version bump
-npm version patch -m "chore: release v%s"
+# tags
+git tag -l --sort=-v:refname | head -3
 
-# Minor version bump
-npm version minor -m "chore: release v%s"
+# GitHub Release
+gh release view v0.10.1
 
-# Major version bump
-npm version major -m "chore: release v%s"
+# npm
+npm view commandmate version
+npm view commandmate@0.10.1 dist --json    # size and provenance
 
-# Push tags
-git push origin main --tags
+# fetch it for real from a clean environment (run this OUTSIDE the repo)
+cd $(mktemp -d) && npx --yes commandmate@latest --version
 ```
 
-**Note**: `npm version` does not automatically update CHANGELOG.md, so a separate update is required.
+> Run the `npx` check from a **neutral directory outside the repository**. Inside the CommandMate repo, npx resolves the local `bin` instead, so you would not be verifying the published artifact at all.
+
+---
+
+## Releasing with the Claude Code Skill
+
+The [`/release`](../../.claude/skills/release/SKILL.md) skill runs the procedure above.
+
+```bash
+/release patch      # patch bump (0.10.0 → 0.10.1)
+/release minor      # minor bump (0.10.0 → 0.11.0)
+/release major      # major bump (0.10.0 → 1.0.0)
+/release 1.0.0      # explicit version
+```
+
+The skill does not merge the PR either -- approval is required.
 
 ---
 
 ## Troubleshooting
 
-### Tag Already Exists
+### Push to main was rejected
 
-```bash
-# Error: fatal: tag 'v0.2.0' already exists
-# Solution: Specify a different version or delete the existing tag
-
-# Delete existing tag (caution: this rewrites history)
-git tag -d v0.2.0
-git push origin :refs/tags/v0.2.0
+```
+❌ Error: Direct push to 'main' is not allowed.
+   Please create a Pull Request instead.
 ```
 
-### Release Rollback
+This is `.git/hooks/pre-push` doing its job. **Do not bypass it with `--no-verify`.** Go back to the PR flow in Step 5.
 
-If a critical issue is discovered after release:
+### The tag already exists
 
-1. **Delete GitHub Release**
-   ```bash
-   gh release delete v0.2.0 --yes
-   ```
+```bash
+# error: fatal: tag 'v0.10.1' already exists
+# fix: pick a different version
+```
 
-2. **Delete the tag**
-   ```bash
-   git tag -d v0.2.0
-   git push origin :refs/tags/v0.2.0
-   ```
+Deleting the existing tag is pointless once the version is published to npm (see below).
 
-3. **After fixing, release as a new patch version**
-   ```bash
-   /release patch  # Release as v0.2.1
-   ```
+### The publish workflow failed
+
+```bash
+gh run view <run-id> --repo Kewton/CommandMate --log-failed
+```
+
+Fix the cause and release again as a new patch version. **The same version number cannot be republished.**
+
+### Rolling back a release
+
+> ⚠️ **Once published to npm, a release cannot meaningfully be rolled back.**
+>
+> - npm heavily restricts unpublishing (only within 72 hours, under conditions)
+> - **A version number, once used, cannot be reused even after unpublishing**
+> - **Deleting the GitHub Release or the tag does not remove the package from npm**
+>
+> The correct response to a problem found after release is to **fix it and ship a new patch version**.
+
+Before publishing (i.e. before the Release is created), you can unwind with:
+
+```bash
+git tag -d v0.10.1
+git push origin :refs/tags/v0.10.1
+```
+
+After publishing, release the fix as the next patch version.
 
 ---
 
 ## Related Documents
 
+- [`/release` skill](../../.claude/skills/release/SKILL.md) -- automates this procedure
+- [CHANGELOG entry template](../../.claude/skills/release/templates/changelog-entry.md)
+- `.github/workflows/publish.yml` -- Release-triggered automatic publish (OIDC)
+- `.git/hooks/pre-push` -- rejects direct pushes to main
 - [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [Semantic Versioning](https://semver.org/)
 - [CHANGELOG.md](../../CHANGELOG.md)

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -37,116 +37,237 @@ MAJOR.MINOR.PATCH
 
 ---
 
+## リリースフロー全体像
+
+```
+develop でバージョン更新（package.json / package-lock.json / CHANGELOG.md）
+   ↓  chore: release vX.Y.Z
+PR "release: vX.Y.Z"（develop → main）※レビュー承認必須
+   ↓  squash マージ
+main にタグ vX.Y.Z（annotated）
+   ↓
+GitHub Release 作成  ──→  publish.yml が発火 ──→ npm publish（自動・OIDC）
+   ↓
+main を develop へマージバック（-s ours・祖先復元）
+```
+
+### 押さえるべき3つの前提
+
+| 前提 | 根拠 |
+|---|---|
+| **main へ直接 push できない** | `.git/hooks/pre-push` が `protected_branch='main'` で拒否する。PR が唯一の経路 |
+| **GitHub Release の作成 = npm への公開** | `.github/workflows/publish.yml` が `release: [published]` で発火し `npm publish` する。Release 作成は公開の実行と等価 |
+| **マージバックが必須** | develop → main の PR は squash されるため develop の祖先が切れる。放置すると次回 PR で幻コンフリクトが出る |
+
+---
+
 ## リリース手順
 
 ### 事前準備
 
-1. **全てのPRがmainにマージされていることを確認**
+1. **`develop` を最新化**（リリースは develop 基点。main 基点ではない）
+
    ```bash
-   git checkout main
-   git pull origin main
-   git status
+   git checkout develop
+   git pull origin develop
+   git rev-list --left-right --count develop...origin/develop   # 0  0 であること
    ```
 
 2. **未コミットの変更がないことを確認**
+
    ```bash
-   git status
-   # "nothing to commit, working tree clean" を確認
+   git status --porcelain    # 空であること
    ```
 
-3. **テストが全てパスすることを確認**
+   > `git stash` は避けてください。他のエージェントが同じ作業ツリーで稼働している場合、作業内容を破損させます。
+
+3. **品質チェックが全てパスすることを確認**
+
    ```bash
    npm run lint
+   npx tsc --noEmit
    npm run test:unit
    npm run build
    ```
 
+4. **main に未反映の変更が実際にあることを確認**
+
+   ```bash
+   git fetch origin
+   git diff --stat origin/main..origin/develop
+   ```
+
+   > **注意**: `git log origin/main..origin/develop` は squash の影響で実態より遥かに多くのコミットを表示します（実差分15ファイルに対し136コミット等）。**tree 差分（`git diff`）が正**です。
+
 ### Step 1: バージョン決定
 
-現在のバージョンを確認し、新バージョンを決定します。
-
 ```bash
-# 現在のバージョンを確認
-cat package.json | grep '"version"'
+node -p "require('./package.json').version"
 ```
 
-### Step 2: package.jsonの更新
+上記の判断基準に従って次バージョンを決定します。
+
+### Step 2: package.json / package-lock.json の更新
 
 ```bash
-# package.jsonのversionを更新
-# 例: 0.1.0 → 0.2.0
+npm version 0.10.1 --no-git-tag-version
 ```
 
-### Step 3: package-lock.jsonの更新
+`npm version` は package.json と package-lock.json の**2箇所（root と `packages[""]`）を同時に整合**させます。手で書き換えないでください。
 
-```bash
-npm install --package-lock-only
-```
+`--no-git-tag-version` は必須です。これが無いと npm がタグを打ち、後段の PR フローと衝突します。
 
-### Step 4: CHANGELOG.mdの更新
+### Step 3: CHANGELOG.md の更新
 
-1. `[Unreleased]`セクションの内容を新バージョンセクションに移動
-2. リリース日を追記（YYYY-MM-DD形式）
-3. 比較リンクを追加
+`## [Unreleased]` の直後に新セクションを挿入します。
 
-**変更前:**
 ```markdown
 ## [Unreleased]
 
-### Added
-- 新機能の説明
+## [0.10.1] - 2026-07-17
 
-### Fixed
-- バグ修正の説明
-```
-
-**変更後:**
-```markdown
-## [Unreleased]
-
-## [0.2.0] - 2026-01-30
+> **Highlight**: このリリースの中心を2〜4文で。何が問題で、何を変えたか。実測値があれば入れる。
 
 ### Added
-- 新機能の説明
+
+- feat(scope): **要点を太字で**。補足説明 (#1234)
+
+### Changed
+
+- fix(docs): **要点**。補足説明 (#1234)
 
 ### Fixed
-- バグ修正の説明
+
+- fix(cli): **要点**。補足説明 (#1234)
+
+## [0.10.0] - 2026-07-16
 ```
 
-**比較リンクの追加（ファイル末尾）:**
-```markdown
-[unreleased]: https://github.com/Kewton/CommandMate/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/Kewton/CommandMate/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/Kewton/CommandMate/releases/tag/v0.1.0
-```
+規約:
 
-### Step 5: コミット作成
+- **比較リンク（`[X.Y.Z]: https://github.com/.../compare/...`）は追加しない**。`0.5.2` で止まっており、以降のリリースでは付けていません（既存の古いリンクはそのまま残す）
+- Issue 番号は **`(#1234)` 形式**。`(Issue #1234)` は v0.9.1 以前の旧表記
+- conventional prefix（`feat(scope):` / `fix(scope):` 等）を付ける
+- 日付は JST 基準
+- 該当が無いカテゴリの見出しは書かない
+
+詳細は [`templates/changelog-entry.md`](../.claude/skills/release/templates/changelog-entry.md) を参照。
+
+### Step 4: コミット & push
 
 ```bash
 git add package.json package-lock.json CHANGELOG.md
-git commit -m "chore: release v0.2.0"
+git commit -m "chore: release v0.10.1"
+git push origin develop
 ```
+
+変更は**この3ファイルのみ**であることを `git diff --stat` で確認してください。
+
+### Step 5: リリース PR（develop → main）
+
+```bash
+gh pr create --repo Kewton/CommandMate --base main --head develop \
+  --title "release: v0.10.1" \
+  --body-file <(...)
+```
+
+PR 本文に含める要素:
+
+- **リリース概要**: 何のためのリリースか
+- **バージョン**: `0.10.0 → 0.10.1`（patch/minor/major の別）
+- **DB マイグレーション**: 有無（有る場合は `CURRENT_SCHEMA_VERSION` の遷移）
+- **実差分**: `git diff --stat origin/main..origin/develop` の実数。「squash 履歴のため `main..develop` のコミット数は実態より多く表示される」旨を注記
+- **対応 Issue** 一覧
+- **主な変更**: Added / Changed / Fixed
+- **品質チェック**結果
+
+CI 通過を確認します。
+
+```bash
+gh pr checks <PR番号> --repo Kewton/CommandMate --watch
+```
+
+> **main 向け PR はレビュー1名以上の承認が必須**です（[CLAUDE.md](../CLAUDE.md) のルール）。承認後に **squash** でマージします。
 
 ### Step 6: タグ作成・プッシュ
 
-```bash
-# タグ作成
-git tag v0.2.0
-
-# mainブランチとタグをプッシュ
-git push origin main
-git push origin v0.2.0
-```
-
-### Step 7: GitHub Releases作成
+マージ後に実行します。
 
 ```bash
-# リリースノートを自動生成
-gh release create v0.2.0 --title "v0.2.0" --generate-notes
+git fetch origin --tags
+MERGE_SHA=$(gh pr view <PR番号> --repo Kewton/CommandMate --json mergeCommit -q '.mergeCommit.oid')
 
-# または、CHANGELOG.mdの内容を使用
-gh release create v0.2.0 --title "v0.2.0" --notes "$(sed -n '/## \[0.2.0\]/,/## \[0.1.0\]/p' CHANGELOG.md | head -n -1)"
+# main と develop の tree が一致していること（内容ドリフトが無いことの証明）
+[ "$(git rev-parse origin/main^{tree})" = "$(git rev-parse origin/develop^{tree})" ] && echo "tree 一致 OK"
+
+git tag -a "v0.10.1" "$MERGE_SHA" -m "v0.10.1"
+git push origin "v0.10.1"
 ```
+
+**annotated タグ（`-a`）**であること。過去のタグは全て annotated です。
+
+### Step 7: GitHub Releases 作成 → npm publish のトリガー
+
+リリースノートは **CHANGELOG の該当セクションを転記**します（`--generate-notes` は v0.9.1 までの形式）。
+
+```bash
+awk '/^## \[0\.10\.1\]/{f=1} /^## \[0\.10\.0\]/{f=0} f' CHANGELOG.md > /tmp/release-notes.md
+
+gh release create "v0.10.1" --repo Kewton/CommandMate \
+  --title "v0.10.1" \
+  --notes-file /tmp/release-notes.md
+```
+
+> ⚠️ **この時点で `publish.yml` が発火し npm publish が始まります。** Release の作成は「npm への公開を実行する」ことと等価です。取り消しは効きません（後述）。
+
+### Step 8: publish ワークフローの完走確認
+
+```bash
+gh run list --repo Kewton/CommandMate --workflow=publish.yml --limit 1
+# status=completed conclusion=success になるまで待つ
+
+npm view commandmate version    # 新バージョンになること
+```
+
+### Step 9: main を develop へマージバック（祖先復元）
+
+**必須。** squash により main のコミットは develop の祖先ではなくなっています。放置すると次回の develop → main PR で幻コンフリクトが出ます。
+
+```bash
+git checkout develop
+git pull origin develop
+git merge -s ours origin/main -m "chore: merge release v0.10.1 to develop (restore ancestry)"
+
+# tree が壊れていないことを検証（-s ours は develop の tree を保持する）
+[ "$(git rev-parse origin/main^{tree})" = "$(git rev-parse develop^{tree})" ] && echo "tree 一致 OK"
+
+git push origin develop
+```
+
+効果を確認します。
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/main origin/develop && echo "祖先切れ解消 OK"
+```
+
+---
+
+## npm への公開について
+
+**`npm publish` を手元で実行しないでください。**
+
+`.github/workflows/publish.yml` が GitHub Release の `published` を契機に、npm Trusted Publishers（OIDC 認証）で `npm publish --provenance --access public` を実行します。
+
+- ローカルには publish 用の認証がありません
+- OIDC は GitHub Actions 実行時にしか成立しません
+- ローカル実行では provenance（来歴証明）が付きません
+
+ワークフローが失敗した場合も、ローカル publish で回避せず、原因を修正してください。
+
+### ワークフローの内容
+
+`npm ci` → `npm audit --audit-level=critical` → `npm run test:unit` → `npm run build` → `npm run build:cli` → `npm run build:server` → パッケージサイズ確認 → `npm publish --provenance --access public`
 
 ---
 
@@ -154,99 +275,93 @@ gh release create v0.2.0 --title "v0.2.0" --notes "$(sed -n '/## \[0.2.0\]/,/## 
 
 ```bash
 # タグ一覧の確認
-git tag -l
+git tag -l --sort=-v:refname | head -3
 
-# 最新タグの確認
-git describe --tags --abbrev=0
+# GitHub Releases の確認
+gh release view v0.10.1
 
-# GitHub Releasesの確認
-gh release list
+# npm の反映確認
+npm view commandmate version
+npm view commandmate@0.10.1 dist --json    # サイズ・provenance
 
-# 特定リリースの詳細確認
-gh release view v0.2.0
+# クリーンな環境で実際に取得できるか（中立ディレクトリで実行すること）
+cd $(mktemp -d) && npx --yes commandmate@latest --version
 ```
+
+> `npx` の検証は**リポジトリ外の中立ディレクトリ**で行ってください。CommandMate のリポジトリ内で実行すると、npx がローカルの `bin` を解決してしまい、公開物を検証したことになりません。
 
 ---
 
 ## Claude Code Skillを使用したリリース
 
-`/release`スキルを使用すると、上記の手順を自動化できます。
+[`/release`](../.claude/skills/release/SKILL.md) スキルを使用すると、上記の手順を実行できます。
 
 ```bash
-# パッチバージョンアップ (0.1.0 → 0.1.1)
-/release patch
-
-# マイナーバージョンアップ (0.1.0 → 0.2.0)
-/release minor
-
-# メジャーバージョンアップ (0.1.0 → 1.0.0)
-/release major
-
-# 直接バージョン指定
-/release 1.0.0
+/release patch      # パッチバージョンアップ (0.10.0 → 0.10.1)
+/release minor      # マイナーバージョンアップ (0.10.0 → 0.11.0)
+/release major      # メジャーバージョンアップ (0.10.0 → 1.0.0)
+/release 1.0.0      # 直接バージョン指定
 ```
 
----
-
-## npm versionコマンド（オプション）
-
-npm versionコマンドを使用すると、バージョン更新とタグ作成を一括で行えます。
-
-```bash
-# パッチバージョンアップ
-npm version patch -m "chore: release v%s"
-
-# マイナーバージョンアップ
-npm version minor -m "chore: release v%s"
-
-# メジャーバージョンアップ
-npm version major -m "chore: release v%s"
-
-# タグをプッシュ
-git push origin main --tags
-```
-
-**注意**: npm versionはCHANGELOG.mdを自動更新しないため、別途更新が必要です。
+スキルも PR のマージは行いません（承認が必須のため）。
 
 ---
 
 ## トラブルシューティング
 
+### main へ push しようとして拒否された
+
+```
+❌ Error: Direct push to 'main' is not allowed.
+   Please create a Pull Request instead.
+```
+
+`.git/hooks/pre-push` による正しい拒否です。**`--no-verify` で回避しないでください。** Step 5 の PR フローに戻ってください。
+
 ### タグが既に存在する場合
 
 ```bash
-# エラー: fatal: tag 'v0.2.0' already exists
-# 対処: 別のバージョンを指定するか、既存タグを削除
-
-# 既存タグの削除（注意: 履歴を書き換えるため慎重に）
-git tag -d v0.2.0
-git push origin :refs/tags/v0.2.0
+# エラー: fatal: tag 'v0.10.1' already exists
+# 対処: 別のバージョンを指定する
 ```
+
+既存タグの削除は、**npm へ publish 済みの場合は無意味**です（下記参照）。
+
+### publish ワークフローが失敗した場合
+
+```bash
+gh run view <run-id> --repo Kewton/CommandMate --log-failed
+```
+
+原因を修正し、新しいパッチバージョンでリリースし直してください。**同一バージョン番号での再公開はできません。**
 
 ### リリースのロールバック
 
-リリース後に重大な問題が発覚した場合：
+> ⚠️ **npm へ publish 済みの場合、実質的にロールバックできません。**
+>
+> - npm は公開済みバージョンの unpublish を厳しく制限しています（72時間以内などの条件付き）
+> - **一度使ったバージョン番号は、unpublish しても再利用できません**
+> - **GitHub Release やタグを削除しても、npm 上のパッケージは消えません**
+>
+> したがって、問題が見つかった場合の正しい対処は **修正して新しいパッチバージョンをリリースする**ことです。
 
-1. **GitHub Releasesの削除**
-   ```bash
-   gh release delete v0.2.0 --yes
-   ```
+publish 前（Release 作成前）であれば、以下で巻き戻せます。
 
-2. **タグの削除**
-   ```bash
-   git tag -d v0.2.0
-   git push origin :refs/tags/v0.2.0
-   ```
+```bash
+git tag -d v0.10.1
+git push origin :refs/tags/v0.10.1
+```
 
-3. **修正後、新しいパッチバージョンでリリース**
-   ```bash
-   /release patch  # v0.2.1 としてリリース
-   ```
+publish 後は、修正後に次のパッチバージョンでリリースしてください。
 
 ---
 
 ## 関連ドキュメント
 
+- [`/release` スキル](../.claude/skills/release/SKILL.md) — 手順の自動化
+- [CHANGELOGエントリテンプレート](../.claude/skills/release/templates/changelog-entry.md)
+- `.github/workflows/publish.yml` — Release 契機の自動 publish（OIDC）
+- `.git/hooks/pre-push` — main 直 push の拒否
 - [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/)
 - [Semantic Versioning](https://semver.org/lang/ja/)
 - [CHANGELOG.md](../CHANGELOG.md)


### PR DESCRIPTION
`/release` スキルと `release-guide` が記述していた手順は、**実際のリリースより2世代前**のものでした。v0.10.1 のリリースを実施する過程で全面的な乖離が判明したため、実態に合わせます。

## なぜズレたか

v0.10.0 で手順が変わっていたのに、ドキュメントが追随していませんでした。

| リリース | PR | マージ形式 |
|---|---|---|
| v0.9.1 (#1202) | `release/v0.9.1 → main` | merge commit |
| **v0.10.0** (#1314) | **`develop → main`** | **squash** |
| **v0.10.1** (#1325) | **`develop → main`** | **squash** |

ドキュメントは v0.9.1 世代（release ブランチ + worktree + `--no-ff`）、`examples` に至っては v0.1.x 世代の記述でした。

## 主な乖離と修正

| | 旧記述 | 実態 |
|---|---|---|
| 基点 | `git checkout main` | **develop 基点** |
| main への反映 | `git push origin main` | **hook が拒否**。PR が唯一の経路 |
| 版上げ | `npm install --package-lock-only` | `npm version --no-git-tag-version`（package-lock の2箇所を同時整合） |
| CHANGELOG | 「比較リンクを追加」 | **追加しない**（`0.5.2` で終了） |
| Issue 表記 | `(Issue #XX)` | **`(#1234)`**（直近3版で 40:7 と新形式が主流） |
| Release ノート | `--generate-notes` | **CHANGELOG セクション転記**（v0.10.0 以降） |
| タグ | `git tag v0.2.0`（lightweight） | **annotated（`-a`）**（既存タグは全て annotated） |
| **npm publish** | **記載なし** | **Release 契機で自動（OIDC / provenance）** |
| **マージバック** | **記載なし** | **必須**（`-s ours` + tree 一致検証） |

### 特に重大だった2点

**1. main 直 push を前提にしていた**

`.git/hooks/pre-push` が `protected_branch='main'` で拒否するため、旧手順どおりに実行すると必ず失敗します。旧 `examples` はこれを**成功例として掲載**していました。

**2. npm publish の記載が一切なかった**

実際は `.github/workflows/publish.yml` が GitHub Release の `published` を契機に OIDC で自動 publish します。つまり **「Release の作成 = npm への公開」** です。これを知らずに Release を作ると、確認なしに公開が走ります。

あわせて**ローカルでの `npm publish` を禁止事項**として明記しました（OIDC は CI 内でしか成立せず、provenance も付きません）。

## ロールバック手順の訂正（最も危険だった誤り）

旧ガイドは以下を「ロールバック」として提示していました。

```
1. GitHub Releases の削除 → 2. タグの削除 → 3. 修正後リリース
```

しかし **GitHub Release やタグを消しても npm 上のパッケージは消えません**。npm は unpublish を厳しく制限しており、一度使ったバージョン番号は再利用できません。旧手順どおりに操作すると「ロールバックした」と誤認したまま、問題のあるパッケージが npm に残り続けます。

publish 済みの場合の正しい対処は **「修正して次のパッチをリリース」** であることを明記しました。

## 追加した内容

- **リリースフロー全体像**の図と「押さえるべき3つの前提」（hook・Release=publish・マージバック必須）を冒頭に配置。個々のコマンドより先に**なぜこの形か**が分かるようにした
- **`npx` 検証の落とし穴**: リポジトリ内で `npx commandmate@latest` を実行すると npx がローカルの `bin` を解決するため、公開物の検証にならない。中立ディレクトリで行うよう明記
- `examples` を実際に行った **v0.10.1 の記録**に差し替え（`git stash` を勧めていた箇所も削除。稼働中エージェントの作業を破損させるため）
- `templates` を実書式に（conventional prefix 必須、`Highlight` 行の書き方）

## その他

- `SKILL.md` のリリースガイドへのリンクが `../../docs/` で `.claude/docs/` を指す**壊れたパス**だったため修正
- worktree + エージェント委譲フェーズを削除（実際のリリースで使われておらず、3ファイルの機械的変更に対して過剰）

## 検証

- **ja / en 同期**: 27見出し・38コードブロックが完全一致
- **相対リンク**: 両版とも全て解決することを確認
- **旧手順の残存**: 0件（`--generate-notes` の言及は「これは旧形式」と説明する散文）

| 項目 | 結果 |
|---|---|
| npm run lint | Pass |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass (581 files / 9888 tests) |
| CLAUDE.md size | 17,804 bytes（上限 35,000） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
