### PR TITLE
feat(website): Track A を可視化しチュートリアル導線を追加する (#1327)

### DIFF
--- a/docs/en/user-guide/tutorial.md
+++ b/docs/en/user-guide/tutorial.md
@@ -1,0 +1,169 @@
+[日本語版](../../user-guide/tutorial.md)
+
+# Tutorial
+
+Use a sample repository with two bugs left in on purpose to work through the core of CommandMate in about ten minutes.
+
+- Sample repository: [Kewton/commandmate-tutorial](https://github.com/Kewton/commandmate-tutorial)
+- It has zero dependencies. There is no `npm install` step — `npm test` and `npm start` work on their own
+
+This document follows the four steps in the sample repository's README, and adds the **CommandMate screen operations** around them.
+
+---
+
+## Prerequisites
+
+- CommandMate is running (if not: `npx commandmate@latest`)
+- Node.js 22 or later
+- One agent CLI: Claude Code, Codex, or Antigravity
+
+---
+
+## What you will use
+
+| Step | CommandMate feature |
+|------|---------------------|
+| 1 | Clone a repository into the managed root |
+| 2 | Run an agent CLI in a session, from any browser |
+| 3 | External Apps — proxy your dev server through CommandMate |
+| 4 | One session per worktree, running in parallel |
+
+---
+
+## Step 1: Clone the repository
+
+You can clone straight from the CommandMate UI.
+
+1. Open the **Repositories** screen
+2. Click **Add Repository**
+3. Choose the **Clone URL** tab
+4. Paste this URL and click **Clone**
+
+```
+https://github.com/Kewton/commandmate-tutorial.git
+```
+
+It lands inside CommandMate's managed root (`CM_ROOT_DIR`) and shows up in the list as a session.
+
+> **Note**: CommandMate refuses to register paths outside the managed root. The worktree you create in Step 4 has to live under that root too.
+
+---
+
+## Step 2: Let an agent fix a failing test
+
+Two tests in this repository **fail on purpose**.
+
+```bash
+npm test
+```
+
+```
+✖ greet ends with an exclamation mark
+    actual:   'Hello, World'
+    expected: 'Hello, World!'
+✖ shout uppercases the greeting
+    Error: shout() is not implemented yet
+```
+
+Open the session and ask your agent:
+
+> `npm test` fails. Fix the first failure only, then run the tests again.
+
+The fix is one character in `src/greet.js`. The point is not the difficulty — it is **watching the agent run the tests, change the code, and re-run them from your browser (or your phone)**.
+
+Leave the second failure (`shout()` is not implemented) alone for now: Step 4 uses it.
+
+---
+
+## Step 3: See the change in the browser
+
+Start the app:
+
+```bash
+npm start
+```
+
+It listens on **port 4173**. Register it so CommandMate can serve it for you.
+
+1. Open External Apps on the **More** screen
+2. Add an app with these values:
+
+| Field | Value |
+|-------|-------|
+| Display Name | `Tutorial` |
+| Identifier Name | `tutorial` |
+| Path Prefix | `tutorial` |
+| Port Number | `4173` |
+| App Type | `Other` |
+
+3. Turn on **App is enabled** and save
+
+It is now reachable at `/proxy/tutorial/`. No separate tab on a raw port, and the same URL works from your phone.
+
+The heading on the page comes from the `greet()` you fixed in Step 2:
+
+- Before: `Hello, CommandMate`
+- After: `Hello, CommandMate!`
+
+That is the loop: **an agent changes code → you see the result.**
+
+> **Security**: proxied apps run under the CommandMate origin and can access CommandMate APIs. Only register applications you trust.
+
+---
+
+## Step 4: Go parallel with a worktree
+
+CommandMate runs **one session per git worktree**, side by side. It does not *create* worktrees, though — it *discovers* existing ones and registers them. So have your agent create it.
+
+### Claude Code / Codex
+
+A `worktree-new` skill ships with the sample repository:
+
+```
+/worktree-new fix/shout
+```
+
+### Antigravity
+
+The `worktree-new` skill is verified on Claude Code (`.claude/skills/`) and Codex (`.agents/skills/`), but is **unverified on Antigravity**. Paste this instead:
+
+> Create a git worktree for a new branch `fix/shout`.
+> Put it next to this repository, as a sibling directory named
+> `commandmate-tutorial-fix-shout`, using
+> `git worktree add -b fix/shout ../commandmate-tutorial-fix-shout`.
+> Stop if that directory already exists. Print the path you created.
+> Do not use `--force`.
+
+### Let CommandMate pick it up
+
+1. Open the **Repositories** screen
+2. Click **Sync All**
+
+The new worktree appears as a second session. Ask *that* session to implement `shout()` — the second failing test you left alone — while the first session stays where it is.
+
+**Two branches, two agents, one browser.**
+
+---
+
+## Notes
+
+- The worktree must live **inside CommandMate's managed root**. A sibling of this repository is inside it
+- Antigravity's non-interactive mode (`agy --print`) **times out silently** on a trust dialog the first time it runs in a new project. Answer it once in interactive mode, or pass `--dangerously-skip-permissions` if you understand what it skips
+
+---
+
+## Cleaning up
+
+```bash
+git worktree remove ../commandmate-tutorial-fix-shout
+```
+
+Then remove the repository from the **Repositories** screen, and remove `tutorial` from External Apps on the **More** screen.
+
+---
+
+## Next steps
+
+- [Quick Start Guide](./quick-start.md) - A development flow using slash commands and agents
+- [CLI Setup Guide](./cli-setup-guide.md) - Installation and configuration details
+- [Workflow Examples](./workflow-examples.md) - Practical usage examples

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -1,0 +1,168 @@
+[English](../en/user-guide/tutorial.md)
+
+# チュートリアル
+
+わざとバグを2つ残したサンプルリポジトリを使って、CommandMate の中核を10分ほどで一通り体験します。
+
+- サンプルリポジトリ: [Kewton/commandmate-tutorial](https://github.com/Kewton/commandmate-tutorial)
+- 依存パッケージはゼロです。`npm install` は不要で、`npm test` と `npm start` がそのまま動きます
+
+このドキュメントは、サンプルリポジトリの README に書かれた4ステップの流れに、**CommandMate 側の画面操作**を補ったものです。
+
+---
+
+## 前提条件
+
+- CommandMate が起動していること（まだなら `npx commandmate@latest`）
+- Node.js 22 以上
+- エージェント CLI がいずれか1つ使えること（Claude Code / Codex / Antigravity）
+
+---
+
+## このチュートリアルで体験すること
+
+| ステップ | 体験する CommandMate の機能 |
+|---------|---------------------------|
+| 1 | リポジトリのクローンと管理ルートへの登録 |
+| 2 | セッション上でのエージェント CLI 実行（ブラウザ／スマホから） |
+| 3 | External Apps による開発サーバーのプロキシ |
+| 4 | worktree ごとのセッション並列実行 |
+
+---
+
+## Step 1: リポジトリをクローンする
+
+CommandMate の画面から直接クローンできます。
+
+1. **リポジトリ** 画面を開く
+2. **リポジトリを追加** をクリック
+3. **クローン URL** タブを選ぶ
+4. 次の URL を貼り付けて **クローン** を実行
+
+```
+https://github.com/Kewton/commandmate-tutorial.git
+```
+
+クローン先は CommandMate の管理ルート（`CM_ROOT_DIR`）配下になり、完了するとセッションとして一覧に現れます。
+
+> **補足**: CommandMate は管理ルート外のパスを登録できません。この後 Step 4 で作る worktree も、必ずルート配下に置く必要があります。
+
+---
+
+## Step 2: 失敗するテストをエージェントに直させる
+
+このリポジトリでは、テストが**わざと2つ失敗**します。
+
+```bash
+npm test
+```
+
+```
+✖ greet ends with an exclamation mark
+    actual:   'Hello, World'
+    expected: 'Hello, World!'
+✖ shout uppercases the greeting
+    Error: shout() is not implemented yet
+```
+
+セッションを開き、エージェントに次のように指示します。
+
+> `npm test` が失敗します。1つ目の失敗だけを修正して、もう一度テストを実行してください。
+
+修正内容は `src/greet.js` の1文字だけです。狙いは難易度ではなく、**エージェントがテストを実行し、コードを直し、再実行する流れをブラウザ（やスマホ）から眺められること**にあります。
+
+2つ目の失敗（`shout()` 未実装）は Step 4 で使うので、ここでは残しておきます。
+
+---
+
+## Step 3: 変更をブラウザで確認する
+
+アプリを起動します。
+
+```bash
+npm start
+```
+
+**ポート 4173** で待ち受けます。これを CommandMate 経由で開けるように登録します。
+
+1. **その他** 画面の External Apps を開く
+2. アプリを追加し、次のように入力する
+
+| 項目 | 値 |
+|------|-----|
+| 表示名 | `Tutorial` |
+| 識別名 | `tutorial` |
+| パスプレフィックス | `tutorial` |
+| ポート番号 | `4173` |
+| アプリ種別 | `Other` |
+
+3. **アプリを有効にする** をオンにして保存
+
+`/proxy/tutorial/` で開けるようになります。別タブでポートを直接開く必要はなく、スマホからも同じ URL で見られます。
+
+ページの見出しは Step 2 で直した `greet()` の戻り値です。
+
+- 修正前: `Hello, CommandMate`
+- 修正後: `Hello, CommandMate!`
+
+これが **エージェントがコードを変える → その結果を自分の目で確認する** というループです。
+
+> **セキュリティ**: プロキシしたアプリは CommandMate と同一オリジンで動作し、CommandMate の API にアクセスできます。信頼できるアプリだけを登録してください。
+
+---
+
+## Step 4: worktree で並列作業にする
+
+CommandMate は **worktree 1つにつきセッション1つ**を割り当て、並べて動かします。ただし worktree を**作る**のは CommandMate ではありません。CommandMate は既存の worktree を**見つけて登録する**だけなので、作成はエージェントに任せます。
+
+### Claude Code / Codex の場合
+
+サンプルリポジトリに `worktree-new` スキルが同梱されています。
+
+```
+/worktree-new fix/shout
+```
+
+### Antigravity の場合
+
+`worktree-new` スキルは Claude Code（`.claude/skills/`）と Codex（`.agents/skills/`）で動作確認済みですが、**Antigravity では未確認**です。代わりに次の指示文を貼り付けてください。
+
+> `fix/shout` という新しいブランチ用の git worktree を作成してください。
+> このリポジトリの隣に `commandmate-tutorial-fix-shout` という名前の兄弟ディレクトリとして、
+> `git worktree add -b fix/shout ../commandmate-tutorial-fix-shout` で作成します。
+> そのディレクトリが既に存在する場合は中断してください。作成したパスを表示してください。
+> `--force` は使わないでください。
+
+### worktree を CommandMate に認識させる
+
+1. **リポジトリ** 画面を開く
+2. **すべて同期** を実行
+
+新しい worktree が2つ目のセッションとして現れます。そのセッションに、残しておいた2つ目の失敗（`shout()` の実装）を指示してください。1つ目のセッションはそのまま維持されます。
+
+**2ブランチ、2エージェント、ブラウザ1つ。**
+
+---
+
+## 注意点
+
+- worktree は **CommandMate の管理ルート配下**に置く必要があります。このリポジトリの兄弟ディレクトリはルート配下に収まります
+- Antigravity の非対話モード（`agy --print`）は、新しいプロジェクトの初回実行時にトラストダイアログで**無言のままタイムアウト**します。一度対話モードで承認するか、内容を理解した上で `--dangerously-skip-permissions` を渡してください
+
+---
+
+## 後片付け
+
+```bash
+git worktree remove ../commandmate-tutorial-fix-shout
+```
+
+そのあと **リポジトリ** 画面からリポジトリを削除し、**その他** 画面の External Apps から `tutorial` を削除してください。
+
+---
+
+## 次のステップ
+
+- [クイックスタートガイド](./quick-start.md) - スラッシュコマンドとエージェントを使った開発フロー
+- [CLI セットアップガイド](./cli-setup-guide.md) - インストールと設定の詳細
+- [ワークフロー例](./workflow-examples.md) - 実践的な使用例

--- a/tests/unit/website/landing-page.test.ts
+++ b/tests/unit/website/landing-page.test.ts
@@ -56,19 +56,51 @@ function extractRefs(html: string): string[] {
 const isExternal = (ref: string) =>
   /^(https?:)?\/\//.test(ref) || ref.startsWith('mailto:') || ref.startsWith('#');
 
+interface CopyableBox {
+  id: string;
+  text: string;
+  /** Marked `.install-url`: pasted into the CommandMate UI, not into a shell. */
+  isUrl: boolean;
+}
+
 /**
- * The shell commands the page offers a working copy button for, as command text.
- * A command box only counts if a `.copy-btn` actually targets its id — markup
- * that renders a command without wiring the button is what this catches.
+ * Every `.install-cmd` box the page offers a working copy button for. A box only
+ * counts if a `.copy-btn` actually targets its id — markup that renders a
+ * command without wiring the button is what this catches.
+ *
+ * The class match is deliberately open-ended (`install-cmd[^"]*`): pinning it to
+ * exactly `class="install-cmd"` meant any added modifier dropped the box out of
+ * this sweep silently, which is a guard that passes by going blind.
  */
-function copyableCommands(html: string): string[] {
+function copyableBoxes(html: string): CopyableBox[] {
   const targeted = new Set(
     Array.from(html.matchAll(/data-copy-target="([^"]+)"/g), (match) => match[1]),
   );
 
-  return Array.from(html.matchAll(/<code class="install-cmd" id="([^"]+)">([^<]+)<\/code>/g))
-    .filter(([, id]) => targeted.has(id))
-    .map(([, , command]) => command.trim());
+  return Array.from(html.matchAll(/<code class="(install-cmd[^"]*)" id="([^"]+)">([^<]+)<\/code>/g))
+    .filter(([, , id]) => targeted.has(id))
+    .map(([, classes, id, text]) => ({
+      id,
+      text: text.trim(),
+      isUrl: classes.split(/\s+/).includes('install-url'),
+    }));
+}
+
+/** The shell commands the page offers a working copy button for, as command text. */
+function copyableCommands(html: string): string[] {
+  return copyableBoxes(html)
+    .filter((box) => !box.isUrl)
+    .map((box) => box.text);
+}
+
+/** Track A's card, i.e. everything the `Just try it` track renders. */
+function trackAMarkup(): string {
+  const article = readIndexHtml().match(
+    /<article class="track" aria-labelledby="track-try-h">[\s\S]*?<\/article>/,
+  );
+
+  expect(article, 'Track A card not found in index.html').not.toBeNull();
+  return article![0];
 }
 
 describe('Issue #1200: landing page structure', () => {
@@ -269,6 +301,66 @@ describe('Issue #1316/#1317: quick start tracks', () => {
 
     expect(html).toMatch(/commandmate stop/);
     expect(html).toMatch(/commandmate status/);
+  });
+});
+
+/**
+ * Issue #1327 — Track A was a prose sentence next to Track B's numbered steps,
+ * so it read as the thinner option when it is in fact the whole flow automated.
+ * It now lists what `npx commandmate@latest` runs (src/cli/commands/quickstart.ts:
+ * preflight -> init on first run -> start --daemon -> wait -> open browser).
+ *
+ * The list describes work the command already does, so it must not grow copy
+ * buttons: a reader who copies them runs an `init` they do not need, and a
+ * `start --daemon` out of npm's `_npx` cache — the fragile form #1318 removed
+ * from the docs. Track A earns its place by being one command; this is the test
+ * that keeps it one.
+ */
+describe('Issue #1327: Track A shows what its one command does', () => {
+  it('still offers exactly one copyable command', () => {
+    expect(copyableCommands(trackAMarkup())).toEqual(['npx commandmate@latest']);
+  });
+
+  it('enumerates the automated steps, rather than burying them in prose', () => {
+    // steps-stack is Track B's list markup: the point of the Issue was that the
+    // two tracks should carry the same weight.
+    const list = trackAMarkup().match(/<ol class="steps steps-stack">([\s\S]*?)<\/ol>/);
+
+    expect(list, 'Track A renders no steps-stack list').not.toBeNull();
+    expect(list![1].match(/<li>/g) ?? []).toHaveLength(4);
+  });
+});
+
+/**
+ * Issue #1329 — the LP sends a reader to a running server and stops there, with
+ * nothing to point the agent at. The tutorial repo is that something. The URL is
+ * pasted into the Repositories screen rather than a shell, so what matters is
+ * that it is copyable at all — an uncopyable URL means transcribing it by hand,
+ * which is the whole reason the copy buttons exist.
+ */
+describe('Issue #1329: tutorial entry point', () => {
+  const TUTORIAL_CLONE_URL = 'https://github.com/Kewton/commandmate-tutorial.git';
+
+  it('wires a copy button to the tutorial clone URL', () => {
+    const box = copyableBoxes(readIndexHtml()).find((b) => b.text === TUTORIAL_CLONE_URL);
+
+    expect(box, `no copy-wired box renders ${TUTORIAL_CLONE_URL}`).toBeDefined();
+  });
+
+  it('marks the clone URL as a URL, so it renders without a shell prompt', () => {
+    // .install-cmd::before prepends "$ ", which would present the URL as a
+    // command to run. .install-url is what suppresses it (styles.css).
+    const box = copyableBoxes(readIndexHtml()).find((b) => b.text === TUTORIAL_CLONE_URL);
+
+    expect(box?.isUrl).toBe(true);
+  });
+
+  it('links out to the tutorial rather than inlining its steps', () => {
+    // The LP has no build step, so every step spelled out here is one more thing
+    // to keep in sync by hand with the doc that already carries it.
+    expect(readIndexHtml()).toMatch(
+      /href="https:\/\/github\.com\/Kewton\/CommandMate\/blob\/main\/docs\/en\/user-guide\/tutorial\.md"/,
+    );
   });
 });
 

--- a/website/index.html
+++ b/website/index.html
@@ -130,8 +130,8 @@
             <p class="track-tag">Track A</p>
             <h3 id="track-try-h">Just try it</h3>
             <p class="track-lede">
-              One command, nothing installed first. It checks your dependencies, walks you through
-              setup, starts the server, and opens your browser.
+              One command, nothing installed first. There is nothing else to type — it runs all
+              four steps below for you.
             </p>
             <div class="install install-sm">
               <code class="install-cmd" id="try-cmd">npx commandmate@latest</code>
@@ -139,9 +139,30 @@
                 <span data-copy-label>Copy</span>
               </button>
             </div>
+            <!-- What the one command above actually does, in order, per
+                 src/cli/commands/quickstart.ts. These steps deliberately carry no
+                 copy buttons: they are not a checklist to work through, and giving
+                 them one would read as "run these too". -->
+            <ol class="steps steps-stack">
+              <li>
+                <h4>Checks your dependencies</h4>
+                <p>Node.js, npm, git and tmux. Stops with an install hint if one is missing.</p>
+              </li>
+              <li>
+                <h4>Asks the setup questions</h4>
+                <p>Repository root, port, external access, database path.</p>
+              </li>
+              <li>
+                <h4>Starts the server in the background</h4>
+                <p>Then waits until it actually answers.</p>
+              </li>
+              <li>
+                <h4>Opens your browser</h4>
+                <p>At <code>http://localhost:3000</code>, once the server is ready.</p>
+              </li>
+            </ol>
             <p class="track-note">
-              The questions are first-run only. Run it again later and it goes straight to the UI at
-              <code>http://localhost:3000</code>.
+              Step 2 is first-run only. Run it again later and it goes straight to the UI.
             </p>
           </article>
 
@@ -192,7 +213,30 @@
         </p>
       </section>
 
-      <!-- 4. Screenshot gallery -->
+      <!-- 4. Tutorial -->
+      <section class="section" id="tutorial" aria-labelledby="tutorial-h">
+        <h2 id="tutorial-h">Then try it on a real repository</h2>
+        <p class="section-lede">
+          A small repo with two failing tests left in on purpose. Hand it to an agent and you
+          will have used the whole loop — a session, a proxied dev server, and two worktrees
+          running side by side — in about ten minutes.
+        </p>
+
+        <div class="install install-sm install-wide">
+          <code class="install-cmd install-url" id="tutorial-clone-url">https://github.com/Kewton/commandmate-tutorial.git</code>
+          <button type="button" class="copy-btn" data-copy-target="tutorial-clone-url">
+            <span data-copy-label>Copy</span>
+          </button>
+        </div>
+
+        <p class="tutorial-note">
+          Paste it into <strong>Repositories → Add Repository → Clone URL</strong>, then follow the
+          <a href="https://github.com/Kewton/CommandMate/blob/main/docs/en/user-guide/tutorial.md">four-step tutorial</a>.
+          No install, no dependencies.
+        </p>
+      </section>
+
+      <!-- 5. Screenshot gallery -->
       <section class="section" aria-labelledby="gallery-h">
         <h2 id="gallery-h">On desktop and on mobile</h2>
         <p class="section-lede">
@@ -239,7 +283,7 @@
         </div>
       </section>
 
-      <!-- 5. Comparison -->
+      <!-- 6. Comparison -->
       <section class="section" id="comparison" aria-labelledby="comparison-h">
         <h2 id="comparison-h">How it compares</h2>
         <div class="table-scroll" tabindex="0" role="region" aria-labelledby="comparison-h">
@@ -324,7 +368,7 @@
       </section>
     </main>
 
-    <!-- 6. Footer -->
+    <!-- 7. Footer -->
     <footer class="site-footer">
       <div class="footer-inner">
         <div class="footer-brand">

--- a/website/styles.css
+++ b/website/styles.css
@@ -517,6 +517,27 @@ a {
   }
 }
 
+/* ---------- tutorial ---------- */
+
+/* Must stay after `.install-sm`: same specificity, so source order decides. The
+   clone URL is the one thing this section hands over, and at 20rem half of it
+   would sit behind a scroll. */
+.install-wide {
+  max-width: 34rem;
+}
+
+/* A URL, not a shell command — it goes into the Repositories screen, so the
+   `$ ` prompt the other boxes carry would be telling the reader to run it. */
+.install-cmd.install-url::before {
+  content: none;
+}
+
+.tutorial-note {
+  margin: 0.9rem 0 0;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
 /* ---------- gallery ---------- */
 
 .gallery {


### PR DESCRIPTION
対応 Issue: #1327 / #1329

LP の quick start 周辺と `landing-page.test.ts` を共有するため、2件を1PRに束ねました。

## #1327: Track A に自動実行される内容を可視化

Track A は `npx commandmate@latest` の1行だけで、3ステップが並ぶ Track B に比べて何が起きるか分からない状態でした。**内部で何を自動実行するか**を表示して情報量を揃えます。

**copy 可能なコマンドは `npx commandmate@latest` の1つのまま**です（増やしていません）。理由:

- `npx commandmate@latest` は init も daemon 起動も自動実行する（`quickstart.ts:90-92` / `:122`）。コマンドを並べると「この3つを順に実行するもの」と誤解させ、不要な操作を促す
- `npx commandmate@latest start --daemon` は npm キャッシュ配下から daemon を起動する構造的に脆い形で、#1318 で docs から削除したばかり。LP で推奨に戻すのは矛盾する

## #1329: チュートリアル導線

quick start の直後に軽いセクションを1つ追加し、サンプルリポジトリの clone URL を copy 可能にしました。手順の詳細は LP に書かず `docs/user-guide/tutorial.md` へリンクしています（LP はビルドなしの静的サイトなので肥大させない方針）。

### サンプルリポジトリ

**https://github.com/Kewton/commandmate-tutorial** （public / MIT、作成・検証済み）

依存ゼロの最小 Web アプリに、意図的に2つのバグを仕込んであります。クリーンな clone から実測済み:

- `npm install` **不要**（`node:test` 使用）
- `npm test` → exit 1 で2件失敗（`greet` の `!` 欠落、`shout` 未実装）
- `npm start` → port 4173 で HTTP 200
- **`greet()` を直すと見出しが `Hello, CommandMate` → `Hello, CommandMate!` に変わる** ← External Apps 体験の核

### チュートリアルの流れ

```
Step 1  clone            Repositories 画面に URL を貼る
Step 2  直させる          エージェントに「失敗するテストを直して」
Step 3  ブラウザで見る     External Apps に登録 → 修正結果が画面に映る
Step 4  並列化            エージェントに worktree を作らせる → 2セッション並列
```

### エージェント CLI 対応（実測）

| CLI | 配置 | 結果 |
|---|---|---|
| Claude Code | `.claude/skills/worktree-new/SKILL.md` | ✅ 動作確認済み |
| Codex | `.agents/skills/worktree-new/SKILL.md` | ✅ 動作確認済み |
| Antigravity | `.agents/skills.json` + `.agents/skills/` | ❌ 未確認 → README に代替の指示文 |

## 検証

### #1328 との整合（Phase 4 設計突合）

#1328 が `CM_ROOT_DIR` の定義を「管理範囲」に統一しており、本 PR のチュートリアルと**用語が一致**することを確認しました。

```
#1328: "Managed repository directory: the scope CommandMate is allowed to manage"
#1329: "CommandMate の管理ルート（CM_ROOT_DIR）配下" / "CommandMate's managed root"
```

チュートリアルは #1328 が削除する③自動発見に**一切依存していません**（言及ゼロ）。

### copy ボタンの結線

全7個の `data-copy-target` に対応する `id` が実在することを確認済み。

### 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass (581 files / 9893 tests) |
| npm run build | Pass |

品質ゲートは**本番サーバーの実行ディレクトリではなく worktree 側**で実行しました（稼働中サーバーの `.next/` 差し替えによる画面破壊を避けるため）。本番 3000 が無傷であることも確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
