### PR TITLE
fix(clone): git spawn に cwd を明示しクローン失敗（exit 128）を解消する

### DIFF
--- a/src/lib/git/clone-manager.ts
+++ b/src/lib/git/clone-manager.ts
@@ -421,8 +421,12 @@ export class CloneManager {
 
     return new Promise<void>((resolve, reject) => {
       // Spawn git clone process
+      // Issue #1334: cwd を省略するとサーバープロセスの cwd を継承する。npx 起動時の cwd は
+      // npm キャッシュ配下であり、消滅すると git が起動時に cwd を読めず exit 128 で失敗する。
+      // 直前に存在を保証した parentDir を明示する。
       const gitProcess = spawn('git', ['clone', '--progress', cloneUrl, targetPath], {
         stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: parentDir,
       });
 
       this.activeProcesses.set(jobId, gitProcess);

--- a/tests/unit/lib/clone-manager.test.ts
+++ b/tests/unit/lib/clone-manager.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { spawn, type ChildProcess } from 'child_process';
 import Database from 'better-sqlite3';
 import { runMigrations } from '@/lib/db/db-migrations';
 import { CloneManager, CloneManagerError, resetWorktreeBasePathWarning, resolveCustomTargetPath } from '@/lib/git/clone-manager';
@@ -312,6 +314,49 @@ describe('CloneManager', () => {
       expect(status?.error).toBeDefined();
       expect(status?.error?.category).toBe('auth');
       expect(status?.error?.code).toBe('AUTH_FAILED');
+    });
+  });
+
+  describe('executeClone', () => {
+    // Issue #1334: cwd 未指定だとサーバープロセスの cwd を継承する。npx 起動時の cwd は
+    // npm キャッシュ配下で、消滅すると git clone が exit 128 で失敗する。
+    function stubGitProcess(): EventEmitter & { stderr: EventEmitter; pid: number } {
+      const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter; pid: number };
+      proc.stderr = new EventEmitter();
+      proc.pid = 4242;
+      vi.mocked(spawn).mockReturnValue(proc as unknown as ChildProcess);
+      return proc;
+    }
+
+    // spawn の引数は clone の成否より前に確定するため、後片付けの要らない失敗パスで確認する
+    // （成功パスは scanWorktrees が mock 済み exec を待ち続けて解決しない）。
+    async function runCloneAndCaptureSpawnOptions(targetPath: string): Promise<{ cwd?: string }> {
+      const proc = stubGitProcess();
+      const cloneUrl = 'https://github.com/test/repo.git';
+      const job = createCloneJob(db, {
+        cloneUrl,
+        normalizedCloneUrl: 'https://github.com/test/repo',
+        targetPath,
+      });
+
+      const promise = cloneManager.executeClone(job.id, cloneUrl, targetPath);
+      proc.emit('close', 1);
+      await expect(promise).rejects.toBeInstanceOf(CloneManagerError);
+
+      return vi.mocked(spawn).mock.calls[0][2] as { cwd?: string };
+    }
+
+    it('should spawn git with cwd set to the target parent directory', async () => {
+      const options = await runCloneAndCaptureSpawnOptions('/tmp/repos/repo');
+
+      expect(options.cwd).toBe('/tmp/repos');
+    });
+
+    it('should set cwd for nested target paths rather than inheriting the server process cwd', async () => {
+      const options = await runCloneAndCaptureSpawnOptions('/tmp/repos/group/nested');
+
+      expect(options.cwd).toBe('/tmp/repos/group');
+      expect(options.cwd).not.toBe(process.cwd());
     });
   });
 


### PR DESCRIPTION
## 概要

`npx commandmate@latest` で起動した環境からクローンすると `exit 128` で失敗する問題を修正します。**v0.10.2 で公開したチュートリアルの Step 1 がこれで止まっており、新規ユーザーが最初に触る導線が機能していません。**

```
Git clone failed (exit code 128): Cloning into '/Users/<user>/repos/commandmate-tutorial'...
fatal: Unable to read current working directory: No such file or directory
fatal: remote helper 'https' aborted session
```

Refs #1334

## 原因

`executeClone` が **`cwd` を指定せずに git を spawn** していたため、子プロセスがサーバープロセスの cwd を継承していました。

`npx` 起動時のサーバーの cwd は **npm キャッシュ配下**（`daemon.ts:126` の `cwd: packageRoot`）です。`npx commandmate@latest` の再実行で同一 hash の `node_modules` が作り直されると、稼働中サーバーの cwd は削除済み inode を指したままになります。git は起動時に cwd を読もうとして失敗します。**クローン先が絶対パスであっても関係なく落ちます。**

`mkdirSync(parentDir)` はクローン**先**の親を作るだけで、サーバー自身の cwd とは無関係です。

## 変更

直前に存在を保証している `parentDir` を `cwd` として明示します。

```diff
   const gitProcess = spawn('git', ['clone', '--progress', cloneUrl, targetPath], {
     stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: parentDir,
   });
```

## なぜ clone-manager だけなのか

`src/lib/git/` の git 実行は `git-exec.ts` の `execFileAsync` に集約されており、**全経路が `cwd` を渡しています**（`git-exec.ts:58,91,261,322` / `git-diff.ts:100` / `git-log.ts:200` / `worktrees.ts:175` / `github-api.ts:60`）。

**`clone-manager.ts` だけが `git-exec.ts` を経由せず生の `spawn` を直接呼んでおり、唯一の例外でした。**

## 他の cwd 未指定箇所は問題なし（実測で確認）

当初「同種の欠陥が他にもあるはず」と見立てましたが、`src/` 全体を洗い出して**親の cwd を削除した状態で実測**した結果、影響を受けるのは git clone だけでした。

| 呼び出し | 箇所 | cwd 指定 | 結果 |
|---|---|---|---|
| `git clone` | `clone-manager.ts:424` | **なし** | ❌ **exit 128** |
| `git --version` | — | なし | ✅ 成功 |
| `ps -eo` | `resource-cleanup.ts:137` | なし | ✅ 成功 |
| `gh --version` | `copilot.ts:76` / `github-api.ts:30` | なし | ✅ 成功 |
| `tmux list-sessions` | `tmux-control-client.ts:42` | なし | ✅ 成功 |
| `process.cwd()` | `update/route.ts:100` | — | ✅ throw しない |

**「cwd 未指定＝危険」ではありません。** `git --version` すら成功します。`clone` はリポジトリ探索のため cwd を実際に読みますが、`--version` は読みません。`tmux new-session` は `-c workingDirectory` を明示済み（`tmux.ts:297`）です。

詳細は #1334 に記録しました。

## 検証

### 実 git での再現と修正確認

親プロセスの cwd を削除した状態で、`clone-manager.ts:424` と同じ形の spawn を実行：

```
修正前 (cwd なし):        exit=128
修正後 (cwd: parentDir):  exit=0   clone成功=true
```

### 追加テスト

`executeClone` のテストが存在しなかったため新設しました（`spawn` は mock 済みだが未アサートでした）。

- `should spawn git with cwd set to the target parent directory`
- `should set cwd for nested target paths rather than inheriting the server process cwd`

**ガードが実際に効くことを確認済み**: `cwd: parentDir` を外すと 2 件とも FAIL、戻すと PASS します。

> spawn の引数は clone の成否より前に確定するため、テストは後片付けの要らない失敗パスで確認しています（成功パスは `scanWorktrees` が mock 済み `exec` を待ち続けて解決しないため）。「cwd 消滅下で実際に成功する」ことは上記の実 git 検証で担保しており、テストランナー自身の cwd を削除する自動テストは行っていません。

### 品質チェック（worktree で実行）

| 項目 | 結果 |
|---|---|
| npm run lint | Pass（0 errors / 既存の warning 4 件のみ） |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass（**9912 tests** / 9910 → +2） |
| npm run build | Pass |

## 残る留意点

- `browser.ts:56`（`open` / `xdg-open`）は cwd 未指定です。URL を開くだけで cwd を読まないため問題ないと考えられますが、**個別の実測はしていません**（本 PR の対象外）。
- 実機での `npx commandmate@latest` → チュートリアル clone の確認は、リリース後に可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
