### PR TITLE
fix(db): 将来版スキーマの DB を検知して起動を停止する (#1353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(db): **将来版スキーマの DB を検知して起動を停止する** (#1353)。`runMigrations()` は `migration.version > currentVersion` で前進のみを見ており、DB の `MAX(schema_version)` が `CURRENT_SCHEMA_VERSION`（現在 42）を**超えていても「Schema is up to date」と判断してそのまま開いていた**。新版が DB を進めた後に旧ビルド（古い dev チェックアウト / PATH に残った旧 global / npx キャッシュ / `CM_DB_PATH` 共有の worktree サーバー）が同じ DB を開くと、起動は成功し、改名・削除済みカラム前提のクエリが**実行時に**診断困難な 500 として初めて表面化していた。版読み取り後・マイグレーション書き込み前にガードを置き、版・対応上限・復旧手段（`commandmate update`）を明示したエラーで起動を止める。あわせて `getDbInstance()` が **`runMigrations()` より前に singleton を代入していた**問題を修正した。マイグレーションが throw しても未検証の接続が module-level キャッシュに残るため、最初の呼び出し元だけがエラーを見て**以降の呼び出し元には同じ DB がエラーなしで返っており**、ガードは一度だけ発火してプロセスの残りの間バイパスされる状態だった。スキーマ検証後にのみ代入し、失敗時は接続を閉じて再 throw する
+
 ## [0.10.3] - 2026-07-17
 
 > **Highlight**: **v0.10.2 で公開したチュートリアルの Step 1 が動作しない問題を修正するパッチリリース**。`npx commandmate@latest` で起動した環境では、リポジトリのクローンが `exit 128`（`fatal: Unable to read current working directory`）で必ず失敗していた。`CloneManager` が `cwd` を指定せずに git を spawn しており、**npm キャッシュ配下にあるサーバープロセスの cwd を継承**していたことが原因。LP からチュートリアルへ送客している状態で新規ユーザーの最初の操作が止まっていたため、緊急度が高い。DB マイグレーションなし。

--- a/src/lib/db/db-instance.ts
+++ b/src/lib/db/db-instance.ts
@@ -44,11 +44,22 @@ export function getDbInstance(): Database.Database {
     }
 
     // Issue #1263: recover from a better-sqlite3 ABI mismatch (Node.js version switch)
-    dbInstance = openDatabaseWithAbiRecovery(dbPath);
+    const db = openDatabaseWithAbiRecovery(dbPath);
     // Issue #294: Enable foreign key enforcement BEFORE migrations
     // This ensures ON DELETE CASCADE works correctly for all tables
-    dbInstance.pragma('foreign_keys = ON');
-    runMigrations(dbInstance);
+    db.pragma('foreign_keys = ON');
+
+    // Issue #1353: only publish the connection once its schema is verified.
+    // Assigning before runMigrations() cached a database whose migrations had
+    // thrown, so every later caller was handed it back without the failure —
+    // the guard would fire once and be bypassed for the rest of the process.
+    try {
+      runMigrations(db);
+    } catch (error) {
+      db.close();
+      throw error;
+    }
+    dbInstance = db;
   }
 
   return dbInstance;

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -71,6 +71,19 @@ export function runMigrations(db: Database.Database, migrations: Migration[]): v
 
   console.log(`Current schema version: ${currentVersion}`);
 
+  // Issue #1353: refuse a database written by a newer build.
+  // Migrations only move forward, so this build has no definition for the
+  // schema it is looking at: queries still written against renamed/dropped
+  // columns would fail at runtime, long after startup reported success.
+  // The check sits after the version read but before any migration writes.
+  if (currentVersion > CURRENT_SCHEMA_VERSION) {
+    throw new Error(
+      `This database (schema v${currentVersion}) was created by a newer version of CommandMate ` +
+      `(this build supports up to v${CURRENT_SCHEMA_VERSION}). ` +
+      `Please update: commandmate update`
+    );
+  }
+
   // Find pending migrations
   const pendingMigrations = migrations.filter(
     migration => migration.version > currentVersion

--- a/tests/unit/db/db-instance-migration-failure.test.ts
+++ b/tests/unit/db/db-instance-migration-failure.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #1353: getDbInstance() must not cache a connection whose migrations threw.
+ *
+ * The singleton was assigned before runMigrations() ran, so a thrown migration
+ * left an open, unverified database in the module-level cache. The first caller
+ * saw the error and every caller after it was handed that same database back
+ * with no error at all — which would let the future-schema guard fire exactly
+ * once and then be bypassed for the lifetime of the process.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-db-instance-'));
+const dbPath = path.join(tmpDir, 'cm.db');
+
+vi.mock('@/lib/env', () => ({
+  getEnv: vi.fn(() => ({ CM_DB_PATH: dbPath })),
+}));
+
+const openDatabaseWithAbiRecovery = vi.fn();
+vi.mock('@/lib/db/abi-recovery', () => ({
+  openDatabaseWithAbiRecovery: (p: string) => openDatabaseWithAbiRecovery(p),
+}));
+
+const runMigrations = vi.fn();
+vi.mock('@/lib/db/db-migrations', () => ({
+  runMigrations: (db: Database.Database) => runMigrations(db),
+}));
+
+import { getDbInstance, closeDbInstance } from '@/lib/db/db-instance';
+
+describe('getDbInstance migration failure (Issue #1353)', () => {
+  let opened: Database.Database[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    opened = [];
+    openDatabaseWithAbiRecovery.mockImplementation(() => {
+      const db = new Database(':memory:');
+      opened.push(db);
+      return db;
+    });
+  });
+
+  afterEach(() => {
+    try {
+      closeDbInstance();
+    } catch {
+      // already closed by the failure path
+    }
+    for (const db of opened) {
+      if (db.open) db.close();
+    }
+  });
+
+  it('rethrows on every call instead of serving an unverified database', () => {
+    const failure = new Error(
+      'This database (schema v50) was created by a newer version of CommandMate'
+    );
+    runMigrations.mockImplementation(() => { throw failure; });
+
+    expect(() => getDbInstance()).toThrow(failure);
+
+    // The regression: this second call used to return the cached, unmigrated
+    // database silently — exactly the "opens anyway" behaviour being fixed.
+    expect(() => getDbInstance()).toThrow(failure);
+    expect(() => getDbInstance()).toThrow(failure);
+  });
+
+  it('closes the database it opened when migrations throw', () => {
+    runMigrations.mockImplementation(() => { throw new Error('migration failed'); });
+
+    expect(() => getDbInstance()).toThrow('migration failed');
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0].open).toBe(false);
+  });
+
+  it('caches the instance once migrations succeed', () => {
+    runMigrations.mockImplementation(() => { /* success */ });
+
+    const first = getDbInstance();
+    const second = getDbInstance();
+
+    expect(second).toBe(first);
+    expect(openDatabaseWithAbiRecovery).toHaveBeenCalledTimes(1);
+    expect(runMigrations).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers on a later call once the underlying failure is resolved', () => {
+    runMigrations.mockImplementationOnce(() => { throw new Error('transient'); });
+
+    expect(() => getDbInstance()).toThrow('transient');
+
+    // Nothing poisoned: a subsequent call re-opens and migrates cleanly.
+    runMigrations.mockImplementation(() => { /* success */ });
+    const db = getDbInstance();
+
+    expect(db.open).toBe(true);
+    expect(openDatabaseWithAbiRecovery).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/db/future-schema-guard.test.ts
+++ b/tests/unit/db/future-schema-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Issue #1353: a database written by a newer build must stop startup.
+ *
+ * Migrations only move forward, so a schema beyond CURRENT_SCHEMA_VERSION has no
+ * definition in this build. Before this guard, runMigrations() reported
+ * "Schema is up to date" and opened it, and queries against renamed/dropped
+ * columns failed later as opaque runtime 500s.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  runMigrations,
+  getCurrentVersion,
+  CURRENT_SCHEMA_VERSION,
+} from '@/lib/db/db-migrations';
+
+/** Record a schema_version row for a version this build does not know about. */
+function stampVersion(db: Database.Database, version: number): void {
+  db.prepare(
+    'INSERT INTO schema_version (version, name, applied_at) VALUES (?, ?, ?)'
+  ).run(version, `future-migration-v${version}`, Date.now());
+}
+
+describe('future schema version guard (Issue #1353)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('throws when the database schema is newer than this build supports', () => {
+    stampVersion(db, CURRENT_SCHEMA_VERSION + 8);
+
+    expect(() => runMigrations(db)).toThrow(
+      new RegExp(`schema v${CURRENT_SCHEMA_VERSION + 8}.*newer version of CommandMate`, 's')
+    );
+  });
+
+  it('names both versions and the recovery action in the error', () => {
+    stampVersion(db, CURRENT_SCHEMA_VERSION + 1);
+
+    let message = '';
+    try {
+      runMigrations(db);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    // The whole point is diagnosability: the operator must be able to tell
+    // version skew from a generic DB error without reading the source.
+    expect(message).toContain(`v${CURRENT_SCHEMA_VERSION + 1}`);
+    expect(message).toContain(`v${CURRENT_SCHEMA_VERSION}`);
+    expect(message).toContain('commandmate update');
+  });
+
+  it('rejects a future database before writing anything to it', () => {
+    stampVersion(db, CURRENT_SCHEMA_VERSION + 3);
+    const before = getCurrentVersion(db);
+
+    expect(() => runMigrations(db)).toThrow();
+
+    // A rejected database must be left exactly as found — the operator may
+    // still open it with the newer build that owns it.
+    expect(getCurrentVersion(db)).toBe(before);
+  });
+
+  it('accepts a database at exactly the supported version', () => {
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(() => runMigrations(db)).not.toThrow();
+  });
+
+  it('still migrates a database older than this build', () => {
+    // The guard must not mistake the normal forward path for version skew.
+    const fresh = new Database(':memory:');
+    try {
+      expect(() => runMigrations(fresh)).not.toThrow();
+      expect(getCurrentVersion(fresh)).toBe(CURRENT_SCHEMA_VERSION);
+    } finally {
+      fresh.close();
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Closes #1353

マイグレーションが「前進のみ」を前提にしているにもかかわらず、**DB のスキーマ版がコードの知る最大版（v42）を超えていても検知せず「Schema is up to date」で続行**していた。旧ビルドが新しい DB を黙って開き、改名・削除済みカラム前提のクエリが実行時エラー（500）になる経路を塞ぐ。

## 変更内容

### 1. 将来版 DB ガード（`src/lib/db/migrations/runner.ts`）

版の読み取り後・マイグレーション書き込み前に `currentVersion > CURRENT_SCHEMA_VERSION` を検知し、両方の版と復旧手段を示して throw する。

### 2. 追加で発見した欠陥の修正（`src/lib/db/db-instance.ts`）

調査中に、Issue 記載の範囲外だが**同じガードを無効化する欠陥**を発見したため併せて修正した。

`dbInstance` が `runMigrations()` の**前に**代入されていたため、マイグレーションが throw しても壊れた接続がモジュールキャッシュに残り、以降の `getDbInstance()` は `if` ブロックを飛ばしてその接続をそのまま返していた。**ガードが初回しか効かず、2回目以降は素通り**する。スキーマ検証が通った接続だけを publish するよう変更し、失敗時は `db.close()` してから再 throw する。

## テスト

- `tests/unit/db/future-schema-guard.test.ts`（5件）: 将来版で throw / 両版とアクションを含むメッセージ / **書き込み前に拒否** / 同一版は許可 / 旧版は従来通りマイグレート
- `tests/unit/db/db-instance-migration-failure.test.ts`（4件）: 毎回 rethrow（未検証 DB を配らない）/ 失敗時に close / 成功時はキャッシュ / 原因解消後は復旧

## 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass（0 errors） |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass（584 files / 9921 tests） |
| npm run build | Pass |

## 補足

Issue 本文の引用（`runner.ts:65-82`、`CURRENT_SCHEMA_VERSION = 42`）は実コードで検証済み・一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)