### PR TITLE
fix(clone): executeClone の同期例外でジョブが running 固着するのを防ぐ (#1342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(clone): **`executeClone` 冒頭の同期例外でクローンジョブが `running` のまま固着するのを防止** (#1342)。`executeClone` はジョブを `running` に更新した直後、`Promise` を生成する前に `mkdirSync`（親ディレクトリ作成）を同期実行していた。ここで throw すると（親ディレクトリの権限不足・ディスク障害等）、失敗は呼び出し元 `startCloneJob` の `.catch()`（ログ出力のみ）に吸われ、**ジョブは terminal state へ一切遷移しない**。利用者には「終わらないクローン」だけが見え、エラーは UI に出ない。準備処理を `try` で包み、例外時に `failed` / `CLONE_SETUP_FAILED`（category: `filesystem`）へ遷移させる。原因の詳細はパス情報を含むためサーバーログのみに出し（`clone:setup-failed`）、ジョブに載せる `errorMessage` は定型文とする（[D4-001] に準拠）。なお `updateCloneJob` 自身が throw する DB 障害時は `failed` の書き込みも成立しないため `pending` のまま残るが、二次例外で原因を握り潰さず構造化エラーとして呼び出し元へ伝える
+
 ## [0.10.3] - 2026-07-17
 
 > **Highlight**: **v0.10.2 で公開したチュートリアルの Step 1 が動作しない問題を修正するパッチリリース**。`npx commandmate@latest` で起動した環境では、リポジトリのクローンが `exit 128`（`fatal: Unable to read current working directory`）で必ず失敗していた。`CloneManager` が `cwd` を指定せずに git を spawn しており、**npm キャッシュ配下にあるサーバープロセスの cwd を継承**していたことが原因。LP からチュートリアルへ送客している状態で新規ユーザーの最初の操作が止まっていたため、緊急度が高い。DB マイグレーションなし。

--- a/src/lib/git/clone-manager.ts
+++ b/src/lib/git/clone-manager.ts
@@ -171,6 +171,15 @@ const ERROR_DEFINITIONS: Record<string, CloneError> = {
     recoverable: true,
     suggestedAction: 'Try again or clone a smaller repository',
   },
+  // Issue #1342: executeClone の準備処理（status 更新・親ディレクトリ作成）が throw した場合。
+  // [D4-001] 原因の詳細はパス情報を含むためログのみに出し、クライアントには定型文を返す。
+  CLONE_SETUP_FAILED: {
+    category: 'filesystem',
+    code: 'CLONE_SETUP_FAILED',
+    message: 'Failed to prepare the clone target directory',
+    recoverable: true,
+    suggestedAction: 'Check the permissions and free space of the target directory, then try again',
+  },
 };
 
 /**
@@ -402,21 +411,59 @@ export class CloneManager {
   }
 
   /**
+   * Mark a job as failed, tolerating a failing DB write.
+   *
+   * Issue #1342: 呼び出し元は失敗パスの最中なので、ここでの throw は元の原因を握り潰す。
+   * DB 書き込みが失敗した場合はログに残すだけにして、元のエラーを伝播させる。
+   */
+  private markJobFailed(jobId: string, error: CloneError): void {
+    try {
+      updateCloneJob(this.db, jobId, {
+        status: 'failed',
+        errorCategory: error.category,
+        errorCode: error.code,
+        errorMessage: error.message,
+        completedAt: new Date(),
+      });
+    } catch (dbError) {
+      logger.error('clone:job-status-update-failed', {
+        jobId,
+        errorCode: error.code,
+        dbError: dbError instanceof Error ? dbError.message : String(dbError),
+      });
+    }
+  }
+
+  /**
    * Execute git clone operation
    *
    * This method runs asynchronously and updates the job status.
    */
   async executeClone(jobId: string, cloneUrl: string, targetPath: string): Promise<void> {
-    // Update job status to running
-    updateCloneJob(this.db, jobId, {
-      status: 'running',
-      startedAt: new Date(),
-    });
+    // Issue #1342: ここは Promise 生成前の同期処理。throw すると失敗が
+    // startCloneJob の .catch()（ログのみ）に吸われ、ジョブが terminal state へ
+    // 遷移しないまま running / pending で固着する。必ず failed へ落とす。
+    let parentDir: string;
+    try {
+      // Update job status to running
+      updateCloneJob(this.db, jobId, {
+        status: 'running',
+        startedAt: new Date(),
+      });
 
-    // Ensure parent directory exists
-    const parentDir = path.dirname(targetPath);
-    if (!existsSync(parentDir)) {
-      mkdirSync(parentDir, { recursive: true });
+      // Ensure parent directory exists
+      parentDir = path.dirname(targetPath);
+      if (!existsSync(parentDir)) {
+        mkdirSync(parentDir, { recursive: true });
+      }
+    } catch (err) {
+      // [D4-001] 原因の詳細（パスを含む）はログのみ。ジョブに載せる message は定型文。
+      logger.error('clone:setup-failed', {
+        jobId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this.markJobFailed(jobId, ERROR_DEFINITIONS.CLONE_SETUP_FAILED);
+      throw new CloneManagerError(ERROR_DEFINITIONS.CLONE_SETUP_FAILED);
     }
 
     return new Promise<void>((resolve, reject) => {

--- a/tests/unit/lib/clone-manager.test.ts
+++ b/tests/unit/lib/clone-manager.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { spawn, type ChildProcess } from 'child_process';
+import { mkdirSync } from 'fs';
 import Database from 'better-sqlite3';
 import { runMigrations } from '@/lib/db/db-migrations';
 import { CloneManager, CloneManagerError, resetWorktreeBasePathWarning, resolveCustomTargetPath } from '@/lib/git/clone-manager';
@@ -357,6 +358,101 @@ describe('CloneManager', () => {
 
       expect(options.cwd).toBe('/tmp/repos/group');
       expect(options.cwd).not.toBe(process.cwd());
+    });
+
+    // Issue #1342: Promise 生成前の同期例外は startCloneJob の .catch()（ログのみ）に吸われる。
+    // failed へ遷移させないと、ジョブは running / pending のまま永久に残る。
+    describe('synchronous setup failures (Issue #1342)', () => {
+      it('should mark the job as failed when mkdirSync throws', async () => {
+        stubGitProcess();
+        const cloneUrl = 'https://github.com/test/repo.git';
+        const targetPath = '/tmp/repos/repo';
+        const job = createCloneJob(db, {
+          cloneUrl,
+          normalizedCloneUrl: 'https://github.com/test/repo',
+          targetPath,
+        });
+        vi.mocked(mkdirSync).mockImplementationOnce(() => {
+          throw new Error("EACCES: permission denied, mkdir '/tmp/repos'");
+        });
+
+        await expect(cloneManager.executeClone(job.id, cloneUrl, targetPath)).rejects.toBeInstanceOf(
+          CloneManagerError
+        );
+
+        const status = cloneManager.getCloneJobStatus(job.id);
+        expect(status?.status).toBe('failed');
+        expect(status?.error?.code).toBe('CLONE_SETUP_FAILED');
+        expect(status?.error?.category).toBe('filesystem');
+        expect(getCloneJob(db, job.id)?.completedAt).toBeDefined();
+      });
+
+      it('should not spawn git when the setup fails', async () => {
+        stubGitProcess();
+        const cloneUrl = 'https://github.com/test/repo.git';
+        const targetPath = '/tmp/repos/repo';
+        const job = createCloneJob(db, {
+          cloneUrl,
+          normalizedCloneUrl: 'https://github.com/test/repo',
+          targetPath,
+        });
+        vi.mocked(mkdirSync).mockImplementationOnce(() => {
+          throw new Error('EACCES: permission denied');
+        });
+
+        await expect(cloneManager.executeClone(job.id, cloneUrl, targetPath)).rejects.toThrow();
+
+        expect(spawn).not.toHaveBeenCalled();
+      });
+
+      // [D4-001] mkdirSync のエラーメッセージは basePath を含む。クライアントに返る
+      // errorMessage へ載せず、詳細はサーバーログのみに出す。
+      it('should keep the filesystem path out of the client-facing error message', async () => {
+        stubGitProcess();
+        const cloneUrl = 'https://github.com/test/repo.git';
+        const targetPath = '/tmp/repos/repo';
+        const job = createCloneJob(db, {
+          cloneUrl,
+          normalizedCloneUrl: 'https://github.com/test/repo',
+          targetPath,
+        });
+        vi.mocked(mkdirSync).mockImplementationOnce(() => {
+          throw new Error("EACCES: permission denied, mkdir '/tmp/repos'");
+        });
+
+        await expect(cloneManager.executeClone(job.id, cloneUrl, targetPath)).rejects.toThrow();
+
+        const status = cloneManager.getCloneJobStatus(job.id);
+        expect(status?.error?.message).not.toContain('/tmp/repos');
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'clone:setup-failed',
+          expect.objectContaining({ jobId: job.id })
+        );
+      });
+
+      // DB が壊れている場合は failed への書き込み自体も失敗する（pending のまま残るのは避けられない）。
+      // 少なくとも二次例外で原因を握り潰さず、構造化エラーとして呼び出し元へ伝えること。
+      it('should reject with a structured error when the status update itself throws', async () => {
+        stubGitProcess();
+        const cloneUrl = 'https://github.com/test/repo.git';
+        const targetPath = '/tmp/repos/repo';
+        const job = createCloneJob(db, {
+          cloneUrl,
+          normalizedCloneUrl: 'https://github.com/test/repo',
+          targetPath,
+        });
+        db.close(); // updateCloneJob を throw させる
+
+        await expect(cloneManager.executeClone(job.id, cloneUrl, targetPath)).rejects.toBeInstanceOf(
+          CloneManagerError
+        );
+
+        expect(spawn).not.toHaveBeenCalled();
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'clone:job-status-update-failed',
+          expect.objectContaining({ jobId: job.id, errorCode: 'CLONE_SETUP_FAILED' })
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## 概要

Closes #1342

`executeClone` はジョブ status を `running` に更新した直後、**Promise 生成前**に `mkdirSync` を同期実行していた。ここで throw すると async 関数は Promise 生成前に reject し、呼び出し元 `startCloneJob` の `.catch()`（ログのみ）に吸われるため、**ジョブが terminal state に一切遷移せず `running` のまま永久に残る**（利用者には「終わらないクローン」がエラー表示なしで見える）。

## 変更内容

- Promise 生成前の同期処理（status 更新・親ディレクトリ作成）を try で囲み、例外時に `CLONE_SETUP_FAILED` でジョブを `failed` に落としてから throw する
- エラー定義 `CLONE_SETUP_FAILED` を追加（category: filesystem / recoverable）
- `markJobFailed()` ヘルパを追加。**失敗パスの最中の DB 書き込み失敗で元の原因を握り潰さない**よう、DB エラーはログに留めて元エラーを伝播させる
- [D4-001] 既存方針に従い、パスを含む詳細はログのみ・クライアントには定型文を返す

## テスト

`tests/unit/lib/clone-manager.test.ts` に `synchronous setup failures (Issue #1342)` を追加（4件）:

- mkdirSync が throw したときジョブが failed になる
- setup 失敗時に git を spawn しない
- クライアント向けメッセージにファイルシステムのパスを含めない
- status 更新自体が throw したときも構造化エラーで reject する

## 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass（0 errors） |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass（582 files / 9916 tests） |
| npm run build | Pass |

## 関連

- #1340 は同一ファイルの `onCloneSuccess` に同じ症状（running 固着）の**別経路**を持つ。本 PR は `executeClone` 冒頭の経路のみを対象とし、#1340 は未着手のまま残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)