### PR TITLE
fix(scheduler): createExecutionLog 例外時に isExecuting が固定されるのを防ぐ (#1343)

### DIFF
--- a/src/lib/job-executor.ts
+++ b/src/lib/job-executor.ts
@@ -189,9 +189,14 @@ export async function executeSchedule(state: ScheduleState): Promise<void> {
   }
 
   state.isExecuting = true;
-  const logId = createExecutionLog(state.scheduleId, state.worktreeId, state.entry.message);
+  // Issue #1343: createExecutionLog() must stay inside the try so that a DB
+  // failure still reaches the finally that resets isExecuting. Otherwise the
+  // schedule is skipped by the guard above until the server restarts.
+  let logId: string | undefined;
 
   try {
+    logId = createExecutionLog(state.scheduleId, state.worktreeId, state.entry.message);
+
     const db = getLazyDbInstance();
     const worktree = db.prepare('SELECT path, vibe_local_model FROM worktrees WHERE id = ?').get(state.worktreeId) as WorktreeRow | undefined;
 
@@ -217,7 +222,9 @@ export async function executeSchedule(state: ScheduleState): Promise<void> {
     logger.info('execution:completed', { name: state.entry.name, status: result.status });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    updateExecutionLog(logId, 'failed', errorMessage, null);
+    if (logId !== undefined) {
+      updateExecutionLog(logId, 'failed', errorMessage, null);
+    }
     logger.error('execution:failed', { name: state.entry.name, error: errorMessage });
   } finally {
     state.isExecuting = false;

--- a/src/lib/schedule-manager.ts
+++ b/src/lib/schedule-manager.ts
@@ -128,7 +128,15 @@ function createScheduleState(
   };
 
   cronJob.schedule(() => {
-    void executeSchedule(state);
+    // Issue #1343: executeSchedule() rejects if its own error handling fails
+    // (e.g. the DB is still down when writing the 'failed' log). Without this
+    // catch the rejection is silently unhandled.
+    void executeSchedule(state).catch((error: unknown) => {
+      logger.error('execution:unhandled', {
+        name: entry.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   });
 
   return state;

--- a/tests/unit/lib/job-executor.test.ts
+++ b/tests/unit/lib/job-executor.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #1343: executeSchedule() must always reset the in-memory isExecuting
+ * guard, even when createExecutionLog() (a DB INSERT) throws. If the flag stays
+ * true the schedule is skipped by the concurrency guard until the server
+ * restarts, with no error surfaced to the user.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Module from 'module';
+import { executeSchedule, type ScheduleState } from '@/lib/job-executor';
+import type { ScheduleEntry } from '@/types/cmate';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn().mockReturnThis(),
+  },
+}));
+vi.mock('@/lib/logger', () => ({ createLogger: vi.fn(() => mockLogger) }));
+
+const mockExecuteClaudeCommand = vi.fn();
+vi.mock('@/lib/session/claude-executor', () => ({
+  executeClaudeCommand: (...args: unknown[]) => mockExecuteClaudeCommand(...args),
+}));
+
+/**
+ * job-executor reaches the DB through a lazy CJS `require('./db/db-instance')`,
+ * which vi.mock does not intercept (it is not resolvable as ESM under vitest).
+ * Patching Module._load is the only way to substitute the DB here.
+ */
+type ModuleWithLoad = { _load: (request: string, parent: unknown, isMain: boolean) => unknown };
+const M = Module as unknown as ModuleWithLoad;
+const originalLoad = M._load;
+
+/** SQL -> statement stub. Any statement may be told to throw. */
+let statements: Array<{ sql: string; run: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> }>;
+let failOnInsert: boolean;
+let failOnUpdateLog: boolean;
+
+function installDbStub(): void {
+  M._load = function (request: string, parent: unknown, isMain: boolean) {
+    if (request.endsWith('db-instance')) {
+      return {
+        getDbInstance: () => ({
+          prepare: (sql: string) => {
+            const stmt = {
+              sql,
+              run: vi.fn(() => {
+                if (failOnInsert && sql.includes('INSERT INTO execution_logs')) {
+                  throw new Error('SQLITE_BUSY: database is locked');
+                }
+                if (failOnUpdateLog && sql.includes('UPDATE execution_logs SET status')) {
+                  throw new Error('SQLITE_BUSY: database is locked');
+                }
+                return { changes: 1 };
+              }),
+              get: vi.fn(() => {
+                if (sql.includes('FROM worktrees')) {
+                  return { path: '/tmp/wt', vibe_local_model: null };
+                }
+                return undefined;
+              }),
+            };
+            statements.push(stmt);
+            return stmt;
+          },
+        }),
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+
+function createState(overrides: Partial<ScheduleState> = {}): ScheduleState {
+  const entry: ScheduleEntry = {
+    name: 'nightly-review',
+    message: 'Review code',
+    cronExpression: '0 3 * * *',
+    cliToolId: 'claude',
+    enabled: true,
+  } as ScheduleEntry;
+
+  return {
+    scheduleId: 'sched-1',
+    worktreeId: 'wt-1',
+    cronJob: {} as ScheduleState['cronJob'],
+    isExecuting: false,
+    entry,
+    ...overrides,
+  };
+}
+
+describe('executeSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    statements = [];
+    failOnInsert = false;
+    failOnUpdateLog = false;
+    mockExecuteClaudeCommand.mockResolvedValue({ status: 'completed', output: 'ok', exitCode: 0 });
+    installDbStub();
+  });
+
+  afterEach(() => {
+    M._load = originalLoad;
+  });
+
+  it('resets isExecuting after a successful run', async () => {
+    const state = createState();
+
+    await executeSchedule(state);
+
+    expect(state.isExecuting).toBe(false);
+    expect(mockExecuteClaudeCommand).toHaveBeenCalledOnce();
+  });
+
+  it('skips execution while another run is in flight', async () => {
+    const state = createState({ isExecuting: true });
+
+    await executeSchedule(state);
+
+    expect(mockExecuteClaudeCommand).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith('execution:skip-concurrent', { name: 'nightly-review' });
+  });
+
+  // Regression: the bug of Issue #1343.
+  it('resets isExecuting when createExecutionLog throws', async () => {
+    failOnInsert = true;
+    const state = createState();
+
+    await expect(executeSchedule(state)).resolves.toBeUndefined();
+
+    expect(state.isExecuting).toBe(false);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'execution:failed',
+      expect.objectContaining({ name: 'nightly-review' })
+    );
+  });
+
+  // The failed INSERT produced no log row, so nothing may be updated afterwards.
+  it('does not update an execution log that was never created', async () => {
+    failOnInsert = true;
+
+    await executeSchedule(createState());
+
+    const updates = statements.filter((s) => s.sql.includes('UPDATE execution_logs SET status'));
+    expect(updates).toHaveLength(0);
+  });
+
+  // A schedule must recover on the next cron tick rather than stay wedged.
+  it('runs again on the next tick after a createExecutionLog failure', async () => {
+    const state = createState();
+
+    failOnInsert = true;
+    await executeSchedule(state);
+    expect(mockExecuteClaudeCommand).not.toHaveBeenCalled();
+
+    failOnInsert = false;
+    await executeSchedule(state);
+
+    expect(mockExecuteClaudeCommand).toHaveBeenCalledOnce();
+    expect(state.isExecuting).toBe(false);
+  });
+
+  it('resets isExecuting when the command execution rejects', async () => {
+    mockExecuteClaudeCommand.mockRejectedValue(new Error('spawn failed'));
+    const state = createState();
+
+    await executeSchedule(state);
+
+    expect(state.isExecuting).toBe(false);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'execution:failed',
+      expect.objectContaining({ error: 'spawn failed' })
+    );
+  });
+
+  // If even the error-path write fails, executeSchedule rejects. The guard must
+  // still be released; schedule-manager attaches the .catch() for the rejection.
+  it('resets isExecuting when the failure log write itself throws', async () => {
+    mockExecuteClaudeCommand.mockRejectedValue(new Error('spawn failed'));
+    failOnUpdateLog = true;
+    const state = createState();
+
+    await expect(executeSchedule(state)).rejects.toThrow('SQLITE_BUSY');
+
+    expect(state.isExecuting).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

Closes #1343

`executeSchedule()` は `state.isExecuting = true` の直後、**try の外**で `createExecutionLog()`（DB INSERT）を実行していた。ここで throw すると finally に到達せず `isExecuting` が `true` のまま固定され、以降そのスケジュールは冒頭のガードで**サーバー再起動まで恒久的に実行スキップ**される。呼び出しが `void executeSchedule(state)` のため rejection はログにも残らず、利用者からは「スケジュールが無言で動かなくなった」ようにしか見えない。

起動時回収 `recoverRunningLogs()` は DB 側の 'running' ログのみを回収するため、この in-memory フラグは救えない。

## 変更内容

### 1. `src/lib/job-executor.ts`

- `createExecutionLog()` を try の内側へ移動し、DB 失敗でも finally（`isExecuting = false`）に到達させる
- `logId` を `string | undefined` にし、catch 側の `updateExecutionLog(logId, ...)` を **logId 未定義時はスキップ**（createExecutionLog 自体が失敗した場合、ログ行は存在しないため）

### 2. `src/lib/schedule-manager.ts`

- `void executeSchedule(state)` に `.catch()` を追加。エラーハンドリング自体が失敗した場合（例: 'failed' ログ書き込み時も DB が落ちている）の rejection が黙って未処理になるのを防ぐ

## テスト

`tests/unit/lib/job-executor.test.ts` を新規追加（job-executor 専用テストはこれまで存在しなかった）。createExecutionLog が throw しても isExecuting がリセットされ、次回実行がスキップされないことを固定。

## 品質チェック

| 項目 | 結果 |
|---|---|
| npm run lint | Pass（0 errors） |
| npx tsc --noEmit | Pass |
| npm run test:unit | Pass（583 files / 9919 tests） |
| npm run build | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)