### PR TITLE
fix(update): npx 起動時に GUI アップデートが誤動作するのを防ぐ (#1394)

### DIFF
--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -201,6 +201,8 @@
     "installTypeGlobal": "npm (global)",
     "installTypeLocal": "Local (git pull)",
     "updateNow": "Update now",
+    "npxTitle": "Running via npx",
+    "npxDescription": "This server was started with npx, which runs from a throwaway cache and cannot update itself in place. Stop it and relaunch with the latest version:",
     "confirmTitle": "Update CommandMate?",
     "confirmDescription": "CommandMate will be updated to v{version}. The server stops, the new version installs, and the server starts again. This takes a few minutes.",
     "confirmButton": "Update",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -201,6 +201,8 @@
     "installTypeGlobal": "npm（グローバル）",
     "installTypeLocal": "ローカル（git pull）",
     "updateNow": "今すぐアップデート",
+    "npxTitle": "npx で起動しています",
+    "npxDescription": "このサーバは npx（使い捨てキャッシュ）から起動されているため、その場では更新できません。停止してから最新版で起動し直してください:",
     "confirmTitle": "CommandMate をアップデートしますか？",
     "confirmDescription": "CommandMate を v{version} に更新します。サーバを停止し、新しいバージョンをインストールして、再度起動します。数分かかります。",
     "confirmButton": "アップデート",

--- a/src/app/api/app/update-check/route.ts
+++ b/src/app/api/app/update-check/route.ts
@@ -18,7 +18,7 @@
 import { NextResponse } from 'next/server';
 import { checkForUpdate, getCurrentVersion } from '@/lib/version-checker';
 // [CONS-001] CLI layer utility. Cross-layer import precedent: db-path-resolver.ts
-import { isGlobalInstall } from '@/cli/utils/install-context';
+import { isGlobalInstall, isNpxExecution } from '@/cli/utils/install-context';
 import type { UpdateCheckResult } from '@/lib/version-checker';
 
 // [FIX-270] Force dynamic route to prevent static prerendering at build time.
@@ -30,8 +30,14 @@ export const dynamic = 'force-dynamic';
 // Types
 // =============================================================================
 
-/** Install type union used across the API response */
-type InstallType = 'global' | 'local' | 'unknown';
+/**
+ * Install type union used across the API response.
+ * 'npx' (Issue #1394): running from the npx cache. isGlobalInstall() reports it
+ * as global on purpose (Issue #1195: config/db still land in ~/.commandmate),
+ * but a throwaway npx process cannot update in place — the banner must show
+ * npx-specific guidance instead of the one-click update button.
+ */
+type InstallType = 'global' | 'local' | 'npx' | 'unknown';
 
 /**
  * API Response type.
@@ -63,6 +69,10 @@ export interface UpdateCheckResponse {
  */
 function detectInstallType(): InstallType {
   try {
+    // Issue #1394: npx first — under npx isGlobalInstall() is also true
+    // (Issue #1195), so testing global first would mislabel it 'global' and
+    // surface a one-click update button that no-ops on a throwaway process.
+    if (isNpxExecution()) return 'npx';
     return isGlobalInstall() ? 'global' : 'local';
   } catch {
     return 'unknown';

--- a/src/app/api/app/update/route.ts
+++ b/src/app/api/app/update/route.ts
@@ -20,7 +20,7 @@ import { closeSync, openSync } from 'fs';
 import { join } from 'path';
 import { NextResponse } from 'next/server';
 // Cross-layer import from the CLI utils, matching the update-check route [CONS-001].
-import { ensureConfigDir, isGlobalInstall } from '@/cli/utils/install-context';
+import { ensureConfigDir, isGlobalInstall, isNpxExecution } from '@/cli/utils/install-context';
 import { getDaemonManagerFactory } from '@/cli/utils/daemon-factory';
 import { acquireUpdateLock, releaseUpdateLock } from '@/lib/app-update/update-lock';
 
@@ -50,7 +50,7 @@ export interface UpdateStartResponse {
 /** Failure payload */
 export interface UpdateErrorResponse {
   error: string;
-  code: 'not_global' | 'in_progress' | 'spawn_failed';
+  code: 'not_global' | 'npx' | 'in_progress' | 'spawn_failed';
 }
 
 type UpdateResponse = UpdateStartResponse | UpdateErrorResponse;
@@ -63,6 +63,25 @@ type UpdateResponse = UpdateStartResponse | UpdateErrorResponse;
 function isGlobalInstallSafe(): boolean {
   try {
     return isGlobalInstall();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * npx detection that treats a detection failure as "not npx", so a failure
+ * falls through to the global-install gate rather than mislabeling the error.
+ *
+ * Issue #1394: a server started with `npx commandmate` runs from the npx cache,
+ * which isGlobalInstall() reports as global (Issue #1195). Spawning
+ * `commandmate update` there is a no-op — the child hits update.ts's own npx
+ * gate (update.ts:54) and exits SUCCESS without touching the install — yet this
+ * route would still answer 202, hanging the banner until its 5-minute timeout.
+ * Refuse it here, before the lock and the spawn.
+ */
+function isNpxExecutionSafe(): boolean {
+  try {
+    return isNpxExecution();
   } catch {
     return false;
   }
@@ -119,6 +138,20 @@ function spawnUpdate(logPath: string): void {
  * parameter — the fixed-command guarantee rests on it.
  */
 export async function POST(): Promise<NextResponse<UpdateResponse>> {
+  // Issue #1394: npx first — under npx isGlobalInstall() is also true (Issue
+  // #1195), so the global gate below would let a throwaway process through to a
+  // no-op spawn. Refuse before the lock/spawn with a dedicated code.
+  if (isNpxExecutionSafe()) {
+    return NextResponse.json(
+      {
+        error:
+          'CommandMate is running via npx and cannot update in place. Relaunch with `npx commandmate@latest`.',
+        code: 'npx' as const,
+      },
+      { status: 400 }
+    );
+  }
+
   if (!isGlobalInstallSafe()) {
     return NextResponse.json(
       {

--- a/src/components/worktree/UpdateNotificationBanner.tsx
+++ b/src/components/worktree/UpdateNotificationBanner.tsx
@@ -25,7 +25,7 @@ export interface UpdateNotificationBannerProps {
   latestVersion: string | null;
   releaseUrl: string | null;
   updateCommand: string | null;
-  installType: 'global' | 'local' | 'unknown';
+  installType: 'global' | 'local' | 'npx' | 'unknown';
 }
 
 /**
@@ -50,6 +50,13 @@ const UPDATE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Fixed command shown when the user has to finish the update by hand */
 const MANUAL_UPDATE_COMMAND = 'commandmate update';
+
+/**
+ * Fixed command an npx-launched server must be relaunched with (Issue #1394).
+ * npx runs from a throwaway cache and cannot update in place, so the banner
+ * shows this guidance instead of the one-click update button.
+ */
+const NPX_UPDATE_COMMAND = 'npx commandmate@latest';
 
 /**
  * Banner displaying version update notification.
@@ -80,6 +87,8 @@ export function UpdateNotificationBanner({
   const seenDownRef = useRef(false);
 
   const isGlobal = installType === 'global';
+  // Issue #1394: npx cannot self-update; show guidance, never the update button.
+  const isNpx = installType === 'npx';
 
   const handleConfirm = useCallback(async () => {
     setState('starting');
@@ -176,6 +185,16 @@ export function UpdateNotificationBanner({
         >
           {t('update.updateNow')}
         </Button>
+      )}
+
+      {isNpx && state === 'idle' && (
+        <div className="mb-2" data-testid="update-npx">
+          <p className="text-sm font-medium text-accent-800">{t('update.npxTitle')}</p>
+          <p className="text-xs text-accent-600 mt-1">{t('update.npxDescription')}</p>
+          <code className="block bg-accent-100 rounded px-2 py-1 mt-1 text-xs text-accent-900 font-mono">
+            {NPX_UPDATE_COMMAND}
+          </code>
+        </div>
       )}
 
       {isBusy && (

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -752,7 +752,8 @@ export interface UpdateCheckResponse {
   releaseUrl: string | null;
   releaseName: string | null;
   publishedAt: string | null;
-  installType: 'global' | 'local' | 'unknown';
+  /** 'npx' (Issue #1394): running from the npx cache — no in-place update */
+  installType: 'global' | 'local' | 'npx' | 'unknown';
   updateCommand: string | null;
 }
 

--- a/tests/unit/api/app-update.test.ts
+++ b/tests/unit/api/app-update.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@/cli/utils/install-context', () => ({
   isGlobalInstall: vi.fn().mockReturnValue(true),
+  isNpxExecution: vi.fn().mockReturnValue(false),
   ensureConfigDir: vi.fn().mockReturnValue('/home/tester/.commandmate'),
 }));
 
@@ -38,7 +39,7 @@ vi.mock('fs', async (importOriginal) => ({
 import { spawn } from 'child_process';
 import { closeSync, openSync } from 'fs';
 import { POST, dynamic } from '@/app/api/app/update/route';
-import { ensureConfigDir, isGlobalInstall } from '@/cli/utils/install-context';
+import { ensureConfigDir, isGlobalInstall, isNpxExecution } from '@/cli/utils/install-context';
 import { acquireUpdateLock, releaseUpdateLock } from '@/lib/app-update/update-lock';
 import { getDaemonManagerFactory } from '@/cli/utils/daemon-factory';
 import { AUTH_EXCLUDED_PATHS } from '@/config/auth-config';
@@ -59,6 +60,7 @@ function mockDaemon(isRunning: boolean | Error) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(isGlobalInstall).mockReturnValue(true);
+  vi.mocked(isNpxExecution).mockReturnValue(false);
   // Re-set here, not only at the vi.mock factory: clearAllMocks keeps
   // implementations, so a test that makes this throw would leak into the next.
   vi.mocked(ensureConfigDir).mockReturnValue('/home/tester/.commandmate');
@@ -117,6 +119,57 @@ describe('POST /api/app/update - fixed command guarantee', () => {
     expect(vi.mocked(spawn).mock.calls[0][2]?.stdio).toEqual(['ignore', 42, 42]);
     // The fd is handed to the child; leaving it open would leak it per request.
     expect(closeSync).toHaveBeenCalledWith(42);
+  });
+});
+
+describe('POST /api/app/update - npx gate (Issue #1394)', () => {
+  /**
+   * A server started with `npx commandmate` runs from the npx cache, which
+   * isGlobalInstall() reports as global (Issue #1195). Without this gate the
+   * request passes the global check, spawns a no-op `commandmate update`, and
+   * still answers 202 — hanging the banner until its 5-minute timeout.
+   */
+  it('returns 400 with code "npx" for an npx run and spawns nothing', async () => {
+    vi.mocked(isNpxExecution).mockReturnValue(true);
+    // npx makes isGlobalInstall() true too; the npx gate must win.
+    vi.mocked(isGlobalInstall).mockReturnValue(true);
+
+    const response = await POST();
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'npx' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('checks npx before taking the lock, so no lock is left behind', async () => {
+    vi.mocked(isNpxExecution).mockReturnValue(true);
+
+    await POST();
+
+    expect(acquireUpdateLock).not.toHaveBeenCalled();
+  });
+
+  it('reports npx (not not_global) so the banner can show the right command', async () => {
+    vi.mocked(isNpxExecution).mockReturnValue(true);
+    vi.mocked(isGlobalInstall).mockReturnValue(true);
+
+    const response = await POST();
+
+    await expect(response.json()).resolves.toMatchObject({ code: 'npx' });
+  });
+
+  it('falls through to the global gate when npx detection fails (fails to "not npx")', async () => {
+    vi.mocked(isNpxExecution).mockImplementation(() => {
+      throw new Error('__dirname not available');
+    });
+    vi.mocked(isGlobalInstall).mockReturnValue(false);
+
+    const response = await POST();
+
+    // Not treated as npx; the ordinary non-global gate answers instead.
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'not_global' });
+    expect(spawn).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/api/update-check.test.ts
+++ b/tests/unit/api/update-check.test.ts
@@ -21,11 +21,12 @@ vi.mock('@/lib/version-checker', () => ({
 // Mock install-context [CONS-001]
 vi.mock('@/cli/utils/install-context', () => ({
   isGlobalInstall: vi.fn().mockReturnValue(false),
+  isNpxExecution: vi.fn().mockReturnValue(false),
 }));
 
 import { GET, dynamic } from '@/app/api/app/update-check/route';
 import { checkForUpdate, getCurrentVersion } from '@/lib/version-checker';
-import { isGlobalInstall } from '@/cli/utils/install-context';
+import { isGlobalInstall, isNpxExecution } from '@/cli/utils/install-context';
 import type { UpdateCheckResult } from '@/lib/version-checker';
 
 // =============================================================================
@@ -49,6 +50,7 @@ describe('GET /api/app/update-check', () => {
     vi.clearAllMocks();
     (getCurrentVersion as ReturnType<typeof vi.fn>).mockReturnValue('0.2.3');
     (isGlobalInstall as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    (isNpxExecution as ReturnType<typeof vi.fn>).mockReturnValue(false);
   });
 
   describe('success response (update available)', () => {
@@ -155,6 +157,60 @@ describe('GET /api/app/update-check', () => {
       const data = await response.json();
 
       expect(data.installType).toBe('unknown');
+    });
+  });
+
+  // Issue #1394: npx runs from the npx cache, which isGlobalInstall() reports as
+  // global (Issue #1195). The route must label it 'npx', not 'global', so the
+  // banner shows guidance instead of a one-click button that would no-op.
+  describe('installType: npx (Issue #1394)', () => {
+    it('returns installType: npx when isNpxExecution is true, even though isGlobalInstall is also true', async () => {
+      const mockResult: UpdateCheckResult = {
+        hasUpdate: true,
+        currentVersion: '0.2.3',
+        latestVersion: '0.3.0',
+        releaseUrl: 'https://github.com/Kewton/CommandMate/releases/tag/v0.3.0',
+        releaseName: 'v0.3.0',
+        publishedAt: '2026-02-10T00:00:00Z',
+      };
+      (checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult);
+      // npx makes both true; the route must prefer 'npx'.
+      (isNpxExecution as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (isGlobalInstall as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.installType).toBe('npx');
+    });
+
+    it('never emits an updateCommand for an npx run, so the banner shows no in-place command', async () => {
+      const mockResult: UpdateCheckResult = {
+        hasUpdate: true,
+        currentVersion: '0.2.3',
+        latestVersion: '0.3.0',
+        releaseUrl: 'https://github.com/Kewton/CommandMate/releases/tag/v0.3.0',
+        releaseName: 'v0.3.0',
+        publishedAt: '2026-02-10T00:00:00Z',
+      };
+      (checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult);
+      (isNpxExecution as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (isGlobalInstall as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.updateCommand).toBeNull();
+    });
+
+    it('is checked before isGlobalInstall (npx short-circuits)', async () => {
+      (checkForUpdate as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (isNpxExecution as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      await GET();
+
+      // Preferring npx means the global check is not even consulted.
+      expect(isGlobalInstall).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/components/worktree/update-notification-banner.test.tsx
+++ b/tests/unit/components/worktree/update-notification-banner.test.tsx
@@ -156,6 +156,47 @@ describe('UpdateNotificationBanner', () => {
   });
 
   // =========================================================================
+  // Issue #1394: npx guidance (no in-place update)
+  // =========================================================================
+  describe('npx guidance (Issue #1394)', () => {
+    const npxProps: UpdateNotificationBannerProps = {
+      ...defaultProps,
+      installType: 'npx',
+      updateCommand: null,
+    };
+
+    it('shows the npx guidance block instead of the update button', () => {
+      render(<UpdateNotificationBanner {...npxProps} />);
+
+      expect(screen.getByTestId('update-npx')).toBeDefined();
+      expect(screen.queryByTestId('update-now-button')).toBeNull();
+    });
+
+    it('displays the correct relaunch command (npx commandmate@latest, not commandmate update)', () => {
+      render(<UpdateNotificationBanner {...npxProps} />);
+
+      expect(screen.getByText('npx commandmate@latest')).toBeDefined();
+      expect(screen.queryByText('commandmate update')).toBeNull();
+    });
+
+    it('renders the npx title and description', () => {
+      render(<UpdateNotificationBanner {...npxProps} />);
+
+      expect(screen.getByText('worktree.update.npxTitle')).toBeDefined();
+      expect(screen.getByText('worktree.update.npxDescription')).toBeDefined();
+    });
+
+    it.each(['global', 'local', 'unknown'] as const)(
+      'never shows the npx block for a %s install',
+      (installType) => {
+        render(<UpdateNotificationBanner {...defaultProps} installType={installType} />);
+
+        expect(screen.queryByTestId('update-npx')).toBeNull();
+      }
+    );
+  });
+
+  // =========================================================================
   // Issue #1198: one-click self-update
   // =========================================================================
   describe('update button (Issue #1198)', () => {
@@ -194,7 +235,7 @@ describe('UpdateNotificationBanner', () => {
       expect(screen.getByTestId('update-now-button')).toBeDefined();
     });
 
-    it.each(['local', 'unknown'] as const)(
+    it.each(['local', 'npx', 'unknown'] as const)(
       'never renders the button for a %s install',
       (installType) => {
         render(

--- a/tests/unit/i18n/worktree-update-keys.test.ts
+++ b/tests/unit/i18n/worktree-update-keys.test.ts
@@ -47,6 +47,9 @@ const UPDATE_KEYS = [
   'version',
   // Issue #1198 (one-click self-update)
   'updateNow',
+  // Issue #1394 (npx guidance)
+  'npxTitle',
+  'npxDescription',
   'confirmTitle',
   'confirmDescription',
   'confirmButton',


### PR DESCRIPTION
## 概要
`npx commandmate` で起動したサーバの GUI アップデート機能が npx を「グローバルインストール」と誤認し、「今すぐアップデート」ボタンが `202 started` を返すのに実体は no-op → 5 分 timeout に陥る不具合を修正します。CLI (#1319) にあった npx ガードが GUI 経路（update-check / update route）に未反映でした。

Closes #1394

## 変更内容
- **GET /api/app/update-check**: `isNpxExecution()` を `isGlobalInstall()` より先に判定し `installType: 'npx'` を新設。`updateCommand` は `=== 'global'` ゲート済みで npx では null 維持。
- **POST /api/app/update**: lock/spawn 前に npx ゲートを追加し `400 code:'npx'` で拒否。検知失敗時は fail-safe で既存 `not_global` ゲートにフォールバック。
- **UpdateNotificationBanner**: `installType: 'npx'` で更新ボタンを出さず、正しいコマンド `npx commandmate@latest` の案内ブロックを表示。
- **i18n**: `update.npxTitle` / `update.npxDescription` を `locales/{en,ja}` に追加。
- **型**: `InstallType` union を `'global' | 'local' | 'npx' | 'unknown'` に拡張（route / api-client / banner props）。

## 受け入れ条件
- [x] npx を global と誤認せず「今すぐアップデート」ボタンを表示しない
- [x] `POST /api/app/update` が npx 実行時に spawn せず `400 code:'npx'` を返す
- [x] GUI が表示する案内コマンドが正しい（`commandmate update` ではなく `npx commandmate@latest`）
- [x] グローバルインストール時の既存ワンクリック更新は不変
- [x] ユニットテスト追加

## 検証
- `npx tsc --noEmit`: exit 0
- `npm run lint`: 0 errors
- 影響4テストファイル: 86 passed（npx 系テスト新規追加）
- 全ユニットスイート: 10132 passed（worker 実行）

## スコープ外
npx 起動サーバの「その場更新」実装は本 PR のスコープ外。別 Issue #1395 (feature) で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqhdEu33W6t3ing8ksA6J3
