### PR TITLE
fix: サイドバー同期トーストの見切れを body ポータルで修正 (#1399)

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
 import { CheckCircle, XCircle, Info, AlertTriangle, X } from 'lucide-react';
 import { Z_INDEX } from '@/config/z-index';
@@ -240,7 +241,20 @@ export interface ToastContainerProps {
  * ```
  */
 export function ToastContainer({ toasts, onClose }: ToastContainerProps) {
-  return (
+  // [Issue #1399] Render through a portal to `document.body` so the container's
+  // `position: fixed` resolves against the viewport. When mounted inside a
+  // transformed ancestor (AppShell's `<aside data-testid="sidebar-container">`
+  // uses a transform), that ancestor becomes the containing block for `fixed`,
+  // pinning the toasts to the sidebar's box and clipping their left edge instead
+  // of the intended bottom-right of the screen. Guarded on `mounted` so the
+  // server render (where `document` is absent) yields null and the portal only
+  // appears after client hydration — the same pattern as CommandPalette / Modal.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const container = (
     <div
       data-testid="toast-container"
       aria-live="polite"
@@ -259,6 +273,10 @@ export function ToastContainer({ toasts, onClose }: ToastContainerProps) {
       ))}
     </div>
   );
+
+  if (!mounted) return null;
+
+  return createPortal(container, document.body);
 }
 
 /**


### PR DESCRIPTION
## 概要

サイドバーの同期（Sync）ボタン押下時に表示されるトーストが、ビューポート右下ではなくサイドバー基準に配置され左端が見切れる不具合を修正する。Closes #1399

## 根本原因

`ToastContainer`（`src/components/common/Toast.tsx`）は `position: fixed` だが、`showToast` を呼ぶ `SyncButton` 内で描画され、その祖先 `<aside data-testid="sidebar-container">`（`AppShell.tsx`）が `transform`（スライド演出）を持つ。CSS 仕様上、`transform` を持つ祖先は `position: fixed` 子孫の containing block になるため、トーストがビューポートではなくサイドバー枠（既定幅 224px）を基準に配置され、`min-w-[300px]` のトーストの左端が画面外へはみ出して見切れていた。

## 変更内容

- `ToastContainer` を `createPortal(..., document.body)` で描画するよう変更（`Toast.tsx` のみ、+19/-1）
- SSR/hydration 対策として `mounted` ガードを追加し、クライアントマウント後のみ portal 描画（既存の `Modal.tsx` / `CommandPalette.tsx` と同パターン）
- これにより呼び出し元のツリー位置に関わらず `fixed` がビューポート基準となり、トーストが右下に全幅で表示される

## テスト

- `npm run lint` : PASS
- `npx tsc --noEmit` : PASS
- `npm run test:unit`（CI=true）: PASS（596 files / 10167 tests）

## 影響範囲

- 現状 transform 祖先内にあるのはサイドバー同期トーストのみ。CommandPalette・worktree 系トーストは transform 外のため現状も正常で回帰なし。
- トーストの重複統合（グローバル1本化）は別 Issue #1400 で対応予定。
