### PR TITLE
fix: GUIアップデート後のclient-side exceptionをエラー境界のChunkLoadError回復で解消 (#1404)

### DIFF
--- a/locales/en/error.json
+++ b/locales/en/error.json
@@ -3,6 +3,14 @@
     "errorOccurredIn": "An error occurred in {componentName}",
     "errorOccurred": "An error occurred"
   },
+  "chunkReload": {
+    "title": "Updating to the latest version",
+    "description": "A newer version of CommandMate is available. Reloading to get the latest update…"
+  },
+  "unexpected": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred. Try again, or reload the page."
+  },
   "fileOps": {
     "failedToCreateFile": "Failed to create file",
     "failedToCreateDirectory": "Failed to create directory",

--- a/locales/ja/error.json
+++ b/locales/ja/error.json
@@ -3,6 +3,14 @@
     "errorOccurredIn": "{componentName}でエラーが発生しました",
     "errorOccurred": "エラーが発生しました"
   },
+  "chunkReload": {
+    "title": "最新バージョンに更新しています",
+    "description": "CommandMate の新しいバージョンが利用可能です。最新の状態にするため再読み込みします…"
+  },
+  "unexpected": {
+    "title": "問題が発生しました",
+    "description": "予期しないエラーが発生しました。もう一度お試しいただくか、ページを再読み込みしてください。"
+  },
   "fileOps": {
     "failedToCreateFile": "ファイルの作成に失敗しました",
     "failedToCreateDirectory": "ディレクトリの作成に失敗しました",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+/**
+ * Route-segment error boundary (Issue #1404).
+ *
+ * A `ChunkLoadError` — a stale tab requesting old-hash chunks after a GUI-driven
+ * server upgrade — self-heals with a single guarded reload. Any other error
+ * shows a normal recoverable UI with a retry button (matching ErrorBoundary),
+ * and is never auto-reloaded.
+ *
+ * This boundary renders inside the root layout, so NextIntlClientProvider is
+ * available and `useTranslations` is safe. The last-resort boundary for errors
+ * in the root layout itself is `app/global-error.tsx`.
+ */
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { isChunkLoadError, recoverFromChunkErrorInBrowser } from '@/lib/error/chunk-reload';
+
+interface AppErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AppError({ error, reset }: AppErrorProps) {
+  const t = useTranslations('error');
+  const tCommon = useTranslations('common');
+  const chunk = isChunkLoadError(error);
+
+  useEffect(() => {
+    if (chunk) {
+      recoverFromChunkErrorInBrowser(error);
+    }
+  }, [chunk, error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 pt-safe pb-safe text-center">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">
+          {chunk ? t('chunkReload.title') : t('unexpected.title')}
+        </h1>
+        <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+          {chunk ? t('chunkReload.description') : t('unexpected.description')}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={chunk ? () => window.location.reload() : reset}
+        className="rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-700"
+      >
+        {chunk ? tCommon('reload') : tCommon('retry')}
+      </button>
+    </main>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * Root error boundary (Issue #1404).
+ *
+ * `global-error.tsx` replaces the root layout when an error escapes it, so it
+ * must render its own `<html>`/`<body>`. Two consequences drive this file:
+ *   1. NextIntlClientProvider is NOT mounted — `useTranslations` would throw, so
+ *      the copy comes from a small provider-independent fallback dictionary.
+ *   2. `globals.css` (imported by the bypassed root layout) is NOT loaded — so
+ *      Tailwind utility classes have no effect and styling must be inline.
+ *
+ * A `ChunkLoadError` (stale tab after a server upgrade) self-heals with a single
+ * guarded reload; any other error stays put with a manual reload button.
+ */
+
+import { useEffect, useState } from 'react';
+import { isChunkLoadError, recoverFromChunkErrorInBrowser } from '@/lib/error/chunk-reload';
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+type FallbackLocale = 'en' | 'ja';
+
+const FALLBACK_MESSAGES: Record<FallbackLocale, {
+  chunkTitle: string;
+  chunkDescription: string;
+  genericTitle: string;
+  genericDescription: string;
+  reload: string;
+}> = {
+  en: {
+    chunkTitle: 'Updating to the latest version',
+    chunkDescription:
+      'A newer version of CommandMate is available. Reloading to get the latest update…',
+    genericTitle: 'Something went wrong',
+    genericDescription: 'An unexpected error occurred. Please reload the page.',
+    reload: 'Reload',
+  },
+  ja: {
+    chunkTitle: '最新バージョンに更新しています',
+    chunkDescription:
+      'CommandMate の新しいバージョンが利用可能です。最新の状態にするため再読み込みします…',
+    genericTitle: '問題が発生しました',
+    genericDescription: '予期しないエラーが発生しました。ページを再読み込みしてください。',
+    reload: '再読み込み',
+  },
+};
+
+/** Best-effort locale detection without the i18n provider (cookie → navigator). */
+function detectLocale(): FallbackLocale {
+  if (typeof document !== 'undefined') {
+    const match = document.cookie.match(/(?:^|;\s*)locale=([^;]+)/);
+    if (match && decodeURIComponent(match[1]).toLowerCase().startsWith('ja')) {
+      return 'ja';
+    }
+  }
+  if (typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('ja')) {
+    return 'ja';
+  }
+  return 'en';
+}
+
+export default function GlobalError({ error }: GlobalErrorProps) {
+  const chunk = isChunkLoadError(error);
+  // Default to 'en' for the SSR/first paint, then refine on the client where
+  // document/navigator are available.
+  const [locale, setLocale] = useState<FallbackLocale>('en');
+
+  useEffect(() => {
+    setLocale(detectLocale());
+    if (chunk) {
+      recoverFromChunkErrorInBrowser(error);
+    }
+  }, [chunk, error]);
+
+  const m = FALLBACK_MESSAGES[locale];
+
+  return (
+    <html lang={locale} style={{ colorScheme: 'light dark' }}>
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '1.5rem',
+          padding: '1.5rem',
+          textAlign: 'center',
+          background: 'Canvas',
+          color: 'CanvasText',
+          fontFamily:
+            'system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+        }}
+      >
+        <div style={{ maxWidth: '24rem' }}>
+          <h1 style={{ fontSize: '1.5rem', fontWeight: 600, margin: '0 0 0.5rem' }}>
+            {chunk ? m.chunkTitle : m.genericTitle}
+          </h1>
+          <p style={{ fontSize: '0.875rem', opacity: 0.75, margin: 0 }}>
+            {chunk ? m.chunkDescription : m.genericDescription}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          style={{
+            appearance: 'none',
+            cursor: 'pointer',
+            borderRadius: '0.5rem',
+            border: '1px solid currentColor',
+            background: 'transparent',
+            color: 'inherit',
+            padding: '0.5rem 1rem',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+          }}
+        >
+          {m.reload}
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/src/lib/error/chunk-reload.ts
+++ b/src/lib/error/chunk-reload.ts
@@ -1,0 +1,110 @@
+/**
+ * ChunkLoadError detection + guarded self-recovery (Issue #1404).
+ *
+ * When the server is upgraded from the GUI, tabs opened against the previous
+ * build request old-hash JS chunks / RSC payloads that the new server no longer
+ * serves, producing a `ChunkLoadError`. Without an App Router error boundary
+ * this surfaces as an unhandled "Application error: a client-side exception".
+ *
+ * The boundaries (`app/error.tsx`, `app/global-error.tsx`) call into this module
+ * so a stale tab reloads *once* to fetch the current build, while a guard
+ * prevents an infinite reload loop when a reload does not resolve the error.
+ */
+
+/** sessionStorage key holding the epoch-ms timestamp of the last recovery reload. */
+export const CHUNK_RELOAD_STORAGE_KEY = 'cm:chunk-reload-at';
+
+/**
+ * If a chunk error recurs within this window after an automatic reload, the
+ * reload did not fix it (e.g. a genuinely missing chunk), so we stop reloading
+ * and fall back to the manual UI. A chunk error that arrives after the window
+ * has elapsed is treated as a fresh incident (a later deploy) and is allowed to
+ * self-heal again.
+ */
+export const CHUNK_RELOAD_GUARD_MS = 30_000;
+
+/**
+ * Detect a chunk/module load failure caused by a stale build.
+ *
+ * Matches `error.name === 'ChunkLoadError'` (webpack) or an error message
+ * containing `Loading chunk` / `Failed to fetch dynamically imported module`.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') return false;
+
+  const { name, message } = error as { name?: unknown; message?: unknown };
+  if (name === 'ChunkLoadError') return true;
+
+  if (typeof message === 'string') {
+    return (
+      message.includes('Loading chunk') ||
+      message.includes('Failed to fetch dynamically imported module')
+    );
+  }
+  return false;
+}
+
+export type ChunkReloadOutcome = 'reloaded' | 'guarded' | 'skipped';
+
+export interface ChunkRecoveryEnv {
+  /** sessionStorage-like store, or `null` when unavailable (private mode / SSR). */
+  storage: Pick<Storage, 'getItem' | 'setItem'> | null;
+  /** Current time in epoch ms (injected for deterministic testing). */
+  now: number;
+  /** Triggers the page reload. */
+  reload: () => void;
+}
+
+/**
+ * Reload once to recover from a `ChunkLoadError`, guarding against reload loops.
+ *
+ * - `'skipped'`  — not a ChunkLoadError; the caller shows its normal error UI.
+ * - `'reloaded'` — a page reload was triggered.
+ * - `'guarded'`  — a recent reload already happened (or storage is unavailable),
+ *                  so no reload is triggered and the caller shows a manual UI.
+ */
+export function recoverFromChunkError(
+  error: unknown,
+  env: ChunkRecoveryEnv
+): ChunkReloadOutcome {
+  if (!isChunkLoadError(error)) return 'skipped';
+
+  const { storage, now, reload } = env;
+
+  // Without storage we cannot detect a loop, so we must not auto-reload.
+  if (!storage) return 'guarded';
+
+  const previous = Number(storage.getItem(CHUNK_RELOAD_STORAGE_KEY));
+  if (Number.isFinite(previous) && previous > 0 && now - previous < CHUNK_RELOAD_GUARD_MS) {
+    return 'guarded';
+  }
+
+  storage.setItem(CHUNK_RELOAD_STORAGE_KEY, String(now));
+  reload();
+  return 'reloaded';
+}
+
+/**
+ * Browser-wired {@link recoverFromChunkError}. Tolerates blocked/absent
+ * sessionStorage (Safari private mode throws on access) and no-ops on the server.
+ */
+export function recoverFromChunkErrorInBrowser(error: unknown): ChunkReloadOutcome {
+  if (typeof window === 'undefined') return 'skipped';
+
+  let storage: Storage | null = null;
+  try {
+    storage = window.sessionStorage;
+    // Probe: some browsers expose the object but throw on write (private mode).
+    const probe = '__cm_chunk_probe__';
+    storage.setItem(probe, '1');
+    storage.removeItem(probe);
+  } catch {
+    storage = null;
+  }
+
+  return recoverFromChunkError(error, {
+    storage,
+    now: Date.now(),
+    reload: () => window.location.reload(),
+  });
+}

--- a/tests/unit/app/error-boundaries.test.tsx
+++ b/tests/unit/app/error-boundaries.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for the App Router error boundaries (Issue #1404).
+ *
+ * Verifies that a ChunkLoadError triggers exactly one guarded recovery reload
+ * and that a non-ChunkLoadError does not auto-reload. The guard/loop logic
+ * itself is covered by tests/unit/lib/error/chunk-reload.test.ts; here we assert
+ * the boundaries wire into it correctly.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// Keep detection real; stub only the browser-wired recovery so no real reload
+// happens and we can assert call counts.
+vi.mock('@/lib/error/chunk-reload', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/error/chunk-reload')>();
+  return {
+    ...actual,
+    recoverFromChunkErrorInBrowser: vi.fn(() => 'reloaded' as const),
+  };
+});
+
+import { recoverFromChunkErrorInBrowser } from '@/lib/error/chunk-reload';
+import AppError from '@/app/error';
+import GlobalError from '@/app/global-error';
+
+const mockedRecover = vi.mocked(recoverFromChunkErrorInBrowser);
+
+function chunkError(): Error & { digest?: string } {
+  const err = new Error('Loading chunk 12 failed.') as Error & { digest?: string };
+  err.name = 'ChunkLoadError';
+  return err;
+}
+
+function genericError(): Error & { digest?: string } {
+  return new Error('boom') as Error & { digest?: string };
+}
+
+beforeEach(() => {
+  mockedRecover.mockClear();
+  // global-error renders <html> into a container div → React logs a nesting
+  // warning; keep test output clean.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('app/error.tsx (Issue #1404)', () => {
+  it('triggers guarded recovery exactly once for a ChunkLoadError', () => {
+    render(<AppError error={chunkError()} reset={vi.fn()} />);
+    expect(mockedRecover).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT auto-reload for a non-ChunkLoadError and calls reset on retry', () => {
+    const reset = vi.fn();
+    render(<AppError error={genericError()} reset={reset} />);
+
+    expect(mockedRecover).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('app/global-error.tsx (Issue #1404)', () => {
+  it('triggers guarded recovery exactly once for a ChunkLoadError', () => {
+    render(<GlobalError error={chunkError()} reset={vi.fn()} />);
+    expect(mockedRecover).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT auto-reload for a non-ChunkLoadError', () => {
+    render(<GlobalError error={genericError()} reset={vi.fn()} />);
+    expect(mockedRecover).not.toHaveBeenCalled();
+  });
+
+  it('renders a provider-independent fallback (no i18n provider required)', () => {
+    const { container } = render(<GlobalError error={genericError()} reset={vi.fn()} />);
+    // English default before client locale detection; copy is inline, not keyed.
+    expect(container.textContent).toContain('Something went wrong');
+  });
+});

--- a/tests/unit/lib/error/chunk-reload.test.ts
+++ b/tests/unit/lib/error/chunk-reload.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for ChunkLoadError detection + guarded self-recovery (Issue #1404).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isChunkLoadError,
+  recoverFromChunkError,
+  CHUNK_RELOAD_STORAGE_KEY,
+  CHUNK_RELOAD_GUARD_MS,
+  type ChunkRecoveryEnv,
+} from '@/lib/error/chunk-reload';
+
+function makeStorage(initial?: string): {
+  storage: Pick<Storage, 'getItem' | 'setItem'>;
+  get: () => string | undefined;
+} {
+  let value = initial;
+  return {
+    storage: {
+      getItem: (key: string) => (key === CHUNK_RELOAD_STORAGE_KEY ? value ?? null : null),
+      setItem: (key: string, next: string) => {
+        if (key === CHUNK_RELOAD_STORAGE_KEY) value = next;
+      },
+    },
+    get: () => value,
+  };
+}
+
+describe('isChunkLoadError (Issue #1404)', () => {
+  it('matches a webpack ChunkLoadError by name', () => {
+    const err = new Error('boom');
+    err.name = 'ChunkLoadError';
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it('matches "Loading chunk" messages', () => {
+    expect(isChunkLoadError(new Error('Loading chunk 42 failed.'))).toBe(true);
+  });
+
+  it('matches dynamic import failures', () => {
+    expect(
+      isChunkLoadError(new Error('Failed to fetch dynamically imported module: /_next/x.js'))
+    ).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isChunkLoadError(new Error('TypeError: undefined is not a function'))).toBe(false);
+    expect(isChunkLoadError(new TypeError('nope'))).toBe(false);
+  });
+
+  it('is null/undefined/non-object safe', () => {
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError('Loading chunk 3 failed')).toBe(false);
+  });
+});
+
+describe('recoverFromChunkError (Issue #1404)', () => {
+  function chunkError(): Error {
+    const err = new Error('Loading chunk 7 failed.');
+    err.name = 'ChunkLoadError';
+    return err;
+  }
+
+  it('reloads once and records the timestamp for a fresh ChunkLoadError', () => {
+    const reload = vi.fn();
+    const { storage, get } = makeStorage();
+    const env: ChunkRecoveryEnv = { storage, now: 1_000_000, reload };
+
+    const outcome = recoverFromChunkError(chunkError(), env);
+
+    expect(outcome).toBe('reloaded');
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(get()).toBe('1000000');
+  });
+
+  it('does NOT reload again while the guard window is still open', () => {
+    const reload = vi.fn();
+    const { storage } = makeStorage(String(1_000_000));
+    const env: ChunkRecoveryEnv = {
+      storage,
+      now: 1_000_000 + CHUNK_RELOAD_GUARD_MS - 1,
+      reload,
+    };
+
+    const outcome = recoverFromChunkError(chunkError(), env);
+
+    expect(outcome).toBe('guarded');
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads again once the guard window has elapsed (later deploy self-heals)', () => {
+    const reload = vi.fn();
+    const { storage, get } = makeStorage(String(1_000_000));
+    const now = 1_000_000 + CHUNK_RELOAD_GUARD_MS + 1;
+    const env: ChunkRecoveryEnv = { storage, now, reload };
+
+    const outcome = recoverFromChunkError(chunkError(), env);
+
+    expect(outcome).toBe('reloaded');
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(get()).toBe(String(now));
+  });
+
+  it('does NOT auto-reload for a non-ChunkLoadError', () => {
+    const reload = vi.fn();
+    const { storage, get } = makeStorage();
+    const env: ChunkRecoveryEnv = { storage, now: 1_000_000, reload };
+
+    const outcome = recoverFromChunkError(new Error('unrelated failure'), env);
+
+    expect(outcome).toBe('skipped');
+    expect(reload).not.toHaveBeenCalled();
+    expect(get()).toBeUndefined();
+  });
+
+  it('does NOT reload when storage is unavailable (cannot guard against a loop)', () => {
+    const reload = vi.fn();
+    const env: ChunkRecoveryEnv = { storage: null, now: 1_000_000, reload };
+
+    const outcome = recoverFromChunkError(chunkError(), env);
+
+    expect(outcome).toBe('guarded');
+    expect(reload).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

`npx commandmate` の GUI アップデート後に発生する `Application error: a client-side exception has occurred` を、App Router のエラー境界で `ChunkLoadError` を検知し**ガード付きの一度だけの自己回復リロード**を行うことで解消する。Closes #1404

## 根本原因

版入替でサーバが新ビルドに差し替わる一方、旧タブが旧ハッシュの chunk/RSC を新サーバへ要求して `ChunkLoadError` になるが、アプリに `error.tsx` / `global-error.tsx` が1つも無いため未処理クラッシュしていた。

## 変更内容（本命修正のみ）

- **`src/lib/error/chunk-reload.ts`（新規）**: `isChunkLoadError()`（`name==='ChunkLoadError'` またはメッセージに `Loading chunk` / `Failed to fetch dynamically imported module` を含む）＋ `recoverFromChunkError()`（DI設計）／`recoverFromChunkErrorInBrowser()`。sessionStorage に前回リロード時刻を記録し、**30秒以内の再発は 'guarded' で自動リロードしない**（無限ループ防止）。storage 不可（Safariプライベート/SSR）時も 'guarded' で安全側に倒す。
- **`src/app/error.tsx`（新規）**: ルートセグメントのエラー境界。`useEffect` で ChunkLoadError 時のみ自己回復。非 ChunkLoadError は自動リロードせず retry ボタン表示。root layout 内なので `next-intl` を使用。
- **`src/app/global-error.tsx`（新規）**: root layout を置き換える最終境界。`<html>`/`<body>` を自前描画、`NextIntlClientProvider` 非依存の en/ja フォールバック辞書＋cookie/navigator ロケール検出、`globals.css` 非ロードを前提とした inline スタイル（`Canvas`/`CanvasText` でテーマ追従）。同様に ChunkLoadError を自己回復。
- **`locales/{en,ja}/error.json`**: `chunkReload.*` / `unexpected.*` キーを追加（既存 `error` 名前空間は `src/i18n.ts` が既にロード済み）。
- **テスト（新規2本）**: `tests/unit/lib/error/chunk-reload.test.ts`（検知・ガード・storage不可の分岐）、`tests/unit/app/error-boundaries.test.tsx`（境界の自動回復/手動フォールバック）。

## スコープ外（別Issue候補）

補強策（UpdateNotificationBanner の reload 発火条件拡張、VersionMismatchBanner の自動リロード化、Service Worker の `/offline` バージョニング）は本PRに含めず、決定打であるエラー境界の ChunkLoadError 回復に集中。

## テスト

- `npm run lint` : PASS
- `npx tsc --noEmit` : PASS
- `npm run test:unit`（CI=true）: PASS（598 files / 10184 tests、新規2本含む）

## 検証メモ

実際の版入替再現はCIでは困難なため、本PRは**単体テスト＋コードレビュー**で検証。実機での版入替（npx GUIアップデート）による最終確認は後段で実施予定。
