### PR TITLE
fix: History表示上限を会話ペア単位で数える (#1407)

### DIFF
--- a/src/app/api/worktrees/[id]/messages/route.ts
+++ b/src/app/api/worktrees/[id]/messages/route.ts
@@ -60,6 +60,18 @@ export async function GET(
     }
     const instanceId = instanceParam ?? undefined;
 
+    // Issue #1407: optional unit for `limit`. 'pairs' counts conversation turns so
+    // the History pane renders `limit` cards; 'messages' (default) keeps the legacy
+    // raw-row semantics for other API consumers.
+    const unitParam = searchParams.get('unit');
+    if (unitParam !== null && unitParam !== 'messages' && unitParam !== 'pairs') {
+      return NextResponse.json(
+        { error: 'Invalid unit parameter (must be "messages" or "pairs")' },
+        { status: 400 }
+      );
+    }
+    const limitUnit = (unitParam ?? 'messages') as 'messages' | 'pairs';
+
     // Validate limit. Upper bound is MAX_MESSAGES_LIMIT (Issue #701).
     if (isNaN(limit) || limit < 1 || limit > MAX_MESSAGES_LIMIT) {
       return NextResponse.json(
@@ -69,7 +81,7 @@ export async function GET(
     }
 
     // Get messages with optional CLI tool / instance filter
-    const messages = getMessages(db, id, { before, limit, cliToolId, instanceId, includeArchived });
+    const messages = getMessages(db, id, { before, limit, cliToolId, instanceId, includeArchived, limitUnit });
 
     // Filter out messages with empty content (defensive programming)
     const validMessages = messages.filter((m) => m.content && m.content.trim() !== '');

--- a/src/hooks/useSplitMessages.ts
+++ b/src/hooks/useSplitMessages.ts
@@ -96,7 +96,10 @@ export function useSplitMessages({
     const requestedInstance = resolvedInstanceId;
     const requestId = ++requestIdRef.current;
     try {
-      const params = new URLSearchParams({ cliTool: requestedCli, instance: requestedInstance });
+      // Issue #1407: History renders conversation-pair cards, so the limit must be
+      // counted in pairs (turns), not raw rows — otherwise codex's many-assistant-rows
+      // -per-turn collapses `limit` rows into far fewer cards.
+      const params = new URLSearchParams({ cliTool: requestedCli, instance: requestedInstance, unit: 'pairs' });
       if (limit !== undefined) {
         params.set('limit', String(limit));
       }

--- a/src/hooks/useWorktreeDetailController.ts
+++ b/src/hooks/useWorktreeDetailController.ts
@@ -468,7 +468,9 @@ export function useWorktreeDetailController({ worktreeId }: { worktreeId: string
     const requestedInstance = activeInstanceIdRef.current;
     const requestId = ++latestMessagesRequestIdRef.current;
     try {
-      const params = new URLSearchParams({ cliTool: requestedCliTool });
+      // Issue #1407: History renders conversation-pair cards, so count the limit in
+      // pairs (turns) rather than raw rows (see useSplitMessages).
+      const params = new URLSearchParams({ cliTool: requestedCliTool, unit: 'pairs' });
       if (onMobile) {
         params.set('instance', requestedInstance);
       }

--- a/src/lib/db/chat-db.ts
+++ b/src/lib/db/chat-db.ts
@@ -24,6 +24,15 @@ export interface GetMessagesOptions {
   /** Issue #868: scope to a single agent instance (overrides cliToolId filtering when set). */
   instanceId?: string;
   includeArchived?: boolean;
+  /**
+   * Issue #1407: unit that `limit` counts.
+   * - 'messages' (default): bounds the number of raw chat rows returned (legacy behavior).
+   * - 'pairs': bounds the number of conversation turns. The newest `limit` user
+   *   messages in scope are located and every row at or after the oldest of them is
+   *   returned, so grouping into conversation pairs yields up to `limit` cards
+   *   regardless of how many assistant rows each turn produced (e.g. codex prompts).
+   */
+  limitUnit?: 'messages' | 'pairs';
 }
 
 type ChatMessageRow = {
@@ -197,35 +206,66 @@ export function getMessages(
   worktreeId: string,
   options: GetMessagesOptions = {}
 ): ChatMessage[] {
-  const { before, limit = 50, cliToolId, instanceId, includeArchived = false } = options;
+  const { before, limit = 50, cliToolId, instanceId, includeArchived = false, limitUnit = 'messages' } = options;
 
-  let query = `
-    SELECT id, worktree_id, role, content, summary, timestamp, log_file_name, request_id, message_type, prompt_data, cli_tool_id, instance_id, archived
-    FROM chat_messages
-    WHERE worktree_id = ? AND (? IS NULL OR timestamp < ?)
-  `;
+  // Build the shared scope clause (worktree + before cursor + archived + instance/cli
+  // filter) and its bound params. Used for both the message-unit and pair-unit paths
+  // so their filtering stays identical.
+  const buildScope = (): { clause: string; params: (string | number | null)[] } => {
+    let clause = `FROM chat_messages
+    WHERE worktree_id = ? AND (? IS NULL OR timestamp < ?)`;
+    const params: (string | number | null)[] = [worktreeId, before?.getTime() || null, before?.getTime() || null];
 
-  const params: (string | number | null)[] = [worktreeId, before?.getTime() || null, before?.getTime() || null];
+    // archived filter (default: non-archived only)
+    if (!includeArchived) {
+      clause += ` ${ACTIVE_FILTER}`;
+    }
 
-  // archived filter (default: non-archived only)
-  if (!includeArchived) {
-    query += ` ${ACTIVE_FILTER}`;
+    // Issue #868: instance filter takes precedence; otherwise fall back to CLI tool filter.
+    if (instanceId) {
+      clause += ` AND instance_id = ?`;
+      params.push(instanceId);
+    } else if (cliToolId) {
+      clause += ` AND cli_tool_id = ?`;
+      params.push(cliToolId);
+    }
+
+    return { clause, params };
+  };
+
+  const SELECT_COLS = `SELECT id, worktree_id, role, content, summary, timestamp, log_file_name, request_id, message_type, prompt_data, cli_tool_id, instance_id, archived`;
+
+  // Issue #1407: pair-unit paging. Resolve a timestamp cutoff so the newest `limit`
+  // user turns are fully included (with all their assistant rows). This keeps the
+  // rendered conversation-pair count equal to `limit` even when a single turn emits
+  // many assistant rows (codex prompts/intermediate outputs). Falls back to
+  // message-unit paging when no user messages exist in scope.
+  if (limitUnit === 'pairs') {
+    const scope = buildScope();
+    const cutoffRow = db
+      .prepare(
+        `SELECT MIN(timestamp) AS cutoff FROM (
+          SELECT timestamp ${scope.clause} AND role = 'user'
+          ORDER BY timestamp DESC LIMIT ?
+        )`
+      )
+      .get(...scope.params, limit) as { cutoff: number | null } | undefined;
+
+    const cutoff = cutoffRow?.cutoff ?? null;
+    if (cutoff !== null) {
+      const full = buildScope();
+      const rows = db
+        .prepare(`${SELECT_COLS} ${full.clause} AND timestamp >= ? ORDER BY timestamp DESC`)
+        .all(...full.params, cutoff) as ChatMessageRow[];
+      return rows.map(mapChatMessage);
+    }
+    // No user messages in scope → fall through to message-unit behavior below.
   }
 
-  // Issue #868: instance filter takes precedence; otherwise fall back to CLI tool filter.
-  if (instanceId) {
-    query += ` AND instance_id = ?`;
-    params.push(instanceId);
-  } else if (cliToolId) {
-    query += ` AND cli_tool_id = ?`;
-    params.push(cliToolId);
-  }
-
-  query += ` ORDER BY timestamp DESC LIMIT ?`;
-  params.push(limit);
-
-  const stmt = db.prepare(query);
-  const rows = stmt.all(...params) as ChatMessageRow[];
+  const scope = buildScope();
+  const rows = db
+    .prepare(`${SELECT_COLS} ${scope.clause} ORDER BY timestamp DESC LIMIT ?`)
+    .all(...scope.params, limit) as ChatMessageRow[];
 
   return rows.map(mapChatMessage);
 }

--- a/tests/integration/api-messages.test.ts
+++ b/tests/integration/api-messages.test.ts
@@ -274,6 +274,78 @@ describe('GET /api/worktrees/:id/messages', () => {
     });
   });
 
+  // Issue #1407: unit parameter (pairs vs messages)
+  describe('unit parameter (Issue #1407)', () => {
+    const seedTurns = () => {
+      let clock = 0;
+      const add = (role: 'user' | 'assistant', content: string) =>
+        createMessage(db, {
+          worktreeId: 'test-worktree',
+          role,
+          content,
+          timestamp: new Date(++clock),
+          messageType: 'normal',
+          cliToolId: 'codex',
+          instanceId: 'codex',
+        });
+      // 2 user turns, each with 3 assistant rows (6 assistant rows total).
+      add('user', 't1-user');
+      add('assistant', 't1-a0');
+      add('assistant', 't1-a1');
+      add('assistant', 't1-a2');
+      add('user', 't2-user');
+      add('assistant', 't2-a0');
+      add('assistant', 't2-a1');
+      add('assistant', 't2-a2');
+    };
+
+    it('unit=pairs returns whole turns, not just `limit` raw rows', async () => {
+      seedTurns();
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=1&unit=pairs&cliTool=codex'
+      );
+      const params = { params: Promise.resolve({ id: 'test-worktree' }) };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(200);
+      const data: ChatMessage[] = await response.json();
+      // Newest turn = 1 user + 3 assistant rows (raw-row limit=1 would have returned 1).
+      expect(data).toHaveLength(4);
+      expect(data.filter((m) => m.role === 'user').map((m) => m.content)).toEqual(['t2-user']);
+    });
+
+    it('default (message unit) still bounds by raw rows', async () => {
+      seedTurns();
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?limit=1&cliTool=codex'
+      );
+      const params = { params: Promise.resolve({ id: 'test-worktree' }) };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(200);
+      const data: ChatMessage[] = await response.json();
+      expect(data).toHaveLength(1);
+    });
+
+    it('should reject an invalid unit with 400', async () => {
+      const request = new Request(
+        'http://localhost:3000/api/worktrees/test-worktree/messages?unit=bogus'
+      );
+      const params = { params: Promise.resolve({ id: 'test-worktree' }) };
+      const response = await getMessages(
+        request as unknown as import('next/server').NextRequest,
+        params
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data).toHaveProperty('error');
+    });
+  });
+
   it('should return 500 on database error', async () => {
     db.close();
 

--- a/tests/unit/db-get-messages-pairs.test.ts
+++ b/tests/unit/db-get-messages-pairs.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for getMessages pair-unit paging (Issue #1407)
+ *
+ * The History pane renders conversation-pair cards, so the display limit must be
+ * counted in turns (pairs), not raw rows. Otherwise agents that emit many
+ * assistant rows per turn (e.g. codex prompts/intermediate outputs) collapse a
+ * `limit`-row window into far fewer cards than the user selected.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { createMessage, getMessages, upsertWorktree } from '@/lib/db';
+import { groupMessagesIntoPairs } from '@/lib/conversation-grouper';
+import type { Worktree } from '@/types/models';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+describe('getMessages pair-unit paging (Issue #1407)', () => {
+  let db: Database.Database;
+  const worktreeId = 'test-worktree-pairs';
+
+  // Monotonically increasing timestamp so ordering is deterministic.
+  let clock = 0;
+
+  const addUser = (content: string, opts: { cliToolId?: CLIToolType; instanceId?: string } = {}) =>
+    createMessage(db, {
+      worktreeId,
+      role: 'user',
+      content,
+      timestamp: new Date(++clock),
+      messageType: 'normal',
+      cliToolId: opts.cliToolId ?? 'codex',
+      instanceId: opts.instanceId ?? opts.cliToolId ?? 'codex',
+    });
+
+  const addAssistant = (content: string, opts: { cliToolId?: CLIToolType; instanceId?: string } = {}) =>
+    createMessage(db, {
+      worktreeId,
+      role: 'assistant',
+      content,
+      timestamp: new Date(++clock),
+      messageType: 'normal',
+      cliToolId: opts.cliToolId ?? 'codex',
+      instanceId: opts.instanceId ?? opts.cliToolId ?? 'codex',
+    });
+
+  /** Seed one user turn followed by `assistantCount` assistant rows (codex-like density). */
+  const addTurn = (
+    label: string,
+    assistantCount: number,
+    opts: { cliToolId?: CLIToolType; instanceId?: string } = {}
+  ) => {
+    addUser(`${label}-user`, opts);
+    for (let i = 0; i < assistantCount; i++) {
+      addAssistant(`${label}-assistant-${i}`, opts);
+    }
+  };
+
+  const userPairs = (messages: ReturnType<typeof getMessages>) =>
+    groupMessagesIntoPairs(messages).filter((p) => p.userMessage !== null);
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    clock = 0;
+
+    const worktree: Worktree = {
+      id: worktreeId,
+      name: 'Test Worktree',
+      path: '/test/path/pairs',
+      repositoryPath: '/test/repo',
+      repositoryName: 'TestRepo',
+      cliToolId: 'codex',
+    };
+    upsertWorktree(db, worktree);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns exactly `limit` conversation turns even when assistant rows dominate', () => {
+    // A leading orphan assistant (no preceding user) must NOT be included by pairs mode.
+    addAssistant('leading-orphan');
+    addTurn('t1', 3);
+    addTurn('t2', 5);
+    addTurn('t3', 2);
+    addTurn('t4', 6);
+    addTurn('t5', 4);
+
+    const messages = getMessages(db, worktreeId, { limit: 3, limitUnit: 'pairs' });
+
+    const pairs = groupMessagesIntoPairs(messages);
+    // Newest 3 turns (t3, t4, t5), no orphan pair.
+    expect(pairs).toHaveLength(3);
+    expect(pairs.every((p) => p.userMessage !== null)).toBe(true);
+    expect(pairs.map((p) => p.userMessage?.content)).toEqual([
+      't3-user',
+      't4-user',
+      't5-user',
+    ]);
+    // All assistant rows for those 3 turns are present (2 + 6 + 4).
+    const assistantTotal = pairs.reduce((n, p) => n + p.assistantMessages.length, 0);
+    expect(assistantTotal).toBe(12);
+  });
+
+  it('demonstrates the legacy defect: message-unit collapses to far fewer cards', () => {
+    addTurn('t1', 3);
+    addTurn('t2', 5);
+    addTurn('t3', 2);
+    addTurn('t4', 6);
+    addTurn('t5', 4);
+
+    // Default (message unit): newest 3 raw rows are all from the last turn's assistants.
+    const legacy = getMessages(db, worktreeId, { limit: 3 });
+    expect(legacy).toHaveLength(3);
+    expect(userPairs(legacy)).toHaveLength(0); // zero user-anchored cards
+
+    // Pair unit: the same limit yields 3 real conversation cards.
+    const fixed = getMessages(db, worktreeId, { limit: 3, limitUnit: 'pairs' });
+    expect(userPairs(fixed)).toHaveLength(3);
+  });
+
+  it('returns all available turns when fewer than `limit` exist', () => {
+    addTurn('t1', 4);
+    addTurn('t2', 6);
+
+    const messages = getMessages(db, worktreeId, { limit: 50, limitUnit: 'pairs' });
+    expect(userPairs(messages)).toHaveLength(2);
+  });
+
+  it('falls back to message-unit when no user messages exist in scope', () => {
+    addAssistant('orphan-1');
+    addAssistant('orphan-2');
+    addAssistant('orphan-3');
+
+    const messages = getMessages(db, worktreeId, { limit: 2, limitUnit: 'pairs' });
+    // No user turns → behaves like the raw-row limit (newest 2 rows).
+    expect(messages).toHaveLength(2);
+    expect(messages.map((m) => m.content)).toEqual(['orphan-3', 'orphan-2']);
+  });
+
+  it('scopes pair counting to a single agent instance', () => {
+    // codex primary and codex-2 interleaved.
+    addTurn('primary-a', 3, { cliToolId: 'codex', instanceId: 'codex' });
+    addTurn('inst2-a', 4, { cliToolId: 'codex', instanceId: 'codex-2' });
+    addTurn('primary-b', 2, { cliToolId: 'codex', instanceId: 'codex' });
+    addTurn('inst2-b', 5, { cliToolId: 'codex', instanceId: 'codex-2' });
+
+    const messages = getMessages(db, worktreeId, {
+      limit: 1,
+      limitUnit: 'pairs',
+      instanceId: 'codex-2',
+    });
+
+    const pairs = userPairs(messages);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].userMessage?.content).toBe('inst2-b-user');
+    // Only codex-2 rows returned.
+    expect(messages.every((m) => m.instanceId === 'codex-2')).toBe(true);
+  });
+
+  it('pages older turns via the `before` cursor', () => {
+    addTurn('t1', 2);
+    addTurn('t2', 2);
+    addTurn('t3', 2);
+
+    // First page: newest turn only.
+    const page1 = getMessages(db, worktreeId, { limit: 1, limitUnit: 'pairs' });
+    const page1Pairs = userPairs(page1);
+    expect(page1Pairs).toHaveLength(1);
+    expect(page1Pairs[0].userMessage?.content).toBe('t3-user');
+
+    // Second page: turns strictly older than the oldest row of page 1.
+    const oldestOnPage1 = page1.reduce((min, m) =>
+      m.timestamp.getTime() < min.timestamp.getTime() ? m : min
+    );
+    const page2 = getMessages(db, worktreeId, {
+      limit: 1,
+      limitUnit: 'pairs',
+      before: oldestOnPage1.timestamp,
+    });
+    const page2Pairs = userPairs(page2);
+    expect(page2Pairs).toHaveLength(1);
+    expect(page2Pairs[0].userMessage?.content).toBe('t2-user');
+  });
+
+  it('leaves message-unit (default) behavior unchanged', () => {
+    addTurn('t1', 2);
+    addTurn('t2', 2);
+
+    const explicit = getMessages(db, worktreeId, { limit: 3, limitUnit: 'messages' });
+    const defaulted = getMessages(db, worktreeId, { limit: 3 });
+    expect(explicit.map((m) => m.content)).toEqual(defaulted.map((m) => m.content));
+    expect(defaulted).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## 概要

Worktree 詳細画面の History ペインで、表示上限に `50` を指定しても 50 未満（codex-2 実測で約 10 枚）の会話ペアカードしか表示されない問題を修正します（#1407）。

## 原因

表示上限セレクタの値は `limit` クエリとして `messages` API に渡り、`getMessages` の `ORDER BY timestamp DESC LIMIT ?` で **user+assistant を合算した生の行**を最大 N 行取得していました。一方、History は取得メッセージを `groupMessagesIntoPairs` で**会話ペア（user 1件＋続く assistant 群）にまとめて表示**するため、1 ターンあたり assistant 行が多い codex 等では、生行 N が少数のカードに畳まれていました。

実データ（`commandagent-develop` / `instance=codex-2` / archived=0）: assistant 211 : user 31（≈6.8:1）。最新 50 行中の user はわずか 9 件 → 約 10 カード。

## 対応（案A: 上限を「会話ペア数」で数える）

- `getMessages` に `limitUnit: 'pairs'` を追加。最新 `limit` 件の user メッセージの timestamp を cutoff にし、以降の全行を返す。**既定の `'messages'` 単位は完全に不変**（他の呼び出し元に影響なし）。
- `messages` route に `unit`（`messages` | `pairs`）パラメータを追加して検証・委譲。
- History 取得系（`useSplitMessages` / `useWorktreeDetailController.fetchMessages`）が `unit=pairs` を送信。
- user メッセージが存在しないスコープでは従来の message 単位にフォールバック。

これによりカード枚数 = セレクタ選択値に一致します。

## テスト

- `tests/unit/db-get-messages-pairs.test.ts`（新規）: ペア単位取得、assistant 過多時のカード枚数一致、旧挙動の退行デモ、instance スコープ、`before` ページング、message 単位不変を検証。
- `tests/integration/api-messages.test.ts`: `unit=pairs` の挙動、既定の raw-row 挙動、不正 `unit` の 400 を追加。

## 品質ゲート

- [x] `npm run lint`（0 errors）
- [x] `npx tsc --noEmit`
- [x] `npm run test:unit`（599 files / 10191 tests pass）
- [x] `npm run build`

Refs #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3YuRQbsJv6epx7umung6r
