### PR TITLE
fix: npx自己更新を安定cwdから実行しuv_cwdクラッシュを防ぐ (#1410)

### DIFF
--- a/src/app/api/app/update/route.ts
+++ b/src/app/api/app/update/route.ts
@@ -131,15 +131,25 @@ function spawnUpdate(logPath: string, relaunchNpx: boolean): void {
     ? ['update', '--yes', '--relaunch-npx']
     : ['update', '--yes'];
 
+  // Issue #1410: resolve the bin from the package root (this process's cwd) at
+  // spawn time, but run the child from a STABLE directory. Under npx the server's
+  // cwd is the npx cache package dir (~/.npm/_npx/<hash>/node_modules/commandmate),
+  // which npx deletes/replaces while fetching the new version; a child that
+  // inherited that cwd then crashes on process.cwd() (ENOENT: uv_cwd) at relaunch,
+  // after the old server has already been stopped. The config dir always exists
+  // (ensureConfigDir created it) and is preserved across updates.
+  const binPath = join(process.cwd(), 'bin', 'commandmate.js');
+  const stableCwd = ensureConfigDir();
+
   const logFd = openSync(logPath, 'a');
   try {
     const child = spawn(
       process.execPath,
-      [join(process.cwd(), 'bin', 'commandmate.js'), ...args],
+      [binPath, ...args],
       {
         detached: true,
         stdio: ['ignore', logFd, logFd],
-        cwd: process.cwd(),
+        cwd: stableCwd,
       }
     );
     child.unref();

--- a/src/cli/utils/npx-runner.ts
+++ b/src/cli/utils/npx-runner.ts
@@ -20,6 +20,7 @@
  */
 
 import { spawnSync, type SpawnSyncReturns } from 'child_process';
+import { homedir } from 'os';
 
 /**
  * Upper bound for the warmup download.
@@ -90,6 +91,23 @@ export function sanitizeNpxEnv(
  * @param packageName - Package name (a literal constant, e.g. `commandmate`)
  * @returns The fetched version, or a classified failure
  */
+/**
+ * Working directory for the npx spawns (Issue #1410).
+ *
+ * The server — and the detached update process it spawns — run from the npx
+ * cache package dir (`~/.npm/_npx/<hash>/node_modules/commandmate`). While
+ * `warmNpxLatest` fetches the new version, npx deletes/replaces that dir, so a
+ * later npx spawn that inherited it crashes when npm calls `process.cwd()`
+ * (`ENOENT: uv_cwd`) during bootstrap, aborting the relaunch after the old
+ * server is already stopped. Running the npx spawns from the always-present home
+ * directory keeps `process.cwd()` valid regardless of npx cache churn. The
+ * relaunched daemon sets its own cwd to the (new) package root, so this does not
+ * change where the server ultimately runs.
+ */
+export function stableNpxCwd(): string {
+  return homedir();
+}
+
 export function warmNpxLatest(packageName: string): NpxWarmResult {
   const result = spawnSync(
     'npx',
@@ -97,6 +115,7 @@ export function warmNpxLatest(packageName: string): NpxWarmResult {
     {
       encoding: 'utf-8',
       timeout: NPX_WARMUP_TIMEOUT_MS,
+      cwd: stableNpxCwd(),
       env: sanitizeNpxEnv(),
     }
   );
@@ -147,6 +166,7 @@ export function spawnNpxDaemon(packageName: string): NpxDaemonResult {
     ['--yes', `${packageName}@latest`, 'start', '--daemon'],
     {
       encoding: 'utf-8',
+      cwd: stableNpxCwd(),
       env: sanitizeNpxEnv(),
     }
   );

--- a/tests/unit/api/app-update.test.ts
+++ b/tests/unit/api/app-update.test.ts
@@ -112,6 +112,17 @@ describe('POST /api/app/update - fixed command guarantee', () => {
     expect(unref).toHaveBeenCalledTimes(1);
   });
 
+  it('runs the detached child from the stable config dir, not the npx cache cwd (Issue #1410)', async () => {
+    await POST();
+
+    const options = vi.mocked(spawn).mock.calls[0][2];
+    // The server's cwd under npx is the npx cache package dir, which npx deletes
+    // while fetching the new version; a child that inherited it would crash on
+    // process.cwd() (ENOENT: uv_cwd) at relaunch. The preserved config dir is stable.
+    expect(options?.cwd).toBe('/home/tester/.commandmate');
+    expect(options?.cwd).not.toBe(process.cwd());
+  });
+
   it('redirects child output to the update log instead of inheriting pipes', async () => {
     await POST();
 

--- a/tests/unit/cli/utils/npx-runner.test.ts
+++ b/tests/unit/cli/utils/npx-runner.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as childProcess from 'child_process';
+import { homedir } from 'os';
 
 vi.mock('child_process');
 
@@ -16,6 +17,7 @@ import {
   warmNpxLatest,
   spawnNpxDaemon,
   sanitizeNpxEnv,
+  stableNpxCwd,
   NPX_WARMUP_TIMEOUT_MS,
 } from '../../../../src/cli/utils/npx-runner';
 
@@ -136,6 +138,14 @@ describe('sanitizeNpxEnv', () => {
   });
 });
 
+describe('stableNpxCwd (Issue #1410)', () => {
+  it('returns an absolute home directory (never the npx cache package dir)', () => {
+    const cwd = stableNpxCwd();
+    expect(cwd).toBe(homedir());
+    expect(cwd).not.toMatch(/_npx/);
+  });
+});
+
 describe('warmNpxLatest', () => {
   it('invokes `npx --yes <pkg>@latest --version` with array argv and no shell', () => {
     mockSpawn(spawnResult({ stdout: '0.10.4\n', status: 0 }));
@@ -159,6 +169,16 @@ describe('warmNpxLatest', () => {
     const env = options.env as NodeJS.ProcessEnv;
     expect(env).toBeDefined();
     expect(Object.keys(env).some((k) => /^npm_/i.test(k))).toBe(false);
+  });
+
+  it('runs from a stable cwd (home dir) so npx cache churn cannot invalidate process.cwd() — Issue #1410', () => {
+    mockSpawn(spawnResult({ stdout: '0.10.4\n', status: 0 }));
+
+    warmNpxLatest(PACKAGE_NAME);
+
+    // The inherited cwd would be the npx cache package dir, which npx deletes
+    // while fetching; an absolute stable cwd keeps the child's process.cwd() valid.
+    expect(lastOptions().cwd).toBe(homedir());
   });
 
   it('keeps the warmup timeout comfortably under the GUI 5-minute timeout', () => {
@@ -235,6 +255,16 @@ describe('spawnNpxDaemon', () => {
 
     const env = lastOptions().env as NodeJS.ProcessEnv;
     expect(Object.keys(env).some((k) => /^npm_/i.test(k))).toBe(false);
+  });
+
+  it('runs from a stable cwd (home dir) so a deleted npx cache dir does not crash the relaunch — Issue #1410', () => {
+    mockSpawn(spawnResult({ status: 0 }));
+
+    spawnNpxDaemon(PACKAGE_NAME);
+
+    // This is the step that crashed with ENOENT (uv_cwd) when it inherited the
+    // (now-deleted) npx cache dir as its cwd; a stable absolute cwd prevents it.
+    expect(lastOptions().cwd).toBe(homedir());
   });
 
   it('reports success when the relaunch exits 0', () => {


### PR DESCRIPTION
## 概要

npx 起動サーバの GUI「今すぐアップデート」が、再起動段で `process.cwd()` の **`ENOENT (uv_cwd)`** により npx がクラッシュして失敗する問題を修正します（#1410）。旧サーバは既に停止済みのためサーバ不在となり、ブラウザは client-side exception になっていました。

## 原因（`~/.commandmate/update.log` の実ログで確定）

- npx 起動サーバの cwd は npx キャッシュ内のパッケージ dir（`~/.npm/_npx/<hash>/node_modules/commandmate`）。
- 分離起動される更新プロセスがこの cwd を継承。
- `warmNpxLatest`（`npx …@latest --version`）が新版を取得すると **npx が旧 `_npx/<hash>`（＝更新プロセスの cwd）を掃除/置換**。
- 続く `spawnNpxDaemon`（`npx …@latest start --daemon`）の npm 起動で `process.cwd()` が **`ENOENT uv_cwd`** → クラッシュ → 「Failed to start the new server」。旧サーバ停止済みでサーバ不在に。
- 対象版が既にキャッシュにある場合のみ掃除が起きず成功（利用者の切り分けと一致）。global 導入は cwd が安定な global package dir のため発生しない。

## 対応

**更新プロセスと npx サブ起動を、消えない安定ディレクトリから実行する。**

- `src/cli/utils/npx-runner.ts`: `warmNpxLatest` / `spawnNpxDaemon` の `spawnSync` に **`cwd: stableNpxCwd()`（= `homedir()`）** を明示。npx キャッシュ掃除の影響を受けない絶対 cwd を子プロセスに渡す。
- `src/app/api/app/update/route.ts`: 分離する更新 child を **`ensureConfigDir()`（`~/.commandmate`、更新後も preserved）** から起動。bin パスは従来どおり package root（`process.cwd()`）から解決。
- 再起動先の daemon は従来どおり自身の cwd を package root に設定するため、**サーバの実行位置は不変**。

## テスト

- `npx-runner.test.ts`: `warmNpxLatest` / `spawnNpxDaemon` が `spawnSync` へ安定 cwd（`homedir()`）を渡すこと、`stableNpxCwd()` が npx キャッシュ dir を返さないことを検証。
- `app-update.test.ts`: 更新 child が `ensureConfigDir()` の安定 dir から起動され、`process.cwd()`（npx キャッシュ dir）ではないことを検証。

## 品質ゲート

- [x] `npm run lint`（0 errors）
- [x] `npx tsc --noEmit`
- [x] `npm run test:unit`（599 files / 10195 tests pass）
- [x] `npm run build`

## 検証上の注意

実機の最終確認（**冷 npx キャッシュからの GUI 更新完走**）は、npx 起動環境（利用者の別マシン）でのみ再現するため、本 PR は単体テスト＋品質ゲートで担保。リリース後に npx マシンでの実機確認を推奨。

Refs #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3YuRQbsJv6epx7umung6r
