### PR TITLE
feat(skills): Skill manifest・Catalog・配布契約と脅威モデルを定義 (#1228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent Skills 配布契約（Skill manifest・Catalog・receipt・脅威モデル）を定義** (#1228): SKILL.md との互換性を保ったまま、CommandMate 固有の配布・Runtime metadata を同一 Skill root の `commandmate.skill.yaml` に分離する契約を確定した。`src/types/skills.ts` に4文書（manifest / Catalog / 検査結果 / installed receipt）の型、`src/lib/skills/` に schema_version 1 の fail-closed validator・厳格 SemVer 2.0・公開 JSON Schema・エラーコードを追加。Skill ID は lowercase ASCII slug（最大64文字・予約名・case/Unicode 衝突検出）、artifact は `tar.gz` / `<skill-id>-<version>.tar.gz` / `application/gzip` / root 1ディレクトリに固定、artifact 全体の SHA-256 は Catalog、個別 payload file の digest は manifest が持ち manifest 自身の digest は要求しない。tag ではなく resolved commit SHA を必須とし、receipt は timestamp・actor・machine absolute path・signed URL を持たない決定的な文書とした。権限は宣言であって enforcement ではないことを命名（`declared_permissions` / `declared_risk`）と UI 注記で区別し、実効 risk は宣言と算出の高い方とする。決定表と脅威モデルは [docs/design/agent-skills-distribution.md](./docs/design/agent-skills-distribution.md)、valid/invalid fixture は `tests/fixtures/skills/contract/` に置いた。本 Issue は契約定義のみで、Catalog 取得・download・install・UI は含まない。
+
 ## [0.11.4] - 2026-07-20
 
 > **Highlight**: **npx 起動サーバの GUI ワンクリック更新が「冷キャッシュ（対象版が未取得）」で失敗する問題を修正**。npx 起動サーバの cwd は npx キャッシュ内のパッケージ dir で、更新の warm（新版取得）時に npx がその dir を掃除/置換するため、続く再起動の npx 起動で `process.cwd()` が `ENOENT (uv_cwd)` を投げてクラッシュし、旧サーバ停止済みのまま再起動に失敗していた（対象版がキャッシュ済みの時のみ成功）。更新プロセスと npx サブ起動を安定 dir（homedir / ~/.commandmate）から実行するようにして解消した。

--- a/docs/design/agent-skills-distribution.md
+++ b/docs/design/agent-skills-distribution.md
@@ -1,0 +1,316 @@
+# ADR: Agent Skills 配布契約と脅威モデル
+
+- **Issue**: [#1228](https://github.com/Kewton/CommandMate/issues/1228)（親Epic [#1227](https://github.com/Kewton/CommandMate/issues/1227) / Phase 1 Wave 1）
+- **ステータス**: Accepted
+- **対象 schema_version**: 1
+- **実装**: `src/types/skills.ts` / `src/lib/skills/*` / `tests/fixtures/skills/contract/`
+
+本ADRは Skill の manifest・Catalog・artifact・installed receipt・脅威モデルの契約を確定する。
+後続 Issue（#1229 Catalog取得 / #1231 install / #1232 UI / #1234 audit）は、本ADRと
+`@/lib/skills` の公開APIだけを前提に実装する。**本Issueの範囲は契約・Schema・fixture・ADRであり、
+取得・download・install・UI・Runtime は実装しない。**
+
+---
+
+## 1. 前提の検証結果（着手時の実コード調査）
+
+Issue 記載の前提を実コードで確認した結果は以下のとおり。
+
+| Issue の記載 | 実コード | 判定 |
+|---|---|---|
+| `src/lib/slash-commands.ts` は `.agents/skills` を検出し、取得情報は主に name / description / cliTools | `AGENTS_SKILLS_SUBDIR = .agents/skills`（同ファイル）。`parseSkillFile()` が name / description / model / cliTools を取得 | 正しい |
+| 公式Skill供給リポジトリと配布artifactの規約は存在しない | 該当コードなし | 正しい |
+| `Kewton/commandmate-skills` は未作成 | — | 正しい。**本Issueでは実在を前提とした検証・network accessを一切実装しない**（fixture 内のURLはすべて例示） |
+| 互換性判定に SemVer 2.0 を用いる | `src/lib/version-checker.ts` の `isNewerVersion()` は `major.minor.patch` のみを数値比較し、`v` prefix を許容し、prerelease を無視する | **要訂正**。CommandMate自身のrelease tag比較としては正しいが SemVer 2.0 ではない。Skill契約は prerelease precedence を必要とするため `src/lib/skills/semver.ts` に厳格実装を分離し、`version-checker.ts` は変更しない |
+| path検証は `src/lib/security/path-validator.ts` を利用しうる | `isPathSafe()` / `validateWorktreePath()` は実在。ただし `WORKTREE_ID_PATTERN` は大文字を許容し、Skill ID の lowercase slug 規約とは別物 | 併存。**filesystem を伴う実path検証は #1231 が `path-validator.ts` を使う。本Issueは文字列レベルのpayload path検証のみを提供する** |
+| Schema検証ライブラリの利用 | `zod` / `ajv` / `js-yaml` / `semver` はいずれも直接依存に存在しない（`js-yaml` は `gray-matter` の推移依存） | **新規runtime依存を追加せず**、手書きの total な validator で実装する |
+
+---
+
+## 2. 責務境界
+
+| 層 | 責務 | 非責務 |
+|---|---|---|
+| Skill package | 標準手順（SKILL.md）と宣言metadata（commandmate.skill.yaml）を持つ | CommandMate内部moduleへの直接依存 |
+| CommandMate本体 | source検証、worktree解決、互換性判定、transaction、receipt/audit、Runtime監督 | — |
+| CLI | 公開APIの薄いclient。UIと同じ plan/apply・validation・audit 経路を使う | 独自の検証経路 |
+| UI | 能力・効果・risk・差分の説明と、選択・確認の受付 | filesystem path や security 判定の信頼 |
+
+`SKILL.md` は Agent Skills 標準の authoring artifact、`commandmate.skill.yaml` は CommandMate の
+配布・Runtime 宣言である。両者は同じ Skill root に置き、責務を分離する。
+
+---
+
+## 3. 決定表
+
+### D-1: manifest は SKILL.md と分離した別ファイルにする
+
+`SKILL.md` frontmatter を拡張せず、同一 Skill root の `commandmate.skill.yaml` に配布metadataを置く。
+標準側の互換性を壊さず、標準Agentは追加fieldを無視できる。
+
+### D-2: schema_version は fail closed
+
+`schema_version` は `1` 固定。欠落・型不一致・`2` 以上のいずれも
+`SKILL_SCHEMA_VERSION_UNSUPPORTED` で拒否し、best-effort parse は行わない。
+未知fieldも `SKILL_UNKNOWN_FIELD` で拒否する（schema_version 1 は閉じた集合）。
+
+### D-3: Skill ID は lowercase ASCII slug
+
+- 文法: `^[a-z0-9]+(?:-[a-z0-9]+)*$`、最大64文字。
+- 予約: `commandmate`, `system`, Windows device 名（`con`, `prn`, `aux`, `nul`, `com1..9`, `lpt1..9`）。
+- dot始まり・大文字・`_`・連続ハイフン・非ASCIIは文法段階で排除されるため、homoglyph 混入は成立しない。
+- case/Unicode衝突は `foldSkillIdForCollision()`（NFKC + toLowerCase）で検出する。
+  大文字小文字を区別しないfilesystemや正規化するfilesystem上での上書きを防ぐ。
+- ディレクトリ名 / `SKILL.md` の `name` / manifest の `id`・`name` の一致を
+  `validateSkillIdentityConsistency()` で必須化する。利用者がレビューしていない名前での
+  install を成立させないための条件である。
+
+### D-4: version と range
+
+- version は厳格 SemVer 2.0（`v` prefix 不可、leading zero 不可、build metadata は precedence 無視）。
+- range 文法は空白区切りの **AND のみ**。`=`, `>`, `>=`, `<`, `<=`, `^`, `~` を受理し、
+  `||`・`*`・x-range・hyphen range は拒否する。rangeの解釈を一意にするための制限である。
+- prerelease は、同一 `major.minor.patch` かつ prerelease を持つ comparator が存在する場合のみ満たす。
+  この規則がないと `>=1.0.0` が `2.0.0-alpha.1` を暗黙に受理する。
+
+### D-5: artifact 形式
+
+| 項目 | 値 |
+|---|---|
+| 形式 | `tar.gz`（PAX拡張不使用） |
+| asset名 | `<skill-id>-<version>.tar.gz` |
+| Content-Type | `application/gzip` |
+| archive root | `<skill-id>/` の1ディレクトリのみ |
+| 必須entry | `<skill-id>/SKILL.md`, `<skill-id>/commandmate.skill.yaml` |
+| 最大サイズ | 16 MiB（単一payload fileは 4 MiB、file数は最大500） |
+
+### D-6: digest の対象と正本
+
+- **artifact全体の SHA-256 は Catalog が持つ**。manifest 自身を含む byte 列を対象にするため、
+  manifest 内に自己digestを置くと自己参照になる。したがって manifest は自己digestを持たない。
+- **manifest.files は個別payload fileのdigest**を持つ。照合集合は
+  「archive内のregular payload file」から `commandmate.skill.yaml` 自身と directory entry を除いた集合。
+  この規則は `validateManifestFileSet()` が実装し、宣言漏れ・未宣言fileの混入をどちらも拒否する。
+- digest はすべて lowercase hex SHA-256（`^[0-9a-f]{64}$`）。大文字は拒否し、byte比較を一意にする。
+- canonicalization: digest対象は「解凍後のfile byte列そのもの」であり、改行変換・正規化・
+  trailing whitespace 除去などの前処理は一切行わない。
+
+### D-7: source の正本は resolved commit SHA
+
+`source.ref`（tag / branch）は人向けの表示にすぎず、後から移動しうる。
+Catalog と receipt は 40桁の resolved commit SHA を必須とし、短縮SHAは拒否する。
+
+### D-8: Agent互換性は4値 + 根拠
+
+`native` / `commandmate_runtime` / `unsupported` / `unknown` と `evidence` を必須にする。
+`unknown` を「対応」と表示してはならない。UI/CLI は `AGENT_SUPPORT_LABEL_KEYS` の
+同一語彙を使う（UX-05）。
+
+### D-9: 権限宣言は enforcement ではない
+
+field名は `declared_permissions`、risk は `declared_risk`。`declared` を落とした命名を禁じる。
+UI は `PERMISSION_DECLARATION_NOTICE_KEY` の注記を必ず併記し、
+「宣言であって隔離・認可ではない」ことを明示する。sandbox enforcement は本Epicの範囲外。
+
+### D-10: risk は宣言と算出を分離し、実効riskは高い方
+
+- `declared_risk`: publisher の申告。
+- `computed_risk`: CommandMate が検査結果から `computeSkillRisk()` で決定論的に算出。
+  - `high`: executable file を含む、または `credential_access` を宣言。
+  - `moderate`: script file を含む、network host を持つ、`process_execution` または
+    `filesystem_write` を宣言。
+  - `low`: 上記以外。
+- `effective_risk = max(declared, computed)`。低く申告して緩和することはできない。
+
+### D-11: receipt は決定的
+
+machine absolute path・actor・timestamp を含めない。同じ version を同じ commit から入れれば
+byte 一致する（`canonicalizeSkillReceipt()` はキーsort・空白なしのJSON、`files` は path 昇順）。
+時刻と actor は #1234 の operation audit に保存する。
+receipt の `artifact` は **`url` を持たない**。download URL は signed URL でありうるため secret として扱う。
+`install_root` は常に repository相対の `.agents/skills/<skill-id>`。
+
+### D-12: 配備先と data root
+
+- Skill payload の配備先は、server登録済み worktree ID から解決した
+  `.agents/skills/<validated-skill-id>/` に限定する。client提供の絶対pathは使用しない。
+- 検査staging・lock・journal・cache・verified backup は service-owned data/config root に置き、
+  Skill payload や Agent discovery の対象にしない。
+- 例外は atomic rename 用の install commit staging のみで、
+  `.agents/skills/.commandmate-staging/<opaque-operation-id>/` に置く。
+  同一filesystemを保証して rename を atomic にするためであり、
+  先頭 dot により Skill ID 文法から外れるため discovery 対象にならない。
+
+### D-13: safe YAML parse profile
+
+manifest の YAML parser は `SKILL_YAML_SAFE_PROFILE` を満たすこと（実装は #1229/#1231 が選定）。
+
+- alias / anchor / merge key / custom tag / duplicate key を拒否。
+- `__proto__` / `constructor` / `prototype` を key として拒否。
+- 上限: 64 KiB、document depth 16、node 数 5000、scalar 8192 文字。
+
+`src/lib/skills/schema.ts` は parse 済みの `unknown` を受け取る純関数であり、
+YAML parser には依存しない。parse と検証の責務を分けることで、parser 差し替えが契約に波及しない。
+
+### D-14: file mode 規約
+
+- 許可するのは regular file と directory のみ。symlink・hardlink・device・FIFO・socket は拒否。
+- 実行bitは manifest で `executable: true` を宣言した file のみ許可する。
+- uid / gid / xattr / setuid / setgid / sticky は継承しない。
+
+### D-15: 表示項目の正本（#1232）
+
+| 表示項目 | 正本 |
+|---|---|
+| 能力（何ができるようになるか） | manifest `capabilities` |
+| 期待効果 | manifest `expected_outcomes` |
+| provider / license | manifest `provider` / `license` |
+| version / changelog | Catalog `versions[].version` / `changelog` |
+| resolved SHA / artifact情報 | Catalog `versions[].source.commit` / `artifact` |
+| scripts / executable / computed risk | 検査結果（`SkillPackageInspection` → `computeSkillRisk()`） |
+| 実際に入ったfile | receipt `files` |
+
+`capabilities` と `expected_outcomes` は空配列を許可しない。install 前に
+「何ができるようになるか」を説明できない Skill を成立させないためである（UX-01 / UX-09）。
+
+### D-16: 完全一致条件（Catalog → artifact → manifest → inventory → receipt）
+
+1. Catalog `artifact.sha256` = download した artifact の SHA-256。
+2. Catalog `artifact.asset_name` = `<skill-id>-<version>.tar.gz`、`content_type` = `application/gzip`。
+3. archive root directory 名 = Catalog `id` = manifest `id` = install 先ディレクトリ名。
+4. manifest `version` = Catalog `versions[].version`。
+5. manifest `files` = archive の payload file 集合（`commandmate.skill.yaml` と directory を除く）。
+6. receipt `files` = 実際に配置した file の path/digest/size/executable、path 昇順。
+7. receipt `source.commit` = Catalog `versions[].source.commit`。
+
+いずれか1つでも不一致なら install を中止する（fail closed）。
+
+---
+
+## 4. 脅威モデル
+
+| # | 脅威 | 契約上の対策 |
+|---|---|---|
+| T-1 | malicious archive（zip-slip、巨大展開、大量entry） | payload path検証（D-6, 3節）、size/file数上限（D-5）、root 1ディレクトリ規約 |
+| T-2 | path / symlink escape | `..`・絶対path・NUL・制御文字・backslash・drive path・trailing slash・非NFC・深さ超過を拒否。symlink は file mode 規約で拒否（D-14）。realpath検証は #1231 |
+| T-3 | case / Unicode collision による既存Skill上書き | `foldSkillIdForCollision()` による衝突検出（D-3） |
+| T-4 | supply-chain改ざん（tag付け替え、artifact差し替え） | resolved commit SHA 必須（D-7）、artifact SHA-256 必須（D-6）、完全一致条件（D-16） |
+| T-5 | prompt injection（SKILL.md本文による指示の乗っ取り） | 契約上は risk / permissions / scripts を install 前に提示し、download/install/update 単体では script も hook も自動実行しないことを規定する。本文自体の無害化は範囲外であり Runtime 側（#1250）の課題とする |
+| T-6 | secret exfiltration | `credential_access` 宣言は `computed_risk = high`。receipt/log に token・signed URL・secret・machine absolute path を含めない（D-11） |
+| T-7 | TOCTOU（検査後の差し替え） | 検査は service-owned staging 上で行い、commit は同一filesystem内 atomic rename（D-12）。plan と apply の間で plan drift を再検証する |
+| T-8 | 同時操作の競合 | 同一 target への操作は排他する（#1231 が lock を data root に置く） |
+| T-9 | prototype pollution（`__proto__` を含む manifest） | YAML safe profile で key を拒否（D-13）、validator も unknown field として拒否し、返す値は検証済みfieldから再構築する |
+| T-10 | 既存fileや local change の暗黙上書き | download/install/update は既存fileを暗黙に上書きしない。差分を提示して確認を得る |
+| T-11 | 権限宣言の誤認 | 命名と注記で宣言と enforcement を区別する（D-9） |
+
+---
+
+## 5. 公開API
+
+後続Issueは `@/lib/skills` からのみ import する。
+
+```ts
+import {
+  // 定数・規約
+  SKILL_SCHEMA_VERSION, SKILL_ID_PATTERN, SKILL_INSTALL_ROOT_PREFIX,
+  SKILL_MANIFEST_FILENAME, SKILL_MD_FILENAME, SKILL_STAGING_DIRNAME,
+  SKILL_ARTIFACT_FORMAT, SKILL_ARTIFACT_CONTENT_TYPE, SKILL_YAML_SAFE_PROFILE,
+  REQUIRED_PACKAGE_ENTRIES, buildSkillAssetName,
+  PERMISSION_DECLARATION_NOTICE_KEY, AGENT_SUPPORT_LABEL_KEYS,
+
+  // エラー
+  SkillContractErrorCode, type SkillContractError, type SkillValidationResult,
+
+  // SemVer
+  isValidSemVer, compareSemVer, satisfiesSkillVersionRange,
+
+  // 検証
+  validateSkillManifest, validateSkillCatalog, validateSkillInstallReceipt,
+  validateSkillId, validateSkillIdentityConsistency, validateSkillPayloadPath,
+  validateManifestFileSet, detectSkillIdCollision,
+  computeSkillRisk, resolveEffectiveSkillRisk, canonicalizeSkillReceipt,
+
+  // 公開 JSON Schema
+  SKILL_MANIFEST_JSON_SCHEMA, SKILL_CATALOG_JSON_SCHEMA, SKILL_RECEIPT_JSON_SCHEMA,
+} from '@/lib/skills';
+```
+
+検証関数は例外を投げず `SkillValidationResult<T>` を返す。成功時の `value` は
+検証済みfieldから再構築した新しいobjectであり、入力の未検証propertyは残らない。
+
+---
+
+## 6. manifest 例
+
+```yaml
+schema_version: 1
+id: release-notes
+name: release-notes
+version: 1.2.0
+summary: Draft release notes from merged pull requests.
+description: >-
+  Collects merged pull requests since the previous tag, groups them by change
+  type and drafts a Keep a Changelog entry for review.
+capabilities:
+  - Group merged pull requests by conventional commit type
+  - Draft a Keep a Changelog entry for the next release
+expected_outcomes:
+  - Release note drafting drops from ~30 minutes to a single review pass
+  - Changelog entries stay consistent across releases
+provider:
+  name: CommandMate
+  url: https://github.com/Kewton/CommandMate
+license: MIT
+compatibility:
+  commandmate: '>=0.11.0 <1.0.0'
+  agents:
+    - agent: claude
+      support: native
+      evidence: SKILL.md discovery verified on claude CLI 2.x
+    - agent: gemini
+      support: unknown
+      evidence: Not verified for this release
+requirements:
+  commands:
+    - name: git
+      version_range: '>=2.30.0'
+  network_hosts: []
+declared_permissions:
+  - filesystem_read
+declared_risk: low
+risk_rationale: Reads repository history only and writes no files.
+files:
+  - path: SKILL.md
+    sha256: <64 hex>
+    size: 2048
+    kind: skill_md
+    executable: false
+    script: false
+```
+
+---
+
+## 7. fixture
+
+`tests/fixtures/skills/contract/{manifest,catalog,receipt}/{valid,invalid}/`。
+invalid fixture は自己記述的な envelope である。
+
+```json
+{
+  "case": "A future schema_version is rejected instead of best-effort parsed",
+  "expectedErrorCode": "SKILL_SCHEMA_VERSION_UNSUPPORTED",
+  "expectedPath": "/schema_version",
+  "document": { "...": "..." }
+}
+```
+
+`tests/unit/lib/skills/schema.test.ts` が全fixtureを走査し、拒否理由のcodeと位置の
+両方を検証する。fixture を追加すればテストは自動的に増える。
+
+---
+
+## 8. 将来拡張
+
+`schema_version: 2` で signature block・publisher identity・外部Registryを追加しうる。
+その際も D-2 の fail closed は維持し、旧版CommandMateが新版manifestを
+誤って部分解釈しないようにする。追加時は本ADRに後方互換方針を追記する。

--- a/src/lib/skills/constants.ts
+++ b/src/lib/skills/constants.ts
@@ -1,0 +1,272 @@
+/**
+ * Agent Skills distribution contract constants (Issue #1228)
+ *
+ * Single source of truth for every limit, pattern and layout rule referenced by
+ * docs/design/agent-skills-distribution.md. Downstream issues (#1229 catalog,
+ * #1231 install, #1234 audit) must import from here rather than re-deriving
+ * values, so a contract change is a one-line change.
+ *
+ * @module lib/skills/constants
+ */
+
+import type {
+  SkillAgentSupport,
+  SkillArtifactFormat,
+  SkillDeclaredPermission,
+  SkillFileKind,
+  SkillRiskLevel,
+} from '@/types/skills';
+
+// =============================================================================
+// Schema version
+// =============================================================================
+
+/** The only schema version this build understands. Anything else fails closed. */
+export const SKILL_SCHEMA_VERSION = 1;
+
+// =============================================================================
+// Skill ID
+// =============================================================================
+
+/**
+ * Skill ID grammar: ASCII lowercase slug.
+ *
+ * Anchored and ASCII-only by construction, so uppercase, Unicode homoglyphs,
+ * leading/trailing hyphens and dot-prefixed names are all rejected here rather
+ * than by a later, easier-to-forget check.
+ */
+export const SKILL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Maximum Skill ID length in characters. */
+export const SKILL_ID_MAX_LENGTH = 64;
+
+/**
+ * IDs that may never be used as a Skill directory name.
+ *
+ * Covers Windows reserved device names (which resolve to devices regardless of
+ * the directory they appear in) and names CommandMate claims for itself.
+ */
+export const RESERVED_SKILL_IDS: readonly string[] = [
+  'commandmate',
+  'system',
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+];
+
+// =============================================================================
+// Layout
+// =============================================================================
+
+/** Skill payload root inside a worktree, resolved from a registered worktree ID. */
+export const SKILL_INSTALL_ROOT_PREFIX = '.agents/skills';
+
+/** Manifest filename, placed at the Skill root next to SKILL.md. */
+export const SKILL_MANIFEST_FILENAME = 'commandmate.skill.yaml';
+
+/** Standard Agent Skills authoring file, required in every package. */
+export const SKILL_MD_FILENAME = 'SKILL.md';
+
+/**
+ * Reserved private namespace for install-commit staging.
+ *
+ * Lives under the target `.agents/skills` so the atomic rename stays on one
+ * filesystem. Excluded from Skill discovery because the leading dot is outside
+ * {@link SKILL_ID_PATTERN}.
+ */
+export const SKILL_STAGING_DIRNAME = '.commandmate-staging';
+
+/** Entries every valid package must contain, relative to the archive root directory. */
+export const REQUIRED_PACKAGE_ENTRIES: readonly string[] = [
+  SKILL_MD_FILENAME,
+  SKILL_MANIFEST_FILENAME,
+];
+
+// =============================================================================
+// Artifact
+// =============================================================================
+
+/** The only artifact format accepted in schema_version 1. */
+export const SKILL_ARTIFACT_FORMAT: SkillArtifactFormat = 'tar.gz';
+
+/** Required Content-Type of a release asset. */
+export const SKILL_ARTIFACT_CONTENT_TYPE = 'application/gzip';
+
+/** Maximum artifact size in bytes (16 MiB). */
+export const SKILL_ARTIFACT_MAX_SIZE = 16 * 1024 * 1024;
+
+/** Maximum size of a single payload file in bytes (4 MiB). */
+export const SKILL_FILE_MAX_SIZE = 4 * 1024 * 1024;
+
+/** Maximum number of payload files declared in a manifest. */
+export const SKILL_FILES_MAX_COUNT = 500;
+
+/** Build the required release asset name for a version. */
+export function buildSkillAssetName(skillId: string, version: string): string {
+  return `${skillId}-${version}.tar.gz`;
+}
+
+// =============================================================================
+// Payload paths
+// =============================================================================
+
+/** Maximum length of a single path segment. */
+export const SKILL_PATH_SEGMENT_MAX_LENGTH = 100;
+
+/** Maximum number of path segments in a payload path. */
+export const SKILL_PATH_MAX_DEPTH = 8;
+
+/** Maximum total length of a payload path. */
+export const SKILL_PATH_MAX_LENGTH = 255;
+
+// =============================================================================
+// Text limits
+// =============================================================================
+
+export const SKILL_NAME_MAX_LENGTH = 100;
+export const SKILL_SUMMARY_MAX_LENGTH = 200;
+export const SKILL_DESCRIPTION_MAX_LENGTH = 2000;
+export const SKILL_BULLET_MAX_LENGTH = 200;
+export const SKILL_BULLET_MAX_COUNT = 10;
+export const SKILL_KEYWORDS_MAX_COUNT = 20;
+export const SKILL_KEYWORD_MAX_LENGTH = 40;
+export const SKILL_CHANGELOG_MAX_LENGTH = 4000;
+export const SKILL_EVIDENCE_MAX_LENGTH = 300;
+export const SKILL_RATIONALE_MAX_LENGTH = 500;
+export const SKILL_COMMANDS_MAX_COUNT = 20;
+export const SKILL_NETWORK_HOSTS_MAX_COUNT = 20;
+export const SKILL_CATALOG_ENTRIES_MAX_COUNT = 500;
+export const SKILL_CATALOG_VERSIONS_MAX_COUNT = 100;
+
+// =============================================================================
+// Safe YAML parse profile
+// =============================================================================
+
+/**
+ * Limits any manifest YAML parser must enforce.
+ *
+ * The contract (not the parser) lives here: #1229/#1231 pick an implementation
+ * but must reject aliases, anchors, merge keys, custom tags, duplicate keys and
+ * prototype-polluting keys, and must apply these bounds.
+ */
+export const SKILL_YAML_SAFE_PROFILE = {
+  maxBytes: 64 * 1024,
+  maxDepth: 16,
+  maxNodes: 5000,
+  maxScalarLength: 8192,
+  allowAliases: false,
+  allowCustomTags: false,
+  allowDuplicateKeys: false,
+  /** Keys rejected outright to prevent prototype pollution through parsed objects. */
+  forbiddenKeys: ['__proto__', 'constructor', 'prototype'],
+} as const;
+
+// =============================================================================
+// Enumerations
+// =============================================================================
+
+export const SKILL_AGENT_SUPPORT_VALUES: readonly SkillAgentSupport[] = [
+  'native',
+  'commandmate_runtime',
+  'unsupported',
+  'unknown',
+];
+
+export const SKILL_RISK_LEVELS: readonly SkillRiskLevel[] = ['low', 'moderate', 'high'];
+
+/** Ordering used to resolve the effective risk. Higher index wins. */
+export const SKILL_RISK_ORDER: Record<SkillRiskLevel, number> = {
+  low: 0,
+  moderate: 1,
+  high: 2,
+};
+
+export const SKILL_DECLARED_PERMISSIONS: readonly SkillDeclaredPermission[] = [
+  'filesystem_read',
+  'filesystem_write',
+  'network_access',
+  'process_execution',
+  'environment_read',
+  'credential_access',
+];
+
+export const SKILL_FILE_KINDS: readonly SkillFileKind[] = [
+  'skill_md',
+  'instruction',
+  'script',
+  'asset',
+];
+
+// =============================================================================
+// Formats
+// =============================================================================
+
+/** Lowercase hex SHA-256. Uppercase is rejected so digests compare byte-wise. */
+export const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+/** Resolved git commit SHA-1, full 40 hex digits. Abbreviations are rejected. */
+export const GIT_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/** `owner/name` source repository coordinate. */
+export const REPOSITORY_SLUG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Human-facing git ref (tag or branch). `..` is rejected separately. */
+export const GIT_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,99}$/;
+
+/** RFC 3339 UTC instant, `Z` suffix only, so published_at compares lexicographically. */
+export const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+
+/** SPDX license identifier shape (expressions are out of scope for schema_version 1). */
+export const SPDX_LICENSE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9.+-]{0,63}$/;
+
+/** External command name a Skill may require. */
+export const COMMAND_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+
+/** Network host: DNS hostname, optionally a leading `*.` wildcard label. */
+export const NETWORK_HOST_PATTERN =
+  /^(?:\*\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/;
+
+/** Artifact and homepage URLs must be HTTPS. */
+export const HTTPS_URL_PREFIX = 'https://';
+
+// =============================================================================
+// UI vocabulary
+// =============================================================================
+
+/**
+ * Wording that must accompany any permission display.
+ *
+ * Prevents the declaration from being read as enforcement (see the ADR's
+ * "declaration is not enforcement" decision).
+ */
+export const PERMISSION_DECLARATION_NOTICE_KEY = 'skills.permissions.declarationOnlyNotice';
+
+/**
+ * Labels for {@link SkillAgentSupport}, so UI and CLI use one vocabulary (UX-05).
+ * Values are i18n message keys, not user-visible strings.
+ */
+export const AGENT_SUPPORT_LABEL_KEYS: Record<SkillAgentSupport, string> = {
+  native: 'skills.compatibility.native',
+  commandmate_runtime: 'skills.compatibility.commandmateRuntime',
+  unsupported: 'skills.compatibility.unsupported',
+  unknown: 'skills.compatibility.unknown',
+};

--- a/src/lib/skills/errors.ts
+++ b/src/lib/skills/errors.ts
@@ -1,0 +1,104 @@
+/**
+ * Typed errors for the Agent Skills distribution contract (Issue #1228)
+ *
+ * Every rejection carries a stable machine code plus a JSON-Pointer-like path,
+ * so callers can branch on the reason and localize the message without parsing
+ * prose. Messages are built from the code and the document path only: they
+ * never embed a token, signed URL, secret or machine-absolute path.
+ *
+ * @module lib/skills/errors
+ */
+
+/** Stable, client-safe reason codes for contract validation failures. */
+export const SkillContractErrorCode = {
+  /** Document is not a plain object. */
+  NOT_AN_OBJECT: 'SKILL_NOT_AN_OBJECT',
+  /** `schema_version` is missing, malformed, or newer than this build supports. */
+  SCHEMA_VERSION_UNSUPPORTED: 'SKILL_SCHEMA_VERSION_UNSUPPORTED',
+  /** A required field is absent. */
+  MISSING_FIELD: 'SKILL_MISSING_FIELD',
+  /** A field exists but has the wrong JSON type. */
+  INVALID_TYPE: 'SKILL_INVALID_TYPE',
+  /** A field carries a value outside its enumeration. */
+  INVALID_ENUM: 'SKILL_INVALID_ENUM',
+  /** A field is syntactically wrong (pattern mismatch). */
+  INVALID_FORMAT: 'SKILL_INVALID_FORMAT',
+  /** A numeric or length bound was exceeded. */
+  LIMIT_EXCEEDED: 'SKILL_LIMIT_EXCEEDED',
+  /** An unspecified field is present; schema_version 1 is closed. */
+  UNKNOWN_FIELD: 'SKILL_UNKNOWN_FIELD',
+  /** Skill ID does not match the slug grammar. */
+  ID_INVALID: 'SKILL_ID_INVALID',
+  /** Skill ID is reserved by CommandMate or by the host filesystem. */
+  ID_RESERVED: 'SKILL_ID_RESERVED',
+  /** Skill ID collides with an existing name under case/Unicode folding. */
+  ID_COLLISION: 'SKILL_ID_COLLISION',
+  /** Directory name, SKILL.md name and manifest id disagree. */
+  ID_MISMATCH: 'SKILL_ID_MISMATCH',
+  /** Version is not valid SemVer 2.0. */
+  VERSION_INVALID: 'SKILL_VERSION_INVALID',
+  /** Version range is not expressible in the supported range grammar. */
+  VERSION_RANGE_INVALID: 'SKILL_VERSION_RANGE_INVALID',
+  /** Digest is not lowercase hex SHA-256. */
+  DIGEST_INVALID: 'SKILL_DIGEST_INVALID',
+  /** Payload path escapes the Skill root or is otherwise unsafe. */
+  FILE_PATH_UNSAFE: 'SKILL_FILE_PATH_UNSAFE',
+  /** Two entries declare the same payload path (possibly after folding). */
+  FILE_PATH_DUPLICATE: 'SKILL_FILE_PATH_DUPLICATE',
+  /** Declared file set does not match the package's payload file set. */
+  FILE_SET_MISMATCH: 'SKILL_FILE_SET_MISMATCH',
+  /** Artifact name, format or Content-Type violates the packaging rule. */
+  ARTIFACT_INVALID: 'SKILL_ARTIFACT_INVALID',
+  /** Source ref is present but the resolved commit SHA is missing or malformed. */
+  SOURCE_COMMIT_INVALID: 'SKILL_SOURCE_COMMIT_INVALID',
+  /** Catalog `latest` does not resolve to a listed version. */
+  CATALOG_LATEST_UNRESOLVED: 'SKILL_CATALOG_LATEST_UNRESOLVED',
+  /** The same identity is declared twice within one document. */
+  DUPLICATE_ENTRY: 'SKILL_DUPLICATE_ENTRY',
+  /** Two fields that must agree do not. */
+  INCONSISTENT_VALUE: 'SKILL_INCONSISTENT_VALUE',
+} as const;
+
+export type SkillContractErrorCodeType =
+  (typeof SkillContractErrorCode)[keyof typeof SkillContractErrorCode];
+
+/** One validation failure, addressed at a specific location in the document. */
+export interface SkillContractError {
+  code: SkillContractErrorCodeType;
+  /** JSON-Pointer-like location, e.g. `/files/2/sha256`. Empty string for the root. */
+  path: string;
+  /** Client-safe description built from code and path only. */
+  message: string;
+  /** Bounded, non-sensitive context (expected pattern, limit, …). */
+  detail?: Record<string, string | number | boolean>;
+}
+
+/** Result of validating one contract document. */
+export type SkillValidationResult<T> =
+  | { ok: true; value: T; errors: readonly [] }
+  | { ok: false; value: null; errors: readonly SkillContractError[] };
+
+/** Build a validation failure. */
+export function skillError(
+  code: SkillContractErrorCodeType,
+  path: string,
+  message: string,
+  detail?: Record<string, string | number | boolean>
+): SkillContractError {
+  return detail ? { code, path, message, detail } : { code, path, message };
+}
+
+/** Wrap a validated document as a success result. */
+export function skillOk<T>(value: T): SkillValidationResult<T> {
+  return { ok: true, value, errors: [] };
+}
+
+/** Wrap one or more failures as a failure result. */
+export function skillFail<T>(errors: readonly SkillContractError[]): SkillValidationResult<T> {
+  return { ok: false, value: null, errors };
+}
+
+/** Append a segment to a JSON-Pointer-like path. */
+export function joinPath(base: string, segment: string | number): string {
+  return `${base}/${segment}`;
+}

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -1,0 +1,113 @@
+/**
+ * Public API of the Agent Skills distribution contract (Issue #1228)
+ *
+ * Downstream issues (#1229 catalog fetch, #1231 install, #1234 audit, #1232 UI)
+ * import from `@/lib/skills` only. Anything not re-exported here is an internal
+ * detail and may change without a contract revision.
+ *
+ * @module lib/skills
+ */
+
+export {
+  AGENT_SUPPORT_LABEL_KEYS,
+  GIT_COMMIT_SHA_PATTERN,
+  GIT_REF_PATTERN,
+  PERMISSION_DECLARATION_NOTICE_KEY,
+  REPOSITORY_SLUG_PATTERN,
+  RESERVED_SKILL_IDS,
+  RFC3339_UTC_PATTERN,
+  SHA256_HEX_PATTERN,
+  SKILL_AGENT_SUPPORT_VALUES,
+  SKILL_ARTIFACT_CONTENT_TYPE,
+  SKILL_ARTIFACT_FORMAT,
+  SKILL_ARTIFACT_MAX_SIZE,
+  SKILL_DECLARED_PERMISSIONS,
+  SKILL_FILE_KINDS,
+  SKILL_FILE_MAX_SIZE,
+  SKILL_FILES_MAX_COUNT,
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+  SKILL_INSTALL_ROOT_PREFIX,
+  SKILL_MANIFEST_FILENAME,
+  SKILL_MD_FILENAME,
+  SKILL_RISK_LEVELS,
+  SKILL_RISK_ORDER,
+  SKILL_SCHEMA_VERSION,
+  SKILL_STAGING_DIRNAME,
+  SKILL_YAML_SAFE_PROFILE,
+  REQUIRED_PACKAGE_ENTRIES,
+  buildSkillAssetName,
+} from '@/lib/skills/constants';
+
+export {
+  SkillContractErrorCode,
+  joinPath as joinSkillErrorPath,
+  skillError,
+  skillFail,
+  skillOk,
+  type SkillContractError,
+  type SkillContractErrorCodeType,
+  type SkillValidationResult,
+} from '@/lib/skills/errors';
+
+export {
+  SEMVER_2_PATTERN,
+  compareParsedSemVer,
+  compareSemVer,
+  isValidSemVer,
+  isValidSkillVersionRange,
+  parseSemVer,
+  parseSkillVersionRange,
+  satisfiesSkillVersionRange,
+  type ParsedSemVer,
+  type SkillVersionComparator,
+  type SkillVersionOperator,
+} from '@/lib/skills/semver';
+
+export {
+  SKILL_DOCUMENT_FIELDS,
+  SKILL_OPTIONAL_FIELDS,
+  canonicalizeSkillReceipt,
+  computeSkillRisk,
+  detectSkillIdCollision,
+  foldSkillIdForCollision,
+  resolveEffectiveSkillRisk,
+  validateManifestFileSet,
+  validateSkillCatalog,
+  validateSkillId,
+  validateSkillIdentityConsistency,
+  validateSkillInstallReceipt,
+  validateSkillManifest,
+  validateSkillPayloadPath,
+} from '@/lib/skills/schema';
+
+export {
+  SKILL_CATALOG_JSON_SCHEMA,
+  SKILL_MANIFEST_JSON_SCHEMA,
+  SKILL_RECEIPT_JSON_SCHEMA,
+  type SkillJsonSchemaDocument,
+} from '@/lib/skills/json-schema';
+
+export type {
+  SkillAgentCompatibility,
+  SkillAgentSupport,
+  SkillArtifactFormat,
+  SkillArtifactRef,
+  SkillCatalog,
+  SkillCatalogEntry,
+  SkillCatalogVersion,
+  SkillCompatibility,
+  SkillDeclaredPermission,
+  SkillFileEntry,
+  SkillFileKind,
+  SkillInstallReceipt,
+  SkillInstalledFile,
+  SkillManifest,
+  SkillPackageInspection,
+  SkillProvider,
+  SkillReceiptArtifact,
+  SkillRequirementCommand,
+  SkillRequirements,
+  SkillRiskLevel,
+  SkillSourceRef,
+} from '@/types/skills';

--- a/src/lib/skills/json-schema.ts
+++ b/src/lib/skills/json-schema.ts
@@ -1,0 +1,418 @@
+/* eslint-disable no-restricted-syntax -- `description` here is JSON Schema documentation
+   published to Skill authors and validators, not UI copy: it must stay in the schema's own
+   language and is never rendered through t(). */
+/**
+ * JSON Schema documents for the Skills distribution contract (Issue #1228)
+ *
+ * These are the publishable, language-neutral form of the contract: a Skill
+ * author or a CI job outside CommandMate can validate a manifest without
+ * running TypeScript. Inside CommandMate the authority is
+ * `src/lib/skills/schema.ts`; the parity test in
+ * `tests/unit/lib/skills/json-schema-parity.test.ts` keeps the two from
+ * drifting.
+ *
+ * @module lib/skills/json-schema
+ */
+
+import {
+  GIT_COMMIT_SHA_PATTERN,
+  GIT_REF_PATTERN,
+  NETWORK_HOST_PATTERN,
+  REPOSITORY_SLUG_PATTERN,
+  RFC3339_UTC_PATTERN,
+  SHA256_HEX_PATTERN,
+  SKILL_AGENT_SUPPORT_VALUES,
+  SKILL_ARTIFACT_CONTENT_TYPE,
+  SKILL_ARTIFACT_FORMAT,
+  SKILL_ARTIFACT_MAX_SIZE,
+  SKILL_BULLET_MAX_COUNT,
+  SKILL_BULLET_MAX_LENGTH,
+  SKILL_CATALOG_ENTRIES_MAX_COUNT,
+  SKILL_CATALOG_VERSIONS_MAX_COUNT,
+  SKILL_CHANGELOG_MAX_LENGTH,
+  SKILL_COMMANDS_MAX_COUNT,
+  SKILL_DECLARED_PERMISSIONS,
+  SKILL_DESCRIPTION_MAX_LENGTH,
+  SKILL_EVIDENCE_MAX_LENGTH,
+  SKILL_FILE_KINDS,
+  SKILL_FILE_MAX_SIZE,
+  SKILL_FILES_MAX_COUNT,
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+  SKILL_KEYWORD_MAX_LENGTH,
+  SKILL_KEYWORDS_MAX_COUNT,
+  SKILL_NAME_MAX_LENGTH,
+  SKILL_NETWORK_HOSTS_MAX_COUNT,
+  SKILL_PATH_MAX_LENGTH,
+  SKILL_RATIONALE_MAX_LENGTH,
+  SKILL_RISK_LEVELS,
+  SKILL_SCHEMA_VERSION,
+  SKILL_SUMMARY_MAX_LENGTH,
+  SPDX_LICENSE_PATTERN,
+} from '@/lib/skills/constants';
+import { CLI_TOOL_IDS } from '@/lib/cli-tools/types';
+import { SEMVER_2_PATTERN } from '@/lib/skills/semver';
+
+/** Shape shared by all three published schema documents. */
+export interface SkillJsonSchemaDocument {
+  $schema: string;
+  $id: string;
+  title: string;
+  type: 'object';
+  additionalProperties: false;
+  required: readonly string[];
+  properties: Record<string, unknown>;
+  $defs?: Record<string, unknown>;
+}
+
+const DRAFT = 'https://json-schema.org/draft/2020-12/schema';
+const BASE_ID = 'https://commandmate.dev/schemas/skills';
+
+const source = (pattern: RegExp): string => pattern.source;
+
+const schemaVersionProperty = {
+  const: SKILL_SCHEMA_VERSION,
+  description: 'Contract version. Consumers reject any other value.',
+};
+
+const providerDef = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: { type: 'string', minLength: 1, maxLength: SKILL_NAME_MAX_LENGTH },
+    url: { type: 'string', format: 'uri', pattern: '^https://' },
+    contact: { type: 'string', minLength: 1, maxLength: 200 },
+  },
+};
+
+const agentCompatibilityDef = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['agent', 'support', 'evidence'],
+  properties: {
+    agent: { type: 'string', enum: [...CLI_TOOL_IDS] },
+    support: { type: 'string', enum: [...SKILL_AGENT_SUPPORT_VALUES] },
+    evidence: { type: 'string', minLength: 1, maxLength: SKILL_EVIDENCE_MAX_LENGTH },
+  },
+};
+
+const compatibilityDef = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['commandmate', 'agents'],
+  properties: {
+    commandmate: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 100,
+      description: 'AND-combined comparator list, e.g. ">=0.11.0 <1.0.0".',
+    },
+    agents: { type: 'array', maxItems: 20, items: { $ref: '#/$defs/agentCompatibility' } },
+  },
+};
+
+const sourceRefDef = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['repository', 'ref', 'commit'],
+  properties: {
+    repository: { type: 'string', pattern: source(REPOSITORY_SLUG_PATTERN) },
+    ref: { type: 'string', pattern: source(GIT_REF_PATTERN) },
+    commit: {
+      type: 'string',
+      pattern: source(GIT_COMMIT_SHA_PATTERN),
+      description: 'Resolved commit SHA. The trusted source coordinate.',
+    },
+  },
+};
+
+const sha256Property = {
+  type: 'string',
+  pattern: source(SHA256_HEX_PATTERN),
+  description: 'Lowercase hex SHA-256.',
+};
+
+const declaredPermissionsProperty = {
+  type: 'array',
+  maxItems: SKILL_DECLARED_PERMISSIONS.length,
+  uniqueItems: true,
+  items: { type: 'string', enum: [...SKILL_DECLARED_PERMISSIONS] },
+  description: 'Publisher declaration only. Not an enforcement boundary.',
+};
+
+const riskProperty = { type: 'string', enum: [...SKILL_RISK_LEVELS] };
+
+const payloadPathProperty = {
+  type: 'string',
+  minLength: 1,
+  maxLength: SKILL_PATH_MAX_LENGTH,
+  description: 'POSIX relative path inside the Skill root. No "..", no absolute path.',
+};
+
+/** JSON Schema for `commandmate.skill.yaml`. */
+export const SKILL_MANIFEST_JSON_SCHEMA: SkillJsonSchemaDocument = {
+  $schema: DRAFT,
+  $id: `${BASE_ID}/manifest-v${SKILL_SCHEMA_VERSION}.json`,
+  title: 'CommandMate Skill manifest',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schema_version',
+    'id',
+    'name',
+    'version',
+    'summary',
+    'description',
+    'capabilities',
+    'expected_outcomes',
+    'provider',
+    'license',
+    'compatibility',
+    'requirements',
+    'declared_permissions',
+    'declared_risk',
+    'risk_rationale',
+    'files',
+  ],
+  properties: {
+    schema_version: schemaVersionProperty,
+    id: { type: 'string', pattern: source(SKILL_ID_PATTERN), maxLength: SKILL_ID_MAX_LENGTH },
+    name: { type: 'string', minLength: 1, maxLength: SKILL_NAME_MAX_LENGTH },
+    version: { type: 'string', pattern: source(SEMVER_2_PATTERN) },
+    summary: { type: 'string', minLength: 1, maxLength: SKILL_SUMMARY_MAX_LENGTH },
+    description: { type: 'string', minLength: 1, maxLength: SKILL_DESCRIPTION_MAX_LENGTH },
+    capabilities: {
+      type: 'array',
+      minItems: 1,
+      maxItems: SKILL_BULLET_MAX_COUNT,
+      items: { type: 'string', minLength: 1, maxLength: SKILL_BULLET_MAX_LENGTH },
+    },
+    expected_outcomes: {
+      type: 'array',
+      minItems: 1,
+      maxItems: SKILL_BULLET_MAX_COUNT,
+      items: { type: 'string', minLength: 1, maxLength: SKILL_BULLET_MAX_LENGTH },
+    },
+    provider: { $ref: '#/$defs/provider' },
+    license: { type: 'string', pattern: source(SPDX_LICENSE_PATTERN) },
+    homepage: { type: 'string', pattern: '^https://' },
+    keywords: {
+      type: 'array',
+      maxItems: SKILL_KEYWORDS_MAX_COUNT,
+      items: { type: 'string', minLength: 1, maxLength: SKILL_KEYWORD_MAX_LENGTH },
+    },
+    compatibility: { $ref: '#/$defs/compatibility' },
+    requirements: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['commands', 'network_hosts'],
+      properties: {
+        commands: {
+          type: 'array',
+          maxItems: SKILL_COMMANDS_MAX_COUNT,
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['name'],
+            properties: {
+              name: { type: 'string', minLength: 1, maxLength: 64 },
+              version_range: { type: 'string', minLength: 1, maxLength: 100 },
+            },
+          },
+        },
+        network_hosts: {
+          type: 'array',
+          maxItems: SKILL_NETWORK_HOSTS_MAX_COUNT,
+          items: { type: 'string', pattern: source(NETWORK_HOST_PATTERN) },
+        },
+      },
+    },
+    declared_permissions: declaredPermissionsProperty,
+    declared_risk: riskProperty,
+    risk_rationale: { type: 'string', minLength: 1, maxLength: SKILL_RATIONALE_MAX_LENGTH },
+    files: {
+      type: 'array',
+      maxItems: SKILL_FILES_MAX_COUNT,
+      description: 'Payload files excluding commandmate.skill.yaml itself and directory entries.',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['path', 'sha256', 'size', 'kind', 'executable', 'script'],
+        properties: {
+          path: payloadPathProperty,
+          sha256: sha256Property,
+          size: { type: 'integer', minimum: 0, maximum: SKILL_FILE_MAX_SIZE },
+          kind: { type: 'string', enum: [...SKILL_FILE_KINDS] },
+          executable: { type: 'boolean' },
+          script: { type: 'boolean' },
+        },
+      },
+    },
+  },
+  $defs: {
+    provider: providerDef,
+    compatibility: compatibilityDef,
+    agentCompatibility: agentCompatibilityDef,
+  },
+};
+
+/** JSON Schema for the Catalog document. */
+export const SKILL_CATALOG_JSON_SCHEMA: SkillJsonSchemaDocument = {
+  $schema: DRAFT,
+  $id: `${BASE_ID}/catalog-v${SKILL_SCHEMA_VERSION}.json`,
+  title: 'CommandMate Skill catalog',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schema_version', 'entries'],
+  properties: {
+    schema_version: schemaVersionProperty,
+    entries: {
+      type: 'array',
+      maxItems: SKILL_CATALOG_ENTRIES_MAX_COUNT,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'name', 'summary', 'provider', 'license', 'latest', 'versions'],
+        properties: {
+          id: { type: 'string', pattern: source(SKILL_ID_PATTERN), maxLength: SKILL_ID_MAX_LENGTH },
+          name: { type: 'string', minLength: 1, maxLength: SKILL_NAME_MAX_LENGTH },
+          summary: { type: 'string', minLength: 1, maxLength: SKILL_SUMMARY_MAX_LENGTH },
+          provider: { $ref: '#/$defs/provider' },
+          license: { type: 'string', pattern: source(SPDX_LICENSE_PATTERN) },
+          homepage: { type: 'string', pattern: '^https://' },
+          keywords: {
+            type: 'array',
+            maxItems: SKILL_KEYWORDS_MAX_COUNT,
+            items: { type: 'string', minLength: 1, maxLength: SKILL_KEYWORD_MAX_LENGTH },
+          },
+          latest: { type: 'string', pattern: source(SEMVER_2_PATTERN) },
+          versions: {
+            type: 'array',
+            minItems: 1,
+            maxItems: SKILL_CATALOG_VERSIONS_MAX_COUNT,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: [
+                'version',
+                'changelog',
+                'published_at',
+                'source',
+                'artifact',
+                'compatibility',
+                'declared_risk',
+              ],
+              properties: {
+                version: { type: 'string', pattern: source(SEMVER_2_PATTERN) },
+                changelog: { type: 'string', minLength: 1, maxLength: SKILL_CHANGELOG_MAX_LENGTH },
+                published_at: { type: 'string', pattern: source(RFC3339_UTC_PATTERN) },
+                source: { $ref: '#/$defs/sourceRef' },
+                artifact: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['asset_name', 'url', 'sha256', 'size', 'content_type', 'format'],
+                  properties: {
+                    asset_name: {
+                      type: 'string',
+                      minLength: 1,
+                      maxLength: 200,
+                      description: '<skill-id>-<version>.tar.gz',
+                    },
+                    url: { type: 'string', pattern: '^https://' },
+                    sha256: sha256Property,
+                    size: { type: 'integer', minimum: 1, maximum: SKILL_ARTIFACT_MAX_SIZE },
+                    content_type: { const: SKILL_ARTIFACT_CONTENT_TYPE },
+                    format: { const: SKILL_ARTIFACT_FORMAT },
+                  },
+                },
+                compatibility: { $ref: '#/$defs/compatibility' },
+                declared_risk: riskProperty,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  $defs: {
+    provider: providerDef,
+    compatibility: compatibilityDef,
+    agentCompatibility: agentCompatibilityDef,
+    sourceRef: sourceRefDef,
+  },
+};
+
+/** JSON Schema for the deterministic install receipt. */
+export const SKILL_RECEIPT_JSON_SCHEMA: SkillJsonSchemaDocument = {
+  $schema: DRAFT,
+  $id: `${BASE_ID}/receipt-v${SKILL_SCHEMA_VERSION}.json`,
+  title: 'CommandMate Skill install receipt',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schema_version',
+    'skill_id',
+    'version',
+    'install_root',
+    'source',
+    'artifact',
+    'files',
+    'declared_risk',
+    'computed_risk',
+    'effective_risk',
+    'declared_permissions',
+    'agent_compatibility',
+  ],
+  properties: {
+    schema_version: schemaVersionProperty,
+    skill_id: { type: 'string', pattern: source(SKILL_ID_PATTERN), maxLength: SKILL_ID_MAX_LENGTH },
+    version: { type: 'string', pattern: source(SEMVER_2_PATTERN) },
+    install_root: {
+      type: 'string',
+      description: 'Repository-relative .agents/skills/<skill-id>. Never a machine-absolute path.',
+    },
+    source: { $ref: '#/$defs/sourceRef' },
+    artifact: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['asset_name', 'sha256', 'size', 'format'],
+      description: 'No url: download URLs may be signed and are treated as secrets.',
+      properties: {
+        asset_name: { type: 'string', minLength: 1, maxLength: 200 },
+        sha256: sha256Property,
+        size: { type: 'integer', minimum: 1, maximum: SKILL_ARTIFACT_MAX_SIZE },
+        format: { const: SKILL_ARTIFACT_FORMAT },
+      },
+    },
+    files: {
+      type: 'array',
+      maxItems: SKILL_FILES_MAX_COUNT,
+      description: 'Sorted by path ascending so receipts are byte-reproducible.',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['path', 'sha256', 'size', 'executable'],
+        properties: {
+          path: payloadPathProperty,
+          sha256: sha256Property,
+          size: { type: 'integer', minimum: 0, maximum: SKILL_FILE_MAX_SIZE },
+          executable: { type: 'boolean' },
+        },
+      },
+    },
+    declared_risk: riskProperty,
+    computed_risk: riskProperty,
+    effective_risk: { ...riskProperty, description: 'max(declared_risk, computed_risk).' },
+    declared_permissions: declaredPermissionsProperty,
+    agent_compatibility: {
+      type: 'array',
+      maxItems: 20,
+      items: { $ref: '#/$defs/agentCompatibility' },
+    },
+  },
+  $defs: {
+    sourceRef: sourceRefDef,
+    agentCompatibility: agentCompatibilityDef,
+  },
+};

--- a/src/lib/skills/schema.ts
+++ b/src/lib/skills/schema.ts
@@ -1,0 +1,1673 @@
+/**
+ * Schema validation for the Agent Skills distribution contract (Issue #1228)
+ *
+ * Pure functions over already-parsed values: no filesystem, no network, no YAML
+ * parser. The caller parses `commandmate.skill.yaml` under
+ * {@link SKILL_YAML_SAFE_PROFILE} and hands the resulting `unknown` here.
+ *
+ * Every validator is fail-closed and total: it returns a
+ * {@link SkillValidationResult} rather than throwing, and on success returns a
+ * freshly constructed object so no unvalidated property from the input
+ * survives.
+ *
+ * @module lib/skills/schema
+ */
+
+import { isCliToolType } from '@/lib/cli-tools/types';
+import {
+  COMMAND_NAME_PATTERN,
+  GIT_COMMIT_SHA_PATTERN,
+  GIT_REF_PATTERN,
+  HTTPS_URL_PREFIX,
+  NETWORK_HOST_PATTERN,
+  REPOSITORY_SLUG_PATTERN,
+  RESERVED_SKILL_IDS,
+  RFC3339_UTC_PATTERN,
+  SHA256_HEX_PATTERN,
+  SKILL_ARTIFACT_CONTENT_TYPE,
+  SKILL_ARTIFACT_FORMAT,
+  SKILL_ARTIFACT_MAX_SIZE,
+  SKILL_AGENT_SUPPORT_VALUES,
+  SKILL_BULLET_MAX_COUNT,
+  SKILL_BULLET_MAX_LENGTH,
+  SKILL_CATALOG_ENTRIES_MAX_COUNT,
+  SKILL_CATALOG_VERSIONS_MAX_COUNT,
+  SKILL_CHANGELOG_MAX_LENGTH,
+  SKILL_COMMANDS_MAX_COUNT,
+  SKILL_DECLARED_PERMISSIONS,
+  SKILL_DESCRIPTION_MAX_LENGTH,
+  SKILL_EVIDENCE_MAX_LENGTH,
+  SKILL_FILE_KINDS,
+  SKILL_FILE_MAX_SIZE,
+  SKILL_FILES_MAX_COUNT,
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+  SKILL_INSTALL_ROOT_PREFIX,
+  SKILL_KEYWORD_MAX_LENGTH,
+  SKILL_KEYWORDS_MAX_COUNT,
+  SKILL_MANIFEST_FILENAME,
+  SKILL_MD_FILENAME,
+  SKILL_NAME_MAX_LENGTH,
+  SKILL_NETWORK_HOSTS_MAX_COUNT,
+  SKILL_PATH_MAX_DEPTH,
+  SKILL_PATH_MAX_LENGTH,
+  SKILL_PATH_SEGMENT_MAX_LENGTH,
+  SKILL_RATIONALE_MAX_LENGTH,
+  SKILL_RISK_LEVELS,
+  SKILL_RISK_ORDER,
+  SKILL_SCHEMA_VERSION,
+  SKILL_SUMMARY_MAX_LENGTH,
+  SPDX_LICENSE_PATTERN,
+  buildSkillAssetName,
+} from '@/lib/skills/constants';
+import {
+  SkillContractErrorCode,
+  joinPath,
+  skillError,
+  skillFail,
+  skillOk,
+  type SkillContractError,
+  type SkillValidationResult,
+} from '@/lib/skills/errors';
+import { isValidSemVer, isValidSkillVersionRange } from '@/lib/skills/semver';
+import type {
+  SkillAgentCompatibility,
+  SkillAgentSupport,
+  SkillArtifactRef,
+  SkillCatalog,
+  SkillCatalogEntry,
+  SkillCatalogVersion,
+  SkillCompatibility,
+  SkillDeclaredPermission,
+  SkillFileEntry,
+  SkillFileKind,
+  SkillInstallReceipt,
+  SkillInstalledFile,
+  SkillManifest,
+  SkillPackageInspection,
+  SkillProvider,
+  SkillReceiptArtifact,
+  SkillRequirementCommand,
+  SkillRequirements,
+  SkillRiskLevel,
+  SkillSourceRef,
+} from '@/types/skills';
+
+// =============================================================================
+// Allowed field sets (schema_version 1 is closed: unknown fields are rejected)
+// =============================================================================
+
+const MANIFEST_FIELDS = [
+  'schema_version',
+  'id',
+  'name',
+  'version',
+  'summary',
+  'description',
+  'capabilities',
+  'expected_outcomes',
+  'provider',
+  'license',
+  'homepage',
+  'keywords',
+  'compatibility',
+  'requirements',
+  'declared_permissions',
+  'declared_risk',
+  'risk_rationale',
+  'files',
+] as const satisfies readonly (keyof SkillManifest)[];
+
+const CATALOG_FIELDS = ['schema_version', 'entries'] as const satisfies readonly (keyof SkillCatalog)[];
+
+const CATALOG_ENTRY_FIELDS = [
+  'id',
+  'name',
+  'summary',
+  'provider',
+  'license',
+  'homepage',
+  'keywords',
+  'latest',
+  'versions',
+] as const satisfies readonly (keyof SkillCatalogEntry)[];
+
+const CATALOG_VERSION_FIELDS = [
+  'version',
+  'changelog',
+  'published_at',
+  'source',
+  'artifact',
+  'compatibility',
+  'declared_risk',
+] as const satisfies readonly (keyof SkillCatalogVersion)[];
+
+const RECEIPT_FIELDS = [
+  'schema_version',
+  'skill_id',
+  'version',
+  'install_root',
+  'source',
+  'artifact',
+  'files',
+  'declared_risk',
+  'computed_risk',
+  'effective_risk',
+  'declared_permissions',
+  'agent_compatibility',
+] as const satisfies readonly (keyof SkillInstallReceipt)[];
+
+const PROVIDER_FIELDS = ['name', 'url', 'contact'] as const satisfies readonly (keyof SkillProvider)[];
+const COMPATIBILITY_FIELDS = ['commandmate', 'agents'] as const satisfies readonly (keyof SkillCompatibility)[];
+const AGENT_COMPAT_FIELDS = ['agent', 'support', 'evidence'] as const satisfies readonly (keyof SkillAgentCompatibility)[];
+const REQUIREMENTS_FIELDS = ['commands', 'network_hosts'] as const satisfies readonly (keyof SkillRequirements)[];
+const COMMAND_FIELDS = ['name', 'version_range'] as const satisfies readonly (keyof SkillRequirementCommand)[];
+const FILE_ENTRY_FIELDS = ['path', 'sha256', 'size', 'kind', 'executable', 'script'] as const satisfies readonly (keyof SkillFileEntry)[];
+const SOURCE_FIELDS = ['repository', 'ref', 'commit'] as const satisfies readonly (keyof SkillSourceRef)[];
+const ARTIFACT_FIELDS = ['asset_name', 'url', 'sha256', 'size', 'content_type', 'format'] as const satisfies readonly (keyof SkillArtifactRef)[];
+const RECEIPT_ARTIFACT_FIELDS = ['asset_name', 'sha256', 'size', 'format'] as const satisfies readonly (keyof SkillReceiptArtifact)[];
+const INSTALLED_FILE_FIELDS = ['path', 'sha256', 'size', 'executable'] as const satisfies readonly (keyof SkillInstalledFile)[];
+
+/**
+ * Compile-time exhaustiveness: adding a field to an interface without adding it
+ * to the list above makes `tsc` fail here, which keeps the JSON Schema, the
+ * validators and the TypeScript types from drifting apart.
+ */
+type MissingFields<TType, TList extends readonly PropertyKey[]> = Exclude<
+  keyof TType,
+  TList[number]
+>;
+type AssertNoMissing<T extends never> = T;
+export type _ManifestFieldsExhaustive = AssertNoMissing<MissingFields<SkillManifest, typeof MANIFEST_FIELDS>>;
+export type _CatalogFieldsExhaustive = AssertNoMissing<MissingFields<SkillCatalog, typeof CATALOG_FIELDS>>;
+export type _CatalogEntryFieldsExhaustive = AssertNoMissing<MissingFields<SkillCatalogEntry, typeof CATALOG_ENTRY_FIELDS>>;
+export type _CatalogVersionFieldsExhaustive = AssertNoMissing<MissingFields<SkillCatalogVersion, typeof CATALOG_VERSION_FIELDS>>;
+export type _ReceiptFieldsExhaustive = AssertNoMissing<MissingFields<SkillInstallReceipt, typeof RECEIPT_FIELDS>>;
+
+/** Field name lists, exposed so schema-parity tests can compare them to the JSON Schema. */
+export const SKILL_DOCUMENT_FIELDS = {
+  manifest: MANIFEST_FIELDS,
+  catalog: CATALOG_FIELDS,
+  catalogEntry: CATALOG_ENTRY_FIELDS,
+  catalogVersion: CATALOG_VERSION_FIELDS,
+  receipt: RECEIPT_FIELDS,
+  provider: PROVIDER_FIELDS,
+  compatibility: COMPATIBILITY_FIELDS,
+  agentCompatibility: AGENT_COMPAT_FIELDS,
+  requirements: REQUIREMENTS_FIELDS,
+  requirementCommand: COMMAND_FIELDS,
+  fileEntry: FILE_ENTRY_FIELDS,
+  source: SOURCE_FIELDS,
+  artifact: ARTIFACT_FIELDS,
+  receiptArtifact: RECEIPT_ARTIFACT_FIELDS,
+  installedFile: INSTALLED_FILE_FIELDS,
+} as const;
+
+/** Optional fields per document, exposed for the same parity check. */
+export const SKILL_OPTIONAL_FIELDS = {
+  manifest: ['homepage', 'keywords'],
+  catalog: [],
+  catalogEntry: ['homepage', 'keywords'],
+  catalogVersion: [],
+  receipt: [],
+  provider: ['url', 'contact'],
+  compatibility: [],
+  agentCompatibility: [],
+  requirements: [],
+  requirementCommand: ['version_range'],
+  fileEntry: [],
+  source: [],
+  artifact: [],
+  receiptArtifact: [],
+  installedFile: [],
+} as const satisfies Record<keyof typeof SKILL_DOCUMENT_FIELDS, readonly string[]>;
+
+// =============================================================================
+// Primitive readers
+// =============================================================================
+
+type Bag = SkillContractError[];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function has(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function readObject(value: unknown, path: string, errors: Bag): Record<string, unknown> | null {
+  if (!isPlainObject(value)) {
+    errors.push(
+      skillError(SkillContractErrorCode.NOT_AN_OBJECT, path, `${path || '/'} must be an object`)
+    );
+    return null;
+  }
+  return value;
+}
+
+function checkUnknownFields(
+  obj: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+  errors: Bag
+): void {
+  for (const key of Object.keys(obj)) {
+    if (!allowed.includes(key)) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.UNKNOWN_FIELD,
+          joinPath(path, key),
+          `unknown field is not allowed in schema_version ${SKILL_SCHEMA_VERSION}`
+        )
+      );
+    }
+  }
+}
+
+interface StringOptions {
+  optional?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: RegExp;
+  patternName?: string;
+  formatCode?: (typeof SkillContractErrorCode)[keyof typeof SkillContractErrorCode];
+}
+
+function readString(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag,
+  options: StringOptions = {}
+): string | undefined {
+  const path = joinPath(parent, key);
+  if (!has(obj, key) || obj[key] === undefined) {
+    if (!options.optional) {
+      errors.push(
+        skillError(SkillContractErrorCode.MISSING_FIELD, path, `${key} is required`)
+      );
+    }
+    return undefined;
+  }
+  const value = obj[key];
+  if (typeof value !== 'string') {
+    errors.push(skillError(SkillContractErrorCode.INVALID_TYPE, path, `${key} must be a string`));
+    return undefined;
+  }
+  // A field with a domain-specific error code reports that code for every
+  // violation, so a truncated digest reads as "invalid digest" rather than as a
+  // generic length problem.
+  const lengthCode = options.formatCode ?? SkillContractErrorCode.LIMIT_EXCEEDED;
+  const min = options.minLength ?? 1;
+  if (value.length < min) {
+    errors.push(
+      skillError(lengthCode, path, `${key} is shorter than the minimum`, { minLength: min })
+    );
+    return undefined;
+  }
+  if (options.maxLength !== undefined && value.length > options.maxLength) {
+    errors.push(
+      skillError(lengthCode, path, `${key} exceeds the maximum length`, {
+        maxLength: options.maxLength,
+      })
+    );
+    return undefined;
+  }
+  if (options.pattern && !options.pattern.test(value)) {
+    errors.push(
+      skillError(
+        options.formatCode ?? SkillContractErrorCode.INVALID_FORMAT,
+        path,
+        `${key} does not match the required format`,
+        options.patternName ? { format: options.patternName } : undefined
+      )
+    );
+    return undefined;
+  }
+  return value;
+}
+
+function readInteger(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag,
+  bounds: { min: number; max: number }
+): number | undefined {
+  const path = joinPath(parent, key);
+  if (!has(obj, key) || obj[key] === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, `${key} is required`));
+    return undefined;
+  }
+  const value = obj[key];
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    errors.push(skillError(SkillContractErrorCode.INVALID_TYPE, path, `${key} must be an integer`));
+    return undefined;
+  }
+  if (value < bounds.min || value > bounds.max) {
+    errors.push(
+      skillError(SkillContractErrorCode.LIMIT_EXCEEDED, path, `${key} is out of range`, bounds)
+    );
+    return undefined;
+  }
+  return value;
+}
+
+function readBoolean(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag
+): boolean | undefined {
+  const path = joinPath(parent, key);
+  if (!has(obj, key) || obj[key] === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, `${key} is required`));
+    return undefined;
+  }
+  const value = obj[key];
+  if (typeof value !== 'boolean') {
+    errors.push(skillError(SkillContractErrorCode.INVALID_TYPE, path, `${key} must be a boolean`));
+    return undefined;
+  }
+  return value;
+}
+
+function readArray(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag,
+  options: { maxItems: number; optional?: boolean }
+): unknown[] | undefined {
+  const path = joinPath(parent, key);
+  if (!has(obj, key) || obj[key] === undefined) {
+    if (!options.optional) {
+      errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, `${key} is required`));
+    }
+    return undefined;
+  }
+  const value = obj[key];
+  if (!Array.isArray(value)) {
+    errors.push(skillError(SkillContractErrorCode.INVALID_TYPE, path, `${key} must be an array`));
+    return undefined;
+  }
+  if (value.length > options.maxItems) {
+    errors.push(
+      skillError(SkillContractErrorCode.LIMIT_EXCEEDED, path, `${key} has too many items`, {
+        maxItems: options.maxItems,
+      })
+    );
+    return undefined;
+  }
+  return value;
+}
+
+function readEnum<T extends string>(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag,
+  allowed: readonly T[]
+): T | undefined {
+  const path = joinPath(parent, key);
+  if (!has(obj, key) || obj[key] === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, `${key} is required`));
+    return undefined;
+  }
+  const value = obj[key];
+  if (typeof value !== 'string' || !(allowed as readonly string[]).includes(value)) {
+    errors.push(
+      skillError(SkillContractErrorCode.INVALID_ENUM, path, `${key} is not an allowed value`, {
+        allowed: allowed.join('|'),
+      })
+    );
+    return undefined;
+  }
+  return value as T;
+}
+
+function readStringList(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag,
+  options: { maxItems: number; maxLength: number; optional?: boolean; pattern?: RegExp }
+): string[] | undefined {
+  const raw = readArray(obj, key, parent, errors, {
+    maxItems: options.maxItems,
+    optional: options.optional,
+  });
+  if (raw === undefined) return undefined;
+
+  const out: string[] = [];
+  let failed = false;
+  raw.forEach((item, index) => {
+    const path = joinPath(joinPath(parent, key), index);
+    if (typeof item !== 'string' || item.length === 0 || item.length > options.maxLength) {
+      errors.push(
+        skillError(SkillContractErrorCode.INVALID_TYPE, path, 'item must be a bounded string', {
+          maxLength: options.maxLength,
+        })
+      );
+      failed = true;
+      return;
+    }
+    if (options.pattern && !options.pattern.test(item)) {
+      errors.push(
+        skillError(SkillContractErrorCode.INVALID_FORMAT, path, 'item does not match the required format')
+      );
+      failed = true;
+      return;
+    }
+    out.push(item);
+  });
+  return failed ? undefined : out;
+}
+
+function readHttpsUrl(
+  obj: Record<string, unknown>,
+  key: string,
+  parent: string,
+  errors: Bag,
+  options: { optional?: boolean } = {}
+): string | undefined {
+  const value = readString(obj, key, parent, errors, { optional: options.optional, maxLength: 512 });
+  if (value === undefined) return undefined;
+  if (!value.startsWith(HTTPS_URL_PREFIX)) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.INVALID_FORMAT,
+        joinPath(parent, key),
+        `${key} must be an https URL`
+      )
+    );
+    return undefined;
+  }
+  return value;
+}
+
+function readSchemaVersion(obj: Record<string, unknown>, errors: Bag): number | undefined {
+  const path = '/schema_version';
+  const value = obj['schema_version'];
+  if (value === undefined) {
+    errors.push(
+      skillError(SkillContractErrorCode.SCHEMA_VERSION_UNSUPPORTED, path, 'schema_version is required')
+    );
+    return undefined;
+  }
+  if (value !== SKILL_SCHEMA_VERSION) {
+    // Fail closed: a future schema_version is rejected, never best-effort parsed.
+    errors.push(
+      skillError(
+        SkillContractErrorCode.SCHEMA_VERSION_UNSUPPORTED,
+        path,
+        'schema_version is not supported by this build',
+        { supported: SKILL_SCHEMA_VERSION }
+      )
+    );
+    return undefined;
+  }
+  return SKILL_SCHEMA_VERSION;
+}
+
+// =============================================================================
+// Skill ID
+// =============================================================================
+
+/**
+ * Fold a name for collision detection.
+ *
+ * Case folding plus NFKC catches directory names that differ only by case or by
+ * a compatibility-equivalent Unicode form but collide on a case-insensitive or
+ * normalizing filesystem.
+ */
+export function foldSkillIdForCollision(name: string): string {
+  return name.normalize('NFKC').toLowerCase();
+}
+
+/** Validate a Skill ID against the slug grammar and the reserved list. */
+export function validateSkillId(
+  id: unknown,
+  path = '/id'
+): SkillValidationResult<string> {
+  if (typeof id !== 'string' || id.length === 0) {
+    return skillFail([skillError(SkillContractErrorCode.ID_INVALID, path, 'id must be a non-empty string')]);
+  }
+  if (id.length > SKILL_ID_MAX_LENGTH) {
+    return skillFail([
+      skillError(SkillContractErrorCode.ID_INVALID, path, 'id exceeds the maximum length', {
+        maxLength: SKILL_ID_MAX_LENGTH,
+      }),
+    ]);
+  }
+  if (!SKILL_ID_PATTERN.test(id)) {
+    return skillFail([
+      skillError(SkillContractErrorCode.ID_INVALID, path, 'id must be a lowercase ASCII slug', {
+        format: 'lowercase-slug',
+      }),
+    ]);
+  }
+  if (RESERVED_SKILL_IDS.includes(id)) {
+    return skillFail([skillError(SkillContractErrorCode.ID_RESERVED, path, 'id is reserved')]);
+  }
+  return skillOk(id);
+}
+
+/**
+ * Detect a case/Unicode collision between a new ID and existing directory names.
+ *
+ * @returns the colliding existing name, or null when the ID is free.
+ */
+export function detectSkillIdCollision(id: string, existingNames: readonly string[]): string | null {
+  const folded = foldSkillIdForCollision(id);
+  for (const name of existingNames) {
+    if (name === id) continue;
+    if (foldSkillIdForCollision(name) === folded) return name;
+  }
+  return null;
+}
+
+/**
+ * Check that the directory name, the SKILL.md frontmatter name and the manifest
+ * agree, which is what stops a package from installing under a name the user
+ * never reviewed.
+ */
+export function validateSkillIdentityConsistency(input: {
+  directoryName: string;
+  skillMdName: string;
+  manifestId: string;
+  manifestName: string;
+}): SkillValidationResult<string> {
+  const idResult = validateSkillId(input.manifestId);
+  if (!idResult.ok) return idResult;
+
+  const errors: Bag = [];
+  if (input.directoryName !== input.manifestId) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.ID_MISMATCH,
+        '/id',
+        'directory name does not match the manifest id'
+      )
+    );
+  }
+  if (input.skillMdName !== input.manifestName) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.ID_MISMATCH,
+        '/name',
+        'SKILL.md name does not match the manifest name'
+      )
+    );
+  }
+  return errors.length > 0 ? skillFail(errors) : skillOk(input.manifestId);
+}
+
+// =============================================================================
+// Payload paths
+// =============================================================================
+
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:/;
+
+/** NUL and other control bytes are rejected by code point, not by a control regex. */
+function hasControlCharOrBackslash(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f || code === 0x5c) return true;
+  }
+  return false;
+}
+
+/**
+ * Validate a payload path declared in a manifest or receipt.
+ *
+ * String-level only: it rejects everything that could escape the Skill root
+ * before any filesystem call happens. Real-path/symlink checks stay with the
+ * installer (#1231), which owns the filesystem.
+ */
+export function validateSkillPayloadPath(
+  value: unknown,
+  path: string
+): SkillValidationResult<string> {
+  const fail = (message: string, detail?: Record<string, string | number | boolean>) =>
+    skillFail<string>([skillError(SkillContractErrorCode.FILE_PATH_UNSAFE, path, message, detail)]);
+
+  if (typeof value !== 'string' || value.length === 0) return fail('path must be a non-empty string');
+  if (value.length > SKILL_PATH_MAX_LENGTH) {
+    return fail('path exceeds the maximum length', { maxLength: SKILL_PATH_MAX_LENGTH });
+  }
+  if (hasControlCharOrBackslash(value)) return fail('path contains a control character or a backslash');
+  if (value.startsWith('/') || WINDOWS_DRIVE_PATH.test(value)) return fail('path must be relative');
+  if (value !== value.normalize('NFC')) return fail('path must be NFC-normalized');
+  if (value.includes('//')) return fail('path must not contain empty segments');
+  if (value.endsWith('/')) return fail('path must not be a directory entry');
+
+  const segments = value.split('/');
+  if (segments.length > SKILL_PATH_MAX_DEPTH) {
+    return fail('path is nested too deeply', { maxDepth: SKILL_PATH_MAX_DEPTH });
+  }
+  for (const segment of segments) {
+    if (segment === '.' || segment === '..') return fail('path must not contain "." or ".." segments');
+    if (segment.length > SKILL_PATH_SEGMENT_MAX_LENGTH) {
+      return fail('path segment is too long', { maxLength: SKILL_PATH_SEGMENT_MAX_LENGTH });
+    }
+    if (segment !== segment.trim()) return fail('path segment must not be padded with whitespace');
+  }
+  return skillOk(value);
+}
+
+// =============================================================================
+// Shared sub-object validators
+// =============================================================================
+
+function readProvider(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillProvider | undefined {
+  const path = joinPath(parent, 'provider');
+  const raw = parentObj['provider'];
+  if (raw === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, 'provider is required'));
+    return undefined;
+  }
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, PROVIDER_FIELDS, path, errors);
+
+  const name = readString(obj, 'name', path, errors, { maxLength: SKILL_NAME_MAX_LENGTH });
+  const url = readHttpsUrl(obj, 'url', path, errors, { optional: true });
+  const contact = readString(obj, 'contact', path, errors, { optional: true, maxLength: 200 });
+  if (name === undefined) return undefined;
+  return { name, ...(url !== undefined ? { url } : {}), ...(contact !== undefined ? { contact } : {}) };
+}
+
+function readAgentCompatibility(
+  raw: unknown,
+  path: string,
+  errors: Bag
+): SkillAgentCompatibility | undefined {
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, AGENT_COMPAT_FIELDS, path, errors);
+
+  const agent = readString(obj, 'agent', path, errors, { maxLength: 40 });
+  if (agent !== undefined && !isCliToolType(agent)) {
+    errors.push(
+      skillError(SkillContractErrorCode.INVALID_ENUM, joinPath(path, 'agent'), 'agent is not a known CLI tool')
+    );
+    return undefined;
+  }
+  const support = readEnum<SkillAgentSupport>(obj, 'support', path, errors, SKILL_AGENT_SUPPORT_VALUES);
+  const evidence = readString(obj, 'evidence', path, errors, { maxLength: SKILL_EVIDENCE_MAX_LENGTH });
+  if (agent === undefined || support === undefined || evidence === undefined) return undefined;
+  return { agent, support, evidence };
+}
+
+function readCompatibility(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillCompatibility | undefined {
+  const path = joinPath(parent, 'compatibility');
+  const raw = parentObj['compatibility'];
+  if (raw === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, 'compatibility is required'));
+    return undefined;
+  }
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, COMPATIBILITY_FIELDS, path, errors);
+
+  const commandmate = readString(obj, 'commandmate', path, errors, { maxLength: 100 });
+  if (commandmate !== undefined && !isValidSkillVersionRange(commandmate)) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.VERSION_RANGE_INVALID,
+        joinPath(path, 'commandmate'),
+        'commandmate is not a supported version range'
+      )
+    );
+    return undefined;
+  }
+
+  const rawAgents = readArray(obj, 'agents', path, errors, { maxItems: 20 });
+  if (commandmate === undefined || rawAgents === undefined) return undefined;
+
+  const agents: SkillAgentCompatibility[] = [];
+  const seen = new Set<string>();
+  let failed = false;
+  rawAgents.forEach((item, index) => {
+    const itemPath = joinPath(joinPath(path, 'agents'), index);
+    const parsed = readAgentCompatibility(item, itemPath, errors);
+    if (!parsed) {
+      failed = true;
+      return;
+    }
+    if (seen.has(parsed.agent)) {
+      errors.push(
+        skillError(SkillContractErrorCode.DUPLICATE_ENTRY, itemPath, 'agent is declared more than once')
+      );
+      failed = true;
+      return;
+    }
+    seen.add(parsed.agent);
+    agents.push(parsed);
+  });
+  return failed ? undefined : { commandmate, agents };
+}
+
+function readRequirements(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillRequirements | undefined {
+  const path = joinPath(parent, 'requirements');
+  const raw = parentObj['requirements'];
+  if (raw === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, 'requirements is required'));
+    return undefined;
+  }
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, REQUIREMENTS_FIELDS, path, errors);
+
+  const rawCommands = readArray(obj, 'commands', path, errors, { maxItems: SKILL_COMMANDS_MAX_COUNT });
+  const networkHosts = readStringList(obj, 'network_hosts', path, errors, {
+    maxItems: SKILL_NETWORK_HOSTS_MAX_COUNT,
+    maxLength: 253,
+    pattern: NETWORK_HOST_PATTERN,
+  });
+  if (rawCommands === undefined || networkHosts === undefined) return undefined;
+
+  const commands: SkillRequirementCommand[] = [];
+  let failed = false;
+  rawCommands.forEach((item, index) => {
+    const itemPath = joinPath(joinPath(path, 'commands'), index);
+    const cmdObj = readObject(item, itemPath, errors);
+    if (!cmdObj) {
+      failed = true;
+      return;
+    }
+    checkUnknownFields(cmdObj, COMMAND_FIELDS, itemPath, errors);
+    const name = readString(cmdObj, 'name', itemPath, errors, {
+      maxLength: 64,
+      pattern: COMMAND_NAME_PATTERN,
+      patternName: 'command-name',
+    });
+    const range = readString(cmdObj, 'version_range', itemPath, errors, {
+      optional: true,
+      maxLength: 100,
+    });
+    if (range !== undefined && !isValidSkillVersionRange(range)) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.VERSION_RANGE_INVALID,
+          joinPath(itemPath, 'version_range'),
+          'version_range is not a supported version range'
+        )
+      );
+      failed = true;
+      return;
+    }
+    if (name === undefined) {
+      failed = true;
+      return;
+    }
+    commands.push({ name, ...(range !== undefined ? { version_range: range } : {}) });
+  });
+  return failed ? undefined : { commands, network_hosts: networkHosts };
+}
+
+function readSource(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillSourceRef | undefined {
+  const path = joinPath(parent, 'source');
+  const raw = parentObj['source'];
+  if (raw === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, 'source is required'));
+    return undefined;
+  }
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, SOURCE_FIELDS, path, errors);
+
+  const repository = readString(obj, 'repository', path, errors, {
+    maxLength: 140,
+    pattern: REPOSITORY_SLUG_PATTERN,
+    patternName: 'owner/name',
+  });
+  const ref = readString(obj, 'ref', path, errors, {
+    maxLength: 100,
+    pattern: GIT_REF_PATTERN,
+    patternName: 'git-ref',
+  });
+  if (ref !== undefined && ref.includes('..')) {
+    errors.push(
+      skillError(SkillContractErrorCode.INVALID_FORMAT, joinPath(path, 'ref'), 'ref must not contain ".."')
+    );
+    return undefined;
+  }
+  const commit = readString(obj, 'commit', path, errors, {
+    maxLength: 40,
+    minLength: 40,
+    pattern: GIT_COMMIT_SHA_PATTERN,
+    patternName: 'sha1-40-hex',
+    formatCode: SkillContractErrorCode.SOURCE_COMMIT_INVALID,
+  });
+  if (repository === undefined || ref === undefined || commit === undefined) return undefined;
+  return { repository, ref, commit };
+}
+
+function readArtifact(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillArtifactRef | undefined {
+  const path = joinPath(parent, 'artifact');
+  const raw = parentObj['artifact'];
+  if (raw === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, 'artifact is required'));
+    return undefined;
+  }
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, ARTIFACT_FIELDS, path, errors);
+
+  const assetName = readString(obj, 'asset_name', path, errors, { maxLength: 200 });
+  const url = readHttpsUrl(obj, 'url', path, errors);
+  const sha256 = readString(obj, 'sha256', path, errors, {
+    minLength: 64,
+    maxLength: 64,
+    pattern: SHA256_HEX_PATTERN,
+    patternName: 'sha256-lowercase-hex',
+    formatCode: SkillContractErrorCode.DIGEST_INVALID,
+  });
+  const size = readInteger(obj, 'size', path, errors, { min: 1, max: SKILL_ARTIFACT_MAX_SIZE });
+  const contentType = readString(obj, 'content_type', path, errors, { maxLength: 100 });
+  const format = readEnum(obj, 'format', path, errors, [SKILL_ARTIFACT_FORMAT] as const);
+
+  if (contentType !== undefined && contentType !== SKILL_ARTIFACT_CONTENT_TYPE) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.ARTIFACT_INVALID,
+        joinPath(path, 'content_type'),
+        'content_type must be the fixed artifact media type',
+        { expected: SKILL_ARTIFACT_CONTENT_TYPE }
+      )
+    );
+    return undefined;
+  }
+  if (
+    assetName === undefined ||
+    url === undefined ||
+    sha256 === undefined ||
+    size === undefined ||
+    contentType === undefined ||
+    format === undefined
+  ) {
+    return undefined;
+  }
+  return { asset_name: assetName, url, sha256, size, content_type: contentType, format };
+}
+
+// =============================================================================
+// Manifest
+// =============================================================================
+
+function readFileEntries(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillFileEntry[] | undefined {
+  const path = joinPath(parent, 'files');
+  const raw = readArray(parentObj, 'files', parent, errors, { maxItems: SKILL_FILES_MAX_COUNT });
+  if (raw === undefined) return undefined;
+
+  const entries: SkillFileEntry[] = [];
+  const seenFolded = new Set<string>();
+  let failed = false;
+
+  raw.forEach((item, index) => {
+    const itemPath = joinPath(path, index);
+    const obj = readObject(item, itemPath, errors);
+    if (!obj) {
+      failed = true;
+      return;
+    }
+    checkUnknownFields(obj, FILE_ENTRY_FIELDS, itemPath, errors);
+
+    const pathResult = validateSkillPayloadPath(obj['path'], joinPath(itemPath, 'path'));
+    const sha256 = readString(obj, 'sha256', itemPath, errors, {
+      minLength: 64,
+      maxLength: 64,
+      pattern: SHA256_HEX_PATTERN,
+      patternName: 'sha256-lowercase-hex',
+      formatCode: SkillContractErrorCode.DIGEST_INVALID,
+    });
+    const size = readInteger(obj, 'size', itemPath, errors, { min: 0, max: SKILL_FILE_MAX_SIZE });
+    const kind = readEnum<SkillFileKind>(obj, 'kind', itemPath, errors, SKILL_FILE_KINDS);
+    const executable = readBoolean(obj, 'executable', itemPath, errors);
+    const script = readBoolean(obj, 'script', itemPath, errors);
+
+    if (!pathResult.ok) {
+      errors.push(...pathResult.errors);
+      failed = true;
+      return;
+    }
+    if (
+      sha256 === undefined ||
+      size === undefined ||
+      kind === undefined ||
+      executable === undefined ||
+      script === undefined
+    ) {
+      failed = true;
+      return;
+    }
+
+    const filePath = pathResult.value;
+    if (filePath === SKILL_MANIFEST_FILENAME) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.FILE_SET_MISMATCH,
+          joinPath(itemPath, 'path'),
+          'the manifest must not declare a digest for itself'
+        )
+      );
+      failed = true;
+      return;
+    }
+    const folded = foldSkillIdForCollision(filePath);
+    if (seenFolded.has(folded)) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.FILE_PATH_DUPLICATE,
+          joinPath(itemPath, 'path'),
+          'path collides with another declared file'
+        )
+      );
+      failed = true;
+      return;
+    }
+    seenFolded.add(folded);
+    entries.push({ path: filePath, sha256, size, kind, executable, script });
+  });
+
+  if (failed) return undefined;
+
+  const skillMd = entries.filter((e) => e.path === SKILL_MD_FILENAME);
+  if (skillMd.length !== 1) {
+    errors.push(
+      skillError(SkillContractErrorCode.FILE_SET_MISMATCH, path, `files must declare exactly one ${SKILL_MD_FILENAME}`)
+    );
+    return undefined;
+  }
+  if (skillMd[0].kind !== 'skill_md') {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.INCONSISTENT_VALUE,
+        path,
+        `${SKILL_MD_FILENAME} must be declared with kind "skill_md"`
+      )
+    );
+    return undefined;
+  }
+  return entries;
+}
+
+/** Validate a parsed `commandmate.skill.yaml` document. */
+export function validateSkillManifest(input: unknown): SkillValidationResult<SkillManifest> {
+  const errors: Bag = [];
+  const obj = readObject(input, '', errors);
+  if (!obj) return skillFail(errors);
+
+  const schemaVersion = readSchemaVersion(obj, errors);
+  if (schemaVersion === undefined) return skillFail(errors);
+
+  checkUnknownFields(obj, MANIFEST_FIELDS, '', errors);
+
+  const idResult = validateSkillId(obj['id']);
+  if (!idResult.ok) errors.push(...idResult.errors);
+
+  const name = readString(obj, 'name', '', errors, { maxLength: SKILL_NAME_MAX_LENGTH });
+  const version = readString(obj, 'version', '', errors, { maxLength: 64 });
+  if (version !== undefined && !isValidSemVer(version)) {
+    errors.push(
+      skillError(SkillContractErrorCode.VERSION_INVALID, '/version', 'version must be SemVer 2.0 without a "v" prefix')
+    );
+  }
+  const summary = readString(obj, 'summary', '', errors, { maxLength: SKILL_SUMMARY_MAX_LENGTH });
+  const description = readString(obj, 'description', '', errors, {
+    maxLength: SKILL_DESCRIPTION_MAX_LENGTH,
+  });
+  const capabilities = readStringList(obj, 'capabilities', '', errors, {
+    maxItems: SKILL_BULLET_MAX_COUNT,
+    maxLength: SKILL_BULLET_MAX_LENGTH,
+  });
+  const expectedOutcomes = readStringList(obj, 'expected_outcomes', '', errors, {
+    maxItems: SKILL_BULLET_MAX_COUNT,
+    maxLength: SKILL_BULLET_MAX_LENGTH,
+  });
+  const provider = readProvider(obj, '', errors);
+  const license = readString(obj, 'license', '', errors, {
+    maxLength: 64,
+    pattern: SPDX_LICENSE_PATTERN,
+    patternName: 'spdx-license-id',
+  });
+  const homepage = readHttpsUrl(obj, 'homepage', '', errors, { optional: true });
+  const keywords = readStringList(obj, 'keywords', '', errors, {
+    maxItems: SKILL_KEYWORDS_MAX_COUNT,
+    maxLength: SKILL_KEYWORD_MAX_LENGTH,
+    optional: true,
+  });
+  const compatibility = readCompatibility(obj, '', errors);
+  const requirements = readRequirements(obj, '', errors);
+  const declaredPermissions = readStringList(obj, 'declared_permissions', '', errors, {
+    maxItems: SKILL_DECLARED_PERMISSIONS.length,
+    maxLength: 40,
+  });
+  if (declaredPermissions) {
+    for (const [index, permission] of declaredPermissions.entries()) {
+      if (!(SKILL_DECLARED_PERMISSIONS as readonly string[]).includes(permission)) {
+        errors.push(
+          skillError(
+            SkillContractErrorCode.INVALID_ENUM,
+            joinPath('/declared_permissions', index),
+            'declared permission is not an allowed value'
+          )
+        );
+      }
+    }
+  }
+  const declaredRisk = readEnum<SkillRiskLevel>(obj, 'declared_risk', '', errors, SKILL_RISK_LEVELS);
+  const riskRationale = readString(obj, 'risk_rationale', '', errors, {
+    maxLength: SKILL_RATIONALE_MAX_LENGTH,
+  });
+  const files = readFileEntries(obj, '', errors);
+
+  // Capabilities and expected outcomes are what the install dialog shows (UX-01),
+  // so an empty list is a contract violation rather than an acceptable default.
+  if (capabilities && capabilities.length === 0) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, '/capabilities', 'capabilities must not be empty'));
+  }
+  if (expectedOutcomes && expectedOutcomes.length === 0) {
+    errors.push(
+      skillError(SkillContractErrorCode.MISSING_FIELD, '/expected_outcomes', 'expected_outcomes must not be empty')
+    );
+  }
+
+  if (
+    errors.length > 0 ||
+    !idResult.ok ||
+    name === undefined ||
+    version === undefined ||
+    summary === undefined ||
+    description === undefined ||
+    capabilities === undefined ||
+    expectedOutcomes === undefined ||
+    provider === undefined ||
+    license === undefined ||
+    compatibility === undefined ||
+    requirements === undefined ||
+    declaredPermissions === undefined ||
+    declaredRisk === undefined ||
+    riskRationale === undefined ||
+    files === undefined
+  ) {
+    return skillFail(
+      errors.length > 0
+        ? errors
+        : [skillError(SkillContractErrorCode.MISSING_FIELD, '', 'manifest is incomplete')]
+    );
+  }
+
+  return skillOk({
+    schema_version: schemaVersion,
+    id: idResult.value,
+    name,
+    version,
+    summary,
+    description,
+    capabilities,
+    expected_outcomes: expectedOutcomes,
+    provider,
+    license,
+    ...(homepage !== undefined ? { homepage } : {}),
+    ...(keywords !== undefined ? { keywords } : {}),
+    compatibility,
+    requirements,
+    declared_permissions: declaredPermissions as SkillDeclaredPermission[],
+    declared_risk: declaredRisk,
+    risk_rationale: riskRationale,
+    files,
+  });
+}
+
+// =============================================================================
+// Catalog
+// =============================================================================
+
+function readCatalogVersion(
+  raw: unknown,
+  path: string,
+  skillId: string,
+  errors: Bag
+): SkillCatalogVersion | undefined {
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, CATALOG_VERSION_FIELDS, path, errors);
+
+  const version = readString(obj, 'version', path, errors, { maxLength: 64 });
+  if (version !== undefined && !isValidSemVer(version)) {
+    errors.push(
+      skillError(SkillContractErrorCode.VERSION_INVALID, joinPath(path, 'version'), 'version must be SemVer 2.0')
+    );
+    return undefined;
+  }
+  const changelog = readString(obj, 'changelog', path, errors, { maxLength: SKILL_CHANGELOG_MAX_LENGTH });
+  const publishedAt = readString(obj, 'published_at', path, errors, {
+    maxLength: 30,
+    pattern: RFC3339_UTC_PATTERN,
+    patternName: 'rfc3339-utc',
+  });
+  const source = readSource(obj, path, errors);
+  const artifact = readArtifact(obj, path, errors);
+  const compatibility = readCompatibility(obj, path, errors);
+  const declaredRisk = readEnum<SkillRiskLevel>(obj, 'declared_risk', path, errors, SKILL_RISK_LEVELS);
+
+  if (
+    version === undefined ||
+    changelog === undefined ||
+    publishedAt === undefined ||
+    source === undefined ||
+    artifact === undefined ||
+    compatibility === undefined ||
+    declaredRisk === undefined
+  ) {
+    return undefined;
+  }
+
+  const expectedAsset = buildSkillAssetName(skillId, version);
+  if (artifact.asset_name !== expectedAsset) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.ARTIFACT_INVALID,
+        joinPath(joinPath(path, 'artifact'), 'asset_name'),
+        'asset_name must follow the <skill-id>-<version>.tar.gz convention',
+        { expected: expectedAsset }
+      )
+    );
+    return undefined;
+  }
+
+  return {
+    version,
+    changelog,
+    published_at: publishedAt,
+    source,
+    artifact,
+    compatibility,
+    declared_risk: declaredRisk,
+  };
+}
+
+function readCatalogEntry(raw: unknown, path: string, errors: Bag): SkillCatalogEntry | undefined {
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, CATALOG_ENTRY_FIELDS, path, errors);
+
+  const idResult = validateSkillId(obj['id'], joinPath(path, 'id'));
+  if (!idResult.ok) {
+    errors.push(...idResult.errors);
+    return undefined;
+  }
+  const id = idResult.value;
+
+  const name = readString(obj, 'name', path, errors, { maxLength: SKILL_NAME_MAX_LENGTH });
+  const summary = readString(obj, 'summary', path, errors, { maxLength: SKILL_SUMMARY_MAX_LENGTH });
+  const provider = readProvider(obj, path, errors);
+  const license = readString(obj, 'license', path, errors, {
+    maxLength: 64,
+    pattern: SPDX_LICENSE_PATTERN,
+    patternName: 'spdx-license-id',
+  });
+  const homepage = readHttpsUrl(obj, 'homepage', path, errors, { optional: true });
+  const keywords = readStringList(obj, 'keywords', path, errors, {
+    maxItems: SKILL_KEYWORDS_MAX_COUNT,
+    maxLength: SKILL_KEYWORD_MAX_LENGTH,
+    optional: true,
+  });
+  const latest = readString(obj, 'latest', path, errors, { maxLength: 64 });
+  const rawVersions = readArray(obj, 'versions', path, errors, {
+    maxItems: SKILL_CATALOG_VERSIONS_MAX_COUNT,
+  });
+
+  if (
+    name === undefined ||
+    summary === undefined ||
+    provider === undefined ||
+    license === undefined ||
+    latest === undefined ||
+    rawVersions === undefined
+  ) {
+    return undefined;
+  }
+
+  if (rawVersions.length === 0) {
+    errors.push(
+      skillError(SkillContractErrorCode.MISSING_FIELD, joinPath(path, 'versions'), 'versions must not be empty')
+    );
+    return undefined;
+  }
+
+  const versions: SkillCatalogVersion[] = [];
+  const seenVersions = new Set<string>();
+  let failed = false;
+  rawVersions.forEach((item, index) => {
+    const itemPath = joinPath(joinPath(path, 'versions'), index);
+    const parsed = readCatalogVersion(item, itemPath, id, errors);
+    if (!parsed) {
+      failed = true;
+      return;
+    }
+    if (seenVersions.has(parsed.version)) {
+      errors.push(
+        skillError(SkillContractErrorCode.DUPLICATE_ENTRY, itemPath, 'version is listed more than once')
+      );
+      failed = true;
+      return;
+    }
+    seenVersions.add(parsed.version);
+    versions.push(parsed);
+  });
+  if (failed) return undefined;
+
+  if (!seenVersions.has(latest)) {
+    errors.push(
+      skillError(
+        SkillContractErrorCode.CATALOG_LATEST_UNRESOLVED,
+        joinPath(path, 'latest'),
+        'latest must reference a listed version'
+      )
+    );
+    return undefined;
+  }
+
+  return {
+    id,
+    name,
+    summary,
+    provider,
+    license,
+    ...(homepage !== undefined ? { homepage } : {}),
+    ...(keywords !== undefined ? { keywords } : {}),
+    latest,
+    versions,
+  };
+}
+
+/** Validate a parsed Catalog document. */
+export function validateSkillCatalog(input: unknown): SkillValidationResult<SkillCatalog> {
+  const errors: Bag = [];
+  const obj = readObject(input, '', errors);
+  if (!obj) return skillFail(errors);
+
+  const schemaVersion = readSchemaVersion(obj, errors);
+  if (schemaVersion === undefined) return skillFail(errors);
+
+  checkUnknownFields(obj, CATALOG_FIELDS, '', errors);
+
+  const rawEntries = readArray(obj, 'entries', '', errors, {
+    maxItems: SKILL_CATALOG_ENTRIES_MAX_COUNT,
+  });
+  if (rawEntries === undefined) return skillFail(errors);
+
+  const entries: SkillCatalogEntry[] = [];
+  const seenIds = new Set<string>();
+  rawEntries.forEach((item, index) => {
+    const itemPath = joinPath('/entries', index);
+    const parsed = readCatalogEntry(item, itemPath, errors);
+    if (!parsed) return;
+    const folded = foldSkillIdForCollision(parsed.id);
+    if (seenIds.has(folded)) {
+      errors.push(
+        skillError(SkillContractErrorCode.ID_COLLISION, itemPath, 'entry id collides with another entry')
+      );
+      return;
+    }
+    seenIds.add(folded);
+    entries.push(parsed);
+  });
+
+  if (errors.length > 0) return skillFail(errors);
+  return skillOk({ schema_version: schemaVersion, entries });
+}
+
+// =============================================================================
+// Receipt
+// =============================================================================
+
+function readReceiptArtifact(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillReceiptArtifact | undefined {
+  const path = joinPath(parent, 'artifact');
+  const raw = parentObj['artifact'];
+  if (raw === undefined) {
+    errors.push(skillError(SkillContractErrorCode.MISSING_FIELD, path, 'artifact is required'));
+    return undefined;
+  }
+  const obj = readObject(raw, path, errors);
+  if (!obj) return undefined;
+  checkUnknownFields(obj, RECEIPT_ARTIFACT_FIELDS, path, errors);
+
+  const assetName = readString(obj, 'asset_name', path, errors, { maxLength: 200 });
+  const sha256 = readString(obj, 'sha256', path, errors, {
+    minLength: 64,
+    maxLength: 64,
+    pattern: SHA256_HEX_PATTERN,
+    patternName: 'sha256-lowercase-hex',
+    formatCode: SkillContractErrorCode.DIGEST_INVALID,
+  });
+  const size = readInteger(obj, 'size', path, errors, { min: 1, max: SKILL_ARTIFACT_MAX_SIZE });
+  const format = readEnum(obj, 'format', path, errors, [SKILL_ARTIFACT_FORMAT] as const);
+  if (assetName === undefined || sha256 === undefined || size === undefined || format === undefined) {
+    return undefined;
+  }
+  return { asset_name: assetName, sha256, size, format };
+}
+
+function readInstalledFiles(
+  parentObj: Record<string, unknown>,
+  parent: string,
+  errors: Bag
+): SkillInstalledFile[] | undefined {
+  const path = joinPath(parent, 'files');
+  const raw = readArray(parentObj, 'files', parent, errors, { maxItems: SKILL_FILES_MAX_COUNT });
+  if (raw === undefined) return undefined;
+
+  const files: SkillInstalledFile[] = [];
+  let failed = false;
+  raw.forEach((item, index) => {
+    const itemPath = joinPath(path, index);
+    const obj = readObject(item, itemPath, errors);
+    if (!obj) {
+      failed = true;
+      return;
+    }
+    checkUnknownFields(obj, INSTALLED_FILE_FIELDS, itemPath, errors);
+    const pathResult = validateSkillPayloadPath(obj['path'], joinPath(itemPath, 'path'));
+    const sha256 = readString(obj, 'sha256', itemPath, errors, {
+      minLength: 64,
+      maxLength: 64,
+      pattern: SHA256_HEX_PATTERN,
+      patternName: 'sha256-lowercase-hex',
+      formatCode: SkillContractErrorCode.DIGEST_INVALID,
+    });
+    const size = readInteger(obj, 'size', itemPath, errors, { min: 0, max: SKILL_FILE_MAX_SIZE });
+    const executable = readBoolean(obj, 'executable', itemPath, errors);
+    if (!pathResult.ok) {
+      errors.push(...pathResult.errors);
+      failed = true;
+      return;
+    }
+    if (sha256 === undefined || size === undefined || executable === undefined) {
+      failed = true;
+      return;
+    }
+    files.push({ path: pathResult.value, sha256, size, executable });
+  });
+  if (failed) return undefined;
+
+  // Receipts must be byte-reproducible, so the file list has one canonical order.
+  for (let i = 1; i < files.length; i++) {
+    if (files[i - 1].path >= files[i].path) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.INCONSISTENT_VALUE,
+          path,
+          'files must be sorted by path in ascending order without duplicates'
+        )
+      );
+      return undefined;
+    }
+  }
+  return files;
+}
+
+/** Validate a parsed install receipt. */
+export function validateSkillInstallReceipt(
+  input: unknown
+): SkillValidationResult<SkillInstallReceipt> {
+  const errors: Bag = [];
+  const obj = readObject(input, '', errors);
+  if (!obj) return skillFail(errors);
+
+  const schemaVersion = readSchemaVersion(obj, errors);
+  if (schemaVersion === undefined) return skillFail(errors);
+
+  checkUnknownFields(obj, RECEIPT_FIELDS, '', errors);
+
+  const idResult = validateSkillId(obj['skill_id'], '/skill_id');
+  if (!idResult.ok) errors.push(...idResult.errors);
+
+  const version = readString(obj, 'version', '', errors, { maxLength: 64 });
+  if (version !== undefined && !isValidSemVer(version)) {
+    errors.push(skillError(SkillContractErrorCode.VERSION_INVALID, '/version', 'version must be SemVer 2.0'));
+  }
+  const installRoot = readString(obj, 'install_root', '', errors, { maxLength: 200 });
+  const source = readSource(obj, '', errors);
+  const artifact = readReceiptArtifact(obj, '', errors);
+  const files = readInstalledFiles(obj, '', errors);
+  const declaredRisk = readEnum<SkillRiskLevel>(obj, 'declared_risk', '', errors, SKILL_RISK_LEVELS);
+  const computedRisk = readEnum<SkillRiskLevel>(obj, 'computed_risk', '', errors, SKILL_RISK_LEVELS);
+  const effectiveRisk = readEnum<SkillRiskLevel>(obj, 'effective_risk', '', errors, SKILL_RISK_LEVELS);
+  const declaredPermissions = readStringList(obj, 'declared_permissions', '', errors, {
+    maxItems: SKILL_DECLARED_PERMISSIONS.length,
+    maxLength: 40,
+  });
+  if (declaredPermissions) {
+    for (const [index, permission] of declaredPermissions.entries()) {
+      if (!(SKILL_DECLARED_PERMISSIONS as readonly string[]).includes(permission)) {
+        errors.push(
+          skillError(
+            SkillContractErrorCode.INVALID_ENUM,
+            joinPath('/declared_permissions', index),
+            'declared permission is not an allowed value'
+          )
+        );
+      }
+    }
+  }
+
+  const rawAgents = readArray(obj, 'agent_compatibility', '', errors, { maxItems: 20 });
+  const agentCompatibility: SkillAgentCompatibility[] = [];
+  if (rawAgents) {
+    rawAgents.forEach((item, index) => {
+      const parsed = readAgentCompatibility(item, joinPath('/agent_compatibility', index), errors);
+      if (parsed) agentCompatibility.push(parsed);
+    });
+  }
+
+  if (idResult.ok && installRoot !== undefined) {
+    const expectedRoot = `${SKILL_INSTALL_ROOT_PREFIX}/${idResult.value}`;
+    if (installRoot !== expectedRoot) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.INCONSISTENT_VALUE,
+          '/install_root',
+          'install_root must be the repository-relative skill root',
+          { expected: expectedRoot }
+        )
+      );
+    }
+  }
+
+  if (idResult.ok && version !== undefined && artifact !== undefined) {
+    const expectedAsset = buildSkillAssetName(idResult.value, version);
+    if (artifact.asset_name !== expectedAsset) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.ARTIFACT_INVALID,
+          '/artifact/asset_name',
+          'asset_name must follow the <skill-id>-<version>.tar.gz convention',
+          { expected: expectedAsset }
+        )
+      );
+    }
+  }
+
+  if (declaredRisk !== undefined && computedRisk !== undefined && effectiveRisk !== undefined) {
+    const expected = resolveEffectiveSkillRisk(declaredRisk, computedRisk);
+    if (effectiveRisk !== expected) {
+      errors.push(
+        skillError(
+          SkillContractErrorCode.INCONSISTENT_VALUE,
+          '/effective_risk',
+          'effective_risk must be the higher of declared_risk and computed_risk',
+          { expected }
+        )
+      );
+    }
+  }
+
+  if (
+    errors.length > 0 ||
+    !idResult.ok ||
+    version === undefined ||
+    installRoot === undefined ||
+    source === undefined ||
+    artifact === undefined ||
+    files === undefined ||
+    declaredRisk === undefined ||
+    computedRisk === undefined ||
+    effectiveRisk === undefined ||
+    declaredPermissions === undefined ||
+    rawAgents === undefined
+  ) {
+    return skillFail(
+      errors.length > 0
+        ? errors
+        : [skillError(SkillContractErrorCode.MISSING_FIELD, '', 'receipt is incomplete')]
+    );
+  }
+
+  return skillOk({
+    schema_version: schemaVersion,
+    skill_id: idResult.value,
+    version,
+    install_root: installRoot,
+    source,
+    artifact,
+    files,
+    declared_risk: declaredRisk,
+    computed_risk: computedRisk,
+    effective_risk: effectiveRisk,
+    declared_permissions: declaredPermissions as SkillDeclaredPermission[],
+    agent_compatibility: agentCompatibility,
+  });
+}
+
+// =============================================================================
+// Cross-document rules
+// =============================================================================
+
+/**
+ * Compare the manifest's declared file set with the package's payload set.
+ *
+ * The comparison set is every regular payload file in the archive minus the
+ * manifest itself and minus directory entries; the manifest's own integrity is
+ * covered by the Catalog artifact digest, so it declares no self-digest.
+ */
+export function validateManifestFileSet(
+  manifest: SkillManifest,
+  payloadPaths: readonly string[]
+): SkillValidationResult<readonly string[]> {
+  const declared = new Set(manifest.files.map((f) => f.path));
+  const actual = new Set(payloadPaths.filter((p) => p !== SKILL_MANIFEST_FILENAME));
+
+  const errors: Bag = [];
+  for (const path of declared) {
+    if (!actual.has(path)) {
+      errors.push(
+        skillError(SkillContractErrorCode.FILE_SET_MISMATCH, '/files', 'declared file is absent from the package', {
+          path,
+        })
+      );
+    }
+  }
+  for (const path of actual) {
+    if (!declared.has(path)) {
+      errors.push(
+        skillError(SkillContractErrorCode.FILE_SET_MISMATCH, '/files', 'package contains an undeclared file', {
+          path,
+        })
+      );
+    }
+  }
+  return errors.length > 0 ? skillFail(errors) : skillOk([...declared].sort());
+}
+
+/** Resolve the effective risk shown to the user: the higher of the two inputs. */
+export function resolveEffectiveSkillRisk(
+  declared: SkillRiskLevel,
+  computed: SkillRiskLevel
+): SkillRiskLevel {
+  return SKILL_RISK_ORDER[computed] > SKILL_RISK_ORDER[declared] ? computed : declared;
+}
+
+/**
+ * Derive the risk level CommandMate computes from inspection facts.
+ *
+ * Deterministic and independent of the publisher's own claim, so a package
+ * cannot talk its way down to `low`.
+ */
+export function computeSkillRisk(inspection: SkillPackageInspection): SkillRiskLevel {
+  if (
+    inspection.executable_paths.length > 0 ||
+    inspection.declared_permissions.includes('credential_access')
+  ) {
+    return 'high';
+  }
+  if (
+    inspection.script_paths.length > 0 ||
+    inspection.network_hosts.length > 0 ||
+    inspection.declared_permissions.includes('process_execution') ||
+    inspection.declared_permissions.includes('filesystem_write')
+  ) {
+    return 'moderate';
+  }
+  return 'low';
+}
+
+// =============================================================================
+// Canonicalization
+// =============================================================================
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      if (value[key] === undefined) continue;
+      out[key] = canonicalize(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Serialize a receipt deterministically: keys sorted, no insignificant
+ * whitespace, no undefined members. Two installs of the same version from the
+ * same commit produce byte-identical output, which is what makes a receipt
+ * diffable and hashable.
+ */
+export function canonicalizeSkillReceipt(receipt: SkillInstallReceipt): string {
+  return JSON.stringify(canonicalize(receipt));
+}

--- a/src/lib/skills/semver.ts
+++ b/src/lib/skills/semver.ts
@@ -1,0 +1,204 @@
+/**
+ * SemVer 2.0 handling for the Skills distribution contract (Issue #1228)
+ *
+ * `src/lib/version-checker.ts` intentionally compares only `major.minor.patch`
+ * of CommandMate's own release tags and tolerates a `v` prefix. The Skill
+ * contract needs full SemVer 2.0 precedence (prerelease ordering, build
+ * metadata ignored) and rejects the `v` prefix, so it gets its own strict
+ * implementation instead of loosening the update-check semantics.
+ *
+ * The range grammar is deliberately a small, total subset of npm's: a
+ * space-separated AND list of comparators. `||`, `x`-ranges, `*` and hyphen
+ * ranges are rejected so a range always has one unambiguous reading.
+ *
+ * @module lib/skills/semver
+ */
+
+/** Strict SemVer 2.0 grammar. No `v` prefix, no leading zeroes. */
+export const SEMVER_2_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/** Maximum accepted length of a version string. */
+export const SEMVER_MAX_LENGTH = 64;
+
+/** Maximum accepted length of a range expression. */
+export const VERSION_RANGE_MAX_LENGTH = 100;
+
+/** Maximum number of comparators in one range. */
+export const VERSION_RANGE_MAX_COMPARATORS = 4;
+
+/** A parsed SemVer 2.0 version. */
+export interface ParsedSemVer {
+  major: number;
+  minor: number;
+  patch: number;
+  /** Dot-separated prerelease identifiers, empty when the version is a release. */
+  prerelease: readonly string[];
+  /** Build metadata identifiers. Ignored for precedence. */
+  build: readonly string[];
+}
+
+/** Operators accepted in a range comparator. */
+export type SkillVersionOperator = '=' | '>' | '>=' | '<' | '<=';
+
+/** One desugared comparator: `^`/`~` expand into `>=` plus `<`. */
+export interface SkillVersionComparator {
+  operator: SkillVersionOperator;
+  version: ParsedSemVer;
+}
+
+/** Parse a strict SemVer 2.0 string. Returns null when invalid. */
+export function parseSemVer(version: string): ParsedSemVer | null {
+  if (typeof version !== 'string' || version.length > SEMVER_MAX_LENGTH) return null;
+  const match = SEMVER_2_PATTERN.exec(version);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+    build: match[5] ? match[5].split('.') : [],
+  };
+}
+
+/** True when the string is a strict SemVer 2.0 version. */
+export function isValidSemVer(version: string): boolean {
+  return parseSemVer(version) !== null;
+}
+
+function comparePrerelease(a: readonly string[], b: readonly string[]): number {
+  // A release outranks any prerelease of the same major.minor.patch.
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const left = a[i];
+    const right = b[i];
+    if (left === right) continue;
+    const leftNumeric = /^\d+$/.test(left);
+    const rightNumeric = /^\d+$/.test(right);
+    if (leftNumeric && rightNumeric) return Number(left) < Number(right) ? -1 : 1;
+    if (leftNumeric) return -1;
+    if (rightNumeric) return 1;
+    return left < right ? -1 : 1;
+  }
+  if (a.length === b.length) return 0;
+  return a.length < b.length ? -1 : 1;
+}
+
+/** Compare two parsed versions by SemVer 2.0 precedence. Build metadata is ignored. */
+export function compareParsedSemVer(a: ParsedSemVer, b: ParsedSemVer): number {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return comparePrerelease(a.prerelease, b.prerelease);
+}
+
+/**
+ * Compare two SemVer 2.0 strings.
+ *
+ * @returns -1, 0 or 1; null when either input is not valid SemVer 2.0.
+ */
+export function compareSemVer(a: string, b: string): number | null {
+  const left = parseSemVer(a);
+  const right = parseSemVer(b);
+  if (!left || !right) return null;
+  return compareParsedSemVer(left, right);
+}
+
+function samePrecedenceTuple(a: ParsedSemVer, b: ParsedSemVer): boolean {
+  return a.major === b.major && a.minor === b.minor && a.patch === b.patch;
+}
+
+function caretUpperBound(v: ParsedSemVer): ParsedSemVer {
+  if (v.major > 0) return { major: v.major + 1, minor: 0, patch: 0, prerelease: [], build: [] };
+  if (v.minor > 0) return { major: 0, minor: v.minor + 1, patch: 0, prerelease: [], build: [] };
+  return { major: 0, minor: 0, patch: v.patch + 1, prerelease: [], build: [] };
+}
+
+function tildeUpperBound(v: ParsedSemVer): ParsedSemVer {
+  return { major: v.major, minor: v.minor + 1, patch: 0, prerelease: [], build: [] };
+}
+
+/**
+ * Parse a range into desugared comparators combined with AND.
+ *
+ * Accepted tokens: `x.y.z`, `=x.y.z`, `>x.y.z`, `>=x.y.z`, `<x.y.z`, `<=x.y.z`,
+ * `^x.y.z`, `~x.y.z`. Returns null for anything else.
+ */
+export function parseSkillVersionRange(range: string): SkillVersionComparator[] | null {
+  if (typeof range !== 'string') return null;
+  const trimmed = range.trim();
+  if (trimmed.length === 0 || trimmed.length > VERSION_RANGE_MAX_LENGTH) return null;
+  if (trimmed.includes('||')) return null;
+
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length > VERSION_RANGE_MAX_COMPARATORS) return null;
+
+  const comparators: SkillVersionComparator[] = [];
+  for (const token of tokens) {
+    const match = /^(>=|<=|>|<|=|\^|~)?(.+)$/.exec(token);
+    if (!match) return null;
+    const operator = match[1] ?? '=';
+    const version = parseSemVer(match[2]);
+    if (!version) return null;
+
+    if (operator === '^' || operator === '~') {
+      const upper = operator === '^' ? caretUpperBound(version) : tildeUpperBound(version);
+      comparators.push({ operator: '>=', version });
+      comparators.push({ operator: '<', version: upper });
+      continue;
+    }
+    comparators.push({ operator: operator as SkillVersionOperator, version });
+  }
+
+  if (comparators.length > VERSION_RANGE_MAX_COMPARATORS * 2) return null;
+  return comparators;
+}
+
+/** True when the range is expressible in the supported grammar. */
+export function isValidSkillVersionRange(range: string): boolean {
+  return parseSkillVersionRange(range) !== null;
+}
+
+function satisfiesComparator(version: ParsedSemVer, comparator: SkillVersionComparator): boolean {
+  const cmp = compareParsedSemVer(version, comparator.version);
+  switch (comparator.operator) {
+    case '=':
+      return cmp === 0;
+    case '>':
+      return cmp > 0;
+    case '>=':
+      return cmp >= 0;
+    case '<':
+      return cmp < 0;
+    case '<=':
+      return cmp <= 0;
+  }
+}
+
+/**
+ * Test a version against a range.
+ *
+ * A prerelease version only satisfies a range when some comparator names the
+ * same `major.minor.patch` *and* itself carries a prerelease. Without this rule
+ * `>=1.0.0` would silently accept `2.0.0-alpha.1`.
+ *
+ * @returns false for an invalid version or an unparsable range (fail closed).
+ */
+export function satisfiesSkillVersionRange(version: string, range: string): boolean {
+  const parsed = parseSemVer(version);
+  const comparators = parseSkillVersionRange(range);
+  if (!parsed || !comparators) return false;
+
+  if (parsed.prerelease.length > 0) {
+    const allowed = comparators.some(
+      (c) => c.version.prerelease.length > 0 && samePrecedenceTuple(parsed, c.version)
+    );
+    if (!allowed) return false;
+  }
+
+  return comparators.every((c) => satisfiesComparator(parsed, c));
+}

--- a/src/types/skills.ts
+++ b/src/types/skills.ts
@@ -1,0 +1,261 @@
+/**
+ * Agent Skills distribution contract types (Issue #1228)
+ *
+ * Canonical TypeScript shapes for the four documents of the distribution
+ * contract. See docs/design/agent-skills-distribution.md for the ADR that
+ * fixes the semantics of every field below.
+ *
+ * Ownership of each display field (Issue #1232):
+ * - manifest  : capability, expected outcome, provider, license, permissions
+ * - catalog   : version, changelog, resolved commit SHA, artifact info
+ * - inspection: scripts / executables / computed risk
+ * - receipt   : what actually landed in the worktree
+ *
+ * @module types/skills
+ */
+
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+// =============================================================================
+// Shared vocabulary
+// =============================================================================
+
+/**
+ * How an Agent can run a Skill.
+ *
+ * - `native`: the Agent itself discovers and executes the Skill.
+ * - `commandmate_runtime`: only runnable through the CommandMate Skill Runtime.
+ * - `unsupported`: known not to work.
+ * - `unknown`: not verified. Never rendered as "supported".
+ */
+export type SkillAgentSupport = 'native' | 'commandmate_runtime' | 'unsupported' | 'unknown';
+
+/** Agent support claim together with the evidence it is based on. */
+export interface SkillAgentCompatibility {
+  agent: CLIToolType;
+  support: SkillAgentSupport;
+  /** Why this claim holds (doc reference, verification run, …). Never a machine path. */
+  evidence: string;
+}
+
+/** Risk vocabulary shared by publisher declaration, computation and effective value. */
+export type SkillRiskLevel = 'low' | 'moderate' | 'high';
+
+/**
+ * Capability a Skill declares it needs.
+ *
+ * These are *declarations by the publisher*, not sandbox enforcement. The field
+ * and type names carry the `declared` prefix so no caller can read them as an
+ * authorization decision.
+ */
+export type SkillDeclaredPermission =
+  | 'filesystem_read'
+  | 'filesystem_write'
+  | 'network_access'
+  | 'process_execution'
+  | 'environment_read'
+  | 'credential_access';
+
+/** Role of a payload file inside a Skill package. */
+export type SkillFileKind = 'skill_md' | 'instruction' | 'script' | 'asset';
+
+/** Distribution artifact format. MVP fixes this to a single value. */
+export type SkillArtifactFormat = 'tar.gz';
+
+// =============================================================================
+// Manifest (commandmate.skill.yaml)
+// =============================================================================
+
+/** Publisher of a Skill. Identity is self-declared; no PKI in schema_version 1. */
+export interface SkillProvider {
+  name: string;
+  url?: string;
+  contact?: string;
+}
+
+/** External command a Skill needs at runtime. */
+export interface SkillRequirementCommand {
+  name: string;
+  /** Range in the grammar of {@link satisfiesSkillVersionRange}. Absent means "any version". */
+  version_range?: string;
+}
+
+/** Runtime requirements declared by the publisher. */
+export interface SkillRequirements {
+  commands: SkillRequirementCommand[];
+  /** Explicit allow-list of hosts. Empty array means "declares no network access". */
+  network_hosts: string[];
+}
+
+/** Compatibility claims for CommandMate itself and for each Agent. */
+export interface SkillCompatibility {
+  /** Required CommandMate version range. */
+  commandmate: string;
+  agents: SkillAgentCompatibility[];
+}
+
+/** One payload file with its digest, as declared by the publisher. */
+export interface SkillFileEntry {
+  /** POSIX relative path inside the Skill root. */
+  path: string;
+  /** Lowercase hex SHA-256 of the file bytes. */
+  sha256: string;
+  size: number;
+  kind: SkillFileKind;
+  /** File is expected to carry the executable bit. */
+  executable: boolean;
+  /** File is a script (interpreted payload) regardless of its mode. */
+  script: boolean;
+}
+
+/**
+ * CommandMate distribution manifest, authored as `commandmate.skill.yaml`
+ * next to the standard `SKILL.md`.
+ */
+export interface SkillManifest {
+  schema_version: number;
+  id: string;
+  /** Must equal the `name` in the sibling SKILL.md frontmatter. */
+  name: string;
+  version: string;
+  /** One-line "what you get". */
+  summary: string;
+  description: string;
+  /** What the user can do after installing (UX-01). */
+  capabilities: string[];
+  /** Expected effect of using the Skill (UX-01). */
+  expected_outcomes: string[];
+  provider: SkillProvider;
+  /** SPDX license identifier. */
+  license: string;
+  homepage?: string;
+  keywords?: string[];
+  compatibility: SkillCompatibility;
+  requirements: SkillRequirements;
+  declared_permissions: SkillDeclaredPermission[];
+  declared_risk: SkillRiskLevel;
+  risk_rationale: string;
+  /** Payload files excluding `commandmate.skill.yaml` itself and directory entries. */
+  files: SkillFileEntry[];
+}
+
+// =============================================================================
+// Catalog
+// =============================================================================
+
+/** Immutable source coordinates of a published version. */
+export interface SkillSourceRef {
+  /** `owner/name` of the source repository. */
+  repository: string;
+  /** Human-facing ref (tag or branch). Never trusted on its own. */
+  ref: string;
+  /** Resolved 40-hex commit SHA. This is the trusted coordinate. */
+  commit: string;
+}
+
+/** Release artifact coordinates published in the Catalog. */
+export interface SkillArtifactRef {
+  asset_name: string;
+  url: string;
+  /** Lowercase hex SHA-256 over the whole artifact byte stream. */
+  sha256: string;
+  size: number;
+  content_type: string;
+  format: SkillArtifactFormat;
+}
+
+/** One published version of a Skill. */
+export interface SkillCatalogVersion {
+  version: string;
+  changelog: string;
+  /** RFC 3339 UTC instant with `Z` suffix. */
+  published_at: string;
+  source: SkillSourceRef;
+  artifact: SkillArtifactRef;
+  compatibility: SkillCompatibility;
+  declared_risk: SkillRiskLevel;
+}
+
+/** Catalog record for one Skill. */
+export interface SkillCatalogEntry {
+  id: string;
+  name: string;
+  summary: string;
+  provider: SkillProvider;
+  license: string;
+  homepage?: string;
+  keywords?: string[];
+  /** Must be present in {@link versions}. */
+  latest: string;
+  versions: SkillCatalogVersion[];
+}
+
+/** Top-level Catalog document. */
+export interface SkillCatalog {
+  schema_version: number;
+  entries: SkillCatalogEntry[];
+}
+
+// =============================================================================
+// Inspection (computed by CommandMate, never authored)
+// =============================================================================
+
+/** Facts CommandMate derives from an extracted package, before install. */
+export interface SkillPackageInspection {
+  /** Paths carrying the executable bit. */
+  executable_paths: string[];
+  /** Paths classified as scripts. */
+  script_paths: string[];
+  /** Hosts declared by the manifest that inspection confirmed as reachable targets. */
+  network_hosts: string[];
+  declared_permissions: SkillDeclaredPermission[];
+}
+
+// =============================================================================
+// Install receipt
+// =============================================================================
+
+/**
+ * Artifact identity kept in a receipt.
+ *
+ * Deliberately has no `url`: download URLs can be signed and are treated as
+ * secrets, so they never reach a receipt.
+ */
+export interface SkillReceiptArtifact {
+  asset_name: string;
+  sha256: string;
+  size: number;
+  format: SkillArtifactFormat;
+}
+
+/** One file as it landed in the worktree. */
+export interface SkillInstalledFile {
+  path: string;
+  sha256: string;
+  size: number;
+  executable: boolean;
+}
+
+/**
+ * Deterministic record of an install.
+ *
+ * Contains no timestamp, no actor and no machine-absolute path: identical
+ * inputs must produce byte-identical receipts. Time and actor belong to the
+ * operation audit log (#1234).
+ */
+export interface SkillInstallReceipt {
+  schema_version: number;
+  skill_id: string;
+  version: string;
+  /** Repository-relative install root, always `.agents/skills/<skill-id>`. */
+  install_root: string;
+  source: SkillSourceRef;
+  artifact: SkillReceiptArtifact;
+  files: SkillInstalledFile[];
+  declared_risk: SkillRiskLevel;
+  computed_risk: SkillRiskLevel;
+  /** The higher of declared and computed risk. */
+  effective_risk: SkillRiskLevel;
+  declared_permissions: SkillDeclaredPermission[];
+  agent_compatibility: SkillAgentCompatibility[];
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/artifact-content-type.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/artifact-content-type.json
@@ -1,0 +1,107 @@
+{
+  "case": "The artifact media type is fixed for schema_version 1",
+  "expectedErrorCode": "SKILL_ARTIFACT_INVALID",
+  "expectedPath": "/entries/0/versions/0/artifact/content_type",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.2.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/zip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/artifact-http-url.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/artifact-http-url.json
@@ -1,0 +1,107 @@
+{
+  "case": "Artifact downloads must use https",
+  "expectedErrorCode": "SKILL_INVALID_FORMAT",
+  "expectedPath": "/entries/0/versions/0/artifact/url",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.2.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "http://example.invalid/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/asset-name-mismatch.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/asset-name-mismatch.json
@@ -1,0 +1,107 @@
+{
+  "case": "The asset name must follow the packaging convention",
+  "expectedErrorCode": "SKILL_ARTIFACT_INVALID",
+  "expectedPath": "/entries/0/versions/0/artifact/asset_name",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.2.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "skill.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/commit-abbreviated.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/commit-abbreviated.json
@@ -1,0 +1,107 @@
+{
+  "case": "An abbreviated commit SHA is not an immutable coordinate",
+  "expectedErrorCode": "SKILL_SOURCE_COMMIT_INVALID",
+  "expectedPath": "/entries/0/versions/0/source/commit",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.2.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "a1b2c3d"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/commit-missing.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/commit-missing.json
@@ -1,0 +1,106 @@
+{
+  "case": "A tag alone is never enough to identify a release",
+  "expectedErrorCode": "SKILL_MISSING_FIELD",
+  "expectedPath": "/entries/0/versions/0/source/commit",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.2.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/duplicate-version.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/duplicate-version.json
@@ -1,0 +1,107 @@
+{
+  "case": "The same version must not be listed twice",
+  "expectedErrorCode": "SKILL_DUPLICATE_ENTRY",
+  "expectedPath": "/entries/0/versions/1",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.1.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/latest-unresolved.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/latest-unresolved.json
@@ -1,0 +1,107 @@
+{
+  "case": "latest must name a listed version",
+  "expectedErrorCode": "SKILL_CATALOG_LATEST_UNRESOLVED",
+  "expectedPath": "/entries/0/latest",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "9.9.9",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/invalid/published-at-local-time.json
+++ b/tests/fixtures/skills/contract/catalog/invalid/published-at-local-time.json
@@ -1,0 +1,107 @@
+{
+  "case": "published_at must be a UTC instant",
+  "expectedErrorCode": "SKILL_INVALID_FORMAT",
+  "expectedPath": "/entries/0/versions/0/published_at",
+  "document": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "id": "release-notes",
+        "name": "release-notes",
+        "summary": "Draft release notes from merged pull requests.",
+        "provider": {
+          "name": "CommandMate",
+          "url": "https://github.com/Kewton/CommandMate",
+          "contact": "skills@commandmate.invalid"
+        },
+        "license": "MIT",
+        "homepage": "https://github.com/Kewton/commandmate-skills",
+        "keywords": [
+          "release",
+          "changelog"
+        ],
+        "latest": "1.2.0",
+        "versions": [
+          {
+            "version": "1.1.0",
+            "changelog": "Release 1.1.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00+09:00",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.1.0",
+              "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.1.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+              "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          },
+          {
+            "version": "1.2.0",
+            "changelog": "Release 1.2.0: grouping rules updated.",
+            "published_at": "2026-07-16T09:30:00Z",
+            "source": {
+              "repository": "Kewton/commandmate-skills",
+              "ref": "release-notes-v1.2.0",
+              "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+            },
+            "artifact": {
+              "asset_name": "release-notes-1.2.0.tar.gz",
+              "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+              "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+              "size": 4096,
+              "content_type": "application/gzip",
+              "format": "tar.gz"
+            },
+            "compatibility": {
+              "commandmate": ">=0.11.0 <1.0.0",
+              "agents": [
+                {
+                  "agent": "claude",
+                  "support": "native",
+                  "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+                },
+                {
+                  "agent": "codex",
+                  "support": "native",
+                  "evidence": "Loaded from .agents/skills by codex CLI"
+                },
+                {
+                  "agent": "gemini",
+                  "support": "unknown",
+                  "evidence": "Not verified for this release"
+                }
+              ]
+            },
+            "declared_risk": "low"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/catalog/valid/catalog.json
+++ b/tests/fixtures/skills/contract/catalog/valid/catalog.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "id": "release-notes",
+      "name": "release-notes",
+      "summary": "Draft release notes from merged pull requests.",
+      "provider": {
+        "name": "CommandMate",
+        "url": "https://github.com/Kewton/CommandMate",
+        "contact": "skills@commandmate.invalid"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/Kewton/commandmate-skills",
+      "keywords": [
+        "release",
+        "changelog"
+      ],
+      "latest": "1.2.0",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "changelog": "Release 1.1.0: grouping rules updated.",
+          "published_at": "2026-07-16T09:30:00Z",
+          "source": {
+            "repository": "Kewton/commandmate-skills",
+            "ref": "release-notes-v1.1.0",
+            "commit": "ef754e3638b357eee53a626541aca267bd57e45c"
+          },
+          "artifact": {
+            "asset_name": "release-notes-1.1.0.tar.gz",
+            "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.1.0/release-notes-1.1.0.tar.gz",
+            "sha256": "481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e",
+            "size": 4096,
+            "content_type": "application/gzip",
+            "format": "tar.gz"
+          },
+          "compatibility": {
+            "commandmate": ">=0.11.0 <1.0.0",
+            "agents": [
+              {
+                "agent": "claude",
+                "support": "native",
+                "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+              },
+              {
+                "agent": "codex",
+                "support": "native",
+                "evidence": "Loaded from .agents/skills by codex CLI"
+              },
+              {
+                "agent": "gemini",
+                "support": "unknown",
+                "evidence": "Not verified for this release"
+              }
+            ]
+          },
+          "declared_risk": "low"
+        },
+        {
+          "version": "1.2.0",
+          "changelog": "Release 1.2.0: grouping rules updated.",
+          "published_at": "2026-07-16T09:30:00Z",
+          "source": {
+            "repository": "Kewton/commandmate-skills",
+            "ref": "release-notes-v1.2.0",
+            "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+          },
+          "artifact": {
+            "asset_name": "release-notes-1.2.0.tar.gz",
+            "url": "https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz",
+            "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+            "size": 4096,
+            "content_type": "application/gzip",
+            "format": "tar.gz"
+          },
+          "compatibility": {
+            "commandmate": ">=0.11.0 <1.0.0",
+            "agents": [
+              {
+                "agent": "claude",
+                "support": "native",
+                "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+              },
+              {
+                "agent": "codex",
+                "support": "native",
+                "evidence": "Loaded from .agents/skills by codex CLI"
+              },
+              {
+                "agent": "gemini",
+                "support": "unknown",
+                "evidence": "Not verified for this release"
+              }
+            ]
+          },
+          "declared_risk": "low"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/agent-support-invalid.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/agent-support-invalid.json
@@ -1,0 +1,84 @@
+{
+  "case": "Agent support uses a closed vocabulary",
+  "expectedErrorCode": "SKILL_INVALID_ENUM",
+  "expectedPath": "/compatibility/agents/0/support",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "partial",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/agent-unknown-tool.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/agent-unknown-tool.json
@@ -1,0 +1,84 @@
+{
+  "case": "Only known CLI tools may appear in a compatibility claim",
+  "expectedErrorCode": "SKILL_INVALID_ENUM",
+  "expectedPath": "/compatibility/agents/0/agent",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "gpt-cli",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/digest-truncated.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/digest-truncated.json
@@ -1,0 +1,84 @@
+{
+  "case": "A short digest is rejected",
+  "expectedErrorCode": "SKILL_DIGEST_INVALID",
+  "expectedPath": "/files/0/sha256",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d0453",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/digest-uppercase.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/digest-uppercase.json
@@ -1,0 +1,84 @@
+{
+  "case": "Digests are lowercase hex so they compare byte-wise",
+  "expectedErrorCode": "SKILL_DIGEST_INVALID",
+  "expectedPath": "/files/0/sha256",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "B82B4E56D9AF25454236E5A05E2D04534BDB94CB05A2C0E542743C0F4C26CA1F",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/empty-expected-outcomes.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/empty-expected-outcomes.json
@@ -1,0 +1,81 @@
+{
+  "case": "expected_outcomes must carry at least one entry",
+  "expectedErrorCode": "SKILL_MISSING_FIELD",
+  "expectedPath": "/expected_outcomes",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-duplicate-path.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-duplicate-path.json
@@ -1,0 +1,84 @@
+{
+  "case": "Two entries must not fold to the same path",
+  "expectedErrorCode": "SKILL_FILE_PATH_DUPLICATE",
+  "expectedPath": "/files/1/path",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "skill.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-missing-skill-md.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-missing-skill-md.json
@@ -1,0 +1,76 @@
+{
+  "case": "SKILL.md must be declared exactly once",
+  "expectedErrorCode": "SKILL_FILE_SET_MISMATCH",
+  "expectedPath": "/files",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-path-absolute.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-path-absolute.json
@@ -1,0 +1,84 @@
+{
+  "case": "A payload path must be relative",
+  "expectedErrorCode": "SKILL_FILE_PATH_UNSAFE",
+  "expectedPath": "/files/1/path",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "/etc/passwd",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-path-backslash.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-path-backslash.json
@@ -1,0 +1,84 @@
+{
+  "case": "Windows-style separators are rejected",
+  "expectedErrorCode": "SKILL_FILE_PATH_UNSAFE",
+  "expectedPath": "/files/1/path",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references\\format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-path-nul.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-path-nul.json
@@ -1,0 +1,84 @@
+{
+  "case": "A NUL byte in a payload path is rejected",
+  "expectedErrorCode": "SKILL_FILE_PATH_UNSAFE",
+  "expectedPath": "/files/1/path",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/format.md\u0000.png",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-path-traversal.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-path-traversal.json
@@ -1,0 +1,84 @@
+{
+  "case": "A payload path must not escape the Skill root",
+  "expectedErrorCode": "SKILL_FILE_PATH_UNSAFE",
+  "expectedPath": "/files/1/path",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "../../.git/config",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/file-self-digest.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/file-self-digest.json
@@ -1,0 +1,84 @@
+{
+  "case": "The manifest never declares a digest for itself",
+  "expectedErrorCode": "SKILL_FILE_SET_MISMATCH",
+  "expectedPath": "/files/1/path",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "commandmate.skill.yaml",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/id-reserved.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/id-reserved.json
@@ -1,0 +1,84 @@
+{
+  "case": "Reserved names cannot be used as a Skill ID",
+  "expectedErrorCode": "SKILL_ID_RESERVED",
+  "expectedPath": "/id",
+  "document": {
+    "schema_version": 1,
+    "id": "commandmate",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/id-too-long.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/id-too-long.json
@@ -1,0 +1,84 @@
+{
+  "case": "Skill IDs are capped at 64 characters",
+  "expectedErrorCode": "SKILL_ID_INVALID",
+  "expectedPath": "/id",
+  "document": {
+    "schema_version": 1,
+    "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/id-unicode-homoglyph.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/id-unicode-homoglyph.json
@@ -1,0 +1,84 @@
+{
+  "case": "Non-ASCII characters cannot enter a Skill ID",
+  "expectedErrorCode": "SKILL_ID_INVALID",
+  "expectedPath": "/id",
+  "document": {
+    "schema_version": 1,
+    "id": "releаse-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/id-uppercase.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/id-uppercase.json
@@ -1,0 +1,84 @@
+{
+  "case": "Skill IDs are lowercase ASCII slugs",
+  "expectedErrorCode": "SKILL_ID_INVALID",
+  "expectedPath": "/id",
+  "document": {
+    "schema_version": 1,
+    "id": "Release-Notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/missing-capabilities.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/missing-capabilities.json
@@ -1,0 +1,80 @@
+{
+  "case": "capabilities is required so the install dialog can explain the Skill",
+  "expectedErrorCode": "SKILL_MISSING_FIELD",
+  "expectedPath": "/capabilities",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/network-host-with-scheme.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/network-host-with-scheme.json
@@ -1,0 +1,86 @@
+{
+  "case": "network_hosts are bare hosts, not URLs",
+  "expectedErrorCode": "SKILL_INVALID_FORMAT",
+  "expectedPath": "/requirements/network_hosts/0",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": [
+        "https://registry.npmjs.org"
+      ]
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/permission-unknown.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/permission-unknown.json
@@ -1,0 +1,84 @@
+{
+  "case": "Declared permissions use a closed vocabulary",
+  "expectedErrorCode": "SKILL_INVALID_ENUM",
+  "expectedPath": "/declared_permissions/0",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "root_access"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/prototype-key.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/prototype-key.json
@@ -1,0 +1,85 @@
+{
+  "case": "A prototype-polluting key is treated as an unknown field",
+  "expectedErrorCode": "SKILL_UNKNOWN_FIELD",
+  "expectedPath": "/__proto__",
+  "document": {
+    "__proto__": { "polluted": true },
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/provider-http-url.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/provider-http-url.json
@@ -1,0 +1,84 @@
+{
+  "case": "Provider URLs must be https",
+  "expectedErrorCode": "SKILL_INVALID_FORMAT",
+  "expectedPath": "/provider/url",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "http://example.invalid",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/range-with-or.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/range-with-or.json
@@ -1,0 +1,84 @@
+{
+  "case": "The range grammar has no \"||\" so a range has one reading",
+  "expectedErrorCode": "SKILL_VERSION_RANGE_INVALID",
+  "expectedPath": "/compatibility/commandmate",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": "^0.11.0 || ^1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/schema-version-future.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/schema-version-future.json
@@ -1,0 +1,84 @@
+{
+  "case": "A future schema_version is rejected instead of best-effort parsed",
+  "expectedErrorCode": "SKILL_SCHEMA_VERSION_UNSUPPORTED",
+  "expectedPath": "/schema_version",
+  "document": {
+    "schema_version": 2,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/schema-version-missing.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/schema-version-missing.json
@@ -1,0 +1,83 @@
+{
+  "case": "schema_version is mandatory",
+  "expectedErrorCode": "SKILL_SCHEMA_VERSION_UNSUPPORTED",
+  "expectedPath": "/schema_version",
+  "document": {
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/unknown-field.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/unknown-field.json
@@ -1,0 +1,85 @@
+{
+  "case": "schema_version 1 is closed to unknown fields",
+  "expectedErrorCode": "SKILL_UNKNOWN_FIELD",
+  "expectedPath": "/entrypoint",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ],
+    "entrypoint": "run.sh"
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/version-partial.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/version-partial.json
@@ -1,0 +1,84 @@
+{
+  "case": "A two-component version is not SemVer 2.0",
+  "expectedErrorCode": "SKILL_VERSION_INVALID",
+  "expectedPath": "/version",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "1.2",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/invalid/version-v-prefix.json
+++ b/tests/fixtures/skills/contract/manifest/invalid/version-v-prefix.json
@@ -1,0 +1,84 @@
+{
+  "case": "A \"v\" prefix is not SemVer 2.0",
+  "expectedErrorCode": "SKILL_VERSION_INVALID",
+  "expectedPath": "/version",
+  "document": {
+    "schema_version": 1,
+    "id": "release-notes",
+    "name": "release-notes",
+    "version": "v1.2.0",
+    "summary": "Draft release notes from merged pull requests.",
+    "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+    "capabilities": [
+      "Group merged pull requests by conventional commit type",
+      "Draft a Keep a Changelog entry for the next release"
+    ],
+    "expected_outcomes": [
+      "Release note drafting drops from ~30 minutes to a single review pass",
+      "Changelog entries stay consistent across releases"
+    ],
+    "provider": {
+      "name": "CommandMate",
+      "url": "https://github.com/Kewton/CommandMate",
+      "contact": "skills@commandmate.invalid"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/Kewton/commandmate-skills",
+    "keywords": [
+      "release",
+      "changelog"
+    ],
+    "compatibility": {
+      "commandmate": ">=0.11.0 <1.0.0",
+      "agents": [
+        {
+          "agent": "claude",
+          "support": "native",
+          "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+        },
+        {
+          "agent": "codex",
+          "support": "native",
+          "evidence": "Loaded from .agents/skills by codex CLI"
+        },
+        {
+          "agent": "gemini",
+          "support": "unknown",
+          "evidence": "Not verified for this release"
+        }
+      ]
+    },
+    "requirements": {
+      "commands": [
+        {
+          "name": "git",
+          "version_range": ">=2.30.0"
+        }
+      ],
+      "network_hosts": []
+    },
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "declared_risk": "low",
+    "risk_rationale": "Reads repository history only and writes no files.",
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "kind": "skill_md",
+        "executable": false,
+        "script": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "kind": "instruction",
+        "executable": false,
+        "script": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/manifest/valid/minimal.json
+++ b/tests/fixtures/skills/contract/manifest/valid/minimal.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "id": "commit-lint",
+  "name": "commit-lint",
+  "version": "0.1.0",
+  "summary": "Check commit messages against the project convention.",
+  "description": "Validates the subject line format of staged commits.",
+  "capabilities": [
+    "Report commit messages that break the convention"
+  ],
+  "expected_outcomes": [
+    "Convention violations are caught before review"
+  ],
+  "provider": {
+    "name": "CommandMate"
+  },
+  "license": "Apache-2.0",
+  "compatibility": {
+    "commandmate": "^0.11.0",
+    "agents": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "Standard SKILL.md discovery"
+      }
+    ]
+  },
+  "requirements": {
+    "commands": [],
+    "network_hosts": []
+  },
+  "declared_permissions": [],
+  "declared_risk": "low",
+  "risk_rationale": "No scripts and no network access.",
+  "files": [
+    {
+      "path": "SKILL.md",
+      "sha256": "4fa2b764cec8420953c3b7006542a70f94357be5af3796a45a493a25bd6f80ea",
+      "size": 900,
+      "kind": "skill_md",
+      "executable": false,
+      "script": false
+    }
+  ]
+}

--- a/tests/fixtures/skills/contract/manifest/valid/release-notes.json
+++ b/tests/fixtures/skills/contract/manifest/valid/release-notes.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "id": "release-notes",
+  "name": "release-notes",
+  "version": "1.2.0",
+  "summary": "Draft release notes from merged pull requests.",
+  "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+  "capabilities": [
+    "Group merged pull requests by conventional commit type",
+    "Draft a Keep a Changelog entry for the next release"
+  ],
+  "expected_outcomes": [
+    "Release note drafting drops from ~30 minutes to a single review pass",
+    "Changelog entries stay consistent across releases"
+  ],
+  "provider": {
+    "name": "CommandMate",
+    "url": "https://github.com/Kewton/CommandMate",
+    "contact": "skills@commandmate.invalid"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/Kewton/commandmate-skills",
+  "keywords": [
+    "release",
+    "changelog"
+  ],
+  "compatibility": {
+    "commandmate": ">=0.11.0 <1.0.0",
+    "agents": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  },
+  "requirements": {
+    "commands": [
+      {
+        "name": "git",
+        "version_range": ">=2.30.0"
+      }
+    ],
+    "network_hosts": []
+  },
+  "declared_permissions": [
+    "filesystem_read"
+  ],
+  "declared_risk": "low",
+  "risk_rationale": "Reads repository history only and writes no files.",
+  "files": [
+    {
+      "path": "SKILL.md",
+      "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+      "size": 2048,
+      "kind": "skill_md",
+      "executable": false,
+      "script": false
+    },
+    {
+      "path": "references/changelog-format.md",
+      "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+      "size": 1024,
+      "kind": "instruction",
+      "executable": false,
+      "script": false
+    }
+  ]
+}

--- a/tests/fixtures/skills/contract/manifest/valid/with-script.json
+++ b/tests/fixtures/skills/contract/manifest/valid/with-script.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "id": "dependency-audit",
+  "name": "dependency-audit",
+  "version": "2.0.0-rc.1",
+  "summary": "Audit dependencies for known advisories.",
+  "description": "Collects merged pull requests since the previous tag, groups them by change type and drafts a Keep a Changelog entry for review.",
+  "capabilities": [
+    "Group merged pull requests by conventional commit type",
+    "Draft a Keep a Changelog entry for the next release"
+  ],
+  "expected_outcomes": [
+    "Release note drafting drops from ~30 minutes to a single review pass",
+    "Changelog entries stay consistent across releases"
+  ],
+  "provider": {
+    "name": "CommandMate",
+    "url": "https://github.com/Kewton/CommandMate",
+    "contact": "skills@commandmate.invalid"
+  },
+  "license": "MIT",
+  "compatibility": {
+    "commandmate": ">=0.11.0 <1.0.0",
+    "agents": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  },
+  "requirements": {
+    "commands": [
+      {
+        "name": "npm",
+        "version_range": ">=10.0.0"
+      }
+    ],
+    "network_hosts": [
+      "registry.npmjs.org"
+    ]
+  },
+  "declared_permissions": [
+    "filesystem_read",
+    "network_access",
+    "process_execution"
+  ],
+  "declared_risk": "moderate",
+  "risk_rationale": "Runs a helper script and contacts the public npm registry.",
+  "files": [
+    {
+      "path": "SKILL.md",
+      "sha256": "2931ec37d3c82dffcea771601b15c65b97292a609d89eae5219e4780d9d627ca",
+      "size": 3072,
+      "kind": "skill_md",
+      "executable": false,
+      "script": false
+    },
+    {
+      "path": "scripts/collect.sh",
+      "sha256": "1d51fa4ee9b198e9c1f926faa1ca5b582b192229549eb9a42571b73dfb69780f",
+      "size": 512,
+      "kind": "script",
+      "executable": true,
+      "script": true
+    }
+  ]
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/actor-present.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/actor-present.json
@@ -1,0 +1,60 @@
+{
+  "case": "Actor identity belongs to the audit log, not the receipt",
+  "expectedErrorCode": "SKILL_UNKNOWN_FIELD",
+  "expectedPath": "/installed_by",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ],
+    "installed_by": "kewton"
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/artifact-url-present.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/artifact-url-present.json
@@ -1,0 +1,60 @@
+{
+  "case": "A signed download URL must never be persisted in a receipt",
+  "expectedErrorCode": "SKILL_UNKNOWN_FIELD",
+  "expectedPath": "/artifact/url",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz",
+      "url": "https://example.invalid/signed?token=redacted"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/asset-name-mismatch.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/asset-name-mismatch.json
@@ -1,0 +1,59 @@
+{
+  "case": "The receipt asset name must match skill id and version",
+  "expectedErrorCode": "SKILL_ARTIFACT_INVALID",
+  "expectedPath": "/artifact/asset_name",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.1.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/effective-risk-understated.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/effective-risk-understated.json
@@ -1,0 +1,59 @@
+{
+  "case": "effective_risk is the higher of declared and computed risk",
+  "expectedErrorCode": "SKILL_INCONSISTENT_VALUE",
+  "expectedPath": "/effective_risk",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "high",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/files-unsorted.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/files-unsorted.json
@@ -1,0 +1,59 @@
+{
+  "case": "A receipt has one canonical file order so it is reproducible",
+  "expectedErrorCode": "SKILL_INCONSISTENT_VALUE",
+  "expectedPath": "/files",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      },
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/install-root-absolute.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/install-root-absolute.json
@@ -1,0 +1,59 @@
+{
+  "case": "A receipt never records a machine-absolute path",
+  "expectedErrorCode": "SKILL_INCONSISTENT_VALUE",
+  "expectedPath": "/install_root",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": "/Users/example/repo/.agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/install-root-other-skill.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/install-root-other-skill.json
@@ -1,0 +1,59 @@
+{
+  "case": "install_root must match the skill id it claims",
+  "expectedErrorCode": "SKILL_INCONSISTENT_VALUE",
+  "expectedPath": "/install_root",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/other-skill",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/invalid/installed-at-present.json
+++ b/tests/fixtures/skills/contract/receipt/invalid/installed-at-present.json
@@ -1,0 +1,60 @@
+{
+  "case": "Timestamps belong to the audit log, not the receipt",
+  "expectedErrorCode": "SKILL_UNKNOWN_FIELD",
+  "expectedPath": "/installed_at",
+  "document": {
+    "schema_version": 1,
+    "skill_id": "release-notes",
+    "version": "1.2.0",
+    "install_root": ".agents/skills/release-notes",
+    "source": {
+      "repository": "Kewton/commandmate-skills",
+      "ref": "release-notes-v1.2.0",
+      "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+    },
+    "artifact": {
+      "asset_name": "release-notes-1.2.0.tar.gz",
+      "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+      "size": 4096,
+      "format": "tar.gz"
+    },
+    "files": [
+      {
+        "path": "SKILL.md",
+        "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+        "size": 2048,
+        "executable": false
+      },
+      {
+        "path": "references/changelog-format.md",
+        "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+        "size": 1024,
+        "executable": false
+      }
+    ],
+    "declared_risk": "low",
+    "computed_risk": "low",
+    "effective_risk": "low",
+    "declared_permissions": [
+      "filesystem_read"
+    ],
+    "agent_compatibility": [
+      {
+        "agent": "claude",
+        "support": "native",
+        "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+      },
+      {
+        "agent": "codex",
+        "support": "native",
+        "evidence": "Loaded from .agents/skills by codex CLI"
+      },
+      {
+        "agent": "gemini",
+        "support": "unknown",
+        "evidence": "Not verified for this release"
+      }
+    ],
+    "installed_at": "2026-07-16T09:30:00Z"
+  }
+}

--- a/tests/fixtures/skills/contract/receipt/valid/release-notes.json
+++ b/tests/fixtures/skills/contract/receipt/valid/release-notes.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "skill_id": "release-notes",
+  "version": "1.2.0",
+  "install_root": ".agents/skills/release-notes",
+  "source": {
+    "repository": "Kewton/commandmate-skills",
+    "ref": "release-notes-v1.2.0",
+    "commit": "7dba1ec2e66342ef578ab57bbdaa9b4327897d47"
+  },
+  "artifact": {
+    "asset_name": "release-notes-1.2.0.tar.gz",
+    "sha256": "4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21",
+    "size": 4096,
+    "format": "tar.gz"
+  },
+  "files": [
+    {
+      "path": "SKILL.md",
+      "sha256": "b82b4e56d9af25454236e5a05e2d04534bdb94cb05a2c0e542743c0f4c26ca1f",
+      "size": 2048,
+      "executable": false
+    },
+    {
+      "path": "references/changelog-format.md",
+      "sha256": "adab9b1ee6042369511dafa9783b3688e5c667fce0d67d0e3d9c8ecc060b5bf3",
+      "size": 1024,
+      "executable": false
+    }
+  ],
+  "declared_risk": "low",
+  "computed_risk": "low",
+  "effective_risk": "low",
+  "declared_permissions": [
+    "filesystem_read"
+  ],
+  "agent_compatibility": [
+    {
+      "agent": "claude",
+      "support": "native",
+      "evidence": "SKILL.md discovery verified on claude CLI 2.x"
+    },
+    {
+      "agent": "codex",
+      "support": "native",
+      "evidence": "Loaded from .agents/skills by codex CLI"
+    },
+    {
+      "agent": "gemini",
+      "support": "unknown",
+      "evidence": "Not verified for this release"
+    }
+  ]
+}

--- a/tests/unit/lib/skills/json-schema-parity.test.ts
+++ b/tests/unit/lib/skills/json-schema-parity.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for src/lib/skills/json-schema.ts
+ * Issue #1228: the published JSON Schema must describe the same contract as the
+ * TypeScript types and the runtime validators.
+ *
+ * Acceptance criterion "every required field defined by the Schema matches the
+ * TypeScript type" is enforced here at runtime and by the `satisfies` guards in
+ * schema.ts at compile time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SKILL_SCHEMA_VERSION } from '@/lib/skills/constants';
+import {
+  SKILL_CATALOG_JSON_SCHEMA,
+  SKILL_MANIFEST_JSON_SCHEMA,
+  SKILL_RECEIPT_JSON_SCHEMA,
+  type SkillJsonSchemaDocument,
+} from '@/lib/skills/json-schema';
+import { SKILL_DOCUMENT_FIELDS, SKILL_OPTIONAL_FIELDS } from '@/lib/skills/schema';
+
+type ObjectSchema = {
+  type?: string;
+  additionalProperties?: boolean;
+  required?: string[];
+  properties?: Record<string, ObjectSchema>;
+  items?: ObjectSchema;
+  $defs?: Record<string, ObjectSchema>;
+};
+
+const DOCUMENTS: Array<[string, SkillJsonSchemaDocument, keyof typeof SKILL_DOCUMENT_FIELDS]> = [
+  ['manifest', SKILL_MANIFEST_JSON_SCHEMA, 'manifest'],
+  ['catalog', SKILL_CATALOG_JSON_SCHEMA, 'catalog'],
+  ['receipt', SKILL_RECEIPT_JSON_SCHEMA, 'receipt'],
+];
+
+describe.each(DOCUMENTS)('%s JSON Schema', (_name, schema, fieldKey) => {
+  it('declares the same property set as the TypeScript type', () => {
+    expect(Object.keys(schema.properties).sort()).toEqual(
+      [...SKILL_DOCUMENT_FIELDS[fieldKey]].sort()
+    );
+  });
+
+  it('requires exactly the non-optional fields', () => {
+    const optional = new Set<string>(SKILL_OPTIONAL_FIELDS[fieldKey]);
+    const expected = SKILL_DOCUMENT_FIELDS[fieldKey].filter((f) => !optional.has(f)).sort();
+    expect([...schema.required].sort()).toEqual(expected);
+  });
+
+  it('is closed to unknown fields at the top level', () => {
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it('pins schema_version to the supported value', () => {
+    const property = schema.properties['schema_version'] as { const?: number };
+    expect(property.const).toBe(SKILL_SCHEMA_VERSION);
+  });
+});
+
+describe('nested object schemas', () => {
+  function collectObjectSchemas(node: ObjectSchema, trail: string, out: Array<[string, ObjectSchema]>): void {
+    if (node.type === 'object' && node.properties) out.push([trail, node]);
+    for (const [key, child] of Object.entries(node.properties ?? {})) {
+      collectObjectSchemas(child, `${trail}/${key}`, out);
+    }
+    if (node.items) collectObjectSchemas(node.items, `${trail}[]`, out);
+    for (const [key, child] of Object.entries(node.$defs ?? {})) {
+      collectObjectSchemas(child, `${trail}/$defs/${key}`, out);
+    }
+  }
+
+  it.each(DOCUMENTS)('%s closes every nested object to unknown fields', (name, schema) => {
+    const found: Array<[string, ObjectSchema]> = [];
+    collectObjectSchemas(schema as unknown as ObjectSchema, name, found);
+    const open = found.filter(([, node]) => node.additionalProperties !== false).map(([trail]) => trail);
+    expect(open).toEqual([]);
+  });
+});
+
+describe('nested schema parity with the TypeScript types', () => {
+  it.each([
+    ['provider', SKILL_MANIFEST_JSON_SCHEMA.$defs?.provider],
+    ['compatibility', SKILL_MANIFEST_JSON_SCHEMA.$defs?.compatibility],
+    ['agentCompatibility', SKILL_MANIFEST_JSON_SCHEMA.$defs?.agentCompatibility],
+    ['sourceRef', SKILL_CATALOG_JSON_SCHEMA.$defs?.sourceRef],
+  ] as const)('%s declares the same property set as the type', (key, def) => {
+    const fieldKey = key === 'sourceRef' ? 'source' : key;
+    const properties = Object.keys((def as ObjectSchema).properties ?? {}).sort();
+    expect(properties).toEqual(
+      [...SKILL_DOCUMENT_FIELDS[fieldKey as keyof typeof SKILL_DOCUMENT_FIELDS]].sort()
+    );
+  });
+
+  it('declares the manifest file entry fields', () => {
+    const files = SKILL_MANIFEST_JSON_SCHEMA.properties['files'] as ObjectSchema;
+    expect(Object.keys(files.items?.properties ?? {}).sort()).toEqual(
+      [...SKILL_DOCUMENT_FIELDS.fileEntry].sort()
+    );
+  });
+
+  it('declares the receipt artifact without a url so signed URLs cannot be persisted', () => {
+    const artifact = SKILL_RECEIPT_JSON_SCHEMA.properties['artifact'] as ObjectSchema;
+    expect(Object.keys(artifact.properties ?? {}).sort()).toEqual(
+      [...SKILL_DOCUMENT_FIELDS.receiptArtifact].sort()
+    );
+    expect(Object.keys(artifact.properties ?? {})).not.toContain('url');
+  });
+});

--- a/tests/unit/lib/skills/schema.test.ts
+++ b/tests/unit/lib/skills/schema.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Tests for src/lib/skills/schema.ts
+ * Issue #1228: Skill manifest / Catalog / receipt contract validation
+ *
+ * The invalid fixtures are self-describing envelopes
+ * (`{ case, expectedErrorCode, expectedPath, document }`), so every rejection
+ * asserts both the machine code and the location it points at.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  SKILL_INSTALL_ROOT_PREFIX,
+  SKILL_MANIFEST_FILENAME,
+} from '@/lib/skills/constants';
+import { SkillContractErrorCode } from '@/lib/skills/errors';
+import {
+  canonicalizeSkillReceipt,
+  computeSkillRisk,
+  detectSkillIdCollision,
+  resolveEffectiveSkillRisk,
+  validateManifestFileSet,
+  validateSkillCatalog,
+  validateSkillId,
+  validateSkillIdentityConsistency,
+  validateSkillInstallReceipt,
+  validateSkillManifest,
+  validateSkillPayloadPath,
+} from '@/lib/skills/schema';
+import type { SkillCatalog, SkillInstallReceipt, SkillManifest } from '@/types/skills';
+
+const FIXTURE_ROOT = path.join(process.cwd(), 'tests/fixtures/skills/contract');
+
+interface InvalidFixture {
+  case: string;
+  expectedErrorCode: string;
+  expectedPath: string;
+  document: unknown;
+}
+
+function readJson(file: string): unknown {
+  return JSON.parse(fs.readFileSync(file, 'utf-8'));
+}
+
+function loadValid(kind: string): Array<[string, unknown]> {
+  const dir = path.join(FIXTURE_ROOT, kind, 'valid');
+  return fs
+    .readdirSync(dir)
+    .sort()
+    .map((name) => [name, readJson(path.join(dir, name))]);
+}
+
+function loadValidNamed(kind: string, name: string): unknown {
+  return readJson(path.join(FIXTURE_ROOT, kind, 'valid', name));
+}
+
+function loadInvalid(kind: string): Array<[string, InvalidFixture]> {
+  const dir = path.join(FIXTURE_ROOT, kind, 'invalid');
+  return fs
+    .readdirSync(dir)
+    .sort()
+    .map((name) => [name, readJson(path.join(dir, name)) as InvalidFixture]);
+}
+
+// ===========================================================================
+// Fixture-driven acceptance and rejection
+// ===========================================================================
+
+describe.each([
+  ['manifest', validateSkillManifest],
+  ['catalog', validateSkillCatalog],
+  ['receipt', validateSkillInstallReceipt],
+] as const)('%s fixtures', (kind, validate) => {
+  it.each(loadValid(kind))('accepts %s', (_name, document) => {
+    const result = validate(document as never);
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it.each(loadInvalid(kind))('rejects %s', (_name, fixture) => {
+    const result = validate(fixture.document as never);
+    expect(result.ok).toBe(false);
+    const match = result.errors.find(
+      (e) => e.code === fixture.expectedErrorCode && e.path === fixture.expectedPath
+    );
+    expect(
+      match,
+      `${fixture.case}: expected ${fixture.expectedErrorCode} at ${fixture.expectedPath}, got ${JSON.stringify(result.errors)}`
+    ).toBeDefined();
+  });
+});
+
+// ===========================================================================
+// Returned value is reconstructed, not the input object
+// ===========================================================================
+
+describe('validateSkillManifest', () => {
+  const validManifest = loadValidNamed('manifest', 'release-notes.json');
+
+  it('returns a value that carries no prototype pollution from the input', () => {
+    const result = validateSkillManifest(validManifest);
+    expect(result.ok).toBe(true);
+    const value = result.value as SkillManifest;
+    expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('drops an optional field rather than materializing it as undefined', () => {
+    const result = validateSkillManifest(loadValidNamed('manifest', 'minimal.json'));
+    expect(result.ok).toBe(true);
+    expect(Object.keys(result.value as SkillManifest)).not.toContain('homepage');
+  });
+
+  it('reports every problem in one pass rather than stopping at the first', () => {
+    const result = validateSkillManifest({
+      ...(validManifest as Record<string, unknown>),
+      id: 'Bad-Id',
+      version: 'v1.0.0',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.map((e) => e.code)).toEqual(
+      expect.arrayContaining([
+        SkillContractErrorCode.ID_INVALID,
+        SkillContractErrorCode.VERSION_INVALID,
+      ])
+    );
+  });
+
+  it('rejects a non-object document', () => {
+    for (const input of ['a string', 42, null, [], undefined]) {
+      const result = validateSkillManifest(input);
+      expect(result.ok).toBe(false);
+      expect(result.errors[0].code).toBe(SkillContractErrorCode.NOT_AN_OBJECT);
+    }
+  });
+});
+
+// ===========================================================================
+// Skill ID
+// ===========================================================================
+
+describe('validateSkillId', () => {
+  it.each(['release-notes', 'a', 'skill-2', 'a'.repeat(64)])('accepts %s', (id) => {
+    expect(validateSkillId(id).ok).toBe(true);
+  });
+
+  it.each([
+    ['Release-Notes', SkillContractErrorCode.ID_INVALID],
+    ['release_notes', SkillContractErrorCode.ID_INVALID],
+    ['-release', SkillContractErrorCode.ID_INVALID],
+    ['release-', SkillContractErrorCode.ID_INVALID],
+    ['release--notes', SkillContractErrorCode.ID_INVALID],
+    ['.hidden', SkillContractErrorCode.ID_INVALID],
+    ['..', SkillContractErrorCode.ID_INVALID],
+    ['.commandmate-staging', SkillContractErrorCode.ID_INVALID],
+    ['a'.repeat(65), SkillContractErrorCode.ID_INVALID],
+    ['', SkillContractErrorCode.ID_INVALID],
+    ['commandmate', SkillContractErrorCode.ID_RESERVED],
+    ['con', SkillContractErrorCode.ID_RESERVED],
+    ['lpt1', SkillContractErrorCode.ID_RESERVED],
+  ])('rejects %s with %s', (id, code) => {
+    const result = validateSkillId(id);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe(code);
+  });
+});
+
+describe('detectSkillIdCollision', () => {
+  it('flags a directory that differs only by case', () => {
+    expect(detectSkillIdCollision('release-notes', ['Release-Notes'])).toBe('Release-Notes');
+  });
+
+  it('flags a directory that differs only by Unicode compatibility form', () => {
+    expect(detectSkillIdCollision('release-notes', ['ｒelease-notes'])).toBe('ｒelease-notes');
+  });
+
+  it('ignores the identical name so re-validating an installed skill is not a collision', () => {
+    expect(detectSkillIdCollision('release-notes', ['release-notes'])).toBeNull();
+  });
+
+  it('returns null when nothing collides', () => {
+    expect(detectSkillIdCollision('release-notes', ['commit-lint'])).toBeNull();
+  });
+});
+
+describe('validateSkillIdentityConsistency', () => {
+  const base = {
+    directoryName: 'release-notes',
+    skillMdName: 'release-notes',
+    manifestId: 'release-notes',
+    manifestName: 'release-notes',
+  };
+
+  it('accepts a package whose three names agree', () => {
+    expect(validateSkillIdentityConsistency(base).ok).toBe(true);
+  });
+
+  it('rejects a directory name that differs from the manifest id', () => {
+    const result = validateSkillIdentityConsistency({ ...base, directoryName: 'other' });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe(SkillContractErrorCode.ID_MISMATCH);
+    expect(result.errors[0].path).toBe('/id');
+  });
+
+  it('rejects a SKILL.md name that differs from the manifest name', () => {
+    const result = validateSkillIdentityConsistency({ ...base, skillMdName: 'Release Notes' });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].path).toBe('/name');
+  });
+});
+
+// ===========================================================================
+// Payload paths
+// ===========================================================================
+
+describe('validateSkillPayloadPath', () => {
+  it.each(['SKILL.md', 'references/format.md', 'assets/img/logo.png'])('accepts %s', (p) => {
+    expect(validateSkillPayloadPath(p, '/files/0/path').ok).toBe(true);
+  });
+
+  it.each([
+    '../escape.md',
+    'nested/../../escape.md',
+    '/absolute.md',
+    'C:/windows.md',
+    'back\\slash.md',
+    'trailing/',
+    'double//slash.md',
+    './relative.md',
+    'with nul.md',
+    'padded /file.md',
+    'a/b/c/d/e/f/g/h/i.md',
+  ])('rejects %s', (p) => {
+    const result = validateSkillPayloadPath(p, '/files/0/path');
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe(SkillContractErrorCode.FILE_PATH_UNSAFE);
+  });
+
+  it('rejects a path that is not NFC-normalized', () => {
+    // "é" written as e + combining acute; NFC would collapse it to one code point.
+    expect(validateSkillPayloadPath('café.md', '/files/0/path').ok).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Cross-document rules
+// ===========================================================================
+
+describe('validateManifestFileSet', () => {
+  const manifest = validateSkillManifest(loadValidNamed('manifest', 'release-notes.json'))
+    .value as SkillManifest;
+
+  it('accepts the archive payload set that matches the declaration', () => {
+    const payload = [...manifest.files.map((f) => f.path), SKILL_MANIFEST_FILENAME];
+    expect(validateManifestFileSet(manifest, payload).ok).toBe(true);
+  });
+
+  it('rejects an undeclared file smuggled into the archive', () => {
+    const payload = [
+      ...manifest.files.map((f) => f.path),
+      SKILL_MANIFEST_FILENAME,
+      'scripts/backdoor.sh',
+    ];
+    const result = validateManifestFileSet(manifest, payload);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe(SkillContractErrorCode.FILE_SET_MISMATCH);
+    expect(result.errors[0].detail?.path).toBe('scripts/backdoor.sh');
+  });
+
+  it('rejects a declared file that is absent from the archive', () => {
+    const result = validateManifestFileSet(manifest, ['SKILL.md', SKILL_MANIFEST_FILENAME]);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe(SkillContractErrorCode.FILE_SET_MISMATCH);
+  });
+});
+
+describe('risk resolution', () => {
+  it.each([
+    ['low', 'low', 'low'],
+    ['low', 'high', 'high'],
+    ['high', 'low', 'high'],
+    ['moderate', 'high', 'high'],
+    ['high', 'moderate', 'high'],
+  ] as const)('declared %s + computed %s = %s', (declared, computed, expected) => {
+    expect(resolveEffectiveSkillRisk(declared, computed)).toBe(expected);
+  });
+
+  it('computes high risk for an executable payload', () => {
+    expect(
+      computeSkillRisk({
+        executable_paths: ['scripts/collect.sh'],
+        script_paths: ['scripts/collect.sh'],
+        network_hosts: [],
+        declared_permissions: [],
+      })
+    ).toBe('high');
+  });
+
+  it('computes high risk when credential access is declared', () => {
+    expect(
+      computeSkillRisk({
+        executable_paths: [],
+        script_paths: [],
+        network_hosts: [],
+        declared_permissions: ['credential_access'],
+      })
+    ).toBe('high');
+  });
+
+  it('computes moderate risk for a non-executable script or a network target', () => {
+    expect(
+      computeSkillRisk({
+        executable_paths: [],
+        script_paths: ['scripts/collect.js'],
+        network_hosts: [],
+        declared_permissions: [],
+      })
+    ).toBe('moderate');
+    expect(
+      computeSkillRisk({
+        executable_paths: [],
+        script_paths: [],
+        network_hosts: ['registry.npmjs.org'],
+        declared_permissions: [],
+      })
+    ).toBe('moderate');
+  });
+
+  it('computes low risk for a read-only instruction-only package', () => {
+    expect(
+      computeSkillRisk({
+        executable_paths: [],
+        script_paths: [],
+        network_hosts: [],
+        declared_permissions: ['filesystem_read'],
+      })
+    ).toBe('low');
+  });
+});
+
+// ===========================================================================
+// Catalog and receipt specifics
+// ===========================================================================
+
+describe('validateSkillCatalog', () => {
+  it('rejects two entries whose ids collide under case folding', () => {
+    const catalog = validateSkillCatalog(loadValidNamed('catalog', 'catalog.json')).value as SkillCatalog;
+    const raw = JSON.parse(JSON.stringify(catalog)) as SkillCatalog;
+    raw.entries.push(JSON.parse(JSON.stringify(raw.entries[0])));
+    const result = validateSkillCatalog(raw);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.code === SkillContractErrorCode.ID_COLLISION)).toBe(true);
+  });
+});
+
+describe('validateSkillInstallReceipt', () => {
+  const receipt = validateSkillInstallReceipt(loadValidNamed('receipt', 'release-notes.json'))
+    .value as SkillInstallReceipt;
+
+  it('anchors install_root under the worktree skills directory', () => {
+    expect(receipt.install_root).toBe(`${SKILL_INSTALL_ROOT_PREFIX}/${receipt.skill_id}`);
+  });
+
+  it('serializes deterministically regardless of key insertion order', () => {
+    const shuffled = Object.fromEntries(
+      Object.entries(receipt as unknown as Record<string, unknown>).reverse()
+    ) as unknown as SkillInstallReceipt;
+    expect(canonicalizeSkillReceipt(shuffled)).toBe(canonicalizeSkillReceipt(receipt));
+  });
+
+  it('carries no timestamp, actor or absolute path', () => {
+    const serialized = canonicalizeSkillReceipt(receipt);
+    expect(serialized).not.toContain('installed_at');
+    expect(serialized).not.toContain('installed_by');
+    expect(serialized).not.toContain('/Users/');
+    expect(serialized).not.toContain('http');
+  });
+});

--- a/tests/unit/lib/skills/semver.test.ts
+++ b/tests/unit/lib/skills/semver.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for src/lib/skills/semver.ts
+ * Issue #1228: SemVer 2.0 handling for the Skills distribution contract
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  compareSemVer,
+  isValidSemVer,
+  isValidSkillVersionRange,
+  parseSemVer,
+  parseSkillVersionRange,
+  satisfiesSkillVersionRange,
+} from '@/lib/skills/semver';
+
+describe('parseSemVer', () => {
+  it('parses a release version', () => {
+    expect(parseSemVer('1.2.3')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: [],
+      build: [],
+    });
+  });
+
+  it('parses prerelease and build metadata', () => {
+    expect(parseSemVer('1.0.0-rc.1+build.5')).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['rc', '1'],
+      build: ['build', '5'],
+    });
+  });
+
+  it.each([
+    ['v1.2.3', 'a "v" prefix is not SemVer 2.0'],
+    ['1.2', 'a two-component version is incomplete'],
+    ['1.2.3.4', 'a four-component version is not SemVer'],
+    ['01.2.3', 'leading zeroes are not allowed'],
+    ['1.2.3-', 'an empty prerelease is not allowed'],
+    ['', 'an empty string is not a version'],
+    ['1.2.3 ', 'trailing whitespace is not tolerated'],
+  ])('rejects %s (%s)', (input) => {
+    expect(parseSemVer(input)).toBeNull();
+    expect(isValidSemVer(input)).toBe(false);
+  });
+
+  it('rejects an over-long version string before running the pattern', () => {
+    expect(parseSemVer(`1.2.3-${'a'.repeat(200)}`)).toBeNull();
+  });
+});
+
+describe('compareSemVer', () => {
+  it.each([
+    ['1.0.0', '2.0.0', -1],
+    ['2.0.0', '2.1.0', -1],
+    ['2.1.0', '2.1.1', -1],
+    ['1.0.0', '1.0.0', 0],
+    ['2.0.0', '1.9.9', 1],
+  ])('orders %s against %s', (a, b, expected) => {
+    expect(compareSemVer(a, b)).toBe(expected);
+  });
+
+  it('ranks a prerelease below its release', () => {
+    expect(compareSemVer('1.0.0-alpha', '1.0.0')).toBe(-1);
+  });
+
+  it('applies SemVer 2.0 prerelease precedence', () => {
+    const ordered = [
+      '1.0.0-alpha',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha.beta',
+      '1.0.0-beta',
+      '1.0.0-beta.2',
+      '1.0.0-beta.11',
+      '1.0.0-rc.1',
+      '1.0.0',
+    ];
+    for (let i = 1; i < ordered.length; i++) {
+      expect(compareSemVer(ordered[i - 1], ordered[i])).toBe(-1);
+    }
+  });
+
+  it('ignores build metadata for precedence', () => {
+    expect(compareSemVer('1.0.0+a', '1.0.0+b')).toBe(0);
+  });
+
+  it('returns null when either side is invalid', () => {
+    expect(compareSemVer('v1.0.0', '1.0.0')).toBeNull();
+  });
+});
+
+describe('parseSkillVersionRange', () => {
+  it('desugars a caret range into a bounded pair', () => {
+    expect(parseSkillVersionRange('^1.2.3')).toEqual([
+      { operator: '>=', version: expect.objectContaining({ major: 1, minor: 2, patch: 3 }) },
+      { operator: '<', version: expect.objectContaining({ major: 2, minor: 0, patch: 0 }) },
+    ]);
+  });
+
+  it('treats a leading-zero caret range as a minor-locked range', () => {
+    expect(parseSkillVersionRange('^0.2.3')).toEqual([
+      { operator: '>=', version: expect.objectContaining({ major: 0, minor: 2, patch: 3 }) },
+      { operator: '<', version: expect.objectContaining({ major: 0, minor: 3, patch: 0 }) },
+    ]);
+  });
+
+  it.each([
+    ['^1.0.0 || ^2.0.0', 'alternation has no single reading'],
+    ['*', 'wildcards are not supported'],
+    ['1.x', 'x-ranges are not supported'],
+    ['>=1.0.0 - <2.0.0', 'hyphen ranges are not supported'],
+    ['', 'an empty range is not a range'],
+  ])('rejects %s (%s)', (range) => {
+    expect(parseSkillVersionRange(range)).toBeNull();
+    expect(isValidSkillVersionRange(range)).toBe(false);
+  });
+});
+
+describe('satisfiesSkillVersionRange', () => {
+  it.each([
+    ['0.11.4', '>=0.11.0 <1.0.0', true],
+    ['1.0.0', '>=0.11.0 <1.0.0', false],
+    ['0.10.9', '>=0.11.0 <1.0.0', false],
+    ['1.2.9', '^1.2.3', true],
+    ['2.0.0', '^1.2.3', false],
+    ['1.2.9', '~1.2.3', true],
+    ['1.3.0', '~1.2.3', false],
+    ['1.2.3', '1.2.3', true],
+    ['1.2.4', '1.2.3', false],
+  ])('%s against %s', (version, range, expected) => {
+    expect(satisfiesSkillVersionRange(version, range)).toBe(expected);
+  });
+
+  it('does not let a prerelease slip into an unrelated range', () => {
+    expect(satisfiesSkillVersionRange('2.0.0-alpha.1', '>=1.0.0')).toBe(false);
+  });
+
+  it('admits a prerelease only when a comparator names the same tuple', () => {
+    expect(satisfiesSkillVersionRange('2.0.0-alpha.2', '>=2.0.0-alpha.1 <3.0.0')).toBe(true);
+    expect(satisfiesSkillVersionRange('2.0.0-alpha.0', '>=2.0.0-alpha.1 <3.0.0')).toBe(false);
+  });
+
+  it('fails closed on an unparsable range', () => {
+    expect(satisfiesSkillVersionRange('1.0.0', 'not-a-range')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1228（Epic #1227 Phase 1 Wave 1）。SKILL.md との互換性を保ったまま、CommandMate 固有の配布・Runtime metadata を同一 Skill root の `commandmate.skill.yaml` へ分離する契約を schema_version 1 として確定する。

後続の #1229 / #1231 / #1232 / #1234 は `@/lib/skills` の公開 API だけを前提に実装できる。

## 主な変更

- `src/types/skills.ts` — manifest / Catalog / 検査結果 / installed receipt の型
- `src/lib/skills/schema.ts` — fail-closed な total validator 群と cross-document 規則
- `src/lib/skills/json-schema.ts` — 公開 JSON Schema (draft 2020-12)
- `src/lib/skills/semver.ts` — 厳格 SemVer 2.0 と AND 限定 range 文法
- `src/lib/skills/constants.ts` / `errors.ts` — 上限・pattern・予約名・layout・安定エラーコード
- `docs/design/agent-skills-distribution.md` — 決定表 D-1..D-16、脅威モデル T-1..T-11
- `tests/fixtures/skills/contract/` — valid 5 / invalid 43 の自己記述 fixture
- `tests/unit/lib/skills/` — 166 test 追加

## 主要な決定

- schema_version は 1 固定。未知 version・未知 field は fail closed で拒否
- Skill ID は lowercase ASCII slug (<=64)。予約名と case/Unicode 衝突を検出し、directory 名 / SKILL.md name / manifest id の一致を必須化
- artifact は tar.gz / `<skill-id>-<version>.tar.gz` / `application/gzip` / root 1 directory
- artifact 全体の SHA-256 は Catalog、個別 payload file の digest は manifest。manifest は自己 digest を持たない（自己参照の回避）
- tag ではなく resolved commit SHA (40 hex) を Catalog/receipt に必須化
- receipt は timestamp・actor・machine absolute path・signed URL を持たない決定的文書
- 権限は宣言であって enforcement ではないことを命名と UI 注記キーで区別し、実効 risk は宣言値と算出値の高い方

## Issue 記載前提の訂正

実装中に Issue の前提が成り立たないことを確認した箇所（Issue 本文は書き換えていない）:

1. `src/lib/version-checker.ts` は SemVer 2.0 ではない（major.minor.patch の数値比較のみ、v prefix 許容、prerelease 無視）。CommandMate の release tag 比較としては正しいため変更せず、`src/lib/skills/semver.ts` に厳格実装を分離した
2. zod / ajv / js-yaml / semver はいずれも直接依存に存在しない。新規 runtime 依存を追加せず手書き validator で実装。YAML safe parse profile は契約として定数化し、parser 選定は #1229 / #1231 に委ねる
3. `path-validator.ts` の `WORKTREE_ID_PATTERN` は大文字を許容するため Skill ID 規約には流用しない。本 PR は文字列レベルの payload path 検証のみ提供し、realpath/symlink 検証は #1231 の責務とした
4. `Kewton/commandmate-skills` は骨組みのみで Catalog/release asset が未作成のため、実在を前提とした検証・network access は含めていない（fixture 内の URL はすべて例示）

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件はいずれも既存ファイル由来） |
| `npm run test:unit` | exit 0 / 602 files / 10361 passed |
| `npm run build` | 成功（worker 側で確認） |

Refs #1228, #1227