### PR TITLE
feat(skills): 公式Skill Catalog client・cache・APIとCommandMate互換性判定 (#1231)

### DIFF
--- a/src/app/api/skills/[id]/route.ts
+++ b/src/app/api/skills/[id]/route.ts
@@ -1,0 +1,74 @@
+/**
+ * GET /api/skills/[id] - one official Skill (Issue #1231)
+ *
+ * The path segment is validated against the Skill ID grammar before it is used
+ * to look anything up, so a malformed or reserved ID is rejected as 400 rather
+ * than silently becoming a miss. This route never touches the filesystem: the
+ * ID only ever indexes the in-memory Catalog.
+ *
+ * @module api/skills/[id]
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createLogger } from '@/lib/logger';
+import { getSkillCatalog } from '@/lib/skills/catalog-client';
+import { findSkillCatalogEntry, normalizeHostVersion } from '@/lib/skills/compatibility';
+import { validateSkillId } from '@/lib/skills/schema';
+import { getServerVersion } from '@/lib/version-checker';
+import {
+  SKILL_API_NO_STORE_HEADERS,
+  readPrereleaseFlag,
+  skillApiError,
+  toCatalogMetaDto,
+  toSkillDto,
+  type SkillApiErrorResponse,
+  type SkillDetailResponse,
+} from '@/lib/api/skills-api';
+
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/skills/[id]');
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse<SkillDetailResponse | SkillApiErrorResponse>> {
+  try {
+    const { id } = await params;
+
+    const idResult = validateSkillId(id);
+    if (!idResult.ok) {
+      return skillApiError(idResult.errors[0].code, 'Invalid Skill ID.', 400);
+    }
+
+    const hostVersion = getServerVersion();
+    const includePrerelease = readPrereleaseFlag(new URL(request.url));
+
+    const result = await getSkillCatalog({ hostVersion });
+    if (!result.ok) {
+      return skillApiError(result.failure.code, result.failure.message, 503);
+    }
+
+    const snapshot = result.snapshot;
+    const entry = findSkillCatalogEntry(snapshot.catalog, idResult.value);
+    if (!entry) {
+      return skillApiError('SKILL_NOT_FOUND', 'Skill not found in the official Catalog.', 404);
+    }
+
+    const body: SkillDetailResponse = {
+      catalog: toCatalogMetaDto(snapshot),
+      skill: toSkillDto(entry, {
+        currentVersion: normalizeHostVersion(hostVersion),
+        includePrerelease,
+      }),
+    };
+
+    return NextResponse.json(body, { headers: SKILL_API_NO_STORE_HEADERS });
+  } catch (error) {
+    logger.error('skill-catalog-detail-failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return skillApiError('SKILL_CATALOG_INTERNAL_ERROR', 'Failed to load the Skill Catalog.', 500);
+  }
+}

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/skills - official Skill Catalog listing (Issue #1231)
+ *
+ * Read-only. The Catalog endpoint is a server-side constant, so no request
+ * input selects what is fetched; `?prerelease=true` only widens which already
+ * fetched versions are listed.
+ *
+ * Status contract:
+ * - 200 with `catalog.stale = false` — the Catalog was confirmed current.
+ * - 200 with `catalog.stale = true`  — last known good, explicitly marked
+ *   stale/offline with a reason (UX-07). Never presented as fresh.
+ * - 503 — retrieval failed and there is no validated Catalog to fall back on.
+ *   An empty list is deliberately not returned here: "no Skills exist" and
+ *   "the Catalog is unreachable" must not look alike.
+ *
+ * @module api/skills
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createLogger } from '@/lib/logger';
+import { getSkillCatalog } from '@/lib/skills/catalog-client';
+import { normalizeHostVersion } from '@/lib/skills/compatibility';
+import { getServerVersion } from '@/lib/version-checker';
+import {
+  SKILL_API_NO_STORE_HEADERS,
+  readPrereleaseFlag,
+  skillApiError,
+  toCatalogMetaDto,
+  toSkillDto,
+  type SkillApiErrorResponse,
+  type SkillListResponse,
+} from '@/lib/api/skills-api';
+
+// Without this the route is prerendered at build time and the Catalog fetch
+// would be frozen into the build output (same reason as api/app/update-check).
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/skills');
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<SkillListResponse | SkillApiErrorResponse>> {
+  try {
+    const hostVersion = getServerVersion();
+    const includePrerelease = readPrereleaseFlag(new URL(request.url));
+
+    const result = await getSkillCatalog({ hostVersion });
+    if (!result.ok) {
+      return skillApiError(result.failure.code, result.failure.message, 503);
+    }
+
+    const currentVersion = normalizeHostVersion(hostVersion);
+    const snapshot = result.snapshot;
+
+    const body: SkillListResponse = {
+      catalog: toCatalogMetaDto(snapshot),
+      skills: snapshot.catalog.entries.map((entry) =>
+        toSkillDto(entry, { currentVersion, includePrerelease })
+      ),
+    };
+
+    return NextResponse.json(body, { headers: SKILL_API_NO_STORE_HEADERS });
+  } catch (error) {
+    logger.error('skill-catalog-list-failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return skillApiError('SKILL_CATALOG_INTERNAL_ERROR', 'Failed to load the Skill Catalog.', 500);
+  }
+}

--- a/src/config/skill-catalog-config.ts
+++ b/src/config/skill-catalog-config.ts
@@ -1,0 +1,69 @@
+/**
+ * Official Skill Catalog endpoint and fetch policy (Issue #1231)
+ *
+ * The Catalog source is a compile-time constant, never an environment variable
+ * and never anything derived from a request. Fetch limits live here so a policy
+ * change is a one-line change rather than a code change in the client.
+ *
+ * @module config/skill-catalog-config
+ */
+
+/** Source repository that publishes the official Catalog. */
+export const SKILL_CATALOG_REPOSITORY = 'Kewton/commandmate-skills' as const;
+
+/** Branch the published Catalog is read from. */
+export const SKILL_CATALOG_REF = 'main' as const;
+
+/**
+ * [SEC] SSRF prevention: the Catalog URL is a hardcoded constant.
+ *
+ * It MUST NOT be derived from environment variables, config files, request
+ * query parameters or Catalog content. Changing it requires security review.
+ * OWASP A10:2021 - Server-Side Request Forgery.
+ */
+export const SKILL_CATALOG_URL =
+  'https://raw.githubusercontent.com/Kewton/commandmate-skills/main/catalog/v1/catalog.json' as const;
+
+/** Every URL the Catalog client is allowed to request. */
+export const SKILL_CATALOG_URL_ALLOWLIST: readonly string[] = [SKILL_CATALOG_URL];
+
+/**
+ * Allow-list check applied immediately before every request.
+ *
+ * Exact string equality, not a prefix or origin test: a prefix rule would admit
+ * `https://raw.githubusercontent.com.evil.example/...` style look-alikes.
+ */
+export function isAllowedSkillCatalogUrl(url: string): boolean {
+  return SKILL_CATALOG_URL_ALLOWLIST.includes(url);
+}
+
+/** Request timeout in milliseconds. */
+export const SKILL_CATALOG_FETCH_TIMEOUT_MS = 5000;
+
+/** How long a validated Catalog is served without revalidation. */
+export const SKILL_CATALOG_CACHE_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Hard cap on the Catalog response body in bytes.
+ *
+ * Enforced against the declared Content-Length *and* against the bytes actually
+ * read, so a response that lies about or omits its length cannot exhaust memory.
+ */
+export const SKILL_CATALOG_MAX_BYTES = 1024 * 1024;
+
+/** Back-off applied after the origin reports a rate limit without a reset hint. */
+export const SKILL_CATALOG_RATE_LIMIT_COOLDOWN_MS = 60 * 60 * 1000;
+
+/** Longest back-off honoured from an origin-supplied reset hint (24h). */
+export const SKILL_CATALOG_RATE_LIMIT_MAX_MS = 24 * 60 * 60 * 1000;
+
+/** Accept header sent with the conditional GET. */
+export const SKILL_CATALOG_ACCEPT = 'application/json';
+
+/** Characters allowed in a cache revision token echoed back to clients. */
+export const SKILL_CATALOG_REVISION_PATTERN = /^[A-Za-z0-9/+=_."-]{1,128}$/;
+
+/** Build the User-Agent identifying this CommandMate build to the origin. */
+export function buildSkillCatalogUserAgent(version: string): string {
+  return `CommandMate/${version}`;
+}

--- a/src/lib/api/skills-api.ts
+++ b/src/lib/api/skills-api.ts
@@ -1,0 +1,236 @@
+/**
+ * Skill Catalog API serialization (Issue #1231)
+ *
+ * The single mapping from the internal Catalog document to the wire shape used
+ * by both `/api/skills` and `/api/skills/[id]`, so UI and CLI consume one
+ * contract and cannot drift apart.
+ *
+ * Two deliberate omissions:
+ * - `artifact.url` is never serialized. Download URLs can be signed, are treated
+ *   as secrets, and resolving one is the server's job at install time (#1229).
+ *   A client therefore has no URL field it could echo back and have honoured.
+ * - No machine-absolute path, token or raw upstream response is ever included.
+ *
+ * @module lib/api/skills-api
+ */
+
+import { NextResponse } from 'next/server';
+import type {
+  SkillCatalogSnapshot,
+  SkillCatalogFailureCode,
+} from '@/lib/skills/catalog-client';
+import {
+  describeAgentCompatibility,
+  evaluateVersionCompatibility,
+  resolveSkillVersions,
+  type SkillAgentCompatibilityView,
+  type SkillCommandMateCompatibility,
+  type SkillRecommendationReasonCode,
+  type SkillResolvedVersion,
+} from '@/lib/skills/compatibility';
+import type {
+  SkillArtifactFormat,
+  SkillCatalogEntry,
+  SkillProvider,
+  SkillRiskLevel,
+} from '@/types/skills';
+
+// =============================================================================
+// Wire types
+// =============================================================================
+
+/** Freshness and provenance of the Catalog the response was built from. */
+export interface SkillCatalogMetaDto {
+  schemaVersion: number;
+  /** RFC 3339 UTC instant the served Catalog was last validated. */
+  fetchedAt: string;
+  /** RFC 3339 UTC instant it was last confirmed current with the origin. */
+  revalidatedAt: string;
+  stale: boolean;
+  offline: boolean;
+  state: SkillCatalogSnapshot['state'];
+  staleReason: SkillCatalogFailureCode | null;
+  source: {
+    repository: string;
+    ref: string;
+    /** Document-level revision (origin ETag), or null. */
+    revision: string | null;
+  };
+}
+
+/** Artifact identity without its URL. */
+export interface SkillArtifactDto {
+  assetName: string;
+  sha256: string;
+  size: number;
+  format: SkillArtifactFormat;
+}
+
+/** One published version with its compatibility verdict. */
+export interface SkillVersionDto {
+  version: string;
+  changelog: string;
+  publishedAt: string;
+  declaredRisk: SkillRiskLevel;
+  prerelease: boolean;
+  source: {
+    repository: string;
+    ref: string;
+    /** Resolved 40-hex commit SHA — the trusted per-release coordinate. */
+    commit: string;
+  };
+  artifact: SkillArtifactDto;
+  compatibility: {
+    commandmate: SkillCommandMateCompatibility;
+    agents: SkillAgentCompatibilityView[];
+  };
+}
+
+/** One Catalog entry as served to clients. */
+export interface SkillDto {
+  id: string;
+  name: string;
+  summary: string;
+  provider: SkillProvider;
+  license: string;
+  homepage: string | null;
+  keywords: string[];
+  /** `latest` as published by the Catalog, regardless of compatibility. */
+  latest: string;
+  /** Version to offer by default, or null when none can be offered. */
+  recommendedVersion: string | null;
+  recommendedReason: SkillRecommendationReasonCode;
+  /**
+   * Verdict for {@link recommendedVersion} when present, otherwise for the
+   * newest listed version — so an incompatible Skill still explains which
+   * CommandMate version it needs (受入条件: 手動確認 2).
+   */
+  compatibility: SkillCommandMateCompatibility | null;
+  versions: SkillVersionDto[];
+}
+
+export interface SkillListResponse {
+  catalog: SkillCatalogMetaDto;
+  skills: SkillDto[];
+}
+
+export interface SkillDetailResponse {
+  catalog: SkillCatalogMetaDto;
+  skill: SkillDto;
+}
+
+/** Error body shared by every Skill API route. */
+export interface SkillApiErrorResponse {
+  error: string;
+  code: string;
+}
+
+// =============================================================================
+// Mapping
+// =============================================================================
+
+/** Serialize the freshness metadata of a snapshot. */
+export function toCatalogMetaDto(snapshot: SkillCatalogSnapshot): SkillCatalogMetaDto {
+  return {
+    schemaVersion: snapshot.catalog.schema_version,
+    fetchedAt: snapshot.fetchedAt,
+    revalidatedAt: snapshot.revalidatedAt,
+    stale: snapshot.stale,
+    offline: snapshot.offline,
+    state: snapshot.state,
+    staleReason: snapshot.staleReason,
+    source: { ...snapshot.source },
+  };
+}
+
+function toVersionDto(resolved: SkillResolvedVersion): SkillVersionDto {
+  const { version, prerelease, compatibility } = resolved;
+  return {
+    version: version.version,
+    changelog: version.changelog,
+    publishedAt: version.published_at,
+    declaredRisk: version.declared_risk,
+    prerelease,
+    source: {
+      repository: version.source.repository,
+      ref: version.source.ref,
+      commit: version.source.commit,
+    },
+    artifact: {
+      assetName: version.artifact.asset_name,
+      sha256: version.artifact.sha256,
+      size: version.artifact.size,
+      format: version.artifact.format,
+    },
+    compatibility: {
+      commandmate: compatibility,
+      agents: describeAgentCompatibility(version.compatibility.agents),
+    },
+  };
+}
+
+/** Serialize one Catalog entry, resolving versions against the running CommandMate. */
+export function toSkillDto(
+  entry: SkillCatalogEntry,
+  options: { currentVersion: string | null; includePrerelease: boolean }
+): SkillDto {
+  const resolution = resolveSkillVersions(entry, {
+    currentVersion: options.currentVersion,
+    includePrerelease: options.includePrerelease,
+  });
+
+  // When every version was filtered out (a prerelease-only entry without opt-in)
+  // the client still needs a reason, so fall back to the publisher's `latest`.
+  const filteredOutFallback = entry.versions.find((v) => v.version === entry.latest);
+  const headline =
+    resolution.recommended?.compatibility ??
+    resolution.versions[0]?.compatibility ??
+    (filteredOutFallback
+      ? evaluateVersionCompatibility(filteredOutFallback, options.currentVersion)
+      : null);
+
+  return {
+    id: entry.id,
+    name: entry.name,
+    summary: entry.summary,
+    provider: { ...entry.provider },
+    license: entry.license,
+    homepage: entry.homepage ?? null,
+    keywords: entry.keywords ? [...entry.keywords] : [],
+    latest: entry.latest,
+    recommendedVersion: resolution.recommended?.version.version ?? null,
+    recommendedReason: resolution.reasonCode,
+    compatibility: headline,
+    versions: resolution.versions.map(toVersionDto),
+  };
+}
+
+// =============================================================================
+// Response helpers
+// =============================================================================
+
+/**
+ * [SEC] Catalog responses must not be stored by intermediaries: freshness is
+ * part of the contract, and a proxy-cached body would defeat the stale flag.
+ */
+export const SKILL_API_NO_STORE_HEADERS = {
+  'Cache-Control': 'no-store, no-cache, must-revalidate',
+  Pragma: 'no-cache',
+} as const;
+
+/** Build a JSON error body with a stable machine code. */
+export function skillApiError(
+  code: string,
+  message: string,
+  status: number
+): NextResponse<SkillApiErrorResponse> {
+  return NextResponse.json(
+    { error: message, code },
+    { status, headers: SKILL_API_NO_STORE_HEADERS }
+  );
+}
+
+/** Read the opt-in prerelease flag. Anything other than `true` means "no". */
+export function readPrereleaseFlag(url: URL): boolean {
+  return url.searchParams.get('prerelease') === 'true';
+}

--- a/src/lib/skills/catalog-client.ts
+++ b/src/lib/skills/catalog-client.ts
@@ -1,0 +1,428 @@
+/**
+ * Official Skill Catalog client (Issue #1231)
+ *
+ * One server-side owner of "what the Catalog says", shared by the UI and the
+ * CLI so a displayed version can never disagree with an installed one.
+ *
+ * Guarantees, in the order they matter:
+ * 1. The cached document is only ever replaced by a response that passed
+ *    {@link validateSkillCatalog}. A failed fetch, an oversized body, malformed
+ *    JSON or a schema violation all leave the last known good document intact.
+ * 2. Anything not confirmed current within the TTL is reported with
+ *    `stale: true` and a reason. Stale data is legal to *browse* (UX-07) and is
+ *    never presented as fresh.
+ * 3. The endpoint is a hardcoded constant behind an exact-match allow-list.
+ *
+ * @module lib/skills/catalog-client
+ */
+
+import {
+  SKILL_CATALOG_ACCEPT,
+  SKILL_CATALOG_CACHE_TTL_MS,
+  SKILL_CATALOG_FETCH_TIMEOUT_MS,
+  SKILL_CATALOG_MAX_BYTES,
+  SKILL_CATALOG_RATE_LIMIT_COOLDOWN_MS,
+  SKILL_CATALOG_RATE_LIMIT_MAX_MS,
+  SKILL_CATALOG_REF,
+  SKILL_CATALOG_REPOSITORY,
+  SKILL_CATALOG_REVISION_PATTERN,
+  SKILL_CATALOG_URL,
+  buildSkillCatalogUserAgent,
+  isAllowedSkillCatalogUrl,
+} from '@/config/skill-catalog-config';
+import { createLogger } from '@/lib/logger';
+import { validateSkillCatalog } from '@/lib/skills/schema';
+import type { SkillContractError } from '@/lib/skills/errors';
+import type { SkillCatalog } from '@/types/skills';
+
+const logger = createLogger('lib/skills/catalog-client');
+
+// =============================================================================
+// Result vocabulary
+// =============================================================================
+
+/** How the returned document was obtained. */
+export type SkillCatalogState =
+  /** Freshly fetched and validated in this call. */
+  | 'fresh'
+  /** Origin answered 304; the cached document is confirmed current. */
+  | 'revalidated'
+  /** Served from cache within the TTL, no request made. */
+  | 'cached'
+  /** Served from cache after revalidation failed. Always `stale: true`. */
+  | 'stale';
+
+/** Why a snapshot is stale. */
+export const SkillCatalogStaleReason = {
+  /** Network error, timeout or non-OK status. */
+  FETCH_FAILED: 'SKILL_CATALOG_FETCH_FAILED',
+  /** Origin is rate limiting; no request was attempted. */
+  RATE_LIMITED: 'SKILL_CATALOG_RATE_LIMITED',
+  /** Response body exceeded the size cap. */
+  OVERSIZED: 'SKILL_CATALOG_OVERSIZED',
+  /** Body was not parsable JSON. */
+  MALFORMED: 'SKILL_CATALOG_MALFORMED',
+  /** Body parsed but failed contract validation (includes unknown schema_version). */
+  INVALID_SCHEMA: 'SKILL_CATALOG_INVALID_SCHEMA',
+} as const;
+
+export type SkillCatalogFailureCode =
+  (typeof SkillCatalogStaleReason)[keyof typeof SkillCatalogStaleReason];
+
+/** Source coordinates of the served document. */
+export interface SkillCatalogSource {
+  repository: string;
+  ref: string;
+  /**
+   * Origin cache validator (ETag) of the served document, or null.
+   *
+   * The Catalog document of schema_version 1 carries no top-level commit SHA,
+   * so this is the only document-level revision identifier available. The
+   * trusted per-release coordinate is `versions[].source.commit`.
+   */
+  revision: string | null;
+}
+
+/** A Catalog document together with everything needed to judge its freshness. */
+export interface SkillCatalogSnapshot {
+  catalog: SkillCatalog;
+  /** RFC 3339 UTC instant the served document was last validated. */
+  fetchedAt: string;
+  /** RFC 3339 UTC instant the document was last confirmed current with the origin. */
+  revalidatedAt: string;
+  state: SkillCatalogState;
+  /** True whenever the document could not be confirmed current. */
+  stale: boolean;
+  /** True when the last attempt could not reach a usable origin response. */
+  offline: boolean;
+  staleReason: SkillCatalogFailureCode | null;
+  source: SkillCatalogSource;
+}
+
+/** Failure returned when there is no last known good document to fall back on. */
+export interface SkillCatalogFailure {
+  code: SkillCatalogFailureCode;
+  message: string;
+  /** Contract validation errors, present only for `INVALID_SCHEMA`. */
+  errors: readonly SkillContractError[];
+}
+
+export type SkillCatalogResult =
+  | { ok: true; snapshot: SkillCatalogSnapshot }
+  | { ok: false; failure: SkillCatalogFailure };
+
+// =============================================================================
+// Cache (globalThis, hot-reload resistant — version-checker.ts precedent)
+// =============================================================================
+
+interface SkillCatalogCache {
+  /** Last document that passed validation. Never overwritten by an invalid one. */
+  catalog: SkillCatalog | null;
+  /** Epoch ms of the last successful validation. */
+  validatedAt: number;
+  /** Epoch ms the document was last confirmed current (200 or 304). */
+  confirmedAt: number;
+  etag: string | null;
+  revision: string | null;
+  rateLimitResetAt: number | null;
+  /** Single-flight guard so concurrent callers share one origin request. */
+  inflight: Promise<SkillCatalogResult> | null;
+}
+
+declare global {
+  // eslint-disable-next-line no-var -- globalThis cache pattern (version-checker.ts:97-107 precedent)
+  var __skillCatalogCache: SkillCatalogCache | undefined;
+}
+
+const cache: SkillCatalogCache = (globalThis.__skillCatalogCache ??= {
+  catalog: null,
+  validatedAt: 0,
+  confirmedAt: 0,
+  etag: null,
+  revision: null,
+  rateLimitResetAt: null,
+  inflight: null,
+});
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+class BoundedBodyError extends Error {}
+
+const FAILURE_MESSAGES: Record<SkillCatalogFailureCode, string> = {
+  [SkillCatalogStaleReason.FETCH_FAILED]: 'The Skill Catalog could not be retrieved.',
+  [SkillCatalogStaleReason.RATE_LIMITED]: 'The Skill Catalog origin is rate limiting requests.',
+  [SkillCatalogStaleReason.OVERSIZED]: 'The Skill Catalog response exceeded the allowed size.',
+  [SkillCatalogStaleReason.MALFORMED]: 'The Skill Catalog response was not valid JSON.',
+  [SkillCatalogStaleReason.INVALID_SCHEMA]:
+    'The Skill Catalog response did not match the supported Catalog schema.',
+};
+
+function toIso(epochMs: number): string {
+  return new Date(epochMs).toISOString();
+}
+
+function sanitizeRevision(raw: string | null): string | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  return SKILL_CATALOG_REVISION_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+function buildSnapshot(
+  catalog: SkillCatalog,
+  state: SkillCatalogState,
+  staleReason: SkillCatalogFailureCode | null
+): SkillCatalogSnapshot {
+  return {
+    catalog,
+    fetchedAt: toIso(cache.validatedAt),
+    revalidatedAt: toIso(cache.confirmedAt),
+    state,
+    stale: state === 'stale',
+    offline: state === 'stale',
+    staleReason,
+    source: {
+      repository: SKILL_CATALOG_REPOSITORY,
+      ref: SKILL_CATALOG_REF,
+      revision: cache.revision,
+    },
+  };
+}
+
+/** Serve the last known good document, or fail when there is none. */
+function degrade(code: SkillCatalogFailureCode, errors: readonly SkillContractError[] = []): SkillCatalogResult {
+  if (cache.catalog) {
+    return { ok: true, snapshot: buildSnapshot(cache.catalog, 'stale', code) };
+  }
+  return { ok: false, failure: { code, message: FAILURE_MESSAGES[code], errors } };
+}
+
+function isFresh(): boolean {
+  return cache.catalog !== null && Date.now() - cache.confirmedAt < SKILL_CATALOG_CACHE_TTL_MS;
+}
+
+function isRateLimited(): boolean {
+  if (cache.rateLimitResetAt === null) return false;
+  if (Date.now() >= cache.rateLimitResetAt) {
+    cache.rateLimitResetAt = null;
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Record a back-off from a rate-limited response.
+ *
+ * Honours `X-RateLimit-Reset` (epoch seconds) and `Retry-After` (delta seconds),
+ * but clamps to {@link SKILL_CATALOG_RATE_LIMIT_MAX_MS} so a hostile or broken
+ * header cannot pin the client offline indefinitely.
+ */
+function recordRateLimit(response: Response): void {
+  const now = Date.now();
+  const max = now + SKILL_CATALOG_RATE_LIMIT_MAX_MS;
+
+  const resetHeader = response.headers.get('X-RateLimit-Reset');
+  if (resetHeader !== null) {
+    const seconds = Number(resetHeader);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      cache.rateLimitResetAt = Math.min(seconds * 1000, max);
+      return;
+    }
+  }
+
+  const retryAfter = response.headers.get('Retry-After');
+  if (retryAfter !== null) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      cache.rateLimitResetAt = Math.min(now + seconds * 1000, max);
+      return;
+    }
+  }
+
+  cache.rateLimitResetAt = now + SKILL_CATALOG_RATE_LIMIT_COOLDOWN_MS;
+}
+
+/**
+ * Read a response body with a hard byte cap.
+ *
+ * The declared Content-Length is checked first as a cheap reject, then the
+ * bytes actually read are counted — a response that omits or understates its
+ * length is still cut off at the cap.
+ */
+async function readBoundedText(response: Response, maxBytes: number): Promise<string> {
+  const declared = response.headers.get('Content-Length');
+  if (declared !== null) {
+    const length = Number(declared);
+    if (!Number.isFinite(length) || length < 0 || length > maxBytes) {
+      throw new BoundedBodyError('content-length out of bounds');
+    }
+  }
+
+  const body = response.body;
+  if (!body || typeof body.getReader !== 'function') {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).length > maxBytes) {
+      throw new BoundedBodyError('body exceeded size cap');
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new BoundedBodyError('body exceeded size cap');
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder('utf-8').decode(merged);
+}
+
+async function revalidate(hostVersion: string): Promise<SkillCatalogResult> {
+  // Re-checked immediately before the request: the URL is a module constant, and
+  // this assertion is what makes that a guarantee rather than a convention.
+  if (!isAllowedSkillCatalogUrl(SKILL_CATALOG_URL)) {
+    return degrade(SkillCatalogStaleReason.FETCH_FAILED);
+  }
+
+  const headers: Record<string, string> = {
+    Accept: SKILL_CATALOG_ACCEPT,
+    'User-Agent': buildSkillCatalogUserAgent(hostVersion),
+  };
+  if (cache.catalog !== null && cache.etag !== null) {
+    headers['If-None-Match'] = cache.etag;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(SKILL_CATALOG_URL, {
+      headers,
+      cache: 'no-store',
+      signal: AbortSignal.timeout(SKILL_CATALOG_FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    // Network error or timeout. No response detail is logged: it can echo the
+    // request URL and, under a proxy, credentials.
+    logger.warn('catalog-fetch-failed', { reason: SkillCatalogStaleReason.FETCH_FAILED });
+    return degrade(SkillCatalogStaleReason.FETCH_FAILED);
+  }
+
+  if (response.status === 304 && cache.catalog !== null) {
+    cache.confirmedAt = Date.now();
+    return { ok: true, snapshot: buildSnapshot(cache.catalog, 'revalidated', null) };
+  }
+
+  if (response.status === 403 || response.status === 429) {
+    recordRateLimit(response);
+    logger.warn('catalog-rate-limited', { status: response.status });
+    return degrade(SkillCatalogStaleReason.RATE_LIMITED);
+  }
+
+  if (!response.ok) {
+    logger.warn('catalog-fetch-failed', { status: response.status });
+    return degrade(SkillCatalogStaleReason.FETCH_FAILED);
+  }
+
+  let text: string;
+  try {
+    text = await readBoundedText(response, SKILL_CATALOG_MAX_BYTES);
+  } catch (error) {
+    const code =
+      error instanceof BoundedBodyError
+        ? SkillCatalogStaleReason.OVERSIZED
+        : SkillCatalogStaleReason.FETCH_FAILED;
+    logger.warn('catalog-body-rejected', { reason: code });
+    return degrade(code);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // The body itself is never logged: it is untrusted remote content.
+    logger.warn('catalog-malformed', { reason: SkillCatalogStaleReason.MALFORMED });
+    return degrade(SkillCatalogStaleReason.MALFORMED);
+  }
+
+  const validation = validateSkillCatalog(parsed);
+  if (!validation.ok) {
+    logger.warn('catalog-invalid-schema', { errorCount: validation.errors.length });
+    return degrade(SkillCatalogStaleReason.INVALID_SCHEMA, validation.errors);
+  }
+
+  const now = Date.now();
+  cache.catalog = validation.value;
+  cache.validatedAt = now;
+  cache.confirmedAt = now;
+  cache.etag = response.headers.get('ETag');
+  cache.revision = sanitizeRevision(cache.etag);
+
+  return { ok: true, snapshot: buildSnapshot(validation.value, 'fresh', null) };
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/** Options for {@link getSkillCatalog}. */
+export interface GetSkillCatalogOptions {
+  /** CommandMate version sent as User-Agent. Never affects the URL. */
+  hostVersion?: string;
+  /** Bypass the TTL and force a conditional revalidation. */
+  forceRevalidate?: boolean;
+}
+
+/**
+ * Get the official Catalog, revalidating against the origin when the TTL lapsed.
+ *
+ * Concurrent callers share a single in-flight request. Returns `ok: false` only
+ * when retrieval failed *and* there is no last known good document to serve.
+ */
+export async function getSkillCatalog(
+  options: GetSkillCatalogOptions = {}
+): Promise<SkillCatalogResult> {
+  const { hostVersion = '0.0.0', forceRevalidate = false } = options;
+
+  if (!forceRevalidate && isFresh() && cache.catalog !== null) {
+    return { ok: true, snapshot: buildSnapshot(cache.catalog, 'cached', null) };
+  }
+
+  if (isRateLimited()) {
+    return degrade(SkillCatalogStaleReason.RATE_LIMITED);
+  }
+
+  if (cache.inflight === null) {
+    cache.inflight = revalidate(hostVersion).finally(() => {
+      cache.inflight = null;
+    });
+  }
+  return cache.inflight;
+}
+
+/**
+ * Reset the module cache.
+ * @internal Test-only.
+ */
+export function resetSkillCatalogCacheForTesting(): void {
+  cache.catalog = null;
+  cache.validatedAt = 0;
+  cache.confirmedAt = 0;
+  cache.etag = null;
+  cache.revision = null;
+  cache.rateLimitResetAt = null;
+  cache.inflight = null;
+}

--- a/src/lib/skills/compatibility.ts
+++ b/src/lib/skills/compatibility.ts
@@ -1,0 +1,317 @@
+/**
+ * CommandMate compatibility judgement and version resolution (Issue #1231)
+ *
+ * Pure functions: no filesystem, no network, no process state. The host version
+ * is always an explicit argument so UI, API and CLI can evaluate the same
+ * Catalog against the same rules and reach the same verdict.
+ *
+ * Every verdict carries a stable machine code *and* a human-readable message
+ * (受入条件: "互換性NGの理由がmachine-readable codeとhuman-readable messageで返る").
+ * Messages are built from the code, the declared range and the host version
+ * only — never from a path, token or URL.
+ *
+ * @module lib/skills/compatibility
+ */
+
+// Sibling modules of the same package are imported directly rather than through
+// the `@/lib/skills` barrel, so adding this module to the barrel later can never
+// introduce an import cycle. External callers still go through the barrel.
+import { AGENT_SUPPORT_LABEL_KEYS } from '@/lib/skills/constants';
+import {
+  compareSemVer,
+  isValidSkillVersionRange,
+  parseSemVer,
+  satisfiesSkillVersionRange,
+} from '@/lib/skills/semver';
+import type {
+  SkillAgentCompatibility,
+  SkillAgentSupport,
+  SkillCatalog,
+  SkillCatalogEntry,
+  SkillCatalogVersion,
+} from '@/types/skills';
+
+// =============================================================================
+// Vocabulary
+// =============================================================================
+
+/**
+ * Three-valued compatibility verdict.
+ *
+ * `unknown` is never rendered as compatible (UX-07): it means the judgement
+ * could not be made, which is a different user-facing state from "will not work".
+ */
+export type SkillCompatibilityStatus = 'compatible' | 'incompatible' | 'unknown';
+
+/** Stable reason codes for a CommandMate compatibility verdict. */
+export const SkillCompatibilityReason = {
+  /** Host version satisfies the declared range. */
+  SATISFIED: 'SKILL_COMPAT_SATISFIED',
+  /** Host version is valid but outside the declared range. */
+  HOST_VERSION_OUT_OF_RANGE: 'SKILL_COMPAT_HOST_VERSION_OUT_OF_RANGE',
+  /** The running CommandMate version could not be determined. */
+  HOST_VERSION_UNKNOWN: 'SKILL_COMPAT_HOST_VERSION_UNKNOWN',
+  /** The publisher's range is not expressible in the supported grammar. */
+  RANGE_UNSUPPORTED: 'SKILL_COMPAT_RANGE_UNSUPPORTED',
+} as const;
+
+export type SkillCompatibilityReasonCode =
+  (typeof SkillCompatibilityReason)[keyof typeof SkillCompatibilityReason];
+
+/** i18n keys paired with each reason code, so UI and CLI share one vocabulary. */
+export const SKILL_COMPATIBILITY_MESSAGE_KEYS: Record<SkillCompatibilityReasonCode, string> = {
+  [SkillCompatibilityReason.SATISFIED]: 'skills.compatibility.reason.satisfied',
+  [SkillCompatibilityReason.HOST_VERSION_OUT_OF_RANGE]:
+    'skills.compatibility.reason.hostVersionOutOfRange',
+  [SkillCompatibilityReason.HOST_VERSION_UNKNOWN]: 'skills.compatibility.reason.hostVersionUnknown',
+  [SkillCompatibilityReason.RANGE_UNSUPPORTED]: 'skills.compatibility.reason.rangeUnsupported',
+};
+
+/** A CommandMate compatibility verdict with everything needed to explain it. */
+export interface SkillCommandMateCompatibility {
+  status: SkillCompatibilityStatus;
+  reasonCode: SkillCompatibilityReasonCode;
+  /** i18n key for {@link message}. */
+  messageKey: string;
+  /** English fallback built from code, range and host version only. */
+  message: string;
+  /** Range as declared by the publisher, echoed verbatim. */
+  requiredRange: string;
+  /** Host version the verdict was computed against; null when undeterminable. */
+  currentVersion: string | null;
+}
+
+// =============================================================================
+// Host version
+// =============================================================================
+
+/**
+ * Sentinel `getServerVersion()` returns when it cannot read a real version.
+ *
+ * It is syntactically valid SemVer, so without this guard an unreadable
+ * package.json would silently produce a confident "incompatible" verdict
+ * instead of the honest "unknown".
+ */
+export const UNKNOWN_HOST_VERSION_SENTINEL = '0.0.0';
+
+/**
+ * Normalize a raw CommandMate version into a strict SemVer 2.0 string.
+ *
+ * @returns The version, or null when it is absent, the unknown sentinel, or not
+ *   strict SemVer 2.0 (the Skill contract rejects the `v` prefix).
+ */
+export function normalizeHostVersion(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed === UNKNOWN_HOST_VERSION_SENTINEL) return null;
+  return parseSemVer(trimmed) === null ? null : trimmed;
+}
+
+// =============================================================================
+// Compatibility
+// =============================================================================
+
+function buildMessage(
+  reasonCode: SkillCompatibilityReasonCode,
+  requiredRange: string,
+  currentVersion: string | null
+): string {
+  switch (reasonCode) {
+    case SkillCompatibilityReason.SATISFIED:
+      return `CommandMate ${currentVersion} satisfies the required range "${requiredRange}".`;
+    case SkillCompatibilityReason.HOST_VERSION_OUT_OF_RANGE:
+      return `This Skill requires CommandMate "${requiredRange}", but CommandMate ${currentVersion} is running.`;
+    case SkillCompatibilityReason.HOST_VERSION_UNKNOWN:
+      return `The running CommandMate version could not be determined, so compatibility with "${requiredRange}" is unverified.`;
+    case SkillCompatibilityReason.RANGE_UNSUPPORTED:
+      return `This Skill declares the unsupported CommandMate version range "${requiredRange}", so compatibility is unverified.`;
+  }
+}
+
+function verdict(
+  status: SkillCompatibilityStatus,
+  reasonCode: SkillCompatibilityReasonCode,
+  requiredRange: string,
+  currentVersion: string | null
+): SkillCommandMateCompatibility {
+  return {
+    status,
+    reasonCode,
+    messageKey: SKILL_COMPATIBILITY_MESSAGE_KEYS[reasonCode],
+    message: buildMessage(reasonCode, requiredRange, currentVersion),
+    requiredRange,
+    currentVersion,
+  };
+}
+
+/**
+ * Judge whether the running CommandMate satisfies a declared version range.
+ *
+ * Fails closed in both directions: an unparsable range and an undeterminable
+ * host version both yield `unknown`, never `compatible`.
+ *
+ * @param requiredRange - Range declared in `compatibility.commandmate`
+ * @param currentVersion - Host version, already passed through {@link normalizeHostVersion}
+ */
+export function evaluateCommandMateCompatibility(
+  requiredRange: string,
+  currentVersion: string | null
+): SkillCommandMateCompatibility {
+  const range = typeof requiredRange === 'string' ? requiredRange : '';
+
+  if (!isValidSkillVersionRange(range)) {
+    return verdict(
+      'unknown',
+      SkillCompatibilityReason.RANGE_UNSUPPORTED,
+      range,
+      currentVersion ?? null
+    );
+  }
+  if (currentVersion === null) {
+    return verdict('unknown', SkillCompatibilityReason.HOST_VERSION_UNKNOWN, range, null);
+  }
+  if (!satisfiesSkillVersionRange(currentVersion, range)) {
+    return verdict(
+      'incompatible',
+      SkillCompatibilityReason.HOST_VERSION_OUT_OF_RANGE,
+      range,
+      currentVersion
+    );
+  }
+  return verdict('compatible', SkillCompatibilityReason.SATISFIED, range, currentVersion);
+}
+
+/** Judge one Catalog version against the running CommandMate. */
+export function evaluateVersionCompatibility(
+  version: SkillCatalogVersion,
+  currentVersion: string | null
+): SkillCommandMateCompatibility {
+  return evaluateCommandMateCompatibility(version.compatibility.commandmate, currentVersion);
+}
+
+// =============================================================================
+// Agent compatibility
+// =============================================================================
+
+/** Agent support claim enriched with its shared label key (UX-05). */
+export interface SkillAgentCompatibilityView {
+  agent: SkillAgentCompatibility['agent'];
+  support: SkillAgentSupport;
+  labelKey: string;
+  evidence: string;
+}
+
+/** Attach the shared i18n label key to each Agent support claim. */
+export function describeAgentCompatibility(
+  agents: readonly SkillAgentCompatibility[]
+): SkillAgentCompatibilityView[] {
+  return agents.map((entry) => ({
+    agent: entry.agent,
+    support: entry.support,
+    labelKey: AGENT_SUPPORT_LABEL_KEYS[entry.support],
+    evidence: entry.evidence,
+  }));
+}
+
+// =============================================================================
+// Version resolution
+// =============================================================================
+
+/** Why a particular version was recommended, or why none was. */
+export const SkillRecommendationReason = {
+  /** Highest listed version that is compatible with the running CommandMate. */
+  HIGHEST_COMPATIBLE: 'SKILL_RECOMMEND_HIGHEST_COMPATIBLE',
+  /** Host version is unknown, so the publisher's `latest` is offered unverified. */
+  LATEST_UNVERIFIED: 'SKILL_RECOMMEND_LATEST_UNVERIFIED',
+  /** Every listed version is incompatible with the running CommandMate. */
+  NONE_COMPATIBLE: 'SKILL_RECOMMEND_NONE_COMPATIBLE',
+  /** No version survived filtering (e.g. prerelease-only entry without opt-in). */
+  NO_VERSIONS: 'SKILL_RECOMMEND_NO_VERSIONS',
+} as const;
+
+export type SkillRecommendationReasonCode =
+  (typeof SkillRecommendationReason)[keyof typeof SkillRecommendationReason];
+
+/** One listed version paired with its compatibility verdict. */
+export interface SkillResolvedVersion {
+  version: SkillCatalogVersion;
+  prerelease: boolean;
+  compatibility: SkillCommandMateCompatibility;
+}
+
+/** Outcome of resolving the version list of one Catalog entry. */
+export interface SkillVersionResolution {
+  /** Listed versions, newest first by SemVer 2.0 precedence. */
+  versions: SkillResolvedVersion[];
+  /** The version to offer by default, or null when nothing can be offered. */
+  recommended: SkillResolvedVersion | null;
+  reasonCode: SkillRecommendationReasonCode;
+}
+
+/** Options for {@link resolveSkillVersions}. */
+export interface SkillVersionResolutionOptions {
+  /** Host version, already passed through {@link normalizeHostVersion}. */
+  currentVersion: string | null;
+  /** Include prerelease versions. Off by default: prereleases require opt-in. */
+  includePrerelease?: boolean;
+}
+
+function isPrerelease(version: string): boolean {
+  const parsed = parseSemVer(version);
+  return parsed !== null && parsed.prerelease.length > 0;
+}
+
+/**
+ * Sort, filter and pick a default version for one Catalog entry.
+ *
+ * Prereleases are excluded unless explicitly requested. Versions the Catalog
+ * validator already accepted are strict SemVer 2.0, so ordering is total.
+ */
+export function resolveSkillVersions(
+  entry: SkillCatalogEntry,
+  options: SkillVersionResolutionOptions
+): SkillVersionResolution {
+  const { currentVersion, includePrerelease = false } = options;
+
+  const versions: SkillResolvedVersion[] = entry.versions
+    .map((version) => ({
+      version,
+      prerelease: isPrerelease(version.version),
+      compatibility: evaluateVersionCompatibility(version, currentVersion),
+    }))
+    .filter((candidate) => includePrerelease || !candidate.prerelease)
+    .sort((a, b) => (compareSemVer(b.version.version, a.version.version) ?? 0));
+
+  if (versions.length === 0) {
+    return { versions, recommended: null, reasonCode: SkillRecommendationReason.NO_VERSIONS };
+  }
+
+  const compatible = versions.find((candidate) => candidate.compatibility.status === 'compatible');
+  if (compatible) {
+    return {
+      versions,
+      recommended: compatible,
+      reasonCode: SkillRecommendationReason.HIGHEST_COMPATIBLE,
+    };
+  }
+
+  // Host version unknown: nothing can be *proven* compatible, so the publisher's
+  // `latest` is offered with an explicit unverified reason rather than hidden.
+  if (currentVersion === null) {
+    const latest =
+      versions.find((candidate) => candidate.version.version === entry.latest) ?? versions[0];
+    return {
+      versions,
+      recommended: latest,
+      reasonCode: SkillRecommendationReason.LATEST_UNVERIFIED,
+    };
+  }
+
+  return { versions, recommended: null, reasonCode: SkillRecommendationReason.NONE_COMPATIBLE };
+}
+
+/** Find one entry by exact Skill ID. Returns null when absent. */
+export function findSkillCatalogEntry(catalog: SkillCatalog, id: string): SkillCatalogEntry | null {
+  return catalog.entries.find((entry) => entry.id === id) ?? null;
+}

--- a/tests/integration/api/skills.test.ts
+++ b/tests/integration/api/skills.test.ts
@@ -1,0 +1,374 @@
+/**
+ * API integration tests - Skill Catalog routes (Issue #1231)
+ *
+ * The Catalog client is mocked, so no test touches the network. What is under
+ * test here is the API contract: status codes, freshness reporting, prerelease
+ * opt-in and the fields the routes are allowed to expose.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { SkillCatalog } from '@/types/skills';
+import type { SkillCatalogResult, SkillCatalogSnapshot } from '@/lib/skills/catalog-client';
+import type { SkillDetailResponse, SkillListResponse } from '@/lib/api/skills-api';
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn(),
+  })),
+  generateRequestId: vi.fn(() => 'test-request-id'),
+}));
+
+vi.mock('@/lib/skills/catalog-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/skills/catalog-client')>();
+  return { ...actual, getSkillCatalog: vi.fn() };
+});
+
+vi.mock('@/lib/version-checker', () => ({
+  getServerVersion: vi.fn(() => '0.11.4'),
+}));
+
+import { GET as listSkills } from '@/app/api/skills/route';
+import { GET as getSkill } from '@/app/api/skills/[id]/route';
+import { getSkillCatalog, SkillCatalogStaleReason } from '@/lib/skills/catalog-client';
+import { getServerVersion } from '@/lib/version-checker';
+
+const getSkillCatalogMock = vi.mocked(getSkillCatalog);
+const getServerVersionMock = vi.mocked(getServerVersion);
+
+const CATALOG: SkillCatalog = {
+  schema_version: 1,
+  entries: [
+    {
+      id: 'release-notes',
+      name: 'release-notes',
+      summary: 'Draft release notes from merged pull requests.',
+      provider: { name: 'CommandMate', url: 'https://github.com/Kewton/CommandMate' },
+      license: 'MIT',
+      latest: '1.2.0',
+      versions: [
+        {
+          version: '1.2.0',
+          changelog: 'Release 1.2.0',
+          published_at: '2026-07-16T09:30:00Z',
+          source: {
+            repository: 'Kewton/commandmate-skills',
+            ref: 'release-notes-v1.2.0',
+            commit: '7dba1ec2e66342ef578ab57bbdaa9b4327897d47',
+          },
+          artifact: {
+            asset_name: 'release-notes-1.2.0.tar.gz',
+            url: 'https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.2.0/release-notes-1.2.0.tar.gz',
+            sha256: '4bdb91f46683de4df48783d57b75248f7c7e8c34619e5cbb090ba69a6c781c21',
+            size: 4096,
+            content_type: 'application/gzip',
+            format: 'tar.gz',
+          },
+          compatibility: {
+            commandmate: '>=0.11.0 <1.0.0',
+            agents: [{ agent: 'claude', support: 'native', evidence: 'verified on claude CLI 2.x' }],
+          },
+          declared_risk: 'low',
+        },
+        {
+          version: '1.3.0-beta.1',
+          changelog: 'Release 1.3.0-beta.1',
+          published_at: '2026-07-17T09:30:00Z',
+          source: {
+            repository: 'Kewton/commandmate-skills',
+            ref: 'release-notes-v1.3.0-beta.1',
+            commit: 'ef754e3638b357eee53a626541aca267bd57e45c',
+          },
+          artifact: {
+            asset_name: 'release-notes-1.3.0-beta.1.tar.gz',
+            url: 'https://github.com/Kewton/commandmate-skills/releases/download/release-notes-v1.3.0-beta.1/release-notes-1.3.0-beta.1.tar.gz',
+            sha256: '481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e',
+            size: 4096,
+            content_type: 'application/gzip',
+            format: 'tar.gz',
+          },
+          compatibility: {
+            commandmate: '>=0.11.0 <1.0.0',
+            agents: [{ agent: 'claude', support: 'unknown', evidence: 'not verified' }],
+          },
+          declared_risk: 'moderate',
+        },
+      ],
+    },
+  ],
+};
+
+function snapshot(overrides: Partial<SkillCatalogSnapshot> = {}): SkillCatalogSnapshot {
+  return {
+    catalog: CATALOG,
+    fetchedAt: '2026-07-20T00:00:00.000Z',
+    revalidatedAt: '2026-07-20T00:00:00.000Z',
+    state: 'fresh',
+    stale: false,
+    offline: false,
+    staleReason: null,
+    source: { repository: 'Kewton/commandmate-skills', ref: 'main', revision: '"rev-1"' },
+    ...overrides,
+  };
+}
+
+function ok(overrides: Partial<SkillCatalogSnapshot> = {}): SkillCatalogResult {
+  return { ok: true, snapshot: snapshot(overrides) };
+}
+
+function listRequest(query = ''): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/skills${query}`);
+}
+
+function detailRequest(id: string, query = ''): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/skills/${id}${query}`);
+}
+
+function detailParams(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getServerVersionMock.mockReturnValue('0.11.4');
+});
+
+describe('GET /api/skills', () => {
+  it('returns the Catalog with freshness metadata', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await listSkills(listRequest());
+    const body = (await response.json()) as SkillListResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.catalog.schemaVersion).toBe(1);
+    expect(body.catalog.fetchedAt).toBe('2026-07-20T00:00:00.000Z');
+    expect(body.catalog.stale).toBe(false);
+    expect(body.catalog.offline).toBe(false);
+    expect(body.catalog.source).toEqual({
+      repository: 'Kewton/commandmate-skills',
+      ref: 'main',
+      revision: '"rev-1"',
+    });
+    expect(body.skills).toHaveLength(1);
+  });
+
+  it('resolves the recommended version and its compatibility reason', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const body = (await (await listSkills(listRequest())).json()) as SkillListResponse;
+    const skill = body.skills[0];
+
+    expect(skill.recommendedVersion).toBe('1.2.0');
+    expect(skill.recommendedReason).toBe('SKILL_RECOMMEND_HIGHEST_COMPATIBLE');
+    expect(skill.compatibility?.status).toBe('compatible');
+    expect(skill.compatibility?.reasonCode).toBe('SKILL_COMPAT_SATISFIED');
+    expect(skill.compatibility?.messageKey.length).toBeGreaterThan(0);
+    expect(skill.compatibility?.message.length).toBeGreaterThan(0);
+  });
+
+  it('hides prereleases unless they are explicitly requested', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const plain = (await (await listSkills(listRequest())).json()) as SkillListResponse;
+    expect(plain.skills[0].versions.map((v) => v.version)).toEqual(['1.2.0']);
+
+    getSkillCatalogMock.mockResolvedValue(ok());
+    const withPrerelease = (await (
+      await listSkills(listRequest('?prerelease=true'))
+    ).json()) as SkillListResponse;
+    expect(withPrerelease.skills[0].versions.map((v) => v.version)).toEqual([
+      '1.3.0-beta.1',
+      '1.2.0',
+    ]);
+    expect(withPrerelease.skills[0].versions[0].prerelease).toBe(true);
+  });
+
+  it('treats any prerelease value other than "true" as opt-out', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const body = (await (await listSkills(listRequest('?prerelease=1'))).json()) as SkillListResponse;
+    expect(body.skills[0].versions.map((v) => v.version)).toEqual(['1.2.0']);
+  });
+
+  it('never exposes the artifact download URL', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await listSkills(listRequest('?prerelease=true'));
+    const raw = await response.text();
+
+    expect(raw).not.toContain('releases/download');
+    const body = JSON.parse(raw) as SkillListResponse;
+    for (const version of body.skills[0].versions) {
+      expect(version.artifact).not.toHaveProperty('url');
+      expect(version.artifact.sha256.length).toBe(64);
+      expect(version.source.commit).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it('marks a stale snapshot as stale rather than presenting it as current', async () => {
+    getSkillCatalogMock.mockResolvedValue(
+      ok({
+        state: 'stale',
+        stale: true,
+        offline: true,
+        staleReason: SkillCatalogStaleReason.FETCH_FAILED,
+      })
+    );
+
+    const response = await listSkills(listRequest());
+    const body = (await response.json()) as SkillListResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.catalog.stale).toBe(true);
+    expect(body.catalog.offline).toBe(true);
+    expect(body.catalog.staleReason).toBe(SkillCatalogStaleReason.FETCH_FAILED);
+    expect(body.skills).toHaveLength(1);
+  });
+
+  it('returns 503 with a machine code instead of an empty list when unavailable', async () => {
+    getSkillCatalogMock.mockResolvedValue({
+      ok: false,
+      failure: {
+        code: SkillCatalogStaleReason.INVALID_SCHEMA,
+        message: 'The Skill Catalog response did not match the supported Catalog schema.',
+        errors: [],
+      },
+    });
+
+    const response = await listSkills(listRequest());
+    const body = (await response.json()) as { error: string; code: string };
+
+    expect(response.status).toBe(503);
+    expect(body.code).toBe(SkillCatalogStaleReason.INVALID_SCHEMA);
+    expect(body).not.toHaveProperty('skills');
+  });
+
+  it('reports unknown, not incompatible, when the host version is undeterminable', async () => {
+    getServerVersionMock.mockReturnValue('0.0.0');
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const body = (await (await listSkills(listRequest())).json()) as SkillListResponse;
+
+    expect(body.skills[0].compatibility?.status).toBe('unknown');
+    expect(body.skills[0].compatibility?.reasonCode).toBe('SKILL_COMPAT_HOST_VERSION_UNKNOWN');
+    expect(body.skills[0].recommendedReason).toBe('SKILL_RECOMMEND_LATEST_UNVERIFIED');
+  });
+
+  it('explains the required version when nothing is compatible', async () => {
+    getServerVersionMock.mockReturnValue('2.0.0');
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const body = (await (await listSkills(listRequest())).json()) as SkillListResponse;
+
+    expect(body.skills[0].recommendedVersion).toBeNull();
+    expect(body.skills[0].recommendedReason).toBe('SKILL_RECOMMEND_NONE_COMPATIBLE');
+    expect(body.skills[0].compatibility?.status).toBe('incompatible');
+    expect(body.skills[0].compatibility?.requiredRange).toBe('>=0.11.0 <1.0.0');
+    expect(body.skills[0].compatibility?.message).toContain('>=0.11.0 <1.0.0');
+  });
+
+  it('forbids intermediary caching of Catalog responses', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await listSkills(listRequest());
+
+    expect(response.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  it('returns 500 when the Catalog client throws', async () => {
+    getSkillCatalogMock.mockRejectedValue(new Error('boom'));
+
+    const response = await listSkills(listRequest());
+    const body = (await response.json()) as { error: string; code: string };
+
+    expect(response.status).toBe(500);
+    expect(body.code).toBe('SKILL_CATALOG_INTERNAL_ERROR');
+    expect(body.error).not.toContain('boom');
+  });
+});
+
+describe('GET /api/skills/[id]', () => {
+  it('returns one Skill with the same shape as the list entry', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await getSkill(detailRequest('release-notes'), detailParams('release-notes'));
+    const body = (await response.json()) as SkillDetailResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.skill.id).toBe('release-notes');
+    expect(body.skill.recommendedVersion).toBe('1.2.0');
+    expect(body.skill.versions[0].compatibility.agents[0].labelKey).toBe(
+      'skills.compatibility.native'
+    );
+    expect(body.catalog.fetchedAt).toBe('2026-07-20T00:00:00.000Z');
+  });
+
+  it('honours the prerelease opt-in', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await getSkill(
+      detailRequest('release-notes', '?prerelease=true'),
+      detailParams('release-notes')
+    );
+    const body = (await response.json()) as SkillDetailResponse;
+
+    expect(body.skill.versions.map((v) => v.version)).toEqual(['1.3.0-beta.1', '1.2.0']);
+  });
+
+  it('returns 404 for an id that is well-formed but absent', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await getSkill(detailRequest('missing-skill'), detailParams('missing-skill'));
+    const body = (await response.json()) as { code: string };
+
+    expect(response.status).toBe(404);
+    expect(body.code).toBe('SKILL_NOT_FOUND');
+  });
+
+  it('rejects malformed and reserved ids with 400 before any lookup', async () => {
+    for (const id of ['Release-Notes', '../etc/passwd', 'con', '']) {
+      getSkillCatalogMock.mockResolvedValue(ok());
+      const response = await getSkill(detailRequest(id), detailParams(id));
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { code: string };
+      expect(body.code).toMatch(/^SKILL_ID_/);
+      expect(getSkillCatalogMock).not.toHaveBeenCalled();
+      vi.clearAllMocks();
+      getServerVersionMock.mockReturnValue('0.11.4');
+    }
+  });
+
+  it('returns 503 when the Catalog is unavailable', async () => {
+    getSkillCatalogMock.mockResolvedValue({
+      ok: false,
+      failure: {
+        code: SkillCatalogStaleReason.FETCH_FAILED,
+        message: 'The Skill Catalog could not be retrieved.',
+        errors: [],
+      },
+    });
+
+    const response = await getSkill(detailRequest('release-notes'), detailParams('release-notes'));
+
+    expect(response.status).toBe(503);
+  });
+
+  it('never exposes the artifact download URL', async () => {
+    getSkillCatalogMock.mockResolvedValue(ok());
+
+    const response = await getSkill(
+      detailRequest('release-notes', '?prerelease=true'),
+      detailParams('release-notes')
+    );
+
+    expect(await response.text()).not.toContain('releases/download');
+  });
+});

--- a/tests/unit/lib/skills/catalog-client.test.ts
+++ b/tests/unit/lib/skills/catalog-client.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Unit tests for the official Skill Catalog client (Issue #1231)
+ *
+ * Every test mocks `fetch`. The commandmate-skills repository is private and
+ * publishes no Catalog yet, so a test that reached the network would assert
+ * nothing useful and would fail in CI.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn(),
+  })),
+  generateRequestId: vi.fn(() => 'test-request-id'),
+}));
+
+import {
+  SkillCatalogStaleReason,
+  getSkillCatalog,
+  resetSkillCatalogCacheForTesting,
+} from '@/lib/skills/catalog-client';
+import {
+  SKILL_CATALOG_CACHE_TTL_MS,
+  SKILL_CATALOG_MAX_BYTES,
+  SKILL_CATALOG_REPOSITORY,
+  SKILL_CATALOG_URL,
+  isAllowedSkillCatalogUrl,
+} from '@/config/skill-catalog-config';
+
+const VALID_CATALOG_JSON = readFileSync(
+  join(process.cwd(), 'tests/fixtures/skills/contract/catalog/valid/catalog.json'),
+  'utf-8'
+);
+
+interface ResponseOptions {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+/** Minimal Response stand-in: the client only uses status, headers and the body. */
+function makeResponse({ status = 200, headers = {}, body = '' }: ResponseOptions): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(headers),
+    body: null,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+function okCatalogResponse(etag = '"rev-1"'): Response {
+  return makeResponse({ headers: { ETag: etag }, body: VALID_CATALOG_JSON });
+}
+
+const fetchMock = vi.fn<(input: unknown, init?: unknown) => Promise<Response>>();
+
+beforeEach(() => {
+  resetSkillCatalogCacheForTesting();
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('Catalog endpoint allow-list', () => {
+  it('accepts only the hardcoded URL', () => {
+    expect(isAllowedSkillCatalogUrl(SKILL_CATALOG_URL)).toBe(true);
+  });
+
+  it('rejects look-alike origins that a prefix check would admit', () => {
+    expect(isAllowedSkillCatalogUrl('https://raw.githubusercontent.com.evil.test/x.json')).toBe(
+      false
+    );
+    expect(isAllowedSkillCatalogUrl(`${SKILL_CATALOG_URL}?x=1`)).toBe(false);
+    expect(isAllowedSkillCatalogUrl('http://raw.githubusercontent.com/x.json')).toBe(false);
+  });
+});
+
+describe('getSkillCatalog - successful fetch', () => {
+  it('fetches, validates and reports a fresh snapshot', async () => {
+    fetchMock.mockResolvedValue(okCatalogResponse());
+
+    const result = await getSkillCatalog({ hostVersion: '0.11.4' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.state).toBe('fresh');
+    expect(result.snapshot.stale).toBe(false);
+    expect(result.snapshot.offline).toBe(false);
+    expect(result.snapshot.staleReason).toBeNull();
+    expect(result.snapshot.catalog.entries[0].id).toBe('release-notes');
+    expect(result.snapshot.source.repository).toBe(SKILL_CATALOG_REPOSITORY);
+    expect(result.snapshot.source.revision).toBe('"rev-1"');
+    expect(result.snapshot.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('requests only the hardcoded URL and identifies itself', async () => {
+    fetchMock.mockResolvedValue(okCatalogResponse());
+
+    await getSkillCatalog({ hostVersion: '0.11.4' });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(SKILL_CATALOG_URL);
+    const headers = (init as { headers: Record<string, string> }).headers;
+    expect(headers['User-Agent']).toBe('CommandMate/0.11.4');
+    expect(headers['If-None-Match']).toBeUndefined();
+  });
+});
+
+describe('getSkillCatalog - caching', () => {
+  it('serves from cache within the TTL without a second request', async () => {
+    fetchMock.mockResolvedValue(okCatalogResponse());
+
+    await getSkillCatalog();
+    const second = await getSkillCatalog();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.snapshot.state).toBe('cached');
+    expect(second.snapshot.stale).toBe(false);
+  });
+
+  it('revalidates with If-None-Match once the TTL lapses and treats 304 as current', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T00:00:00Z'));
+
+    fetchMock.mockResolvedValueOnce(okCatalogResponse('"rev-1"'));
+    await getSkillCatalog();
+
+    vi.setSystemTime(new Date(Date.now() + SKILL_CATALOG_CACHE_TTL_MS + 1000));
+    fetchMock.mockResolvedValueOnce(makeResponse({ status: 304 }));
+
+    const result = await getSkillCatalog();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const headers = (fetchMock.mock.calls[1][1] as { headers: Record<string, string> }).headers;
+    expect(headers['If-None-Match']).toBe('"rev-1"');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.state).toBe('revalidated');
+    expect(result.snapshot.stale).toBe(false);
+  });
+
+  it('shares one origin request between concurrent callers', async () => {
+    fetchMock.mockResolvedValue(okCatalogResponse());
+
+    const [a, b] = await Promise.all([getSkillCatalog(), getSkillCatalog()]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(a.ok && b.ok).toBe(true);
+  });
+});
+
+describe('getSkillCatalog - degraded paths', () => {
+  async function primeCache(): Promise<void> {
+    fetchMock.mockResolvedValueOnce(okCatalogResponse());
+    await getSkillCatalog();
+    fetchMock.mockReset();
+  }
+
+  const failures: Array<[string, () => void, string]> = [
+    [
+      'network error',
+      () => fetchMock.mockRejectedValue(new Error('ECONNREFUSED')),
+      SkillCatalogStaleReason.FETCH_FAILED,
+    ],
+    [
+      'non-OK status',
+      () => fetchMock.mockResolvedValue(makeResponse({ status: 500 })),
+      SkillCatalogStaleReason.FETCH_FAILED,
+    ],
+    [
+      'malformed JSON',
+      () => fetchMock.mockResolvedValue(makeResponse({ body: 'not json' })),
+      SkillCatalogStaleReason.MALFORMED,
+    ],
+    [
+      'schema violation',
+      () =>
+        fetchMock.mockResolvedValue(
+          makeResponse({ body: JSON.stringify({ schema_version: 1, entries: [{ id: 'x' }] }) })
+        ),
+      SkillCatalogStaleReason.INVALID_SCHEMA,
+    ],
+    [
+      'unknown schema_version',
+      () =>
+        fetchMock.mockResolvedValue(
+          makeResponse({ body: JSON.stringify({ schema_version: 2, entries: [] }) })
+        ),
+      SkillCatalogStaleReason.INVALID_SCHEMA,
+    ],
+    [
+      'oversized declared length',
+      () =>
+        fetchMock.mockResolvedValue(
+          makeResponse({
+            headers: { 'Content-Length': String(SKILL_CATALOG_MAX_BYTES + 1) },
+            body: VALID_CATALOG_JSON,
+          })
+        ),
+      SkillCatalogStaleReason.OVERSIZED,
+    ],
+    [
+      'oversized undeclared body',
+      () => fetchMock.mockResolvedValue(makeResponse({ body: 'x'.repeat(SKILL_CATALOG_MAX_BYTES + 1) })),
+      SkillCatalogStaleReason.OVERSIZED,
+    ],
+  ];
+
+  for (const [label, arrange, expectedCode] of failures) {
+    it(`fails closed with no cache: ${label}`, async () => {
+      arrange();
+
+      const result = await getSkillCatalog();
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.code).toBe(expectedCode);
+      expect(result.failure.message.length).toBeGreaterThan(0);
+    });
+
+    it(`serves last known good marked stale: ${label}`, async () => {
+      await primeCache();
+      arrange();
+
+      const result = await getSkillCatalog({ forceRevalidate: true });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.snapshot.stale).toBe(true);
+      expect(result.snapshot.offline).toBe(true);
+      expect(result.snapshot.staleReason).toBe(expectedCode);
+      expect(result.snapshot.catalog.entries[0].id).toBe('release-notes');
+    });
+  }
+
+  it('never replaces the cached document with an unvalidated one', async () => {
+    await primeCache();
+    fetchMock.mockResolvedValue(
+      makeResponse({ body: JSON.stringify({ schema_version: 1, entries: [{ id: 'evil' }] }) })
+    );
+
+    const stale = await getSkillCatalog({ forceRevalidate: true });
+    expect(stale.ok).toBe(true);
+    if (!stale.ok) return;
+    expect(stale.snapshot.catalog.entries.map((e) => e.id)).toEqual(['release-notes']);
+
+    // The next successful fetch is what replaces it.
+    fetchMock.mockResolvedValue(okCatalogResponse('"rev-2"'));
+    const fresh = await getSkillCatalog({ forceRevalidate: true });
+    expect(fresh.ok).toBe(true);
+    if (!fresh.ok) return;
+    expect(fresh.snapshot.state).toBe('fresh');
+  });
+
+  it('reports schema errors so a caller can explain the rejection', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse({ body: JSON.stringify({ schema_version: 2, entries: [] }) })
+    );
+
+    const result = await getSkillCatalog();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.errors.length).toBeGreaterThan(0);
+    expect(result.failure.errors[0].code).toBe('SKILL_SCHEMA_VERSION_UNSUPPORTED');
+  });
+});
+
+describe('getSkillCatalog - rate limiting', () => {
+  it('backs off after 429 without issuing another request', async () => {
+    fetchMock.mockResolvedValue(makeResponse({ status: 429, headers: { 'Retry-After': '120' } }));
+
+    const first = await getSkillCatalog();
+    const second = await getSkillCatalog();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first.ok).toBe(false);
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.failure.code).toBe(SkillCatalogStaleReason.RATE_LIMITED);
+  });
+
+  it('serves last known good while rate limited', async () => {
+    fetchMock.mockResolvedValueOnce(okCatalogResponse());
+    await getSkillCatalog();
+
+    fetchMock.mockResolvedValue(makeResponse({ status: 403, headers: { 'Retry-After': '120' } }));
+    const limited = await getSkillCatalog({ forceRevalidate: true });
+
+    expect(limited.ok).toBe(true);
+    if (!limited.ok) return;
+    expect(limited.snapshot.stale).toBe(true);
+    expect(limited.snapshot.staleReason).toBe(SkillCatalogStaleReason.RATE_LIMITED);
+  });
+
+  it('resumes requesting once the back-off window elapses', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T00:00:00Z'));
+
+    fetchMock.mockResolvedValueOnce(makeResponse({ status: 429, headers: { 'Retry-After': '60' } }));
+    await getSkillCatalog();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date(Date.now() + 61_000));
+    fetchMock.mockResolvedValueOnce(okCatalogResponse());
+    const result = await getSkillCatalog();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+  });
+
+  it('clamps a hostile reset hint so the client cannot be pinned offline', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T00:00:00Z'));
+
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 403, headers: { 'X-RateLimit-Reset': '99999999999' } })
+    );
+    await getSkillCatalog();
+
+    // Past the 24h clamp, requests resume even though the header asked for years.
+    vi.setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000));
+    fetchMock.mockResolvedValueOnce(okCatalogResponse());
+    const result = await getSkillCatalog();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('getSkillCatalog - streaming body cap', () => {
+  it('cuts off a streamed body that exceeds the cap', async () => {
+    const chunk = new TextEncoder().encode('x'.repeat(64 * 1024));
+    let emitted = 0;
+    const response = {
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            emitted += 1;
+            return emitted > 1000 ? { done: true, value: undefined } : { done: false, value: chunk };
+          },
+          cancel: async () => undefined,
+        }),
+      },
+      text: async () => '',
+    } as unknown as Response;
+
+    fetchMock.mockResolvedValue(response);
+
+    const result = await getSkillCatalog();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe(SkillCatalogStaleReason.OVERSIZED);
+  });
+
+  it('decodes a streamed body that fits the cap', async () => {
+    const bytes = new TextEncoder().encode(VALID_CATALOG_JSON);
+    let done = false;
+    const response = {
+      status: 200,
+      ok: true,
+      headers: new Headers({ ETag: '"rev-stream"' }),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: bytes };
+          },
+          cancel: async () => undefined,
+        }),
+      },
+      text: async () => {
+        throw new Error('text() must not be used when a stream is available');
+      },
+    } as unknown as Response;
+
+    fetchMock.mockResolvedValue(response);
+
+    const result = await getSkillCatalog();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.catalog.entries[0].id).toBe('release-notes');
+  });
+});

--- a/tests/unit/lib/skills/compatibility.test.ts
+++ b/tests/unit/lib/skills/compatibility.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for CommandMate compatibility judgement and version resolution
+ * (Issue #1231)
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SKILL_COMPATIBILITY_MESSAGE_KEYS,
+  SkillCompatibilityReason,
+  SkillRecommendationReason,
+  describeAgentCompatibility,
+  evaluateCommandMateCompatibility,
+  evaluateVersionCompatibility,
+  findSkillCatalogEntry,
+  normalizeHostVersion,
+  resolveSkillVersions,
+} from '@/lib/skills/compatibility';
+import { AGENT_SUPPORT_LABEL_KEYS } from '@/lib/skills/constants';
+import type { SkillCatalog, SkillCatalogEntry, SkillCatalogVersion } from '@/types/skills';
+
+function makeVersion(
+  version: string,
+  commandmate: string,
+  overrides: Partial<SkillCatalogVersion> = {}
+): SkillCatalogVersion {
+  return {
+    version,
+    changelog: `Release ${version}`,
+    published_at: '2026-07-16T09:30:00Z',
+    source: {
+      repository: 'Kewton/commandmate-skills',
+      ref: `release-notes-v${version}`,
+      commit: 'ef754e3638b357eee53a626541aca267bd57e45c',
+    },
+    artifact: {
+      asset_name: `release-notes-${version}.tar.gz`,
+      url: `https://github.com/Kewton/commandmate-skills/releases/download/v${version}/release-notes-${version}.tar.gz`,
+      sha256: '481be185fb462c8d41c09e118ed631a7e10d670c13413f669dce72ba3aeee97e',
+      size: 4096,
+      content_type: 'application/gzip',
+      format: 'tar.gz',
+    },
+    compatibility: {
+      commandmate,
+      agents: [{ agent: 'claude', support: 'native', evidence: 'verified' }],
+    },
+    declared_risk: 'low',
+    ...overrides,
+  };
+}
+
+function makeEntry(latest: string, versions: SkillCatalogVersion[]): SkillCatalogEntry {
+  return {
+    id: 'release-notes',
+    name: 'release-notes',
+    summary: 'Draft release notes.',
+    provider: { name: 'CommandMate' },
+    license: 'MIT',
+    latest,
+    versions,
+  };
+}
+
+describe('normalizeHostVersion', () => {
+  it('accepts a strict SemVer 2.0 version', () => {
+    expect(normalizeHostVersion('0.11.4')).toBe('0.11.4');
+    expect(normalizeHostVersion(' 1.2.3-beta.1 ')).toBe('1.2.3-beta.1');
+  });
+
+  it('rejects the unknown-version sentinel getServerVersion() falls back to', () => {
+    expect(normalizeHostVersion('0.0.0')).toBeNull();
+  });
+
+  it('rejects a v-prefixed version, which the Skill contract does not allow', () => {
+    expect(normalizeHostVersion('v0.11.4')).toBeNull();
+  });
+
+  it('rejects absent, empty and non-SemVer input', () => {
+    expect(normalizeHostVersion(null)).toBeNull();
+    expect(normalizeHostVersion(undefined)).toBeNull();
+    expect(normalizeHostVersion('   ')).toBeNull();
+    expect(normalizeHostVersion('0.11')).toBeNull();
+  });
+});
+
+describe('evaluateCommandMateCompatibility', () => {
+  it('reports compatible when the host version satisfies the range', () => {
+    const result = evaluateCommandMateCompatibility('>=0.11.0 <1.0.0', '0.11.4');
+    expect(result.status).toBe('compatible');
+    expect(result.reasonCode).toBe(SkillCompatibilityReason.SATISFIED);
+    expect(result.currentVersion).toBe('0.11.4');
+  });
+
+  it('reports incompatible with the required range in the message', () => {
+    const result = evaluateCommandMateCompatibility('>=1.0.0', '0.11.4');
+    expect(result.status).toBe('incompatible');
+    expect(result.reasonCode).toBe(SkillCompatibilityReason.HOST_VERSION_OUT_OF_RANGE);
+    expect(result.requiredRange).toBe('>=1.0.0');
+    expect(result.message).toContain('>=1.0.0');
+    expect(result.message).toContain('0.11.4');
+  });
+
+  it('reports unknown, never compatible, when the host version is undeterminable', () => {
+    const result = evaluateCommandMateCompatibility('>=0.11.0', null);
+    expect(result.status).toBe('unknown');
+    expect(result.reasonCode).toBe(SkillCompatibilityReason.HOST_VERSION_UNKNOWN);
+    expect(result.currentVersion).toBeNull();
+  });
+
+  it('fails closed to unknown when the declared range is unparsable', () => {
+    for (const range of ['^1 || ^2', 'not-a-range', '1.x', '']) {
+      const result = evaluateCommandMateCompatibility(range, '0.11.4');
+      expect(result.status).toBe('unknown');
+      expect(result.reasonCode).toBe(SkillCompatibilityReason.RANGE_UNSUPPORTED);
+    }
+  });
+
+  it('pairs every verdict with a machine code and an i18n key', () => {
+    const result = evaluateCommandMateCompatibility('>=1.0.0', '0.11.4');
+    expect(result.messageKey).toBe(
+      SKILL_COMPATIBILITY_MESSAGE_KEYS[SkillCompatibilityReason.HOST_VERSION_OUT_OF_RANGE]
+    );
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+
+  it('does not let a prerelease host version satisfy a release range', () => {
+    const result = evaluateCommandMateCompatibility('>=0.11.0 <1.0.0', '0.12.0-rc.1');
+    expect(result.status).toBe('incompatible');
+  });
+
+  it('reads the range from a Catalog version', () => {
+    const version = makeVersion('1.0.0', '>=0.11.0 <1.0.0');
+    expect(evaluateVersionCompatibility(version, '0.11.4').status).toBe('compatible');
+  });
+});
+
+describe('describeAgentCompatibility', () => {
+  it('attaches the shared label key to each support claim', () => {
+    const views = describeAgentCompatibility([
+      { agent: 'claude', support: 'native', evidence: 'verified' },
+      { agent: 'gemini', support: 'unknown', evidence: 'not verified' },
+    ]);
+    expect(views[0].labelKey).toBe(AGENT_SUPPORT_LABEL_KEYS.native);
+    expect(views[1].labelKey).toBe(AGENT_SUPPORT_LABEL_KEYS.unknown);
+    expect(views[1].support).toBe('unknown');
+  });
+});
+
+describe('resolveSkillVersions', () => {
+  const range = '>=0.11.0 <1.0.0';
+
+  it('sorts versions newest first by SemVer precedence', () => {
+    const entry = makeEntry('1.10.0', [
+      makeVersion('1.2.0', range),
+      makeVersion('1.10.0', range),
+      makeVersion('1.9.0', range),
+    ]);
+    const result = resolveSkillVersions(entry, { currentVersion: '0.11.4' });
+    expect(result.versions.map((v) => v.version.version)).toEqual(['1.10.0', '1.9.0', '1.2.0']);
+  });
+
+  it('excludes prereleases unless they are explicitly requested', () => {
+    const entry = makeEntry('1.0.0', [
+      makeVersion('1.0.0', range),
+      makeVersion('1.1.0-beta.1', range),
+    ]);
+
+    const without = resolveSkillVersions(entry, { currentVersion: '0.11.4' });
+    expect(without.versions.map((v) => v.version.version)).toEqual(['1.0.0']);
+
+    const withPrerelease = resolveSkillVersions(entry, {
+      currentVersion: '0.11.4',
+      includePrerelease: true,
+    });
+    expect(withPrerelease.versions.map((v) => v.version.version)).toEqual([
+      '1.1.0-beta.1',
+      '1.0.0',
+    ]);
+    expect(withPrerelease.versions[0].prerelease).toBe(true);
+  });
+
+  it('recommends the highest compatible version, skipping newer incompatible ones', () => {
+    const entry = makeEntry('2.0.0', [
+      makeVersion('1.0.0', '>=0.11.0 <1.0.0'),
+      makeVersion('2.0.0', '>=1.0.0'),
+    ]);
+    const result = resolveSkillVersions(entry, { currentVersion: '0.11.4' });
+    expect(result.recommended?.version.version).toBe('1.0.0');
+    expect(result.reasonCode).toBe(SkillRecommendationReason.HIGHEST_COMPATIBLE);
+  });
+
+  it('recommends nothing when every version is incompatible', () => {
+    const entry = makeEntry('2.0.0', [makeVersion('2.0.0', '>=1.0.0')]);
+    const result = resolveSkillVersions(entry, { currentVersion: '0.11.4' });
+    expect(result.recommended).toBeNull();
+    expect(result.reasonCode).toBe(SkillRecommendationReason.NONE_COMPATIBLE);
+    expect(result.versions[0].compatibility.status).toBe('incompatible');
+  });
+
+  it('offers the publisher latest as unverified when the host version is unknown', () => {
+    const entry = makeEntry('1.0.0', [makeVersion('1.0.0', range), makeVersion('2.0.0', range)]);
+    const result = resolveSkillVersions(entry, { currentVersion: null });
+    expect(result.recommended?.version.version).toBe('1.0.0');
+    expect(result.reasonCode).toBe(SkillRecommendationReason.LATEST_UNVERIFIED);
+    expect(result.recommended?.compatibility.status).toBe('unknown');
+  });
+
+  it('reports no versions when filtering removes them all', () => {
+    const entry = makeEntry('1.0.0-beta.1', [makeVersion('1.0.0-beta.1', range)]);
+    const result = resolveSkillVersions(entry, { currentVersion: '0.11.4' });
+    expect(result.versions).toEqual([]);
+    expect(result.recommended).toBeNull();
+    expect(result.reasonCode).toBe(SkillRecommendationReason.NO_VERSIONS);
+  });
+});
+
+describe('findSkillCatalogEntry', () => {
+  const catalog: SkillCatalog = {
+    schema_version: 1,
+    entries: [makeEntry('1.0.0', [makeVersion('1.0.0', '>=0.11.0')])],
+  };
+
+  it('finds an entry by exact id', () => {
+    expect(findSkillCatalogEntry(catalog, 'release-notes')?.id).toBe('release-notes');
+  });
+
+  it('does not match on case-folded or partial ids', () => {
+    expect(findSkillCatalogEntry(catalog, 'Release-Notes')).toBeNull();
+    expect(findSkillCatalogEntry(catalog, 'release')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1231（Epic #1227 Phase 1 Wave 2）。公式 Catalog の取得・厳格検証・cache・version resolution・互換性判定を server-side の単一 domain service に集約し、UI/CLI が同じ Catalog と同じ互換性結果を参照できる read-only API を追加する。

artifact download と install は本 PR のスコープ外（#1229 / #1233）。

## 主な変更

- `src/config/skill-catalog-config.ts` — hardcode した Catalog endpoint と完全一致 allow-list、timeout / TTL / size cap / rate limit 上限
- `src/lib/skills/catalog-client.ts` — 条件付き GET (ETag/If-None-Match)、TTL、last-known-good、single-flight、rate limit back-off、body の byte cap
- `src/lib/skills/compatibility.ts` — CommandMate 互換性の 3 値判定（純関数）と version 解決（prerelease は明示 opt-in 時のみ）
- `src/lib/api/skills-api.ts` — Catalog document → wire 形式の単一 mapping
- `src/app/api/skills/route.ts`, `src/app/api/skills/[id]/route.ts`
- tests: unit 49 / integration 17

## 主要な決定

- **cache は `validateSkillCatalog` を通過した document でしか置換しない。** fetch 失敗・oversized・JSON 不正・schema 違反はいずれも last-known-good を残し、`stale=true` + 理由 code で返す（未検証 data へ置換しない）
- 取得失敗かつ last-known-good が無い場合は **503**。空 list を返すと「Skill が無い」と「Catalog に到達できない」が区別できなくなるため
- 互換性は compatible / incompatible / unknown の 3 値。range が解釈不能な場合も host version 不明の場合も **unknown へ fail close**（compatible にしない）。判定は machine-readable code + i18n key + human-readable message を必ず伴う
- **`artifact.url` を response に含めない。** 署名付きになりうる download URL は secret 扱いで、URL 解決は install 時の server 側責務（#1229）。結果として client が書き換えて送り返せる URL field が存在しない
- Catalog endpoint は compile-time 定数 + **完全一致** allow-list。前方一致だと `raw.githubusercontent.com.evil.example` 形の look-alike を通すため
- rate limit の reset hint は 24h で clamp（敵対的/壊れた header で無期限 offline に固定されない）
- log に upstream response 本文・URL・token を残さない

## Issue 記載前提の訂正

Issue 本文は書き換えていない。

1. 「YAML parser 選定は #1229/#1231 に委ねる」とあるが、**Catalog document は JSON** であり本 PR の範囲に YAML parse は発生しない。`SKILL_YAML_SAFE_PROFILE` は未消費のまま、manifest YAML の parser 選定は artifact 展開を扱う #1229 の責務として残る
2. 「catalog の source commit を response へ含める」とあるが、schema_version 1 の Catalog document には **document 単位の commit field が無い**（#1228 の `SkillCatalog` は `schema_version` と `entries` のみ）。document 単位は origin の ETag を `catalog.source.revision` として返し、信頼できる coordinate である `versions[].source.commit`（40 hex）を version 単位で返す形に読み替えた
3. `version-checker.ts` の `getServerVersion()` は読み取り失敗時に `'0.0.0'` を返す。構文上 valid な SemVer なのでそのまま比較すると **「incompatible」と誤って断定する**。`normalizeHostVersion()` で sentinel として弾き unknown 扱いにした

## Issue の変更対象候補からの差分

- `src/lib/api/skills-api.ts` を追加。Next.js の route module は handler と route config 以外の export を型検査で拒否するため、2 つの route が共有する serializer を `route.ts` に置けない。`src/lib/api/` は既存の API helper 置き場（`template-helpers.ts`, `todo-api.ts`）でありその規約に合わせた
- `src/lib/skills/index.ts`（barrel）には追加していない。#1229/#1234 が並列作業中で同一 barrel への追記は 3-way conflict になるため。consumer は当面 `@/lib/skills/catalog-client` / `@/lib/skills/compatibility` を直接 import する。sibling import も具体 module 指定にしてあるので、後から barrel へ re-export しても import cycle にならない

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run test:unit` / `test:integration` | worker 側で unit 10410 / integration 728 passed |

Refs #1231, #1227