### PR TITLE
feat(security): 公式Skill Catalog・artifactの安全な取得とsnapshot管理 (#1229)

### DIFF
--- a/src/config/skill-security-config.ts
+++ b/src/config/skill-security-config.ts
@@ -1,0 +1,189 @@
+/**
+ * Skill fetch/snapshot security policy (Issue #1229)
+ *
+ * Single source of truth for *where* CommandMate is allowed to fetch Skill
+ * documents from and *how much* it is allowed to keep on disk. Every value here
+ * is a hardcoded constant: none of it may be derived from environment
+ * variables, config files or client input, because that is exactly the SSRF
+ * lever this module exists to remove (OWASP A10:2021, same rule as
+ * `GITHUB_API_URL` in src/lib/version-checker.ts).
+ *
+ * Catalog JSON and release assets get *separate* policies: they are served by
+ * different origins with different media types, and a Catalog response must
+ * never be accepted where an artifact is expected (or vice versa).
+ *
+ * @module config/skill-security-config
+ */
+
+import { GIT_COMMIT_SHA_PATTERN, SKILL_ARTIFACT_CONTENT_TYPE, SKILL_ARTIFACT_MAX_SIZE } from '@/lib/skills';
+
+// =============================================================================
+// Official source coordinates
+// =============================================================================
+
+/** The only repository Skills may be distributed from in schema_version 1. */
+export const SKILL_OFFICIAL_REPOSITORY = 'Kewton/commandmate-skills' as const;
+
+/** Catalog document filename at the repository root. */
+export const SKILL_CATALOG_FILENAME = 'catalog.json' as const;
+
+// =============================================================================
+// Host rules
+// =============================================================================
+
+/** One allowed origin, optionally narrowed to a path prefix. */
+export interface SkillHostRule {
+  /** Lowercase DNS host. Matched exactly; wildcards are deliberately not supported. */
+  readonly host: string;
+  /** Required path prefix. Absent means any path on this host is acceptable. */
+  readonly pathPrefix?: string;
+}
+
+/** Catalog JSON is served by the raw content host, pinned to the official repo. */
+const CATALOG_HOSTS: readonly SkillHostRule[] = [
+  { host: 'raw.githubusercontent.com', pathPrefix: `/${SKILL_OFFICIAL_REPOSITORY}/` },
+];
+
+/** Release asset downloads always start at the release download path. */
+const ARTIFACT_ENTRY_HOSTS: readonly SkillHostRule[] = [
+  { host: 'github.com', pathPrefix: `/${SKILL_OFFICIAL_REPOSITORY}/releases/download/` },
+];
+
+/**
+ * Hosts a release asset download may be redirected to.
+ *
+ * GitHub hands release assets off to a storage CDN with an opaque, signed path,
+ * so no path prefix can be asserted on these hops. The artifact digest check is
+ * what makes that acceptable: a wrong body from an allowed host still fails.
+ */
+const ARTIFACT_REDIRECT_HOSTS: readonly SkillHostRule[] = [
+  ...ARTIFACT_ENTRY_HOSTS,
+  { host: 'objects.githubusercontent.com' },
+  { host: 'release-assets.githubusercontent.com' },
+];
+
+// =============================================================================
+// Source policies
+// =============================================================================
+
+/** Which document a request is for. Policies are never interchangeable. */
+export type SkillSourceKind = 'catalog' | 'artifact';
+
+/** Complete fetch policy for one document kind. */
+export interface SkillSourcePolicy {
+  readonly kind: SkillSourceKind;
+  /** Origins accepted for the first request. */
+  readonly entryHosts: readonly SkillHostRule[];
+  /** Origins accepted for any redirect hop. */
+  readonly redirectHosts: readonly SkillHostRule[];
+  /** Value sent as `Accept`. */
+  readonly accept: string;
+  /** Media types accepted in the response, parameters stripped. */
+  readonly contentTypes: readonly string[];
+  /** Hard cap on the response body in bytes, enforced against the measured stream. */
+  readonly maxBytes: number;
+}
+
+/** Maximum Catalog document size in bytes (4 MiB). */
+export const SKILL_CATALOG_MAX_SIZE = 4 * 1024 * 1024;
+
+/**
+ * `raw.githubusercontent.com` serves `.json` as `text/plain`, so the Catalog
+ * policy has to accept it. The document is parsed as JSON regardless of the
+ * declared type, and validated by `validateSkillCatalog` afterwards.
+ */
+const CATALOG_CONTENT_TYPES = ['application/json', 'text/plain'] as const;
+
+export const SKILL_SOURCE_POLICIES: Readonly<Record<SkillSourceKind, SkillSourcePolicy>> = {
+  catalog: {
+    kind: 'catalog',
+    entryHosts: CATALOG_HOSTS,
+    redirectHosts: CATALOG_HOSTS,
+    accept: 'application/json',
+    contentTypes: CATALOG_CONTENT_TYPES,
+    maxBytes: SKILL_CATALOG_MAX_SIZE,
+  },
+  artifact: {
+    kind: 'artifact',
+    entryHosts: ARTIFACT_ENTRY_HOSTS,
+    redirectHosts: ARTIFACT_REDIRECT_HOSTS,
+    accept: SKILL_ARTIFACT_CONTENT_TYPE,
+    contentTypes: [SKILL_ARTIFACT_CONTENT_TYPE, 'application/octet-stream'],
+    maxBytes: SKILL_ARTIFACT_MAX_SIZE,
+  },
+};
+
+// =============================================================================
+// Transport limits
+// =============================================================================
+
+/** Maximum number of redirect hops before a fetch fails closed. */
+export const SKILL_FETCH_MAX_REDIRECTS = 5;
+
+/** Timeout for receiving response headers, in milliseconds. */
+export const SKILL_FETCH_HEADER_TIMEOUT_MS = 10_000;
+
+/** Timeout for the whole request including body transfer, in milliseconds. */
+export const SKILL_FETCH_TOTAL_TIMEOUT_MS = 120_000;
+
+/**
+ * Request headers dropped when a redirect crosses an origin.
+ *
+ * `fetch` with `redirect: 'manual'` gives us the hop, so credential forwarding
+ * is our responsibility: a signed CDN redirect must never carry a GitHub token.
+ */
+export const SKILL_CREDENTIAL_HEADERS: readonly string[] = [
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+];
+
+/** Value sent as `User-Agent`, matching the version-checker convention. */
+export const SKILL_FETCH_USER_AGENT_PREFIX = 'CommandMate' as const;
+
+// =============================================================================
+// Snapshot store limits
+// =============================================================================
+
+/** Directory name of the snapshot store under the service-owned data root. */
+export const SKILL_SNAPSHOT_DIRNAME = 'skill-snapshots' as const;
+
+/** Snapshot directory mode: service-owned, not group/world readable. */
+export const SKILL_SNAPSHOT_DIR_MODE = 0o700;
+
+/** Snapshot file mode: read-only for the owning service account. */
+export const SKILL_SNAPSHOT_FILE_MODE = 0o400;
+
+/** Lifetime of an unreferenced snapshot before sweeping, in milliseconds. */
+export const SKILL_SNAPSHOT_TTL_MS = 30 * 60 * 1000;
+
+/** Total bytes the snapshot store may hold (256 MiB). */
+export const SKILL_SNAPSHOT_TOTAL_QUOTA_BYTES = 256 * 1024 * 1024;
+
+/** Maximum number of concurrently retained snapshots. */
+export const SKILL_SNAPSHOT_MAX_COUNT = 64;
+
+/** Random bytes behind an opaque snapshot ID. */
+export const SKILL_SNAPSHOT_ID_BYTES = 16;
+
+/** Opaque snapshot ID grammar: lowercase hex of {@link SKILL_SNAPSHOT_ID_BYTES}. */
+export const SKILL_SNAPSHOT_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+// =============================================================================
+// URL construction
+// =============================================================================
+
+/**
+ * Build the Catalog URL for an immutable commit.
+ *
+ * Takes a resolved 40-hex commit rather than a branch so the Catalog a user
+ * reviewed is the Catalog that gets installed. Callers never supply a URL.
+ *
+ * @throws Error when the commit is not a resolved 40-hex SHA
+ */
+export function buildSkillCatalogUrl(commit: string): string {
+  if (!GIT_COMMIT_SHA_PATTERN.test(commit)) {
+    throw new Error('Skill catalog URL requires a resolved 40-hex commit SHA');
+  }
+  return `https://raw.githubusercontent.com/${SKILL_OFFICIAL_REPOSITORY}/${commit}/${SKILL_CATALOG_FILENAME}`;
+}

--- a/src/lib/skills/artifact-downloader.ts
+++ b/src/lib/skills/artifact-downloader.ts
@@ -1,0 +1,437 @@
+/**
+ * Guarded fetching of official Skill Catalogs and release artifacts (Issue #1229)
+ *
+ * Every request this module makes is pinned to the allowlist in
+ * `src/config/skill-security-config.ts`. Redirects are followed manually so
+ * each hop is re-validated and credential headers are dropped when the origin
+ * changes — `redirect: 'follow'` would hand both decisions to undici.
+ *
+ * Bodies are streamed with a running size cap and hashed as they arrive, so an
+ * oversized or wrong-digest response is abandoned mid-transfer instead of being
+ * buffered first. Archives are never opened here: extraction and entry
+ * inspection are #1230's responsibility.
+ *
+ * @module lib/skills/artifact-downloader
+ */
+
+import {
+  SKILL_CREDENTIAL_HEADERS,
+  SKILL_FETCH_HEADER_TIMEOUT_MS,
+  SKILL_FETCH_MAX_REDIRECTS,
+  SKILL_FETCH_TOTAL_TIMEOUT_MS,
+  SKILL_FETCH_USER_AGENT_PREFIX,
+  SKILL_SOURCE_POLICIES,
+  type SkillHostRule,
+  type SkillSourceKind,
+  type SkillSourcePolicy,
+} from '@/config/skill-security-config';
+import {
+  SkillFetchError,
+  SkillFetchErrorCode,
+  assertArtifactBinding,
+  createSha256Accumulator,
+  verifyArtifactIntegrity,
+} from '@/lib/skills/integrity';
+import { getCurrentVersion } from '@/lib/version-checker';
+import type { SkillCatalogVersion } from '@/types/skills';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Bytes received from an allowed source, with the digest measured in transit. */
+export interface SkillSourcePayload {
+  bytes: Uint8Array;
+  /** Lowercase hex SHA-256 of {@link bytes}. */
+  sha256: string;
+  size: number;
+}
+
+/** A verified artifact, bound to the Catalog coordinates it was fetched for. */
+export interface SkillArtifactDownload extends SkillSourcePayload {
+  skillId: string;
+  version: string;
+  /** Resolved 40-hex commit the version was published from. */
+  commit: string;
+}
+
+/** Caller-controlled knobs. No URL and no host may be supplied here by design. */
+export interface SkillFetchOptions {
+  signal?: AbortSignal;
+}
+
+// =============================================================================
+// URL policy
+// =============================================================================
+
+const REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Validate a URL against a set of host rules.
+ *
+ * Rejects anything that could be used to reach a host the allowlist did not
+ * name: non-HTTPS schemes, embedded credentials and explicit non-default ports.
+ *
+ * The path check runs against `URL.pathname`, which WHATWG parsing has already
+ * stripped of dot segments (raw and `%2e`-encoded alike). That is what makes a
+ * plain prefix comparison sufficient: `…/releases/download/../../x` normalizes
+ * to a path outside the prefix and is rejected as a disallowed source.
+ *
+ * @throws SkillFetchError with `URL_INVALID` or `SOURCE_NOT_ALLOWED`
+ */
+export function assertAllowedSkillUrl(rawUrl: string, rules: readonly SkillHostRule[]): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new SkillFetchError(SkillFetchErrorCode.URL_INVALID, { reason: 'malformed' });
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new SkillFetchError(SkillFetchErrorCode.URL_INVALID, { reason: 'scheme' });
+  }
+  if (url.username !== '' || url.password !== '') {
+    throw new SkillFetchError(SkillFetchErrorCode.URL_INVALID, { reason: 'userinfo' });
+  }
+  if (url.port !== '') {
+    throw new SkillFetchError(SkillFetchErrorCode.URL_INVALID, { reason: 'port' });
+  }
+  const host = url.hostname.toLowerCase();
+  const rule = rules.find((candidate) => candidate.host === host);
+  if (!rule) {
+    throw new SkillFetchError(SkillFetchErrorCode.SOURCE_NOT_ALLOWED, { host });
+  }
+  if (rule.pathPrefix !== undefined && !url.pathname.startsWith(rule.pathPrefix)) {
+    throw new SkillFetchError(SkillFetchErrorCode.SOURCE_NOT_ALLOWED, { host });
+  }
+  return url;
+}
+
+// =============================================================================
+// Request scope (timeouts + abort classification)
+// =============================================================================
+
+/**
+ * Owns the AbortController for one logical fetch.
+ *
+ * Timeouts and caller aborts both surface as the same `AbortError` from
+ * `fetch`, so the reason has to be recorded when it is triggered rather than
+ * inferred afterwards.
+ */
+class FetchScope {
+  readonly controller = new AbortController();
+  private timedOut = false;
+  private callerAborted = false;
+  private readonly totalTimer: ReturnType<typeof setTimeout>;
+  private readonly callerSignal?: AbortSignal;
+  private readonly onCallerAbort = (): void => {
+    this.callerAborted = true;
+    this.controller.abort();
+  };
+
+  constructor(callerSignal?: AbortSignal) {
+    this.totalTimer = setTimeout(() => {
+      this.timedOut = true;
+      this.controller.abort();
+    }, SKILL_FETCH_TOTAL_TIMEOUT_MS);
+
+    if (callerSignal) {
+      this.callerSignal = callerSignal;
+      if (callerSignal.aborted) this.onCallerAbort();
+      else callerSignal.addEventListener('abort', this.onCallerAbort, { once: true });
+    }
+  }
+
+  /** Run one request phase under the shorter header timeout. */
+  async withHeaderTimeout<T>(run: () => Promise<T>): Promise<T> {
+    const timer = setTimeout(() => {
+      this.timedOut = true;
+      this.controller.abort();
+    }, SKILL_FETCH_HEADER_TIMEOUT_MS);
+    try {
+      return await run();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  dispose(): void {
+    clearTimeout(this.totalTimer);
+    this.callerSignal?.removeEventListener('abort', this.onCallerAbort);
+  }
+
+  /** Map a thrown transport error onto the reason we actually recorded. */
+  translate(error: unknown): SkillFetchError {
+    if (error instanceof SkillFetchError) return error;
+    if (this.timedOut) return new SkillFetchError(SkillFetchErrorCode.TIMEOUT);
+    if (this.callerAborted) return new SkillFetchError(SkillFetchErrorCode.ABORTED);
+    return new SkillFetchError(SkillFetchErrorCode.NETWORK);
+  }
+}
+
+// =============================================================================
+// Guarded transport
+// =============================================================================
+
+function buildBaseHeaders(policy: SkillSourcePolicy): Record<string, string> {
+  return {
+    accept: policy.accept,
+    'user-agent': `${SKILL_FETCH_USER_AGENT_PREFIX}/${getCurrentVersion()}`,
+  };
+}
+
+/**
+ * Drop every credential header before a cross-origin hop.
+ *
+ * CommandMate attaches none today, but a redirect to a signed CDN URL is
+ * exactly where a future token would leak, so the strip is unconditional
+ * rather than a property of the current header set.
+ */
+export function stripCredentialHeaders(headers: Record<string, string>): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (!SKILL_CREDENTIAL_HEADERS.includes(name.toLowerCase())) next[name] = value;
+  }
+  return next;
+}
+
+async function discardBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The socket is being discarded anyway; a cancel failure changes nothing.
+  }
+}
+
+async function followToFinalResponse(
+  rawUrl: string,
+  policy: SkillSourcePolicy,
+  scope: FetchScope
+): Promise<Response> {
+  let current = assertAllowedSkillUrl(rawUrl, policy.entryHosts);
+  let headers = buildBaseHeaders(policy);
+
+  for (let hop = 0; ; hop++) {
+    const response = await scope.withHeaderTimeout(() =>
+      fetch(current.toString(), {
+        method: 'GET',
+        redirect: 'manual',
+        cache: 'no-store',
+        headers,
+        signal: scope.controller.signal,
+      })
+    );
+
+    if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+    const location = response.headers.get('location');
+    await discardBody(response);
+
+    if (hop >= SKILL_FETCH_MAX_REDIRECTS) {
+      throw new SkillFetchError(SkillFetchErrorCode.REDIRECT_LIMIT_EXCEEDED, {
+        limit: SKILL_FETCH_MAX_REDIRECTS,
+      });
+    }
+    if (!location) {
+      throw new SkillFetchError(SkillFetchErrorCode.REDIRECT_INVALID, { reason: 'no-location' });
+    }
+
+    let candidate: URL;
+    try {
+      candidate = new URL(location, current);
+    } catch {
+      throw new SkillFetchError(SkillFetchErrorCode.REDIRECT_INVALID, { reason: 'malformed' });
+    }
+
+    const next = assertAllowedSkillUrl(candidate.toString(), policy.redirectHosts);
+    if (next.origin !== current.origin) headers = stripCredentialHeaders(headers);
+    current = next;
+  }
+}
+
+function assertResponseHeaders(
+  response: Response,
+  policy: SkillSourcePolicy,
+  expectedSize?: number
+): void {
+  if (!response.ok) {
+    throw new SkillFetchError(SkillFetchErrorCode.HTTP_STATUS, { status: response.status });
+  }
+
+  const rawContentType = response.headers.get('content-type');
+  const mediaType = rawContentType?.split(';')[0]?.trim().toLowerCase() ?? '';
+  if (!policy.contentTypes.includes(mediaType)) {
+    throw new SkillFetchError(SkillFetchErrorCode.CONTENT_TYPE_INVALID, {
+      received: mediaType || '<absent>',
+    });
+  }
+
+  const rawLength = response.headers.get('content-length');
+  if (rawLength === null) return;
+  const declared = Number(rawLength);
+  if (!Number.isSafeInteger(declared) || declared < 0) {
+    throw new SkillFetchError(SkillFetchErrorCode.SIZE_MISMATCH, { reason: 'content-length' });
+  }
+  if (declared > policy.maxBytes) {
+    throw new SkillFetchError(SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED, { limit: policy.maxBytes });
+  }
+  if (expectedSize !== undefined && declared !== expectedSize) {
+    throw new SkillFetchError(SkillFetchErrorCode.SIZE_MISMATCH, {
+      expected: expectedSize,
+      actual: declared,
+    });
+  }
+}
+
+/** Stream the body, aborting the moment the running total passes the cap. */
+async function readBoundedBody(response: Response, maxBytes: number): Promise<SkillSourcePayload> {
+  const body = response.body;
+  if (!body) throw new SkillFetchError(SkillFetchErrorCode.BODY_MISSING);
+
+  const reader = body.getReader();
+  const digest = createSha256Accumulator();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value || value.byteLength === 0) continue;
+
+    size += value.byteLength;
+    if (size > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new SkillFetchError(SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED, { limit: maxBytes });
+    }
+    digest.update(value);
+    chunks.push(value);
+  }
+
+  return { bytes: Buffer.concat(chunks, size), sha256: digest.hex(), size };
+}
+
+/**
+ * Fetch one document from its official source under the matching policy.
+ *
+ * Exported so the Catalog client (#1231) reuses exactly this transport rather
+ * than growing a second, subtly different one.
+ */
+export async function fetchSkillSource(
+  rawUrl: string,
+  kind: SkillSourceKind,
+  options: SkillFetchOptions & { expectedSize?: number } = {}
+): Promise<SkillSourcePayload> {
+  const policy = SKILL_SOURCE_POLICIES[kind];
+  const scope = new FetchScope(options.signal);
+  try {
+    const response = await followToFinalResponse(rawUrl, policy, scope);
+    try {
+      assertResponseHeaders(response, policy, options.expectedSize);
+    } catch (error) {
+      await discardBody(response);
+      throw error;
+    }
+    return await readBoundedBody(response, policy.maxBytes);
+  } catch (error) {
+    throw scope.translate(error);
+  } finally {
+    scope.dispose();
+  }
+}
+
+// =============================================================================
+// Artifact download with in-flight de-duplication
+// =============================================================================
+
+declare global {
+  // eslint-disable-next-line no-var -- globalThis cache pattern for hot-reload persistence (version-checker.ts precedent)
+  var __skillArtifactDownloads: Map<string, Promise<SkillArtifactDownload>> | undefined;
+}
+
+const inFlight: Map<string, Promise<SkillArtifactDownload>> =
+  globalThis.__skillArtifactDownloads ?? (globalThis.__skillArtifactDownloads = new Map());
+
+/**
+ * Reject as soon as the caller aborts, without cancelling a download that other
+ * callers are still waiting on.
+ */
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new SkillFetchError(SkillFetchErrorCode.ABORTED));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => reject(new SkillFetchError(SkillFetchErrorCode.ABORTED));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error as Error);
+      }
+    );
+  });
+}
+
+async function runArtifactDownload(
+  skillId: string,
+  version: SkillCatalogVersion
+): Promise<SkillArtifactDownload> {
+  const { artifact } = version;
+  const payload = await fetchSkillSource(artifact.url, 'artifact', {
+    expectedSize: artifact.size,
+  });
+
+  verifyArtifactIntegrity({
+    expectedSha256: artifact.sha256,
+    expectedSize: artifact.size,
+    actualSha256: payload.sha256,
+    actualSize: payload.size,
+  });
+
+  return {
+    ...payload,
+    skillId,
+    version: version.version,
+    commit: version.source.commit,
+  };
+}
+
+/**
+ * Download and verify the artifact for one Catalog version.
+ *
+ * The URL comes from the validated Catalog entry, never from a client. Two
+ * callers asking for the same artifact share one transfer; a caller aborting
+ * only detaches itself, so a concurrent installer is not collateral damage.
+ *
+ * @throws SkillFetchError — see {@link SkillFetchErrorCode} for the reasons
+ */
+export async function downloadSkillArtifact(
+  skillId: string,
+  version: SkillCatalogVersion,
+  options: SkillFetchOptions = {}
+): Promise<SkillArtifactDownload> {
+  assertArtifactBinding(skillId, version);
+
+  const key = `${skillId}@${version.version}#${version.artifact.sha256}`;
+  let shared = inFlight.get(key);
+  if (!shared) {
+    shared = runArtifactDownload(skillId, version);
+    inFlight.set(key, shared);
+    void shared
+      .catch(() => undefined)
+      .finally(() => {
+        if (inFlight.get(key) === shared) inFlight.delete(key);
+      });
+  }
+
+  return options.signal ? raceAbort(shared, options.signal) : shared;
+}
+
+/**
+ * Drop the in-flight table.
+ * @internal
+ */
+export function resetSkillDownloadsForTesting(): void {
+  inFlight.clear();
+}

--- a/src/lib/skills/integrity.ts
+++ b/src/lib/skills/integrity.ts
@@ -1,0 +1,259 @@
+/**
+ * Integrity verification and failure vocabulary for Skill fetching (Issue #1229)
+ *
+ * Two responsibilities that belong together: deciding whether a byte stream is
+ * the artifact the Catalog promised, and naming the ways that decision can fail.
+ *
+ * The error type is deliberately separate from `SkillContractError` (#1228):
+ * that one describes a *document* that failed validation and is addressed by a
+ * JSON pointer. These describe a *transfer or storage* failure and carry a
+ * retryability hint instead, because that is the question the UI has to answer
+ * ("can I press retry?", UX-09). Messages are derived from the code alone, so
+ * no token, signed query or machine-absolute path can leak through them.
+ *
+ * @module lib/skills/integrity
+ */
+
+import { createHash, timingSafeEqual } from 'crypto';
+import {
+  GIT_COMMIT_SHA_PATTERN,
+  SHA256_HEX_PATTERN,
+  SKILL_ARTIFACT_CONTENT_TYPE,
+  SKILL_ARTIFACT_FORMAT,
+  SKILL_ARTIFACT_MAX_SIZE,
+  buildSkillAssetName,
+  isValidSemVer,
+} from '@/lib/skills';
+import type { SkillCatalogVersion } from '@/types/skills';
+
+// =============================================================================
+// Error vocabulary
+// =============================================================================
+
+/** Stable, client-safe reason codes for fetch and snapshot failures. */
+export const SkillFetchErrorCode = {
+  /** URL is syntactically unusable (not absolute, not HTTPS, carries userinfo, …). */
+  URL_INVALID: 'SKILL_FETCH_URL_INVALID',
+  /** URL points outside the official allowlist for its document kind. */
+  SOURCE_NOT_ALLOWED: 'SKILL_FETCH_SOURCE_NOT_ALLOWED',
+  /** A redirect response was malformed or had no usable `Location`. */
+  REDIRECT_INVALID: 'SKILL_FETCH_REDIRECT_INVALID',
+  /** More redirect hops than the policy permits. */
+  REDIRECT_LIMIT_EXCEEDED: 'SKILL_FETCH_REDIRECT_LIMIT_EXCEEDED',
+  /** Server answered with a non-success status. */
+  HTTP_STATUS: 'SKILL_FETCH_HTTP_STATUS',
+  /** Response media type is not the one this document kind requires. */
+  CONTENT_TYPE_INVALID: 'SKILL_FETCH_CONTENT_TYPE_INVALID',
+  /** Response had no readable body. */
+  BODY_MISSING: 'SKILL_FETCH_BODY_MISSING',
+  /** Declared or measured size exceeded the policy limit. */
+  SIZE_LIMIT_EXCEEDED: 'SKILL_FETCH_SIZE_LIMIT_EXCEEDED',
+  /** Transferred size did not match the size the Catalog declared. */
+  SIZE_MISMATCH: 'SKILL_FETCH_SIZE_MISMATCH',
+  /** SHA-256 over the received bytes did not match the Catalog digest. */
+  CHECKSUM_MISMATCH: 'SKILL_FETCH_CHECKSUM_MISMATCH',
+  /** Catalog version is not bound to an immutable commit and exact version. */
+  BINDING_INVALID: 'SKILL_FETCH_BINDING_INVALID',
+  /** Request exceeded the header or total timeout. */
+  TIMEOUT: 'SKILL_FETCH_TIMEOUT',
+  /** Caller aborted the operation. */
+  ABORTED: 'SKILL_FETCH_ABORTED',
+  /** Transport-level failure (DNS, TLS, connection reset, …). */
+  NETWORK: 'SKILL_FETCH_NETWORK',
+  /** Snapshot ID is unknown, already released or malformed. */
+  SNAPSHOT_NOT_FOUND: 'SKILL_SNAPSHOT_NOT_FOUND',
+  /** Snapshot exists but its TTL has elapsed. */
+  SNAPSHOT_EXPIRED: 'SKILL_SNAPSHOT_EXPIRED',
+  /** Storing the snapshot would exceed the disk or count quota. */
+  QUOTA_EXCEEDED: 'SKILL_SNAPSHOT_QUOTA_EXCEEDED',
+  /** Snapshot store could not read or write the service-owned data root. */
+  STORE_IO: 'SKILL_SNAPSHOT_STORE_IO',
+  /** Snapshot store was used before initialization. */
+  STORE_UNINITIALIZED: 'SKILL_SNAPSHOT_STORE_UNINITIALIZED',
+} as const;
+
+export type SkillFetchErrorCodeType =
+  (typeof SkillFetchErrorCode)[keyof typeof SkillFetchErrorCode];
+
+/** Bounded, non-sensitive context attached to a failure. */
+export type SkillFetchErrorDetail = Record<string, string | number | boolean>;
+
+/**
+ * Codes worth retrying without user intervention.
+ *
+ * A checksum mismatch or a disallowed source is *not* here on purpose: retrying
+ * either one would just re-download bytes we already decided not to trust.
+ */
+const RETRYABLE_CODES: ReadonlySet<string> = new Set<string>([
+  SkillFetchErrorCode.TIMEOUT,
+  SkillFetchErrorCode.NETWORK,
+  SkillFetchErrorCode.HTTP_STATUS,
+  SkillFetchErrorCode.STORE_IO,
+]);
+
+/** Human-readable text per code. Contains no interpolated runtime value. */
+const MESSAGES: Record<SkillFetchErrorCodeType, string> = {
+  [SkillFetchErrorCode.URL_INVALID]: 'Skill source URL is not a usable HTTPS URL',
+  [SkillFetchErrorCode.SOURCE_NOT_ALLOWED]: 'Skill source is not on the official allowlist',
+  [SkillFetchErrorCode.REDIRECT_INVALID]: 'Skill source redirect was malformed',
+  [SkillFetchErrorCode.REDIRECT_LIMIT_EXCEEDED]: 'Skill source exceeded the redirect limit',
+  [SkillFetchErrorCode.HTTP_STATUS]: 'Skill source responded with an error status',
+  [SkillFetchErrorCode.CONTENT_TYPE_INVALID]: 'Skill source returned an unexpected media type',
+  [SkillFetchErrorCode.BODY_MISSING]: 'Skill source response had no body',
+  [SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED]: 'Skill source response exceeded the size limit',
+  [SkillFetchErrorCode.SIZE_MISMATCH]: 'Skill artifact size did not match the catalog',
+  [SkillFetchErrorCode.CHECKSUM_MISMATCH]: 'Skill artifact checksum did not match the catalog',
+  [SkillFetchErrorCode.BINDING_INVALID]: 'Skill catalog version is not bound to an immutable source',
+  [SkillFetchErrorCode.TIMEOUT]: 'Skill source request timed out',
+  [SkillFetchErrorCode.ABORTED]: 'Skill source request was aborted',
+  [SkillFetchErrorCode.NETWORK]: 'Skill source could not be reached',
+  [SkillFetchErrorCode.SNAPSHOT_NOT_FOUND]: 'Skill snapshot is unknown or already released',
+  [SkillFetchErrorCode.SNAPSHOT_EXPIRED]: 'Skill snapshot has expired',
+  [SkillFetchErrorCode.QUOTA_EXCEEDED]: 'Skill snapshot store quota exceeded',
+  [SkillFetchErrorCode.STORE_IO]: 'Skill snapshot store could not be accessed',
+  [SkillFetchErrorCode.STORE_UNINITIALIZED]: 'Skill snapshot store is not initialized',
+};
+
+/** A fetch or snapshot failure, safe to surface to API clients and logs. */
+export class SkillFetchError extends Error {
+  readonly code: SkillFetchErrorCodeType;
+  /** Whether a plain retry could plausibly succeed. */
+  readonly retryable: boolean;
+  readonly detail?: SkillFetchErrorDetail;
+
+  constructor(code: SkillFetchErrorCodeType, detail?: SkillFetchErrorDetail) {
+    super(MESSAGES[code]);
+    this.name = 'SkillFetchError';
+    this.code = code;
+    this.retryable = RETRYABLE_CODES.has(code);
+    if (detail) this.detail = detail;
+  }
+}
+
+/** Narrow an unknown thrown value to a {@link SkillFetchError}. */
+export function isSkillFetchError(value: unknown): value is SkillFetchError {
+  return value instanceof SkillFetchError;
+}
+
+// =============================================================================
+// Redaction
+// =============================================================================
+
+/**
+ * Reduce a URL to its origin for logging.
+ *
+ * Release asset URLs carry signed query parameters that are credentials in
+ * everything but name, and the path can identify a private repository. Only the
+ * origin is ever safe to record.
+ */
+export function redactUrlForLog(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).origin;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+// =============================================================================
+// Digests
+// =============================================================================
+
+/** Incremental SHA-256 over a stream, so nothing has to be buffered twice. */
+export interface Sha256Accumulator {
+  update(chunk: Uint8Array): void;
+  /** Lowercase hex digest. Calling twice is not supported. */
+  hex(): string;
+}
+
+/** Create an incremental SHA-256 accumulator. */
+export function createSha256Accumulator(): Sha256Accumulator {
+  const hash = createHash('sha256');
+  return {
+    update(chunk: Uint8Array): void {
+      hash.update(chunk);
+    },
+    hex(): string {
+      return hash.digest('hex');
+    },
+  };
+}
+
+/** Lowercase hex SHA-256 of a complete buffer. */
+export function computeSha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Compare two lowercase hex SHA-256 digests without leaking timing.
+ *
+ * Malformed input is a mismatch rather than a throw, so no caller can turn a
+ * bad digest into an accepted artifact by catching the wrong exception.
+ */
+export function digestMatches(expected: string, actual: string): boolean {
+  if (!SHA256_HEX_PATTERN.test(expected) || !SHA256_HEX_PATTERN.test(actual)) return false;
+  return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(actual, 'hex'));
+}
+
+// =============================================================================
+// Catalog binding
+// =============================================================================
+
+/**
+ * Assert that a Catalog version identifies one immutable artifact.
+ *
+ * `validateSkillCatalog` (#1228) already proves the document is well-formed.
+ * This is the separate question of whether the entry pins its bytes: an exact
+ * SemVer, a resolved 40-hex commit, the conventional asset name, and the one
+ * artifact format and media type this build accepts.
+ *
+ * @throws SkillFetchError with `BINDING_INVALID`
+ */
+export function assertArtifactBinding(skillId: string, version: SkillCatalogVersion): void {
+  const fail = (field: string): never => {
+    throw new SkillFetchError(SkillFetchErrorCode.BINDING_INVALID, { field });
+  };
+
+  if (!isValidSemVer(version.version)) fail('version');
+  if (!GIT_COMMIT_SHA_PATTERN.test(version.source.commit)) fail('source.commit');
+  if (version.artifact.asset_name !== buildSkillAssetName(skillId, version.version)) {
+    fail('artifact.asset_name');
+  }
+  if (version.artifact.format !== SKILL_ARTIFACT_FORMAT) fail('artifact.format');
+  if (version.artifact.content_type !== SKILL_ARTIFACT_CONTENT_TYPE) fail('artifact.content_type');
+  if (!SHA256_HEX_PATTERN.test(version.artifact.sha256)) fail('artifact.sha256');
+  if (
+    !Number.isSafeInteger(version.artifact.size) ||
+    version.artifact.size <= 0 ||
+    version.artifact.size > SKILL_ARTIFACT_MAX_SIZE
+  ) {
+    fail('artifact.size');
+  }
+}
+
+/** What a transfer claimed to be, checked against what the Catalog promised. */
+export interface ArtifactIntegrityInput {
+  expectedSha256: string;
+  expectedSize: number;
+  actualSha256: string;
+  actualSize: number;
+}
+
+/**
+ * Verify transferred bytes against the Catalog record.
+ *
+ * Size is checked first so a truncated transfer reports the useful reason
+ * rather than the digest mismatch it also causes.
+ *
+ * @throws SkillFetchError with `SIZE_MISMATCH` or `CHECKSUM_MISMATCH`
+ */
+export function verifyArtifactIntegrity(input: ArtifactIntegrityInput): void {
+  if (input.actualSize !== input.expectedSize) {
+    throw new SkillFetchError(SkillFetchErrorCode.SIZE_MISMATCH, {
+      expected: input.expectedSize,
+      actual: input.actualSize,
+    });
+  }
+  if (!digestMatches(input.expectedSha256, input.actualSha256)) {
+    throw new SkillFetchError(SkillFetchErrorCode.CHECKSUM_MISMATCH);
+  }
+}

--- a/src/lib/skills/snapshot-store.ts
+++ b/src/lib/skills/snapshot-store.ts
@@ -1,0 +1,406 @@
+/**
+ * Read-only snapshot store for verified Skill artifacts (Issue #1229)
+ *
+ * A snapshot is verified artifact bytes parked in the service-owned data root
+ * so a later step (#1230 extraction, #1231 install) can read them without
+ * re-downloading. Snapshots are addressed by an opaque ID: absolute paths never
+ * leave this module, because they identify the machine and the data root.
+ *
+ * Lifetime is reference-counted with a TTL backstop. A snapshot with live
+ * references is never swept, no matter how much quota pressure there is —
+ * failing the new download is correct, corrupting an in-progress install is
+ * not. Process restart drops every reference, so initialization treats whatever
+ * is on disk as orphaned and removes it.
+ *
+ * @module lib/skills/snapshot-store
+ */
+
+import { randomBytes } from 'crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import path from 'path';
+import { getConfigDir } from '@/cli/utils/install-context';
+import {
+  SKILL_SNAPSHOT_DIRNAME,
+  SKILL_SNAPSHOT_DIR_MODE,
+  SKILL_SNAPSHOT_FILE_MODE,
+  SKILL_SNAPSHOT_ID_BYTES,
+  SKILL_SNAPSHOT_ID_PATTERN,
+  SKILL_SNAPSHOT_MAX_COUNT,
+  SKILL_SNAPSHOT_TOTAL_QUOTA_BYTES,
+  SKILL_SNAPSHOT_TTL_MS,
+} from '@/config/skill-security-config';
+import { isSystemDirectory } from '@/config/system-directories';
+import { SKILL_ARTIFACT_MAX_SIZE } from '@/lib/skills';
+import {
+  SkillFetchError,
+  SkillFetchErrorCode,
+  computeSha256Hex,
+  digestMatches,
+} from '@/lib/skills/integrity';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Artifact bytes to snapshot, together with the coordinates they are bound to. */
+export interface SkillSnapshotInput {
+  skillId: string;
+  version: string;
+  /** Resolved 40-hex commit the version was published from. */
+  commit: string;
+  /** Lowercase hex SHA-256 the Catalog declared. Re-verified before storing. */
+  sha256: string;
+  bytes: Uint8Array;
+}
+
+/** What a consumer may know about a snapshot. Deliberately carries no path. */
+export interface SkillSnapshotHandle {
+  /** Opaque identifier. Safe to return from an API or write to a log. */
+  snapshotId: string;
+  skillId: string;
+  version: string;
+  commit: string;
+  sha256: string;
+  size: number;
+  /** Epoch milliseconds after which an unreferenced snapshot may be swept. */
+  expiresAt: number;
+}
+
+interface SnapshotRecord extends SkillSnapshotHandle {
+  refCount: number;
+  lastAccessedAt: number;
+  filename: string;
+}
+
+interface SnapshotStoreState {
+  rootDir: string | null;
+  records: Map<string, SnapshotRecord>;
+  totalBytes: number;
+}
+
+// =============================================================================
+// State
+// =============================================================================
+
+declare global {
+  // eslint-disable-next-line no-var -- globalThis cache pattern for hot-reload persistence (version-checker.ts precedent)
+  var __skillSnapshotStore: SnapshotStoreState | undefined;
+}
+
+const state: SnapshotStoreState =
+  globalThis.__skillSnapshotStore ??
+  (globalThis.__skillSnapshotStore = { rootDir: null, records: new Map(), totalBytes: 0 });
+
+const SNAPSHOT_FILE_SUFFIX = '.artifact';
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+function resolveDefaultRoot(): string {
+  return path.join(getConfigDir(), 'data', SKILL_SNAPSHOT_DIRNAME);
+}
+
+/**
+ * Prepare the snapshot root and drop anything left behind by a previous process.
+ *
+ * Repeated calls with the same root are no-ops so a warm store is not wiped by
+ * a second consumer initializing lazily.
+ *
+ * @param options.rootDir Override for tests and for callers that own their data root
+ * @returns The resolved snapshot root
+ * @throws SkillFetchError with `STORE_IO`
+ */
+export function initSkillSnapshotStore(options: { rootDir?: string } = {}): string {
+  const rootDir = path.resolve(options.rootDir ?? resolveDefaultRoot());
+
+  if (isSystemDirectory(rootDir)) {
+    throw new SkillFetchError(SkillFetchErrorCode.STORE_IO, { reason: 'system-directory' });
+  }
+  if (state.rootDir === rootDir) return rootDir;
+
+  try {
+    mkdirSync(rootDir, { recursive: true, mode: SKILL_SNAPSHOT_DIR_MODE });
+    chmodSync(rootDir, SKILL_SNAPSHOT_DIR_MODE);
+  } catch {
+    throw new SkillFetchError(SkillFetchErrorCode.STORE_IO, { reason: 'mkdir' });
+  }
+
+  state.rootDir = rootDir;
+  state.records.clear();
+  state.totalBytes = 0;
+  purgeOrphanFiles();
+  return rootDir;
+}
+
+function requireRoot(): string {
+  if (!state.rootDir) throw new SkillFetchError(SkillFetchErrorCode.STORE_UNINITIALIZED);
+  return state.rootDir;
+}
+
+/** Remove every snapshot file the in-memory index does not account for. */
+function purgeOrphanFiles(): void {
+  const rootDir = requireRoot();
+  const tracked = new Set([...state.records.values()].map((record) => record.filename));
+  let entries: string[];
+  try {
+    entries = readdirSync(rootDir);
+  } catch {
+    throw new SkillFetchError(SkillFetchErrorCode.STORE_IO, { reason: 'readdir' });
+  }
+  for (const entry of entries) {
+    if (tracked.has(entry)) continue;
+    rmSync(path.join(rootDir, entry), { force: true, recursive: true });
+  }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+function filePathOf(record: SnapshotRecord): string {
+  return path.join(requireRoot(), record.filename);
+}
+
+function removeRecord(record: SnapshotRecord): void {
+  rmSync(filePathOf(record), { force: true });
+  state.records.delete(record.snapshotId);
+  state.totalBytes -= record.size;
+}
+
+function requireRecord(snapshotId: string): SnapshotRecord {
+  requireRoot();
+  if (!SKILL_SNAPSHOT_ID_PATTERN.test(snapshotId)) {
+    throw new SkillFetchError(SkillFetchErrorCode.SNAPSHOT_NOT_FOUND);
+  }
+  const record = state.records.get(snapshotId);
+  if (!record) throw new SkillFetchError(SkillFetchErrorCode.SNAPSHOT_NOT_FOUND);
+  if (record.refCount === 0 && Date.now() >= record.expiresAt) {
+    removeRecord(record);
+    throw new SkillFetchError(SkillFetchErrorCode.SNAPSHOT_EXPIRED);
+  }
+  return record;
+}
+
+function toHandle(record: SnapshotRecord): SkillSnapshotHandle {
+  return {
+    snapshotId: record.snapshotId,
+    skillId: record.skillId,
+    version: record.version,
+    commit: record.commit,
+    sha256: record.sha256,
+    size: record.size,
+    expiresAt: record.expiresAt,
+  };
+}
+
+function touch(record: SnapshotRecord, now: number): void {
+  record.lastAccessedAt = now;
+  record.expiresAt = now + SKILL_SNAPSHOT_TTL_MS;
+}
+
+/**
+ * Free space for an incoming snapshot by evicting unreferenced ones.
+ *
+ * Expired entries go first, then least-recently-used. Referenced snapshots are
+ * never candidates, so a full store rejects the newcomer instead.
+ */
+function makeRoomFor(size: number, now: number): void {
+  const fits = (): boolean =>
+    state.totalBytes + size <= SKILL_SNAPSHOT_TOTAL_QUOTA_BYTES &&
+    state.records.size < SKILL_SNAPSHOT_MAX_COUNT;
+
+  if (fits()) return;
+
+  const candidates = [...state.records.values()]
+    .filter((record) => record.refCount === 0)
+    .sort((a, b) => {
+      const aExpired = now >= a.expiresAt ? 0 : 1;
+      const bExpired = now >= b.expiresAt ? 0 : 1;
+      if (aExpired !== bExpired) return aExpired - bExpired;
+      return a.lastAccessedAt - b.lastAccessedAt;
+    });
+
+  for (const candidate of candidates) {
+    if (fits()) return;
+    removeRecord(candidate);
+  }
+
+  if (!fits()) {
+    throw new SkillFetchError(SkillFetchErrorCode.QUOTA_EXCEEDED, {
+      requested: size,
+      limit: SKILL_SNAPSHOT_TOTAL_QUOTA_BYTES,
+    });
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Store verified artifact bytes as a read-only snapshot with one reference held.
+ *
+ * The digest is recomputed here rather than trusted from the downloader: this
+ * is the last point before bytes become readable by another module, and bytes
+ * that do not match the Catalog must never become visible as a snapshot.
+ *
+ * Bytes already snapshotted under the same digest are shared: the existing
+ * snapshot gains a reference and no second copy is written.
+ *
+ * @throws SkillFetchError — `CHECKSUM_MISMATCH`, `QUOTA_EXCEEDED`, `STORE_IO`
+ */
+export function createSkillSnapshot(input: SkillSnapshotInput): SkillSnapshotHandle {
+  const rootDir = requireRoot();
+  const now = Date.now();
+  const size = input.bytes.byteLength;
+
+  if (size <= 0 || size > SKILL_ARTIFACT_MAX_SIZE) {
+    throw new SkillFetchError(SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED, {
+      limit: SKILL_ARTIFACT_MAX_SIZE,
+    });
+  }
+  if (!digestMatches(input.sha256, computeSha256Hex(input.bytes))) {
+    throw new SkillFetchError(SkillFetchErrorCode.CHECKSUM_MISMATCH);
+  }
+
+  for (const record of state.records.values()) {
+    if (record.sha256 === input.sha256 && existsSync(filePathOf(record))) {
+      record.refCount += 1;
+      touch(record, now);
+      return toHandle(record);
+    }
+  }
+
+  makeRoomFor(size, now);
+
+  const snapshotId = randomBytes(SKILL_SNAPSHOT_ID_BYTES).toString('hex');
+  const filename = `${snapshotId}${SNAPSHOT_FILE_SUFFIX}`;
+  const finalPath = path.join(rootDir, filename);
+  const stagingPath = `${finalPath}.tmp`;
+
+  try {
+    writeFileSync(stagingPath, input.bytes, { mode: 0o600 });
+    chmodSync(stagingPath, SKILL_SNAPSHOT_FILE_MODE);
+    renameSync(stagingPath, finalPath);
+  } catch {
+    rmSync(stagingPath, { force: true });
+    throw new SkillFetchError(SkillFetchErrorCode.STORE_IO, { reason: 'write' });
+  }
+
+  const record: SnapshotRecord = {
+    snapshotId,
+    skillId: input.skillId,
+    version: input.version,
+    commit: input.commit,
+    sha256: input.sha256,
+    size,
+    expiresAt: now + SKILL_SNAPSHOT_TTL_MS,
+    refCount: 1,
+    lastAccessedAt: now,
+    filename,
+  };
+  state.records.set(snapshotId, record);
+  state.totalBytes += size;
+  return toHandle(record);
+}
+
+/** Take an additional reference, extending the TTL. */
+export function acquireSkillSnapshot(snapshotId: string): SkillSnapshotHandle {
+  const record = requireRecord(snapshotId);
+  record.refCount += 1;
+  touch(record, Date.now());
+  return toHandle(record);
+}
+
+/**
+ * Drop one reference.
+ *
+ * The bytes stay until the TTL elapses or quota pressure evicts them, so a
+ * retry right after a failed install does not have to re-download. Releasing an
+ * unknown ID is a no-op: cleanup paths must be safe to run twice.
+ */
+export function releaseSkillSnapshot(snapshotId: string): void {
+  const record = state.records.get(snapshotId);
+  if (!record) return;
+  if (record.refCount > 0) record.refCount -= 1;
+  if (record.refCount === 0) record.lastAccessedAt = Date.now();
+}
+
+/** Read a snapshot's metadata without taking a reference. */
+export function getSkillSnapshot(snapshotId: string): SkillSnapshotHandle {
+  return toHandle(requireRecord(snapshotId));
+}
+
+/** Read the snapshot bytes. */
+export function readSkillSnapshotBytes(snapshotId: string): Uint8Array {
+  const record = requireRecord(snapshotId);
+  try {
+    const bytes = readFileSync(filePathOf(record));
+    record.lastAccessedAt = Date.now();
+    return bytes;
+  } catch {
+    throw new SkillFetchError(SkillFetchErrorCode.STORE_IO, { reason: 'read' });
+  }
+}
+
+/**
+ * Absolute path of a snapshot file.
+ *
+ * For modules that must hand a path to a streaming reader (#1230 extraction).
+ * The result identifies the machine's data root and must never reach an API
+ * response, a log line or an error message.
+ *
+ * @internal
+ */
+export function resolveSkillSnapshotPath(snapshotId: string): string {
+  return filePathOf(requireRecord(snapshotId));
+}
+
+/**
+ * Remove expired, unreferenced snapshots and any untracked file in the root.
+ *
+ * @returns Number of snapshots removed
+ */
+export function sweepSkillSnapshots(): number {
+  requireRoot();
+  const now = Date.now();
+  let removed = 0;
+  for (const record of [...state.records.values()]) {
+    if (record.refCount === 0 && now >= record.expiresAt) {
+      removeRecord(record);
+      removed += 1;
+    }
+  }
+  purgeOrphanFiles();
+  return removed;
+}
+
+/** Current disk usage in bytes, for quota assertions and diagnostics. */
+export function getSkillSnapshotUsage(): { totalBytes: number; count: number } {
+  return { totalBytes: state.totalBytes, count: state.records.size };
+}
+
+/**
+ * Drop every snapshot and forget the root.
+ * @internal
+ */
+export function resetSkillSnapshotStoreForTesting(): void {
+  if (state.rootDir && existsSync(state.rootDir)) {
+    for (const record of [...state.records.values()]) {
+      rmSync(path.join(state.rootDir, record.filename), { force: true });
+    }
+  }
+  state.rootDir = null;
+  state.records.clear();
+  state.totalBytes = 0;
+}

--- a/tests/unit/lib/skills/artifact-downloader.test.ts
+++ b/tests/unit/lib/skills/artifact-downloader.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for src/lib/skills/artifact-downloader.ts
+ * Issue #1229: allowlisted, redirect-guarded, size- and digest-verified fetching
+ *
+ * The official Skills repository is private and has no published assets, so
+ * every test drives a mocked fetch. Nothing here touches the network.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SKILL_FETCH_MAX_REDIRECTS, SKILL_SOURCE_POLICIES } from '@/config/skill-security-config';
+import {
+  assertAllowedSkillUrl,
+  downloadSkillArtifact,
+  fetchSkillSource,
+  resetSkillDownloadsForTesting,
+  stripCredentialHeaders,
+} from '@/lib/skills/artifact-downloader';
+import { SkillFetchError, SkillFetchErrorCode } from '@/lib/skills/integrity';
+import {
+  ARTIFACT_BYTES,
+  ARTIFACT_SHA256,
+  ARTIFACT_URL,
+  CDN_URL,
+  SKILL_ID,
+  artifactResponse,
+  bodyStream,
+  makeCatalogVersion,
+  redirectResponse,
+} from './fixtures';
+
+const fetchMock = vi.fn();
+
+/** Assert a rejection is a SkillFetchError with the expected code. */
+async function expectFetchError(promise: Promise<unknown>, code: string): Promise<SkillFetchError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillFetchError);
+    expect((error as SkillFetchError).code).toBe(code);
+    return error as SkillFetchError;
+  }
+  throw new Error(`expected rejection with ${code}`);
+}
+
+/** Assert a synchronous throw is a SkillFetchError with the expected code. */
+function expectSyncFetchError(run: () => unknown, code: string): void {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillFetchError);
+    expect((error as SkillFetchError).code).toBe(code);
+    return;
+  }
+  throw new Error(`expected throw with ${code}`);
+}
+
+function headersOfCall(index: number): Record<string, string> {
+  return (fetchMock.mock.calls[index][1] as RequestInit).headers as Record<string, string>;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  resetSkillDownloadsForTesting();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetSkillDownloadsForTesting();
+});
+
+describe('assertAllowedSkillUrl', () => {
+  const artifactRules = SKILL_SOURCE_POLICIES.artifact.entryHosts;
+
+  it('accepts an official release download URL', () => {
+    expect(assertAllowedSkillUrl(ARTIFACT_URL, artifactRules).hostname).toBe('github.com');
+  });
+
+  it.each([
+    ['http scheme', 'http://github.com/Kewton/commandmate-skills/releases/download/a/b.tar.gz'],
+    ['file scheme', 'file:///etc/passwd'],
+    ['embedded credentials', 'https://tok:en@github.com/Kewton/commandmate-skills/releases/download/a/b.tar.gz'],
+    ['explicit port', 'https://github.com:8443/Kewton/commandmate-skills/releases/download/a/b.tar.gz'],
+    ['not a url', 'Kewton/commandmate-skills'],
+  ])('rejects %s as an invalid URL', (_label, url) => {
+    expectSyncFetchError(
+      () => assertAllowedSkillUrl(url, artifactRules),
+      SkillFetchErrorCode.URL_INVALID
+    );
+  });
+
+  it.each([
+    ['a foreign host', 'https://evil.example.com/Kewton/commandmate-skills/releases/download/a/b.tar.gz'],
+    ['a lookalike host', 'https://github.com.evil.example/Kewton/commandmate-skills/releases/download/a.tar.gz'],
+    ['an internal address', 'https://169.254.169.254/latest/meta-data'],
+    ['another repository on an allowed host', 'https://github.com/attacker/skills/releases/download/a/b.tar.gz'],
+    ['a non-release path on an allowed host', 'https://github.com/Kewton/commandmate-skills/archive/main.tar.gz'],
+    ['traversal that normalizes out of the release path', 'https://github.com/Kewton/commandmate-skills/releases/download/../../x.tar.gz'],
+    ['percent-encoded traversal', 'https://github.com/Kewton/commandmate-skills/releases/download/%2e%2e/%2e%2e/x.tar.gz'],
+  ])('rejects %s as a disallowed source', (_label, url) => {
+    expectSyncFetchError(
+      () => assertAllowedSkillUrl(url, artifactRules),
+      SkillFetchErrorCode.SOURCE_NOT_ALLOWED
+    );
+  });
+
+  it('does not accept the CDN host as an entry point', () => {
+    expectSyncFetchError(
+      () => assertAllowedSkillUrl(CDN_URL, artifactRules),
+      SkillFetchErrorCode.SOURCE_NOT_ALLOWED
+    );
+    expect(() =>
+      assertAllowedSkillUrl(CDN_URL, SKILL_SOURCE_POLICIES.artifact.redirectHosts)
+    ).not.toThrow();
+  });
+
+  it('does not accept an artifact URL under the catalog policy', () => {
+    expectSyncFetchError(
+      () => assertAllowedSkillUrl(ARTIFACT_URL, SKILL_SOURCE_POLICIES.catalog.entryHosts),
+      SkillFetchErrorCode.SOURCE_NOT_ALLOWED
+    );
+  });
+});
+
+describe('stripCredentialHeaders', () => {
+  it('removes credential headers regardless of case and keeps the rest', () => {
+    expect(
+      stripCredentialHeaders({
+        Authorization: 'Bearer token',
+        cookie: 'session=1',
+        'proxy-authorization': 'Basic x',
+        accept: 'application/gzip',
+      })
+    ).toEqual({ accept: 'application/gzip' });
+  });
+});
+
+describe('downloadSkillArtifact', () => {
+  it('returns verified bytes bound to the catalog coordinates', async () => {
+    fetchMock.mockResolvedValueOnce(artifactResponse());
+
+    const result = await downloadSkillArtifact(SKILL_ID, makeCatalogVersion());
+
+    expect(Buffer.from(result.bytes).equals(ARTIFACT_BYTES)).toBe(true);
+    expect(result.sha256).toBe(ARTIFACT_SHA256);
+    expect(result.size).toBe(ARTIFACT_BYTES.byteLength);
+    expect(result.skillId).toBe(SKILL_ID);
+    expect(result.version).toBe('1.2.3');
+    expect(result.commit).toBe(makeCatalogVersion().source.commit);
+  });
+
+  it('never sends a credential header and disables redirect following', async () => {
+    fetchMock.mockResolvedValueOnce(artifactResponse());
+    await downloadSkillArtifact(SKILL_ID, makeCatalogVersion());
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.redirect).toBe('manual');
+    expect(Object.keys(headersOfCall(0)).sort()).toEqual(['accept', 'user-agent']);
+  });
+
+  it('refuses a catalog entry whose artifact URL is off the allowlist without any request', async () => {
+    const version = makeCatalogVersion();
+    version.artifact.url = 'https://evil.example.com/demo-skill-1.2.3.tar.gz';
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, version),
+      SkillFetchErrorCode.SOURCE_NOT_ALLOWED
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses an entry that is not bound to a resolved commit without any request', async () => {
+    const version = makeCatalogVersion({
+      source: { repository: 'Kewton/commandmate-skills', ref: 'main', commit: 'abc1234' },
+    });
+
+    const error = await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, version),
+      SkillFetchErrorCode.BINDING_INVALID
+    );
+    expect(error.retryable).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('follows a redirect to the release CDN and re-validates the hop', async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirectResponse(CDN_URL))
+      .mockResolvedValueOnce(artifactResponse());
+
+    const result = await downloadSkillArtifact(SKILL_ID, makeCatalogVersion());
+
+    expect(result.sha256).toBe(ARTIFACT_SHA256);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe(CDN_URL);
+    expect(headersOfCall(1)).not.toHaveProperty('authorization');
+    expect(headersOfCall(1)).not.toHaveProperty('cookie');
+  });
+
+  it('rejects a redirect that leaves the allowlist', async () => {
+    fetchMock.mockResolvedValueOnce(redirectResponse('https://evil.example.com/payload.tar.gz'));
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.SOURCE_NOT_ALLOWED
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a redirect without a Location header', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 302 }));
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.REDIRECT_INVALID
+    );
+  });
+
+  it('stops at the redirect limit instead of looping', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(redirectResponse(CDN_URL)));
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.REDIRECT_LIMIT_EXCEEDED
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(SKILL_FETCH_MAX_REDIRECTS + 1);
+  });
+
+  it('rejects a non-success status as retryable', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404 }));
+
+    const error = await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.HTTP_STATUS
+    );
+    expect(error.retryable).toBe(true);
+    expect(error.detail).toEqual({ status: 404 });
+  });
+
+  it('rejects an HTML error page served with a 200', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(bodyStream(Buffer.from('<html></html>')), {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    );
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.CONTENT_TYPE_INVALID
+    );
+  });
+
+  it('rejects a Content-Length that disagrees with the catalog before reading the body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      artifactResponse(ARTIFACT_BYTES, { 'content-length': String(ARTIFACT_BYTES.byteLength + 1) })
+    );
+
+    const error = await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.SIZE_MISMATCH
+    );
+    expect(error.detail).toMatchObject({ expected: ARTIFACT_BYTES.byteLength });
+  });
+
+  it('rejects a body whose digest does not match the catalog', async () => {
+    fetchMock.mockResolvedValueOnce(
+      artifactResponse(Buffer.from('tampered payload bytes tampered!!'), {
+        'content-length': String(ARTIFACT_BYTES.byteLength),
+      })
+    );
+
+    const error = await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.CHECKSUM_MISMATCH
+    );
+    expect(error.retryable).toBe(false);
+  });
+
+  it('rejects a body that is shorter than the catalog declared', async () => {
+    fetchMock.mockResolvedValueOnce(
+      artifactResponse(ARTIFACT_BYTES.subarray(0, 10), { 'content-length': '' })
+    );
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.SIZE_MISMATCH
+    );
+  });
+
+  it('shares one transfer between concurrent callers', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(artifactResponse()));
+
+    const [first, second] = await Promise.all([
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first.sha256).toBe(second.sha256);
+  });
+
+  it('lets a later caller start a fresh transfer once the shared one settled', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(artifactResponse()));
+
+    await downloadSkillArtifact(SKILL_ID, makeCatalogVersion());
+    await downloadSkillArtifact(SKILL_ID, makeCatalogVersion());
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('detaches an aborting caller without cancelling the shared transfer', async () => {
+    let release: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        })
+    );
+
+    const controller = new AbortController();
+    const aborted = downloadSkillArtifact(SKILL_ID, makeCatalogVersion(), {
+      signal: controller.signal,
+    });
+    const survivor = downloadSkillArtifact(SKILL_ID, makeCatalogVersion());
+
+    controller.abort();
+    await expectFetchError(aborted, SkillFetchErrorCode.ABORTED);
+
+    release?.(artifactResponse());
+    await expect(survivor).resolves.toMatchObject({ sha256: ARTIFACT_SHA256 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects immediately when the caller signal is already aborted', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(artifactResponse()));
+
+    await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion(), {
+        signal: AbortSignal.abort(),
+      }),
+      SkillFetchErrorCode.ABORTED
+    );
+  });
+
+  it('reports a transport failure as retryable', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const error = await expectFetchError(
+      downloadSkillArtifact(SKILL_ID, makeCatalogVersion()),
+      SkillFetchErrorCode.NETWORK
+    );
+    expect(error.retryable).toBe(true);
+  });
+});
+
+describe('fetchSkillSource', () => {
+  const CATALOG_URL = `https://raw.githubusercontent.com/Kewton/commandmate-skills/${'a'.repeat(40)}/catalog.json`;
+
+  it('accepts the text/plain media type raw.githubusercontent.com serves JSON with', async () => {
+    const body = Buffer.from('{"schema_version":1,"entries":[]}');
+    fetchMock.mockResolvedValueOnce(
+      new Response(bodyStream(body), {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      })
+    );
+
+    const payload = await fetchSkillSource(CATALOG_URL, 'catalog');
+    expect(Buffer.from(payload.bytes).toString()).toBe(body.toString());
+  });
+
+  it('aborts a body that grows past the policy limit instead of buffering it', async () => {
+    const chunk = new Uint8Array(1024 * 1024);
+    let pulled = 0;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pulled += 1;
+            controller.enqueue(chunk);
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const error = await expectFetchError(
+      fetchSkillSource(CATALOG_URL, 'catalog'),
+      SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED
+    );
+    expect(error.detail).toEqual({ limit: SKILL_SOURCE_POLICIES.catalog.maxBytes });
+    expect(pulled).toBeLessThanOrEqual(SKILL_SOURCE_POLICIES.catalog.maxBytes / chunk.byteLength + 2);
+  });
+
+  it('rejects a declared Content-Length beyond the policy limit before reading', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(bodyStream(Buffer.from('{}')), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': String(SKILL_SOURCE_POLICIES.catalog.maxBytes + 1),
+        },
+      })
+    );
+
+    await expectFetchError(
+      fetchSkillSource(CATALOG_URL, 'catalog'),
+      SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED
+    );
+  });
+
+  it('does not follow a catalog redirect onto the artifact CDN', async () => {
+    fetchMock.mockResolvedValueOnce(redirectResponse(CDN_URL));
+
+    await expectFetchError(
+      fetchSkillSource(CATALOG_URL, 'catalog'),
+      SkillFetchErrorCode.SOURCE_NOT_ALLOWED
+    );
+  });
+});

--- a/tests/unit/lib/skills/fixtures.ts
+++ b/tests/unit/lib/skills/fixtures.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared fixtures for the Skill fetch/snapshot tests (Issue #1229)
+ */
+
+import { createHash } from 'crypto';
+import type { SkillCatalogVersion } from '@/types/skills';
+
+export const SKILL_ID = 'demo-skill';
+export const COMMIT = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+
+export const ARTIFACT_BYTES = Buffer.from('demo-skill artifact payload bytes');
+export const ARTIFACT_SHA256 = createHash('sha256').update(ARTIFACT_BYTES).digest('hex');
+
+export const ARTIFACT_URL =
+  'https://github.com/Kewton/commandmate-skills/releases/download/demo-skill-v1.2.3/demo-skill-1.2.3.tar.gz';
+
+export const CDN_URL =
+  'https://objects.githubusercontent.com/github-production-release-asset/1/2?X-Amz-Signature=deadbeef';
+
+/** A well-formed catalog version bound to {@link ARTIFACT_BYTES}. */
+export function makeCatalogVersion(
+  overrides: Partial<SkillCatalogVersion> = {}
+): SkillCatalogVersion {
+  return {
+    version: '1.2.3',
+    changelog: 'Initial release.',
+    published_at: '2026-07-01T00:00:00Z',
+    source: {
+      repository: 'Kewton/commandmate-skills',
+      ref: 'demo-skill-v1.2.3',
+      commit: COMMIT,
+    },
+    artifact: {
+      asset_name: 'demo-skill-1.2.3.tar.gz',
+      url: ARTIFACT_URL,
+      sha256: ARTIFACT_SHA256,
+      size: ARTIFACT_BYTES.byteLength,
+      content_type: 'application/gzip',
+      format: 'tar.gz',
+    },
+    compatibility: { commandmate: '>=0.11.0', agents: [] },
+    declared_risk: 'low',
+    ...overrides,
+  };
+}
+
+/** A response body that yields `bytes` in small chunks, like a real transfer. */
+export function bodyStream(bytes: Uint8Array, chunkSize = 8): ReadableStream<Uint8Array> {
+  let offset = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= bytes.byteLength) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.subarray(offset, offset + chunkSize));
+      offset += chunkSize;
+    },
+  });
+}
+
+/** A 200 response carrying `bytes`. */
+export function artifactResponse(
+  bytes: Uint8Array = ARTIFACT_BYTES,
+  headerOverrides: Record<string, string> = {}
+): Response {
+  const headers: Record<string, string> = {
+    'content-type': 'application/gzip',
+    'content-length': String(bytes.byteLength),
+    ...headerOverrides,
+  };
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === '') delete headers[name];
+  }
+  return new Response(bodyStream(bytes), { status: 200, headers });
+}
+
+/** A redirect response pointing at `location`. */
+export function redirectResponse(location: string, status = 302): Response {
+  return new Response(null, { status, headers: { location } });
+}

--- a/tests/unit/lib/skills/integrity.test.ts
+++ b/tests/unit/lib/skills/integrity.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for src/lib/skills/integrity.ts
+ * Issue #1229: artifact integrity verification and failure vocabulary
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SkillFetchError,
+  SkillFetchErrorCode,
+  assertArtifactBinding,
+  computeSha256Hex,
+  createSha256Accumulator,
+  digestMatches,
+  isSkillFetchError,
+  redactUrlForLog,
+  verifyArtifactIntegrity,
+} from '@/lib/skills/integrity';
+import { ARTIFACT_BYTES, ARTIFACT_SHA256, CDN_URL, SKILL_ID, makeCatalogVersion } from './fixtures';
+
+describe('SkillFetchError', () => {
+  it('builds its message from the code alone', () => {
+    const error = new SkillFetchError(SkillFetchErrorCode.CHECKSUM_MISMATCH);
+    expect(error.message).not.toContain('http');
+    expect(error.message).not.toContain('/');
+    expect(error.detail).toBeUndefined();
+  });
+
+  it('marks transport failures retryable and trust failures not', () => {
+    expect(new SkillFetchError(SkillFetchErrorCode.TIMEOUT).retryable).toBe(true);
+    expect(new SkillFetchError(SkillFetchErrorCode.NETWORK).retryable).toBe(true);
+    expect(new SkillFetchError(SkillFetchErrorCode.CHECKSUM_MISMATCH).retryable).toBe(false);
+    expect(new SkillFetchError(SkillFetchErrorCode.SOURCE_NOT_ALLOWED).retryable).toBe(false);
+  });
+
+  it('is narrowable from an unknown catch binding', () => {
+    expect(isSkillFetchError(new SkillFetchError(SkillFetchErrorCode.NETWORK))).toBe(true);
+    expect(isSkillFetchError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('redactUrlForLog', () => {
+  it('drops the signed query and path of a CDN URL', () => {
+    const redacted = redactUrlForLog(CDN_URL);
+    expect(redacted).toBe('https://objects.githubusercontent.com');
+    expect(redacted).not.toContain('X-Amz-Signature');
+  });
+
+  it('drops embedded credentials', () => {
+    expect(redactUrlForLog('https://user:secret@github.com/a/b')).toBe('https://github.com');
+  });
+
+  it('does not echo an unparsable value back', () => {
+    expect(redactUrlForLog('not a url')).toBe('<invalid-url>');
+  });
+});
+
+describe('digests', () => {
+  it('hashes a buffer and a stream to the same value', () => {
+    const accumulator = createSha256Accumulator();
+    accumulator.update(ARTIFACT_BYTES.subarray(0, 5));
+    accumulator.update(ARTIFACT_BYTES.subarray(5));
+    expect(accumulator.hex()).toBe(ARTIFACT_SHA256);
+    expect(computeSha256Hex(ARTIFACT_BYTES)).toBe(ARTIFACT_SHA256);
+  });
+
+  it('matches identical digests', () => {
+    expect(digestMatches(ARTIFACT_SHA256, ARTIFACT_SHA256)).toBe(true);
+  });
+
+  it('rejects a differing digest', () => {
+    expect(digestMatches(ARTIFACT_SHA256, 'b'.repeat(64))).toBe(false);
+  });
+
+  it('treats an uppercase or malformed digest as a mismatch rather than throwing', () => {
+    expect(digestMatches(ARTIFACT_SHA256, ARTIFACT_SHA256.toUpperCase())).toBe(false);
+    expect(digestMatches(ARTIFACT_SHA256, 'short')).toBe(false);
+    expect(digestMatches('', '')).toBe(false);
+  });
+});
+
+describe('assertArtifactBinding', () => {
+  it('accepts a version pinned to an exact SemVer and a resolved commit', () => {
+    expect(() => assertArtifactBinding(SKILL_ID, makeCatalogVersion())).not.toThrow();
+  });
+
+  const cases: Array<[string, ReturnType<typeof makeCatalogVersion>]> = [
+    ['version', makeCatalogVersion({ version: '1.2' })],
+    [
+      'source.commit',
+      makeCatalogVersion({
+        source: { repository: 'Kewton/commandmate-skills', ref: 'main', commit: 'a1b2c3d' },
+      }),
+    ],
+    [
+      'artifact.asset_name',
+      makeCatalogVersion({
+        artifact: { ...makeCatalogVersion().artifact, asset_name: 'other-1.2.3.tar.gz' },
+      }),
+    ],
+    [
+      'artifact.content_type',
+      makeCatalogVersion({
+        artifact: { ...makeCatalogVersion().artifact, content_type: 'application/zip' },
+      }),
+    ],
+    [
+      'artifact.sha256',
+      makeCatalogVersion({
+        artifact: { ...makeCatalogVersion().artifact, sha256: 'A'.repeat(64) },
+      }),
+    ],
+    [
+      'artifact.size',
+      makeCatalogVersion({ artifact: { ...makeCatalogVersion().artifact, size: 0 } }),
+    ],
+    [
+      'artifact.size',
+      makeCatalogVersion({
+        artifact: { ...makeCatalogVersion().artifact, size: 64 * 1024 * 1024 },
+      }),
+    ],
+  ];
+
+  it.each(cases)('rejects an unbound %s', (field, version) => {
+    try {
+      assertArtifactBinding(SKILL_ID, version);
+      throw new Error('expected assertArtifactBinding to throw');
+    } catch (error) {
+      expect(isSkillFetchError(error)).toBe(true);
+      const fetchError = error as SkillFetchError;
+      expect(fetchError.code).toBe(SkillFetchErrorCode.BINDING_INVALID);
+      expect(fetchError.detail).toEqual({ field });
+    }
+  });
+});
+
+describe('verifyArtifactIntegrity', () => {
+  const base = {
+    expectedSha256: ARTIFACT_SHA256,
+    expectedSize: ARTIFACT_BYTES.byteLength,
+    actualSha256: ARTIFACT_SHA256,
+    actualSize: ARTIFACT_BYTES.byteLength,
+  };
+
+  it('accepts matching size and digest', () => {
+    expect(() => verifyArtifactIntegrity(base)).not.toThrow();
+  });
+
+  it('reports a truncated transfer as a size mismatch, not a checksum mismatch', () => {
+    try {
+      verifyArtifactIntegrity({ ...base, actualSize: 4, actualSha256: 'c'.repeat(64) });
+      throw new Error('expected verifyArtifactIntegrity to throw');
+    } catch (error) {
+      expect((error as SkillFetchError).code).toBe(SkillFetchErrorCode.SIZE_MISMATCH);
+    }
+  });
+
+  it('rejects same-length bytes with a different digest', () => {
+    try {
+      verifyArtifactIntegrity({ ...base, actualSha256: 'c'.repeat(64) });
+      throw new Error('expected verifyArtifactIntegrity to throw');
+    } catch (error) {
+      expect((error as SkillFetchError).code).toBe(SkillFetchErrorCode.CHECKSUM_MISMATCH);
+    }
+  });
+});

--- a/tests/unit/lib/skills/skill-security-config.test.ts
+++ b/tests/unit/lib/skills/skill-security-config.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for src/config/skill-security-config.ts
+ * Issue #1229: official source allowlist and snapshot limits
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SKILL_CREDENTIAL_HEADERS,
+  SKILL_FETCH_MAX_REDIRECTS,
+  SKILL_OFFICIAL_REPOSITORY,
+  SKILL_SNAPSHOT_DIR_MODE,
+  SKILL_SNAPSHOT_FILE_MODE,
+  SKILL_SOURCE_POLICIES,
+  buildSkillCatalogUrl,
+} from '@/config/skill-security-config';
+import { SKILL_ARTIFACT_CONTENT_TYPE, SKILL_ARTIFACT_MAX_SIZE } from '@/lib/skills';
+
+const COMMIT = 'a'.repeat(40);
+
+describe('buildSkillCatalogUrl', () => {
+  it('pins the catalog to the official repository at an immutable commit', () => {
+    expect(buildSkillCatalogUrl(COMMIT)).toBe(
+      `https://raw.githubusercontent.com/${SKILL_OFFICIAL_REPOSITORY}/${COMMIT}/catalog.json`
+    );
+  });
+
+  it('rejects a branch name', () => {
+    expect(() => buildSkillCatalogUrl('main')).toThrow(/40-hex commit/);
+  });
+
+  it('rejects an abbreviated commit', () => {
+    expect(() => buildSkillCatalogUrl('a'.repeat(7))).toThrow(/40-hex commit/);
+  });
+
+  it('rejects an uppercase commit so digests compare byte-wise', () => {
+    expect(() => buildSkillCatalogUrl('A'.repeat(40))).toThrow(/40-hex commit/);
+  });
+});
+
+describe('SKILL_SOURCE_POLICIES', () => {
+  it('keeps catalog and artifact origins disjoint', () => {
+    const catalogHosts = SKILL_SOURCE_POLICIES.catalog.redirectHosts.map((rule) => rule.host);
+    const artifactHosts = SKILL_SOURCE_POLICIES.artifact.redirectHosts.map((rule) => rule.host);
+    expect(catalogHosts.some((host) => artifactHosts.includes(host))).toBe(false);
+  });
+
+  it('narrows every entry host to the official repository path', () => {
+    for (const policy of Object.values(SKILL_SOURCE_POLICIES)) {
+      for (const rule of policy.entryHosts) {
+        expect(rule.pathPrefix).toContain(SKILL_OFFICIAL_REPOSITORY);
+      }
+    }
+  });
+
+  it('allows redirect-only CDN hosts without a path prefix, guarded by the digest', () => {
+    const cdnHosts = SKILL_SOURCE_POLICIES.artifact.redirectHosts.filter(
+      (rule) => rule.pathPrefix === undefined
+    );
+    expect(cdnHosts.length).toBeGreaterThan(0);
+    expect(cdnHosts.every((rule) => rule.host.endsWith('.githubusercontent.com'))).toBe(true);
+  });
+
+  it('caps the artifact body at the contract limit and accepts only its media type', () => {
+    expect(SKILL_SOURCE_POLICIES.artifact.maxBytes).toBe(SKILL_ARTIFACT_MAX_SIZE);
+    expect(SKILL_SOURCE_POLICIES.artifact.contentTypes).toContain(SKILL_ARTIFACT_CONTENT_TYPE);
+    expect(SKILL_SOURCE_POLICIES.artifact.contentTypes).not.toContain('text/html');
+  });
+
+  it('does not accept the artifact media type for catalog responses', () => {
+    expect(SKILL_SOURCE_POLICIES.catalog.contentTypes).not.toContain(SKILL_ARTIFACT_CONTENT_TYPE);
+  });
+});
+
+describe('transport and storage limits', () => {
+  it('bounds redirects', () => {
+    expect(SKILL_FETCH_MAX_REDIRECTS).toBeGreaterThan(0);
+    expect(SKILL_FETCH_MAX_REDIRECTS).toBeLessThanOrEqual(10);
+  });
+
+  it('lists the credential headers that must not cross an origin', () => {
+    expect(SKILL_CREDENTIAL_HEADERS).toContain('authorization');
+    expect(SKILL_CREDENTIAL_HEADERS).toContain('cookie');
+    expect(SKILL_CREDENTIAL_HEADERS.every((name) => name === name.toLowerCase())).toBe(true);
+  });
+
+  it('keeps the snapshot root service-owned and its files read-only', () => {
+    expect(SKILL_SNAPSHOT_DIR_MODE).toBe(0o700);
+    expect(SKILL_SNAPSHOT_FILE_MODE & 0o222).toBe(0);
+  });
+});

--- a/tests/unit/lib/skills/snapshot-store.test.ts
+++ b/tests/unit/lib/skills/snapshot-store.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for src/lib/skills/snapshot-store.ts
+ * Issue #1229: read-only snapshots with TTL, reference counting and quota
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash, randomBytes } from 'crypto';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs';
+import path from 'path';
+import {
+  SKILL_SNAPSHOT_ID_PATTERN,
+  SKILL_SNAPSHOT_MAX_COUNT,
+  SKILL_SNAPSHOT_TTL_MS,
+} from '@/config/skill-security-config';
+import { SkillFetchError, SkillFetchErrorCode } from '@/lib/skills/integrity';
+import {
+  acquireSkillSnapshot,
+  createSkillSnapshot,
+  getSkillSnapshot,
+  getSkillSnapshotUsage,
+  initSkillSnapshotStore,
+  readSkillSnapshotBytes,
+  releaseSkillSnapshot,
+  resetSkillSnapshotStoreForTesting,
+  resolveSkillSnapshotPath,
+  sweepSkillSnapshots,
+} from '@/lib/skills/snapshot-store';
+import { ARTIFACT_BYTES, ARTIFACT_SHA256, COMMIT, SKILL_ID } from './fixtures';
+
+/**
+ * The store refuses system directories, and os.tmpdir() resolves under /var on
+ * macOS, so test roots live in the repo-local (gitignored) temp directory.
+ */
+const TEST_ROOT_PARENT = path.join(process.cwd(), 'temp');
+
+let rootDir: string;
+
+function snapshotInput(bytes: Uint8Array = ARTIFACT_BYTES) {
+  return {
+    skillId: SKILL_ID,
+    version: '1.2.3',
+    commit: COMMIT,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    bytes,
+  };
+}
+
+function expectFetchError(run: () => unknown, code: string): SkillFetchError {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillFetchError);
+    expect((error as SkillFetchError).code).toBe(code);
+    return error as SkillFetchError;
+  }
+  throw new Error(`expected throw with ${code}`);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-20T00:00:00Z'));
+  mkdirSync(TEST_ROOT_PARENT, { recursive: true });
+  rootDir = mkdtempSync(path.join(TEST_ROOT_PARENT, 'skill-snapshots-'));
+  initSkillSnapshotStore({ rootDir });
+});
+
+afterEach(() => {
+  resetSkillSnapshotStoreForTesting();
+  rmSync(rootDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+describe('initSkillSnapshotStore', () => {
+  it('creates a service-owned root that is not group or world readable', () => {
+    expect(existsSync(rootDir)).toBe(true);
+    expect(statSync(rootDir).mode & 0o077).toBe(0);
+  });
+
+  it('removes files left behind by a previous process', () => {
+    resetSkillSnapshotStoreForTesting();
+    writeFileSync(path.join(rootDir, 'orphan.artifact'), 'left over');
+
+    initSkillSnapshotStore({ rootDir });
+
+    expect(readdirSync(rootDir)).toEqual([]);
+  });
+
+  it('does not wipe live snapshots when initialized again with the same root', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+
+    initSkillSnapshotStore({ rootDir });
+
+    expect(getSkillSnapshot(handle.snapshotId).sha256).toBe(ARTIFACT_SHA256);
+  });
+
+  it('refuses a system directory as the data root', () => {
+    resetSkillSnapshotStoreForTesting();
+    expectFetchError(
+      () => initSkillSnapshotStore({ rootDir: '/etc/cm-skill-snapshots' }),
+      SkillFetchErrorCode.STORE_IO
+    );
+  });
+
+  it('refuses use before initialization', () => {
+    resetSkillSnapshotStoreForTesting();
+    expectFetchError(
+      () => createSkillSnapshot(snapshotInput()),
+      SkillFetchErrorCode.STORE_UNINITIALIZED
+    );
+  });
+});
+
+describe('createSkillSnapshot', () => {
+  it('stores verified bytes behind an opaque id and exposes no path', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+
+    expect(handle.snapshotId).toMatch(SKILL_SNAPSHOT_ID_PATTERN);
+    expect(handle).not.toHaveProperty('path');
+    expect(JSON.stringify(handle)).not.toContain(rootDir);
+    expect(handle.sha256).toBe(ARTIFACT_SHA256);
+    expect(handle.size).toBe(ARTIFACT_BYTES.byteLength);
+    expect(handle.commit).toBe(COMMIT);
+  });
+
+  it('writes the snapshot file read-only', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+
+    const mode = statSync(resolveSkillSnapshotPath(handle.snapshotId)).mode & 0o777;
+    expect(mode & 0o222).toBe(0);
+    expect(mode & 0o077).toBe(0);
+  });
+
+  it('returns the stored bytes verbatim', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+
+    expect(Buffer.from(readSkillSnapshotBytes(handle.snapshotId)).equals(ARTIFACT_BYTES)).toBe(true);
+  });
+
+  it('never publishes bytes whose digest does not match the declared one', () => {
+    expectFetchError(
+      () => createSkillSnapshot({ ...snapshotInput(), sha256: 'b'.repeat(64) }),
+      SkillFetchErrorCode.CHECKSUM_MISMATCH
+    );
+
+    expect(readdirSync(rootDir)).toEqual([]);
+    expect(getSkillSnapshotUsage()).toEqual({ totalBytes: 0, count: 0 });
+  });
+
+  it('rejects empty bytes', () => {
+    expectFetchError(
+      () => createSkillSnapshot(snapshotInput(Buffer.alloc(0))),
+      SkillFetchErrorCode.SIZE_LIMIT_EXCEEDED
+    );
+  });
+
+  it('shares one copy between identical artifacts', () => {
+    const first = createSkillSnapshot(snapshotInput());
+    const second = createSkillSnapshot(snapshotInput());
+
+    expect(second.snapshotId).toBe(first.snapshotId);
+    expect(readdirSync(rootDir)).toHaveLength(1);
+    expect(getSkillSnapshotUsage().count).toBe(1);
+  });
+});
+
+describe('reference counting and TTL', () => {
+  it('keeps a referenced snapshot past its TTL', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS * 2);
+
+    expect(sweepSkillSnapshots()).toBe(0);
+    expect(getSkillSnapshot(handle.snapshotId).snapshotId).toBe(handle.snapshotId);
+  });
+
+  it('sweeps a released snapshot once the TTL elapsed', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+    releaseSkillSnapshot(handle.snapshotId);
+
+    expect(sweepSkillSnapshots()).toBe(0);
+
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS + 1);
+
+    expect(sweepSkillSnapshots()).toBe(1);
+    expect(readdirSync(rootDir)).toEqual([]);
+    expect(getSkillSnapshotUsage()).toEqual({ totalBytes: 0, count: 0 });
+  });
+
+  it('requires every reference to be released before sweeping', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+    acquireSkillSnapshot(handle.snapshotId);
+    releaseSkillSnapshot(handle.snapshotId);
+
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS + 1);
+    expect(sweepSkillSnapshots()).toBe(0);
+
+    releaseSkillSnapshot(handle.snapshotId);
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS + 1);
+    expect(sweepSkillSnapshots()).toBe(1);
+  });
+
+  it('extends the TTL on acquire', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+    releaseSkillSnapshot(handle.snapshotId);
+
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS - 1);
+    const reacquired = acquireSkillSnapshot(handle.snapshotId);
+    expect(reacquired.expiresAt).toBe(Date.now() + SKILL_SNAPSHOT_TTL_MS);
+
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS + 1);
+    releaseSkillSnapshot(handle.snapshotId);
+    expect(sweepSkillSnapshots()).toBe(1);
+  });
+
+  it('reports an expired snapshot as expired and drops it', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+    releaseSkillSnapshot(handle.snapshotId);
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS + 1);
+
+    expectFetchError(
+      () => getSkillSnapshot(handle.snapshotId),
+      SkillFetchErrorCode.SNAPSHOT_EXPIRED
+    );
+    expectFetchError(
+      () => getSkillSnapshot(handle.snapshotId),
+      SkillFetchErrorCode.SNAPSHOT_NOT_FOUND
+    );
+  });
+
+  it('treats an unknown or malformed id as not found', () => {
+    expectFetchError(
+      () => getSkillSnapshot(randomBytes(16).toString('hex')),
+      SkillFetchErrorCode.SNAPSHOT_NOT_FOUND
+    );
+    expectFetchError(
+      () => getSkillSnapshot('../../etc/passwd'),
+      SkillFetchErrorCode.SNAPSHOT_NOT_FOUND
+    );
+  });
+
+  it('tolerates releasing an unknown id so cleanup paths are safe to repeat', () => {
+    expect(() => releaseSkillSnapshot('deadbeef')).not.toThrow();
+  });
+});
+
+describe('quota', () => {
+  function fillStore(count: number, release: boolean): string[] {
+    const ids: string[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const handle = createSkillSnapshot(snapshotInput(randomBytes(32)));
+      ids.push(handle.snapshotId);
+      if (release) releaseSkillSnapshot(handle.snapshotId);
+      vi.advanceTimersByTime(1);
+    }
+    return ids;
+  }
+
+  it('evicts the least recently used unreferenced snapshot at the count limit', () => {
+    const ids = fillStore(SKILL_SNAPSHOT_MAX_COUNT, true);
+    expect(getSkillSnapshotUsage().count).toBe(SKILL_SNAPSHOT_MAX_COUNT);
+
+    createSkillSnapshot(snapshotInput(randomBytes(32)));
+
+    expect(getSkillSnapshotUsage().count).toBeLessThanOrEqual(SKILL_SNAPSHOT_MAX_COUNT);
+    expectFetchError(() => getSkillSnapshot(ids[0]), SkillFetchErrorCode.SNAPSHOT_NOT_FOUND);
+    expect(getSkillSnapshot(ids[ids.length - 1]).snapshotId).toBe(ids[ids.length - 1]);
+  });
+
+  it('refuses a new snapshot rather than evicting one that is in use', () => {
+    const ids = fillStore(SKILL_SNAPSHOT_MAX_COUNT, false);
+
+    expectFetchError(
+      () => createSkillSnapshot(snapshotInput(randomBytes(32))),
+      SkillFetchErrorCode.QUOTA_EXCEEDED
+    );
+
+    for (const id of ids) {
+      expect(getSkillSnapshot(id).snapshotId).toBe(id);
+    }
+  });
+});
+
+describe('resolveSkillSnapshotPath', () => {
+  it('stays inside the snapshot root', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+    const filePath = resolveSkillSnapshotPath(handle.snapshotId);
+
+    expect(path.dirname(filePath)).toBe(rootDir);
+    expect(path.basename(filePath).startsWith(handle.snapshotId)).toBe(true);
+  });
+
+  it('refuses to resolve a released and expired snapshot', () => {
+    const handle = createSkillSnapshot(snapshotInput());
+    releaseSkillSnapshot(handle.snapshotId);
+    vi.advanceTimersByTime(SKILL_SNAPSHOT_TTL_MS + 1);
+
+    expectFetchError(
+      () => resolveSkillSnapshotPath(handle.snapshotId),
+      SkillFetchErrorCode.SNAPSHOT_EXPIRED
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1229（Epic #1227 Phase 1 Wave 2）。公式 allowlist の Catalog/artifact のみを stream 取得し、immutable SHA・checksum・容量を検証した read-only snapshot として期限・参照数・quota つきで管理する。

**archive 展開・entry 解析は行わない**（#1230 の責務）。

## 追加モジュール

- **`src/config/skill-security-config.ts`** — 公式 host/owner/repository/release asset path、許可 CDN host、redirect 上限、timeout、snapshot TTL/quota/mode を hardcoded 定数として定義。`version-checker.ts` の `GITHUB_API_URL` と同じく env/config/client 由来の値を一切受け付けない。Catalog policy と artifact policy を分離し、両者の host 集合を素集合に保つ
- **`src/lib/skills/integrity.ts`** — `SkillFetchError`（stable code + retryable + 安全な detail）、streaming SHA-256、timing-safe digest 比較、Catalog version の immutable binding 検証、URL redaction
- **`src/lib/skills/artifact-downloader.ts`** — `redirect: 'manual'` で各 hop の scheme/host/path を再検証し、origin 変更時に credential header を除去。Content-Type / Content-Length / 実測 size を検証し、上限超過は転送途中で abort。同一 artifact の並行取得は in-flight 共有し、caller abort は自分だけを切り離す
- **`src/lib/skills/snapshot-store.ts`** — 0700 の service-owned data root 配下に 0400 の read-only snapshot を保存。opaque ID でアクセスし、TTL・reference count・per-artifact/total quota・LRU eviction を実装。使用中 snapshot は決して evict/sweep しない。process restart 時は参照が全て失われるため init 時に残存 file を orphan として除去

## Issue 記載前提に対する訂正・判断

Issue 本文は書き換えていない。

1. **URL path traversal 検証を独立 check として実装しなかった。** WHATWG URL は `..` および `%2e%2e` を pathname 生成時に dot-segment として解決・除去するため、`releases/download/../../x` は正規化後に path prefix 検証で `SOURCE_NOT_ALLOWED` として弾かれる。独立 check は到達不能な dead code になるため、prefix 検証がなぜ十分かをコメントで明示（両形式が実際に拒否されることをテストで確認済み）
2. **YAML parser の選定は本 Issue では不要だった。** Catalog は JSON であり、`SKILL_YAML_SAFE_PROFILE` を必要とするのは manifest を読む側（#1230）。#1228 が残した parser 未決事項はそちらに残る
3. `src/lib/skills/index.ts` は変更していない。#1231/#1234 と同時に触ると衝突するため。consumer は当面 `@/lib/skills/artifact-downloader` 等を直接 import する。**マージ後に barrel へ re-export を一括追加することを推奨**
4. #1228 の Schema に追加が必要な型は現時点でなし。本 Issue の型（`SkillHostRule` / `SkillSourcePolicy` / `SkillFetchError` / `SkillSnapshotHandle`）はいずれも transport・storage 層の関心であり配布契約 document の型ではないため `src/types/skills.ts` に移していない
5. error は `SkillContractError`（#1228）とは別型にした。前者は document 検証 failure を JSON Pointer で指すもの、後者は transfer/storage failure で、UI が判断すべきは「再試行可能か」であるため `retryable` を持たせた
6. **snapshot root に `os.tmpdir()` は使えない。** 既存の `isSystemDirectory()` が `/tmp`・`/var` を system directory として拒否し、macOS の `os.tmpdir()` は `/var/folders` 配下に解決されるため。「service-owned data root に限定する」という共通前提と整合するので guard は維持し、テストは repo 直下の gitignore 済み `temp/` に root を作る
7. 新規 runtime 依存は追加していない（#1228 の方針を維持）。digest は `node:crypto`、HTTP は global fetch のみ
8. `Kewton/commandmate-skills` は private かつ骨組みのみのため実ネットワークテストは書いていない（全て fetch を mock）。受入条件の「公式 GitHub release の実 redirect chain」確認は **repository 公開後の手動確認項目として残る**
9. snapshot path の realpath/symlink 検証は実装していない（#1228 の責務境界どおり）。`resolveSkillSnapshotPath()` は `@internal` とし、API 応答・log・error に絶対 path が出ないことをテストで固定

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run test:unit` | worker 側 exit 0 / 606 files / 10454 tests（本 Issue 分 148） |
| `npm run build` | worker 側 exit 0 |

digest 比較と host allowlist を**意図的に破壊した mutation run で 13 件が失敗する**ことを確認し、テストがガードとして実効していることを検証済み。

Refs #1229, #1227