### PR TITLE
feat(ui): Skill Catalog一覧・検索・詳細画面 (#1232)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -23,7 +23,8 @@
     "repositoriesShort": "Repos",
     "review": "Review",
     "reviewReport": "Review/Report",
-    "more": "More"
+    "more": "More",
+    "skills": "Skills"
   },
   "repositories": {
     "empty": "No repositories registered yet.",

--- a/locales/en/skills.json
+++ b/locales/en/skills.json
@@ -1,0 +1,147 @@
+{
+  "page": {
+    "title": "Skills",
+    "description": "Browse the official Skill Catalog. Each entry shows what a Skill is, who publishes it, which CommandMate versions it needs, and what its publisher declares about risk.",
+    "backToCatalog": "Back to the Catalog"
+  },
+  "search": {
+    "label": "Search Skills",
+    "placeholder": "Name, summary, keyword or provider",
+    "resultCount": "Showing {shown} of {total} Skills"
+  },
+  "filters": {
+    "compatibility": "CommandMate compatibility",
+    "risk": "Publisher-declared risk",
+    "agent": "Agent support",
+    "all": "All",
+    "reset": "Reset filters"
+  },
+  "compatibility": {
+    "label": "CommandMate compatibility",
+    "native": "Runs natively",
+    "commandmateRuntime": "Runs via CommandMate Runtime",
+    "unsupported": "Not supported",
+    "unknown": "Not verified",
+    "status": {
+      "compatible": "Compatible",
+      "incompatible": "Incompatible",
+      "unknown": "Unverified"
+    },
+    "requiredRange": "Requires CommandMate {range}",
+    "currentVersion": "Running CommandMate {version}",
+    "currentVersionUnknown": "The running CommandMate version could not be determined.",
+    "unverifiedNotice": "Unverified is not the same as compatible. CommandMate could not decide, so this Skill may fail to run.",
+    "agentsHeading": "Agent support",
+    "agentsNotice": "Agent support is a claim made by the publisher, shown with the evidence they supplied. CommandMate does not verify it.",
+    "agentsUnknown": "No Agent support is declared for this version.",
+    "evidence": "Evidence",
+    "reason": {
+      "satisfied": "CommandMate {currentVersion} satisfies the required range {range}.",
+      "hostVersionOutOfRange": "This Skill requires CommandMate {range}, but CommandMate {currentVersion} is running.",
+      "hostVersionUnknown": "The running CommandMate version could not be determined, so compatibility with {range} is unverified.",
+      "rangeUnsupported": "This Skill declares the version range {range}, which CommandMate cannot interpret, so compatibility is unverified."
+    }
+  },
+  "risk": {
+    "declaredLabel": "Declared risk: {level}",
+    "declaredHeading": "Publisher-declared risk",
+    "level": {
+      "low": "Low",
+      "moderate": "Moderate",
+      "high": "High"
+    },
+    "declaredNotice": "This level is declared by the publisher of the Skill. It is a claim, not a CommandMate assessment.",
+    "computedHeading": "CommandMate-computed risk",
+    "computedUnavailable": "Not available from the Catalog. CommandMate computes its own risk level by inspecting the package contents, which only happens once the package has been downloaded.",
+    "highWarning": "The publisher declares this Skill as high risk. Read the changelog and the source coordinates before installing it."
+  },
+  "permissions": {
+    "heading": "Declared permissions",
+    "declarationOnlyNotice": "Permissions are declarations written by the publisher, not restrictions CommandMate enforces. Installing a Skill does not sandbox what it can do.",
+    "unavailable": "The Catalog does not carry declared permissions. They live in the Skill manifest inside the package, which CommandMate only reads after downloading it."
+  },
+  "capabilities": {
+    "heading": "What this Skill does",
+    "unavailable": "Detailed capabilities and expected outcomes live in the Skill manifest inside the package and are not part of the Catalog. The summary below is what the Catalog publishes."
+  },
+  "requirements": {
+    "heading": "Required commands and network access",
+    "unavailable": "The Catalog does not carry runtime requirements. Required commands and network hosts live in the Skill manifest inside the package."
+  },
+  "contents": {
+    "heading": "Files and scripts",
+    "unavailable": "The Catalog does not list package contents. Files, scripts and executables are enumerated when CommandMate downloads and inspects the package."
+  },
+  "detail": {
+    "overview": "Overview",
+    "provider": "Provider",
+    "providerContact": "Contact",
+    "license": "License",
+    "homepage": "Homepage",
+    "keywords": "Keywords",
+    "skillId": "Skill ID",
+    "latestVersion": "Latest published version",
+    "recommendedVersion": "Recommended version",
+    "recommendedVersionNone": "None",
+    "requiredRangeLabel": "Required CommandMate range",
+    "publishedAt": "Published",
+    "sourceRepository": "Repository",
+    "sourceRef": "Ref",
+    "sourceCommit": "Commit",
+    "packageAsset": "Asset name",
+    "packageDigest": "SHA-256",
+    "packageSize": "Size",
+    "packageBytes": "{bytes} bytes",
+    "versionsHeading": "Version history",
+    "versionsEmpty": "This Skill lists no published versions that apply to this CommandMate.",
+    "changelogHeading": "Changelog",
+    "changelogEmpty": "This version publishes no changelog.",
+    "mediaStripped": "Images and embedded media are removed from Catalog text, so nothing is loaded from an external host.",
+    "prerelease": "Prerelease",
+    "recommendation": {
+      "highestCompatible": "This is the newest published version that works with the CommandMate you are running.",
+      "latestUnverified": "The running CommandMate version could not be determined, so the publisher's latest version is offered without a compatibility check.",
+      "noneCompatible": "No published version of this Skill works with the CommandMate you are running.",
+      "noVersions": "No published version of this Skill applies to this CommandMate."
+    },
+    "install": {
+      "action": "Choose an install target",
+      "unavailableYet": "Choosing an install target is not available yet. This screen covers browsing the Catalog only.",
+      "blockedIncompatible": "Install is unavailable: {reason}",
+      "blockedNoVersion": "Install is unavailable because no published version applies to the CommandMate you are running."
+    }
+  },
+  "card": {
+    "provider": "by {provider}",
+    "noRecommendedVersion": "No installable version"
+  },
+  "state": {
+    "loading": "Loading the Skill Catalog…",
+    "empty": "The official Catalog publishes no Skills yet.",
+    "noResults": "No Skill matches the current search and filters.",
+    "noResultsHint": "Try a different keyword or reset the filters.",
+    "errorHeading": "The Skill Catalog could not be loaded",
+    "errorNotice": "This is a retrieval failure, not an empty Catalog. No conclusion can be drawn about which Skills exist.",
+    "errorCode": "Error code: {code}",
+    "retry": "Retry",
+    "notFoundHeading": "Skill not found",
+    "notFoundNotice": "The official Catalog has no Skill with this ID."
+  },
+  "catalog": {
+    "staleHeading": "Showing a cached Catalog",
+    "staleNotice": "CommandMate could not confirm this Catalog is current, so what you see may be out of date.",
+    "offlineNotice": "The Catalog origin could not be reached on the last attempt.",
+    "freshLabel": "Catalog confirmed current",
+    "fetchedAt": "Last validated: {timestamp}",
+    "revalidatedAt": "Last confirmed current: {timestamp}",
+    "sourceLabel": "Source: {repository} at {ref}",
+    "reason": {
+      "fetchFailed": "The Catalog could not be retrieved.",
+      "rateLimited": "The Catalog origin is rate limiting requests.",
+      "oversized": "The Catalog response exceeded the allowed size.",
+      "malformed": "The Catalog response was not valid JSON.",
+      "invalidSchema": "The Catalog response failed contract validation.",
+      "unknown": "The reason was not reported."
+    }
+  }
+}

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -23,7 +23,8 @@
     "repositoriesShort": "リポジトリ",
     "review": "レビュー",
     "reviewReport": "レビュー/レポート",
-    "more": "その他"
+    "more": "その他",
+    "skills": "スキル"
   },
   "repositories": {
     "empty": "リポジトリが登録されていません。",

--- a/locales/ja/skills.json
+++ b/locales/ja/skills.json
@@ -1,0 +1,147 @@
+{
+  "page": {
+    "title": "スキル",
+    "description": "公式Skill Catalogを閲覧します。各Skillの内容、提供元、必要なCommandMateのversion、提供元が宣言するriskを確認できます。",
+    "backToCatalog": "Catalogに戻る"
+  },
+  "search": {
+    "label": "Skillを検索",
+    "placeholder": "名前・概要・キーワード・提供元",
+    "resultCount": "{total}件中{shown}件を表示"
+  },
+  "filters": {
+    "compatibility": "CommandMate互換性",
+    "risk": "提供元が宣言したrisk",
+    "agent": "Agent対応",
+    "all": "すべて",
+    "reset": "絞り込みを解除"
+  },
+  "compatibility": {
+    "label": "CommandMate互換性",
+    "native": "Agent単体で実行可能",
+    "commandmateRuntime": "CommandMate Runtime経由で実行",
+    "unsupported": "非対応",
+    "unknown": "未検証",
+    "status": {
+      "compatible": "互換あり",
+      "incompatible": "互換なし",
+      "unknown": "未検証"
+    },
+    "requiredRange": "必要なCommandMate: {range}",
+    "currentVersion": "稼働中のCommandMate: {version}",
+    "currentVersionUnknown": "稼働中のCommandMateのversionを特定できませんでした。",
+    "unverifiedNotice": "「未検証」は「互換あり」ではありません。CommandMateが判定できなかった状態であり、動作しない可能性があります。",
+    "agentsHeading": "Agent対応状況",
+    "agentsNotice": "Agent対応状況は提供元による申告であり、根拠として提示された内容をそのまま表示しています。CommandMateは検証していません。",
+    "agentsUnknown": "このversionにはAgent対応の宣言がありません。",
+    "evidence": "根拠",
+    "reason": {
+      "satisfied": "CommandMate {currentVersion} は要求範囲 {range} を満たしています。",
+      "hostVersionOutOfRange": "このSkillはCommandMate {range} を要求しますが、稼働中のversionは {currentVersion} です。",
+      "hostVersionUnknown": "稼働中のCommandMateのversionを特定できないため、{range} との互換性は未検証です。",
+      "rangeUnsupported": "このSkillはCommandMateが解釈できないversion範囲 {range} を宣言しているため、互換性は未検証です。"
+    }
+  },
+  "risk": {
+    "declaredLabel": "宣言risk: {level}",
+    "declaredHeading": "提供元が宣言したrisk",
+    "level": {
+      "low": "低",
+      "moderate": "中",
+      "high": "高"
+    },
+    "declaredNotice": "このrisk水準はSkillの提供元による自己申告です。CommandMateによる評価ではありません。",
+    "computedHeading": "CommandMateが算出するrisk",
+    "computedUnavailable": "Catalogからは取得できません。CommandMateはpackageの内容を検査してriskを算出しますが、それはpackageをダウンロードした後に行われます。",
+    "highWarning": "提供元はこのSkillをhigh riskと宣言しています。導入前に更新履歴と提供元の情報を確認してください。"
+  },
+  "permissions": {
+    "heading": "宣言された権限",
+    "declarationOnlyNotice": "権限は提供元が記載した宣言であり、CommandMateが強制する制限ではありません。Skillを導入してもsandboxで隔離されるわけではありません。",
+    "unavailable": "Catalogは宣言された権限を保持していません。権限はpackage内のSkill manifestに記載されており、CommandMateはダウンロード後に読み取ります。"
+  },
+  "capabilities": {
+    "heading": "このSkillでできること",
+    "unavailable": "詳細な能力と期待効果はpackage内のSkill manifestに記載されており、Catalogには含まれていません。以下はCatalogが公開している概要です。"
+  },
+  "requirements": {
+    "heading": "必要なコマンドとネットワークアクセス",
+    "unavailable": "Catalogは実行時の要件を保持していません。必要なコマンドや接続先hostはpackage内のSkill manifestに記載されています。"
+  },
+  "contents": {
+    "heading": "ファイルとスクリプト",
+    "unavailable": "Catalogはpackageの中身を列挙していません。ファイル・スクリプト・実行可能ファイルは、CommandMateがpackageをダウンロードして検査した時点で列挙されます。"
+  },
+  "detail": {
+    "overview": "概要",
+    "provider": "提供元",
+    "providerContact": "連絡先",
+    "license": "ライセンス",
+    "homepage": "ホームページ",
+    "keywords": "キーワード",
+    "skillId": "Skill ID",
+    "latestVersion": "公開されている最新version",
+    "recommendedVersion": "推奨version",
+    "recommendedVersionNone": "なし",
+    "requiredRangeLabel": "必要なCommandMateのversion範囲",
+    "publishedAt": "公開日時",
+    "sourceRepository": "リポジトリ",
+    "sourceRef": "Ref",
+    "sourceCommit": "コミット",
+    "packageAsset": "アセット名",
+    "packageDigest": "SHA-256",
+    "packageSize": "サイズ",
+    "packageBytes": "{bytes} バイト",
+    "versionsHeading": "更新履歴",
+    "versionsEmpty": "このCommandMateに適用できる公開versionがありません。",
+    "changelogHeading": "変更内容",
+    "changelogEmpty": "このversionには変更内容の記載がありません。",
+    "mediaStripped": "Catalog由来のテキストから画像と埋め込みメディアを除去しているため、外部ホストからの読み込みは発生しません。",
+    "prerelease": "プレリリース",
+    "recommendation": {
+      "highestCompatible": "稼働中のCommandMateで動作する、最も新しい公開versionです。",
+      "latestUnverified": "稼働中のCommandMateのversionを特定できなかったため、互換性を確認せずに提供元の最新versionを表示しています。",
+      "noneCompatible": "稼働中のCommandMateで動作する公開versionはありません。",
+      "noVersions": "このCommandMateに適用できる公開versionがありません。"
+    },
+    "install": {
+      "action": "導入先を選択",
+      "unavailableYet": "導入先の選択はまだ利用できません。この画面はCatalogの閲覧のみを扱います。",
+      "blockedIncompatible": "導入できません: {reason}",
+      "blockedNoVersion": "稼働中のCommandMateに適用できる公開versionがないため導入できません。"
+    }
+  },
+  "card": {
+    "provider": "提供元: {provider}",
+    "noRecommendedVersion": "導入可能なversionなし"
+  },
+  "state": {
+    "loading": "Skill Catalogを読み込んでいます…",
+    "empty": "公式Catalogにはまだ公開されているSkillがありません。",
+    "noResults": "現在の検索条件と絞り込みに一致するSkillはありません。",
+    "noResultsHint": "キーワードを変えるか、絞り込みを解除してください。",
+    "errorHeading": "Skill Catalogを読み込めませんでした",
+    "errorNotice": "これは取得に失敗した状態であり、Catalogが空であることを意味しません。どのSkillが存在するかは判断できません。",
+    "errorCode": "エラーコード: {code}",
+    "retry": "再試行",
+    "notFoundHeading": "Skillが見つかりません",
+    "notFoundNotice": "このIDに一致するSkillは公式Catalogに存在しません。"
+  },
+  "catalog": {
+    "staleHeading": "キャッシュされたCatalogを表示しています",
+    "staleNotice": "このCatalogが最新であることを確認できなかったため、内容が古い可能性があります。",
+    "offlineNotice": "直近の試行ではCatalogの取得元に到達できませんでした。",
+    "freshLabel": "Catalogは最新であることを確認済み",
+    "fetchedAt": "最終検証: {timestamp}",
+    "revalidatedAt": "最新であることを最後に確認: {timestamp}",
+    "sourceLabel": "取得元: {repository} ({ref})",
+    "reason": {
+      "fetchFailed": "Catalogを取得できませんでした。",
+      "rateLimited": "Catalogの取得元がレート制限を適用しています。",
+      "oversized": "Catalogの応答が許容サイズを超えました。",
+      "malformed": "Catalogの応答が正しいJSONではありませんでした。",
+      "invalidSchema": "Catalogの応答が契約検証に失敗しました。",
+      "unknown": "理由は報告されていません。"
+    }
+  }
+}

--- a/src/app/more/page.tsx
+++ b/src/app/more/page.tsx
@@ -17,6 +17,8 @@ import { NotificationsSettings } from '@/components/notifications';
 
 export default function MorePage() {
   const tNotifications = useTranslations('notifications');
+  const tCommon = useTranslations('common');
+  const tSkills = useTranslations('skills');
   return (
     <AppShell>
       <div className="container-custom py-8 overflow-auto h-full">
@@ -39,6 +41,12 @@ export default function MorePage() {
               <Card hover className="transition-colors hover:border-accent-300 dark:hover:border-accent-700">
                 <div className="text-sm font-medium text-foreground">Repositories</div>
                 <div className="text-xs text-muted-foreground">Manage repositories and worktrees</div>
+              </Card>
+            </Link>
+            <Link href="/skills" className="block" data-testid="more-link-skills">
+              <Card hover className="transition-colors hover:border-accent-300 dark:hover:border-accent-700">
+                <div className="text-sm font-medium text-foreground">{tCommon('nav.skills')}</div>
+                <div className="text-xs text-muted-foreground">{tSkills('page.description')}</div>
               </Card>
             </Link>
           </div>

--- a/src/app/skills/[skillId]/page.tsx
+++ b/src/app/skills/[skillId]/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * Skill Detail Page (/skills/[skillId])
+ *
+ * Issue #1232: one Catalog entry, presented as an installable capability.
+ */
+
+'use client';
+
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/layout';
+import { SkillDetailView } from '@/components/skills/SkillDetailView';
+
+export default function SkillDetailPage() {
+  const params = useParams();
+  const skillId = typeof params.skillId === 'string' ? params.skillId : '';
+
+  return (
+    <AppShell>
+      <div className="container-custom py-8 overflow-auto h-full">
+        <SkillDetailView skillId={skillId} />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * Skills Page (/skills)
+ *
+ * Issue #1232: browse the official Skill Catalog.
+ */
+
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { AppShell } from '@/components/layout';
+// Imported concretely rather than through a barrel: a barrel would pull the
+// detail view's markdown renderer (react-markdown / highlight.js) into the list
+// route, which never renders markdown.
+import { SkillCatalogView } from '@/components/skills/SkillCatalogView';
+
+export default function SkillsPage() {
+  const t = useTranslations('skills');
+
+  return (
+    <AppShell>
+      <div className="container-custom py-8 overflow-auto h-full">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-foreground mb-2">{t('page.title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('page.description')}</p>
+        </div>
+        <SkillCatalogView />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -36,6 +36,7 @@ import {
   AlignJustify,
   FolderGit2,
   CircleCheck,
+  Sparkles,
   MoreHorizontal,
   GitBranch,
   Sun,
@@ -67,6 +68,7 @@ const NAV_ITEMS = [
   { key: 'sessions', href: '/sessions' },
   { key: 'repositories', href: '/repositories' },
   { key: 'review', href: '/review' },
+  { key: 'skills', href: '/skills' },
   { key: 'more', href: '/more' },
 ] as const;
 
@@ -77,6 +79,7 @@ const NAV_ICONS: Record<string, LucideIcon> = {
   sessions: AlignJustify,
   repositories: FolderGit2,
   review: CircleCheck,
+  skills: Sparkles,
   more: MoreHorizontal,
 };
 

--- a/src/components/skills/CatalogStatusBanner.tsx
+++ b/src/components/skills/CatalogStatusBanner.tsx
@@ -1,0 +1,65 @@
+/**
+ * CatalogStatusBanner (Issue #1232)
+ *
+ * Freshness of the served Catalog. A stale or offline snapshot is announced
+ * with its reason and both timestamps instead of being presented as the current
+ * state of the world (UX-07).
+ *
+ * Timestamps render as the RFC 3339 strings the API returns rather than a
+ * locale-formatted date, so what is shown is exactly what was served.
+ *
+ * @module components/skills/CatalogStatusBanner
+ */
+
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { SkillNotice } from './SkillNotice';
+import { catalogReasonLabelKey } from './skill-vocabulary';
+import type { SkillCatalogMetaDto } from './types';
+
+export interface CatalogStatusBannerProps {
+  catalog: SkillCatalogMetaDto;
+}
+
+export function CatalogStatusBanner({ catalog }: CatalogStatusBannerProps) {
+  const t = useTranslations('skills');
+  const degraded = catalog.stale || catalog.offline;
+
+  if (!degraded) {
+    return (
+      <p data-testid="skill-catalog-fresh" className="text-xs text-muted-foreground break-words">
+        {t('catalog.freshLabel')} ·{' '}
+        {t('catalog.revalidatedAt', { timestamp: catalog.revalidatedAt })} ·{' '}
+        {t('catalog.sourceLabel', {
+          repository: catalog.source.repository,
+          ref: catalog.source.ref,
+        })}
+      </p>
+    );
+  }
+
+  return (
+    <SkillNotice tone="warning" data-testid="skill-catalog-stale" className="flex-col sm:flex-row">
+      <div className="space-y-1">
+        <p className="font-medium">{t('catalog.staleHeading')}</p>
+        <p>{t('catalog.staleNotice')}</p>
+        {catalog.offline && <p>{t('catalog.offlineNotice')}</p>}
+        <p>{t(catalogReasonLabelKey(catalog.staleReason))}</p>
+        <p className="break-words">
+          {t('catalog.fetchedAt', { timestamp: catalog.fetchedAt })} ·{' '}
+          {t('catalog.revalidatedAt', { timestamp: catalog.revalidatedAt })}
+        </p>
+        <p className="break-words">
+          {t('catalog.sourceLabel', {
+            repository: catalog.source.repository,
+            ref: catalog.source.ref,
+          })}
+        </p>
+      </div>
+    </SkillNotice>
+  );
+}
+
+export default CatalogStatusBanner;

--- a/src/components/skills/SkillBadges.tsx
+++ b/src/components/skills/SkillBadges.tsx
@@ -1,0 +1,87 @@
+/**
+ * Badges for the Skill Catalog vocabulary (Issue #1232)
+ *
+ * Every badge carries a text label and, where it signals a hazard, an icon —
+ * colour alone never distinguishes "compatible" from "unverified" or "low" from
+ * "high" risk (受入条件: high riskが視覚・アクセシビリティ上識別できる).
+ *
+ * @module components/skills/SkillBadges
+ */
+
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { ShieldAlert } from 'lucide-react';
+import { Badge } from '@/components/ui';
+import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
+import type { SkillCompatibilityStatus } from '@/lib/skills/compatibility';
+import type { SkillRiskLevel } from '@/types/skills';
+import {
+  AGENT_SUPPORT_BADGE_VARIANT,
+  COMPATIBILITY_BADGE_VARIANT,
+  COMPATIBILITY_LABEL_KEY,
+  RISK_BADGE_VARIANT,
+  RISK_LABEL_KEY,
+  resolveSkillMessageKey,
+} from './skill-vocabulary';
+import type { SkillVersionDto } from './types';
+
+export interface SkillCompatibilityBadgeProps {
+  status: SkillCompatibilityStatus;
+  className?: string;
+}
+
+/** CommandMate compatibility verdict. `unknown` is styled as a warning, never success. */
+export function SkillCompatibilityBadge({ status, className }: SkillCompatibilityBadgeProps) {
+  const t = useTranslations('skills');
+  return (
+    <Badge
+      variant={COMPATIBILITY_BADGE_VARIANT[status]}
+      className={className}
+      data-testid={`skill-compatibility-${status}`}
+    >
+      {t(COMPATIBILITY_LABEL_KEY[status])}
+    </Badge>
+  );
+}
+
+export interface SkillRiskBadgeProps {
+  risk: SkillRiskLevel;
+  className?: string;
+}
+
+/**
+ * Publisher-declared risk. The label always names it as declared so it is never
+ * mistaken for the risk CommandMate computes from the package contents.
+ */
+export function SkillRiskBadge({ risk, className }: SkillRiskBadgeProps) {
+  const t = useTranslations('skills');
+  return (
+    <Badge
+      variant={RISK_BADGE_VARIANT[risk]}
+      className={className}
+      data-testid={`skill-declared-risk-${risk}`}
+    >
+      {risk === 'high' && <ShieldAlert size={12} aria-hidden="true" className="mr-1 shrink-0" />}
+      {t('risk.declaredLabel', { level: t(RISK_LABEL_KEY[risk]) })}
+    </Badge>
+  );
+}
+
+export interface AgentSupportBadgeProps {
+  agent: SkillVersionDto['compatibility']['agents'][number];
+}
+
+/** One Agent support claim, using the label key the contract publishes (UX-05). */
+export function AgentSupportBadge({ agent }: AgentSupportBadgeProps) {
+  const t = useTranslations('skills');
+  return (
+    <Badge
+      variant={AGENT_SUPPORT_BADGE_VARIANT[agent.support]}
+      data-testid={`skill-agent-${agent.agent}-${agent.support}`}
+    >
+      {getCliToolDisplayNameSafe(agent.agent)}: {t(resolveSkillMessageKey(agent.labelKey))}
+    </Badge>
+  );
+}

--- a/src/components/skills/SkillCard.tsx
+++ b/src/components/skills/SkillCard.tsx
@@ -1,0 +1,71 @@
+/**
+ * SkillCard (Issue #1232)
+ *
+ * One Catalog entry in the list. Presents a Skill as an installable capability:
+ * what it is, who publishes it, whether it runs on the CommandMate in front of
+ * the user, and what risk its publisher declares — never as a file bundle.
+ *
+ * Everything is rendered unconditionally; no badge or warning appears only on
+ * hover, which would be permanently invisible on a touch device.
+ *
+ * @module components/skills/SkillCard
+ */
+
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { Badge, Card } from '@/components/ui';
+import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
+import { SkillCompatibilityBadge, SkillRiskBadge } from './SkillBadges';
+import { headlineDeclaredRisk, supportedAgents } from './skill-vocabulary';
+import type { SkillDto } from './types';
+
+export interface SkillCardProps {
+  skill: SkillDto;
+}
+
+export function SkillCard({ skill }: SkillCardProps) {
+  const t = useTranslations('skills');
+  const declaredRisk = headlineDeclaredRisk(skill);
+  const agents = supportedAgents(skill);
+
+  return (
+    <Link
+      href={`/skills/${encodeURIComponent(skill.id)}`}
+      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg"
+      data-testid={`skill-card-${skill.id}`}
+    >
+      <Card variant="interactive" className="h-full">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="truncate text-base font-semibold text-foreground">{skill.name}</h3>
+              <p className="truncate text-xs text-muted-foreground">
+                {t('card.provider', { provider: skill.provider.name })}
+              </p>
+            </div>
+            <span className="shrink-0 text-xs font-medium text-muted-foreground">
+              {skill.recommendedVersion ?? t('card.noRecommendedVersion')}
+            </span>
+          </div>
+
+          <p className="text-sm text-muted-foreground line-clamp-3">{skill.summary}</p>
+
+          <div className="flex flex-wrap items-center gap-1.5">
+            {skill.compatibility && <SkillCompatibilityBadge status={skill.compatibility.status} />}
+            {declaredRisk && <SkillRiskBadge risk={declaredRisk} />}
+            {agents.map((agent) => (
+              <Badge key={agent} variant="gray">
+                {getCliToolDisplayNameSafe(agent)}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+export default SkillCard;

--- a/src/components/skills/SkillCatalogView.tsx
+++ b/src/components/skills/SkillCatalogView.tsx
@@ -1,0 +1,229 @@
+/**
+ * SkillCatalogView (Issue #1232)
+ *
+ * The /skills list: search, filter and browse the official Catalog through the
+ * #1231 API. Loading, empty, no-match, stale and error are four distinct
+ * renderings — in particular a retrieval failure never degrades into an empty
+ * list, because "no Skills exist" and "the Catalog is unreachable" would lead a
+ * user to opposite conclusions.
+ *
+ * @module components/skills/SkillCatalogView
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button, Card, Input, Skeleton } from '@/components/ui';
+import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
+import { CatalogStatusBanner } from './CatalogStatusBanner';
+import { SkillCard } from './SkillCard';
+import { SkillNotice } from './SkillNotice';
+import { fetchSkillList, type SkillFetchFailure } from './skills-client';
+import {
+  COMPATIBILITY_LABEL_KEY,
+  EMPTY_SKILL_FILTERS,
+  RISK_LABEL_KEY,
+  collectAgentOptions,
+  filterSkills,
+  type SkillFilterState,
+} from './skill-vocabulary';
+import type { SkillCatalogMetaDto, SkillDto } from './types';
+
+const SELECT_CLASS =
+  'w-full rounded-md border border-input bg-surface px-3 py-2 text-sm text-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+const COMPATIBILITY_OPTIONS = ['compatible', 'incompatible', 'unknown'] as const;
+const RISK_OPTIONS = ['low', 'moderate', 'high'] as const;
+
+interface LoadState {
+  status: 'loading' | 'loaded' | 'error';
+  catalog: SkillCatalogMetaDto | null;
+  skills: SkillDto[];
+  failure: SkillFetchFailure | null;
+}
+
+const INITIAL_STATE: LoadState = {
+  status: 'loading',
+  catalog: null,
+  skills: [],
+  failure: null,
+};
+
+export function SkillCatalogView() {
+  const t = useTranslations('skills');
+  const [state, setState] = useState<LoadState>(INITIAL_STATE);
+  const [filters, setFilters] = useState<SkillFilterState>(EMPTY_SKILL_FILTERS);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState(INITIAL_STATE);
+
+    fetchSkillList(controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setState(
+          result.ok
+            ? {
+                status: 'loaded',
+                catalog: result.data.catalog,
+                skills: result.data.skills,
+                failure: null,
+              }
+            : { status: 'error', catalog: null, skills: [], failure: result.failure }
+        );
+      })
+      .catch(() => {
+        // Only an abort reaches here; the request has no outcome to render.
+      });
+
+    return () => controller.abort();
+  }, [reloadToken]);
+
+  const retry = useCallback(() => setReloadToken((token) => token + 1), []);
+  const updateFilter = useCallback(
+    <K extends keyof SkillFilterState>(key: K, value: SkillFilterState[K]) =>
+      setFilters((prev) => ({ ...prev, [key]: value })),
+    []
+  );
+
+  const agentOptions = useMemo(() => collectAgentOptions(state.skills), [state.skills]);
+  const visible = useMemo(() => filterSkills(state.skills, filters), [state.skills, filters]);
+
+  if (state.status === 'loading') {
+    return (
+      <div data-testid="skill-catalog-loading" className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t('state.loading')}</p>
+        {[0, 1, 2].map((index) => (
+          <Skeleton key={index} className="h-28 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <Card data-testid="skill-catalog-error" className="space-y-3">
+        <h2 className="text-base font-semibold text-foreground">{t('state.errorHeading')}</h2>
+        <SkillNotice tone="danger">
+          <p>{t('state.errorNotice')}</p>
+          <p className="mt-1 break-words">
+            {t('state.errorCode', { code: state.failure?.code ?? '' })}
+          </p>
+        </SkillNotice>
+        <Button variant="secondary" size="sm" onClick={retry} data-testid="skill-catalog-retry">
+          {t('state.retry')}
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {state.catalog && <CatalogStatusBanner catalog={state.catalog} />}
+
+      <div className="space-y-3">
+        <Input
+          type="search"
+          value={filters.query}
+          onChange={(event) => updateFilter('query', event.target.value)}
+          aria-label={t('search.label')}
+          placeholder={t('search.placeholder')}
+          data-testid="skill-search-input"
+        />
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <label className="block text-xs font-medium text-muted-foreground">
+            {t('filters.compatibility')}
+            <select
+              className={`${SELECT_CLASS} mt-1`}
+              value={filters.compatibility}
+              onChange={(event) =>
+                updateFilter('compatibility', event.target.value as SkillFilterState['compatibility'])
+              }
+              data-testid="skill-filter-compatibility"
+            >
+              <option value="all">{t('filters.all')}</option>
+              {COMPATIBILITY_OPTIONS.map((status) => (
+                <option key={status} value={status}>
+                  {t(COMPATIBILITY_LABEL_KEY[status])}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-xs font-medium text-muted-foreground">
+            {t('filters.risk')}
+            <select
+              className={`${SELECT_CLASS} mt-1`}
+              value={filters.risk}
+              onChange={(event) =>
+                updateFilter('risk', event.target.value as SkillFilterState['risk'])
+              }
+              data-testid="skill-filter-risk"
+            >
+              <option value="all">{t('filters.all')}</option>
+              {RISK_OPTIONS.map((risk) => (
+                <option key={risk} value={risk}>
+                  {t(RISK_LABEL_KEY[risk])}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-xs font-medium text-muted-foreground">
+            {t('filters.agent')}
+            <select
+              className={`${SELECT_CLASS} mt-1`}
+              value={filters.agent}
+              onChange={(event) => updateFilter('agent', event.target.value)}
+              data-testid="skill-filter-agent"
+            >
+              <option value="all">{t('filters.all')}</option>
+              {agentOptions.map((agent) => (
+                <option key={agent} value={agent}>
+                  {getCliToolDisplayNameSafe(agent)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground" data-testid="skill-result-count">
+            {t('search.resultCount', { shown: visible.length, total: state.skills.length })}
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setFilters(EMPTY_SKILL_FILTERS)}
+            data-testid="skill-filter-reset"
+          >
+            {t('filters.reset')}
+          </Button>
+        </div>
+      </div>
+
+      {state.skills.length === 0 ? (
+        <Card data-testid="skill-catalog-empty">
+          <p className="text-sm text-muted-foreground">{t('state.empty')}</p>
+        </Card>
+      ) : visible.length === 0 ? (
+        <Card data-testid="skill-catalog-no-results">
+          <p className="text-sm text-foreground">{t('state.noResults')}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{t('state.noResultsHint')}</p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {visible.map((skill) => (
+            <SkillCard key={skill.id} skill={skill} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SkillCatalogView;

--- a/src/components/skills/SkillChangelog.tsx
+++ b/src/components/skills/SkillChangelog.tsx
@@ -1,0 +1,48 @@
+/**
+ * SkillChangelog (Issue #1232)
+ *
+ * Renders Catalog-supplied changelog text through the shared, rehype-sanitize'd
+ * MarkdownPreview, with every image and embed removed first.
+ *
+ * Sanitization alone is not enough here: the shared schema permits `img[src]`
+ * over http(s), so publisher-controlled text could make merely browsing the
+ * Catalog fetch a tracking pixel from an external host. `stripRemoteMedia`
+ * removes those nodes before rendering, so no outbound request is possible.
+ *
+ * @module components/skills/SkillChangelog
+ */
+
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { MarkdownPreview } from '@/components/worktree/MarkdownPreview';
+import { stripRemoteMedia } from './skill-vocabulary';
+
+export interface SkillChangelogProps {
+  changelog: string;
+}
+
+export function SkillChangelog({ changelog }: SkillChangelogProps) {
+  const t = useTranslations('skills');
+  const safe = stripRemoteMedia(changelog).trim();
+
+  if (safe.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="skill-changelog-empty">
+        {t('detail.changelogEmpty')}
+      </p>
+    );
+  }
+
+  return (
+    <div data-testid="skill-changelog">
+      <div className="prose prose-sm max-w-none dark:prose-invert break-words">
+        <MarkdownPreview content={safe} />
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">{t('detail.mediaStripped')}</p>
+    </div>
+  );
+}
+
+export default SkillChangelog;

--- a/src/components/skills/SkillDetailView.tsx
+++ b/src/components/skills/SkillDetailView.tsx
@@ -1,0 +1,446 @@
+/**
+ * SkillDetailView (Issue #1232)
+ *
+ * The /skills/[skillId] screen. Presents one Catalog entry as a capability the
+ * user is deciding whether to adopt: what it is, who publishes it, whether it
+ * runs here, and — stated plainly rather than implied — what the Catalog cannot
+ * tell them.
+ *
+ * Three distinctions the wording must keep, because collapsing any of them
+ * would let a user approve something they did not understand:
+ * - Publisher-declared risk is a claim; the risk CommandMate computes comes
+ *   from inspecting the downloaded package and is not in the Catalog.
+ * - Declared permissions are declarations, not enforcement.
+ * - `unknown` compatibility is a judgement CommandMate could not make, which is
+ *   not the same as "compatible".
+ *
+ * The Catalog also carries no manifest: capabilities, expected outcomes,
+ * permissions, required commands/hosts and the file/script list live inside the
+ * package. Those sections say so rather than rendering blank, so an absent
+ * section is never mistaken for "this Skill needs nothing".
+ *
+ * @module components/skills/SkillDetailView
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { ArrowLeft } from 'lucide-react';
+import { Badge, Button, Card, Skeleton } from '@/components/ui';
+import { PERMISSION_DECLARATION_NOTICE_KEY } from '@/lib/skills/constants';
+import type { SkillCommandMateCompatibility } from '@/lib/skills/compatibility';
+import { AgentSupportBadge, SkillCompatibilityBadge, SkillRiskBadge } from './SkillBadges';
+import { CatalogStatusBanner } from './CatalogStatusBanner';
+import { SkillChangelog } from './SkillChangelog';
+import { SkillNotice } from './SkillNotice';
+import { fetchSkillDetail, type SkillFetchFailure } from './skills-client';
+import { RECOMMENDATION_LABEL_KEY, resolveSkillMessageKey } from './skill-vocabulary';
+import type { SkillCatalogMetaDto, SkillDto, SkillVersionDto } from './types';
+
+interface DetailState {
+  status: 'loading' | 'loaded' | 'error';
+  catalog: SkillCatalogMetaDto | null;
+  skill: SkillDto | null;
+  failure: SkillFetchFailure | null;
+}
+
+const INITIAL_STATE: DetailState = { status: 'loading', catalog: null, skill: null, failure: null };
+
+/** A labelled value in one of the definition lists. */
+function Field({
+  label,
+  children,
+  mono = false,
+}: {
+  label: string;
+  children: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className={`mt-0.5 text-sm text-foreground ${mono ? 'break-all font-mono text-xs' : 'break-words'}`}>
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+function SectionCard({
+  title,
+  children,
+  testId,
+}: {
+  title: string;
+  children: React.ReactNode;
+  testId?: string;
+}) {
+  return (
+    <Card data-testid={testId} className="space-y-3">
+      <h2 className="text-base font-semibold text-foreground">{title}</h2>
+      {children}
+    </Card>
+  );
+}
+
+/** The human-readable verdict, interpolated from the contract's message key. */
+function CompatibilityReason({ compatibility }: { compatibility: SkillCommandMateCompatibility }) {
+  const t = useTranslations('skills');
+  return (
+    <p className="text-sm text-foreground" data-testid="skill-compatibility-reason">
+      {t(resolveSkillMessageKey(compatibility.messageKey), {
+        range: compatibility.requiredRange,
+        currentVersion: compatibility.currentVersion ?? '',
+      })}
+    </p>
+  );
+}
+
+function VersionCard({ version }: { version: SkillVersionDto }) {
+  const t = useTranslations('skills');
+  return (
+    <Card
+      data-testid={`skill-version-${version.version}`}
+      className="space-y-3"
+      padding="sm"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-sm font-semibold text-foreground">{version.version}</span>
+        {version.prerelease && <Badge variant="warning">{t('detail.prerelease')}</Badge>}
+        <SkillCompatibilityBadge status={version.compatibility.commandmate.status} />
+        <SkillRiskBadge risk={version.declaredRisk} />
+      </div>
+
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label={t('detail.publishedAt')}>{version.publishedAt}</Field>
+        <Field label={t('detail.requiredRangeLabel')}>
+          {version.compatibility.commandmate.requiredRange}
+        </Field>
+        <Field label={t('detail.sourceRepository')}>{version.source.repository}</Field>
+        <Field label={t('detail.sourceRef')}>{version.source.ref}</Field>
+        <Field label={t('detail.sourceCommit')} mono>
+          {version.source.commit}
+        </Field>
+        <Field label={t('detail.packageAsset')} mono>
+          {version.artifact.assetName}
+        </Field>
+        <Field label={t('detail.packageDigest')} mono>
+          {version.artifact.sha256}
+        </Field>
+        <Field label={t('detail.packageSize')}>
+          {t('detail.packageBytes', { bytes: version.artifact.size })}
+        </Field>
+      </dl>
+
+      <div className="flex flex-wrap gap-1.5">
+        {version.compatibility.agents.length > 0 ? (
+          version.compatibility.agents.map((agent) => (
+            <AgentSupportBadge key={agent.agent} agent={agent} />
+          ))
+        ) : (
+          <p className="text-xs text-muted-foreground">{t('compatibility.agentsUnknown')}</p>
+        )}
+      </div>
+
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground">{t('detail.changelogHeading')}</h3>
+        <div className="mt-1">
+          <SkillChangelog changelog={version.changelog} />
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export interface SkillDetailViewProps {
+  skillId: string;
+}
+
+export function SkillDetailView({ skillId }: SkillDetailViewProps) {
+  const t = useTranslations('skills');
+  const [state, setState] = useState<DetailState>(INITIAL_STATE);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState(INITIAL_STATE);
+
+    fetchSkillDetail(skillId, controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setState(
+          result.ok
+            ? {
+                status: 'loaded',
+                catalog: result.data.catalog,
+                skill: result.data.skill,
+                failure: null,
+              }
+            : { status: 'error', catalog: null, skill: null, failure: result.failure }
+        );
+      })
+      .catch(() => {
+        // Only an abort reaches here; the request has no outcome to render.
+      });
+
+    return () => controller.abort();
+  }, [skillId, reloadToken]);
+
+  const retry = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  const backLink = (
+    <Link
+      href="/skills"
+      className="inline-flex items-center gap-1 text-sm text-accent-600 hover:underline dark:text-accent-400"
+      data-testid="skill-detail-back"
+    >
+      <ArrowLeft size={14} aria-hidden="true" />
+      {t('page.backToCatalog')}
+    </Link>
+  );
+
+  if (state.status === 'loading') {
+    return (
+      <div className="space-y-4" data-testid="skill-detail-loading">
+        {backLink}
+        <p className="text-sm text-muted-foreground">{t('state.loading')}</p>
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (state.status === 'error' || !state.skill) {
+    const notFound = state.failure?.status === 404;
+    return (
+      <div className="space-y-4">
+        {backLink}
+        <Card data-testid={notFound ? 'skill-detail-not-found' : 'skill-detail-error'} className="space-y-3">
+          <h2 className="text-base font-semibold text-foreground">
+            {notFound ? t('state.notFoundHeading') : t('state.errorHeading')}
+          </h2>
+          <SkillNotice tone="danger">
+            <p>{notFound ? t('state.notFoundNotice') : t('state.errorNotice')}</p>
+            <p className="mt-1 break-words">
+              {t('state.errorCode', { code: state.failure?.code ?? '' })}
+            </p>
+          </SkillNotice>
+          {!notFound && (
+            <Button variant="secondary" size="sm" onClick={retry} data-testid="skill-detail-retry">
+              {t('state.retry')}
+            </Button>
+          )}
+        </Card>
+      </div>
+    );
+  }
+
+  const skill = state.skill;
+  const compatibility = skill.compatibility;
+  const recommended =
+    skill.versions.find((version) => version.version === skill.recommendedVersion) ?? null;
+  const declaredRisk = (recommended ?? skill.versions[0])?.declaredRisk ?? null;
+
+  // Install is offered only from a version that is present AND confirmed
+  // compatible: an `unknown` verdict means CommandMate could not decide, and
+  // offering it anyway would be exactly the "unknown shown as compatible" this
+  // screen must avoid.
+  const installBlockedReason = !skill.recommendedVersion
+    ? t('detail.install.blockedNoVersion')
+    : compatibility && compatibility.status !== 'compatible'
+      ? t('detail.install.blockedIncompatible', {
+          reason: t(resolveSkillMessageKey(compatibility.messageKey), {
+            range: compatibility.requiredRange,
+            currentVersion: compatibility.currentVersion ?? '',
+          }),
+        })
+      : t('detail.install.unavailableYet');
+
+  return (
+    <div className="space-y-4">
+      {backLink}
+      {state.catalog && <CatalogStatusBanner catalog={state.catalog} />}
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-foreground break-words">{skill.name}</h1>
+        <p className="text-sm text-muted-foreground break-words">{skill.summary}</p>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {compatibility && <SkillCompatibilityBadge status={compatibility.status} />}
+          {declaredRisk && <SkillRiskBadge risk={declaredRisk} />}
+        </div>
+      </div>
+
+      <SectionCard title={t('detail.install.action')} testId="skill-install-section">
+        <Button
+          variant="primary"
+          disabled
+          data-testid="skill-install-action"
+          aria-describedby="skill-install-reason"
+        >
+          {t('detail.install.action')}
+        </Button>
+        <p id="skill-install-reason" className="text-sm text-muted-foreground" data-testid="skill-install-reason">
+          {installBlockedReason}
+        </p>
+      </SectionCard>
+
+      <SectionCard title={t('capabilities.heading')} testId="skill-capabilities-section">
+        <p className="text-sm text-foreground break-words">{skill.summary}</p>
+        <SkillNotice tone="neutral">{t('capabilities.unavailable')}</SkillNotice>
+      </SectionCard>
+
+      <SectionCard title={t('detail.overview')} testId="skill-overview-section">
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label={t('detail.skillId')} mono>
+            {skill.id}
+          </Field>
+          <Field label={t('detail.provider')}>
+            {skill.provider.url ? (
+              <a
+                href={skill.provider.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-600 hover:underline dark:text-accent-400"
+              >
+                {skill.provider.name}
+              </a>
+            ) : (
+              skill.provider.name
+            )}
+          </Field>
+          {skill.provider.contact && (
+            <Field label={t('detail.providerContact')}>{skill.provider.contact}</Field>
+          )}
+          <Field label={t('detail.license')}>{skill.license}</Field>
+          {skill.homepage && (
+            <Field label={t('detail.homepage')}>
+              <a
+                href={skill.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-accent-600 hover:underline dark:text-accent-400"
+              >
+                {skill.homepage}
+              </a>
+            </Field>
+          )}
+          <Field label={t('detail.latestVersion')} mono>
+            {skill.latest}
+          </Field>
+          <Field label={t('detail.recommendedVersion')} mono>
+            {skill.recommendedVersion ?? t('detail.recommendedVersionNone')}
+          </Field>
+        </dl>
+        <p className="text-xs text-muted-foreground" data-testid="skill-recommendation-reason">
+          {t(RECOMMENDATION_LABEL_KEY[skill.recommendedReason])}
+        </p>
+        {skill.keywords.length > 0 && (
+          <div>
+            <h3 className="text-xs font-medium text-muted-foreground">{t('detail.keywords')}</h3>
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {skill.keywords.map((keyword) => (
+                <Badge key={keyword} variant="gray">
+                  {keyword}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard title={t('compatibility.label')} testId="skill-compatibility-section">
+        {compatibility ? (
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <SkillCompatibilityBadge status={compatibility.status} />
+              <span className="text-sm text-muted-foreground">
+                {t('compatibility.requiredRange', { range: compatibility.requiredRange })}
+              </span>
+            </div>
+            <CompatibilityReason compatibility={compatibility} />
+            <p className="text-xs text-muted-foreground">
+              {compatibility.currentVersion
+                ? t('compatibility.currentVersion', { version: compatibility.currentVersion })
+                : t('compatibility.currentVersionUnknown')}
+            </p>
+            {compatibility.status === 'unknown' && (
+              <SkillNotice tone="warning" data-testid="skill-compatibility-unknown-notice">
+                {t('compatibility.unverifiedNotice')}
+              </SkillNotice>
+            )}
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">{t('compatibility.currentVersionUnknown')}</p>
+        )}
+
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-foreground">{t('compatibility.agentsHeading')}</h3>
+          {recommended && recommended.compatibility.agents.length > 0 ? (
+            <>
+              <div className="flex flex-wrap gap-1.5">
+                {recommended.compatibility.agents.map((agent) => (
+                  <AgentSupportBadge key={agent.agent} agent={agent} />
+                ))}
+              </div>
+              <ul className="space-y-1">
+                {recommended.compatibility.agents.map((agent) => (
+                  <li key={agent.agent} className="text-xs text-muted-foreground break-words">
+                    {t('compatibility.evidence')}: {agent.evidence}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p className="text-xs text-muted-foreground">{t('compatibility.agentsUnknown')}</p>
+          )}
+          <SkillNotice tone="neutral">{t('compatibility.agentsNotice')}</SkillNotice>
+        </div>
+      </SectionCard>
+
+      <SectionCard title={t('risk.declaredHeading')} testId="skill-risk-section">
+        {declaredRisk ? <SkillRiskBadge risk={declaredRisk} /> : null}
+        <SkillNotice tone="neutral">{t('risk.declaredNotice')}</SkillNotice>
+        {declaredRisk === 'high' && (
+          <SkillNotice tone="danger" data-testid="skill-high-risk-warning">
+            {t('risk.highWarning')}
+          </SkillNotice>
+        )}
+        <div>
+          <h3 className="text-sm font-medium text-foreground">{t('risk.computedHeading')}</h3>
+          <p className="mt-1 text-sm text-muted-foreground" data-testid="skill-computed-risk-unavailable">
+            {t('risk.computedUnavailable')}
+          </p>
+        </div>
+      </SectionCard>
+
+      <SectionCard title={t('permissions.heading')} testId="skill-permissions-section">
+        <SkillNotice tone="warning" data-testid="skill-permission-declaration-notice">
+          {t(resolveSkillMessageKey(PERMISSION_DECLARATION_NOTICE_KEY))}
+        </SkillNotice>
+        <p className="text-sm text-muted-foreground">{t('permissions.unavailable')}</p>
+      </SectionCard>
+
+      <SectionCard title={t('requirements.heading')} testId="skill-requirements-section">
+        <p className="text-sm text-muted-foreground">{t('requirements.unavailable')}</p>
+      </SectionCard>
+
+      <SectionCard title={t('contents.heading')} testId="skill-contents-section">
+        <p className="text-sm text-muted-foreground">{t('contents.unavailable')}</p>
+      </SectionCard>
+
+      <section className="space-y-3" data-testid="skill-versions-section">
+        <h2 className="text-base font-semibold text-foreground">{t('detail.versionsHeading')}</h2>
+        {skill.versions.length === 0 ? (
+          <Card>
+            <p className="text-sm text-muted-foreground">{t('detail.versionsEmpty')}</p>
+          </Card>
+        ) : (
+          skill.versions.map((version) => <VersionCard key={version.version} version={version} />)
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default SkillDetailView;

--- a/src/components/skills/SkillNotice.tsx
+++ b/src/components/skills/SkillNotice.tsx
@@ -1,0 +1,61 @@
+/**
+ * SkillNotice (Issue #1232)
+ *
+ * Always-visible explanatory box used for the statements the Catalog UI is not
+ * allowed to hide: that a permission is a declaration, that a risk level is the
+ * publisher's claim, that a field is simply not in the Catalog. Rendered inline
+ * rather than behind a disclosure so導入前に確認できる (UX-09).
+ *
+ * @module components/skills/SkillNotice
+ */
+
+import React from 'react';
+import { AlertTriangle, Info, ShieldAlert } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+
+export type SkillNoticeTone = 'info' | 'warning' | 'danger' | 'neutral';
+
+const TONE_CLASS: Record<SkillNoticeTone, string> = {
+  info: 'bg-info-subtle border-info-border text-info-foreground',
+  warning: 'bg-warning-subtle border-warning-border text-warning-foreground',
+  danger: 'bg-danger-subtle border-danger-border text-danger-foreground',
+  neutral: 'bg-muted border-border text-muted-foreground',
+};
+
+const TONE_ICON: Record<SkillNoticeTone, typeof Info> = {
+  info: Info,
+  warning: AlertTriangle,
+  danger: ShieldAlert,
+  neutral: Info,
+};
+
+export interface SkillNoticeProps {
+  tone?: SkillNoticeTone;
+  children: React.ReactNode;
+  className?: string;
+  'data-testid'?: string;
+}
+
+export function SkillNotice({
+  tone = 'neutral',
+  children,
+  className,
+  'data-testid': testId,
+}: SkillNoticeProps) {
+  const Icon = TONE_ICON[tone];
+  return (
+    <div
+      data-testid={testId}
+      className={cn(
+        'flex items-start gap-2 rounded-md border px-3 py-2 text-xs leading-relaxed',
+        TONE_CLASS[tone],
+        className
+      )}
+    >
+      <Icon size={14} aria-hidden="true" className="mt-0.5 shrink-0" />
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+export default SkillNotice;

--- a/src/components/skills/skill-vocabulary.ts
+++ b/src/components/skills/skill-vocabulary.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared display vocabulary for the Skill Catalog UI (Issue #1232)
+ *
+ * Pure functions and lookup tables only, so list, detail and their tests read
+ * the same mapping from a wire value to a badge, a label key and a filter
+ * decision. Nothing here fetches or interprets a Catalog.
+ *
+ * @module components/skills/skill-vocabulary
+ */
+
+import type { BadgeVariant } from '@/components/ui';
+import type {
+  SkillCompatibilityStatus,
+  SkillRecommendationReasonCode,
+} from '@/lib/skills/compatibility';
+import type { SkillAgentSupport, SkillRiskLevel } from '@/types/skills';
+import type { SkillDto } from './types';
+
+/**
+ * `unknown` is warning, never success.
+ *
+ * A verdict CommandMate could not reach must not share a colour with one it
+ * confirmed — otherwise "unverified" reads as "compatible" (UX-07).
+ */
+export const COMPATIBILITY_BADGE_VARIANT: Record<SkillCompatibilityStatus, BadgeVariant> = {
+  compatible: 'success',
+  incompatible: 'error',
+  unknown: 'warning',
+};
+
+export const COMPATIBILITY_LABEL_KEY: Record<SkillCompatibilityStatus, string> = {
+  compatible: 'compatibility.status.compatible',
+  incompatible: 'compatibility.status.incompatible',
+  unknown: 'compatibility.status.unknown',
+};
+
+/**
+ * Risk never renders as success: `low` is the publisher's lowest claim, not a
+ * CommandMate endorsement, so it gets the neutral variant.
+ */
+export const RISK_BADGE_VARIANT: Record<SkillRiskLevel, BadgeVariant> = {
+  low: 'gray',
+  moderate: 'warning',
+  high: 'error',
+};
+
+export const RISK_LABEL_KEY: Record<SkillRiskLevel, string> = {
+  low: 'risk.level.low',
+  moderate: 'risk.level.moderate',
+  high: 'risk.level.high',
+};
+
+export const AGENT_SUPPORT_BADGE_VARIANT: Record<SkillAgentSupport, BadgeVariant> = {
+  native: 'success',
+  commandmate_runtime: 'info',
+  unsupported: 'error',
+  unknown: 'warning',
+};
+
+export const RECOMMENDATION_LABEL_KEY: Record<SkillRecommendationReasonCode, string> = {
+  SKILL_RECOMMEND_HIGHEST_COMPATIBLE: 'detail.recommendation.highestCompatible',
+  SKILL_RECOMMEND_LATEST_UNVERIFIED: 'detail.recommendation.latestUnverified',
+  SKILL_RECOMMEND_NONE_COMPATIBLE: 'detail.recommendation.noneCompatible',
+  SKILL_RECOMMEND_NO_VERSIONS: 'detail.recommendation.noVersions',
+};
+
+const CATALOG_REASON_LABEL_KEY: Record<string, string> = {
+  SKILL_CATALOG_FETCH_FAILED: 'catalog.reason.fetchFailed',
+  SKILL_CATALOG_RATE_LIMITED: 'catalog.reason.rateLimited',
+  SKILL_CATALOG_OVERSIZED: 'catalog.reason.oversized',
+  SKILL_CATALOG_MALFORMED: 'catalog.reason.malformed',
+  SKILL_CATALOG_INVALID_SCHEMA: 'catalog.reason.invalidSchema',
+};
+
+/** Label key for a stale/failure code, falling back to an explicit "unknown". */
+export function catalogReasonLabelKey(code: string | null): string {
+  return (code && CATALOG_REASON_LABEL_KEY[code]) || 'catalog.reason.unknown';
+}
+
+/**
+ * Strip the `skills.` prefix off a contract-supplied message key.
+ *
+ * `lib/skills` publishes fully-qualified keys (`skills.compatibility.native`)
+ * so UI and CLI share one vocabulary, while `useTranslations('skills')` expects
+ * them relative to the namespace.
+ */
+export function resolveSkillMessageKey(key: string): string {
+  return key.startsWith('skills.') ? key.slice('skills.'.length) : key;
+}
+
+const MARKDOWN_IMAGE = /!\[([^\]]*)\]\([^)]*\)/g;
+const HTML_MEDIA_TAG = /<\/?(?:img|picture|source|video|audio|iframe|embed|object|track)\b[^>]*>/gi;
+
+/**
+ * Remove every construct that would make the renderer load a remote asset.
+ *
+ * The shared MarkdownPreview sanitizer allows `img[src]` over http(s), so
+ * sanitization alone still lets Catalog text pull a tracking pixel from the
+ * publisher's host. Removing the nodes before rendering is what actually keeps
+ * browsing the Catalog from emitting outbound requests. Alt text is kept so the
+ * changelog does not silently lose meaning.
+ */
+export function stripRemoteMedia(markdown: string): string {
+  return markdown.replace(MARKDOWN_IMAGE, '$1').replace(HTML_MEDIA_TAG, '');
+}
+
+/** Case-insensitive match over the fields a user would search by. */
+export function matchesSkillQuery(skill: SkillDto, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (needle.length === 0) return true;
+  return [skill.name, skill.summary, skill.id, skill.provider.name, ...skill.keywords].some(
+    (field) => field.toLowerCase().includes(needle)
+  );
+}
+
+/** Active filter selection. `all` means the dimension is not filtered. */
+export interface SkillFilterState {
+  query: string;
+  compatibility: SkillCompatibilityStatus | 'all';
+  risk: SkillRiskLevel | 'all';
+  agent: string | 'all';
+}
+
+export const EMPTY_SKILL_FILTERS: SkillFilterState = {
+  query: '',
+  compatibility: 'all',
+  risk: 'all',
+  agent: 'all',
+};
+
+/**
+ * Risk shown for an entry in the list: the recommended version's declaration,
+ * falling back to the newest listed version. Null when nothing is listed.
+ */
+export function headlineDeclaredRisk(skill: SkillDto): SkillRiskLevel | null {
+  const recommended = skill.versions.find((v) => v.version === skill.recommendedVersion);
+  return (recommended ?? skill.versions[0])?.declaredRisk ?? null;
+}
+
+/** Agents any listed version claims to run on, natively or via the Runtime. */
+export function supportedAgents(skill: SkillDto): string[] {
+  const agents = new Set<string>();
+  for (const version of skill.versions) {
+    for (const agent of version.compatibility.agents) {
+      if (agent.support === 'native' || agent.support === 'commandmate_runtime') {
+        agents.add(agent.agent);
+      }
+    }
+  }
+  return [...agents].sort();
+}
+
+/** Apply search and every active filter. Order of the input list is preserved. */
+export function filterSkills(skills: SkillDto[], filters: SkillFilterState): SkillDto[] {
+  return skills.filter((skill) => {
+    if (!matchesSkillQuery(skill, filters.query)) return false;
+    if (filters.compatibility !== 'all' && skill.compatibility?.status !== filters.compatibility) {
+      return false;
+    }
+    if (filters.risk !== 'all' && headlineDeclaredRisk(skill) !== filters.risk) return false;
+    if (filters.agent !== 'all' && !supportedAgents(skill).includes(filters.agent)) return false;
+    return true;
+  });
+}
+
+/** Every agent named by any listed version, for the filter options. */
+export function collectAgentOptions(skills: SkillDto[]): string[] {
+  const agents = new Set<string>();
+  for (const skill of skills) {
+    for (const version of skill.versions) {
+      for (const agent of version.compatibility.agents) agents.add(agent.agent);
+    }
+  }
+  return [...agents].sort();
+}

--- a/src/components/skills/skills-client.ts
+++ b/src/components/skills/skills-client.ts
@@ -1,0 +1,85 @@
+/**
+ * Browser client for the Skill Catalog API (Issue #1232)
+ *
+ * The UI reads the Catalog only through `GET /api/skills` and
+ * `GET /api/skills/[id]` (#1231); it never fetches or parses the upstream
+ * Catalog itself, so server and client can never disagree about what a Skill is
+ * or whether it is compatible.
+ *
+ * A failed retrieval is a distinct result from an empty Catalog: `ok: false`
+ * carries the machine code so the UI can say "could not load" rather than
+ * rendering a reassuring empty list (受入条件: Catalog errorを空Catalogとして誤表示しない).
+ *
+ * @module components/skills/skills-client
+ */
+
+import type { SkillApiErrorResponse, SkillDetailResponse, SkillListResponse } from './types';
+
+/** Code used when the request never produced a JSON error body. */
+export const SKILL_CATALOG_UNREACHABLE = 'SKILL_CATALOG_UNREACHABLE';
+
+export interface SkillFetchFailure {
+  code: string;
+  message: string;
+  /** HTTP status, or null when the request never completed. */
+  status: number | null;
+}
+
+export type SkillFetchResult<T> = { ok: true; data: T } | { ok: false; failure: SkillFetchFailure };
+
+function isApiError(value: unknown): value is SkillApiErrorResponse {
+  if (!value || typeof value !== 'object') return false;
+  const { error, code } = value as Record<string, unknown>;
+  return typeof error === 'string' && typeof code === 'string';
+}
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<SkillFetchResult<T>> {
+  const response = await fetch(url, { signal, headers: { Accept: 'application/json' } });
+  const body: unknown = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      failure: {
+        code: isApiError(body) ? body.code : SKILL_CATALOG_UNREACHABLE,
+        message: isApiError(body) ? body.error : '',
+        status: response.status,
+      },
+    };
+  }
+  return { ok: true, data: body as T };
+}
+
+/**
+ * Run a Catalog request, turning transport failures into a result.
+ *
+ * An abort is rethrown rather than reported: a cancelled request has no
+ * outcome to show, and rendering it as an error would flash a false failure
+ * whenever the user navigates away mid-fetch.
+ */
+async function request<T>(url: string, signal?: AbortSignal): Promise<SkillFetchResult<T>> {
+  try {
+    return await getJson<T>(url, signal);
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    return {
+      ok: false,
+      failure: {
+        code: SKILL_CATALOG_UNREACHABLE,
+        message: error instanceof Error ? error.message : '',
+        status: null,
+      },
+    };
+  }
+}
+
+export function fetchSkillList(signal?: AbortSignal): Promise<SkillFetchResult<SkillListResponse>> {
+  return request<SkillListResponse>('/api/skills', signal);
+}
+
+export function fetchSkillDetail(
+  skillId: string,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<SkillDetailResponse>> {
+  return request<SkillDetailResponse>(`/api/skills/${encodeURIComponent(skillId)}`, signal);
+}

--- a/src/components/skills/types.ts
+++ b/src/components/skills/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Wire types the Skill Catalog UI consumes (Issue #1232)
+ *
+ * Type-only re-export of the #1231 serialization contract. `export type` is
+ * erased at compile time, so nothing from `lib/api/skills-api` (which imports
+ * `next/server`) reaches the client bundle.
+ *
+ * @module components/skills/types
+ */
+
+export type {
+  SkillApiErrorResponse,
+  SkillArtifactDto,
+  SkillCatalogMetaDto,
+  SkillDetailResponse,
+  SkillDto,
+  SkillListResponse,
+  SkillVersionDto,
+} from '@/lib/api/skills-api';

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -17,7 +17,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   }
 
   // Load all namespace files and merge them
-  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette, home, review, pwa, notifications, keyboardShortcuts, externalApps] = await Promise.all([
+  const [common, worktree, autoYes, error, prompt, auth, schedule, commandPalette, home, review, pwa, notifications, keyboardShortcuts, externalApps, skills] = await Promise.all([
     import(`../locales/${locale}/common.json`),
     import(`../locales/${locale}/worktree.json`),
     import(`../locales/${locale}/autoYes.json`),
@@ -32,6 +32,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
     import(`../locales/${locale}/notifications.json`),
     import(`../locales/${locale}/keyboardShortcuts.json`),
     import(`../locales/${locale}/externalApps.json`),
+    import(`../locales/${locale}/skills.json`),
   ]);
 
   return {
@@ -53,6 +54,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
       notifications: notifications.default,
       keyboardShortcuts: keyboardShortcuts.default,
       externalApps: externalApps.default,
+      skills: skills.default,
     },
   };
 });

--- a/tests/integration/i18n-namespace-loading.test.ts
+++ b/tests/integration/i18n-namespace-loading.test.ts
@@ -24,8 +24,9 @@ const LOCALES_DIR = path.resolve(__dirname, '../../locales');
  * Issue #1125: Added 'notifications' namespace
  * Issue #1130: Added 'keyboardShortcuts' namespace
  * Issue #1273: Added 'externalApps' namespace
+ * Issue #1232: Added 'skills' namespace
  */
-const EXPECTED_NAMESPACES = ['common', 'worktree', 'autoYes', 'error', 'prompt', 'auth', 'schedule', 'commandPalette', 'home', 'review', 'pwa', 'notifications', 'keyboardShortcuts', 'externalApps'] as const;
+const EXPECTED_NAMESPACES = ['common', 'worktree', 'autoYes', 'error', 'prompt', 'auth', 'schedule', 'commandPalette', 'home', 'review', 'pwa', 'notifications', 'keyboardShortcuts', 'externalApps', 'skills'] as const;
 
 describe('i18n Namespace Loading', () => {
   for (const locale of SUPPORTED_LOCALES) {

--- a/tests/unit/components/skills/SkillCatalogView.test.tsx
+++ b/tests/unit/components/skills/SkillCatalogView.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * SkillCatalogView (Issue #1232)
+ *
+ * The load states are the point of these tests: a Catalog that failed to load
+ * and a Catalog that is genuinely empty must never render the same way, and a
+ * stale snapshot must never render as current.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+// The global next-intl mock in tests/setup.ts drops interpolation params, which
+// would hide exactly the values these tests care about (the failure code, the
+// result counts). This variant renders them so an assertion can see them.
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace?: string) =>
+    (key: string, params?: Record<string, string | number>) => {
+      const full = namespace ? `${namespace}.${key}` : key;
+      if (!params) return full;
+      const rendered = Object.entries(params)
+        .map(([name, value]) => `${name}=${value}`)
+        .join(',');
+      return `${full}(${rendered})`;
+    },
+  useLocale: () => 'en',
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { SkillCatalogView } from '@/components/skills/SkillCatalogView';
+import { makeCatalogMeta, makeIncompatibleSkill, makeSkill, makeUnknownSkill } from './fixtures';
+import type { SkillDto } from '@/components/skills/types';
+
+function mockListResponse(skills: SkillDto[], catalog = makeCatalogMeta()) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ catalog, skills }),
+  } as unknown as Response;
+}
+
+function mockErrorResponse(code: string, status = 503) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ error: 'boom', code }),
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SkillCatalogView loading', () => {
+  it('shows a loading state before the Catalog resolves', () => {
+    fetchMock.mockReturnValue(new Promise(() => {}));
+    render(<SkillCatalogView />);
+    expect(screen.getByTestId('skill-catalog-loading')).toBeInTheDocument();
+  });
+});
+
+describe('SkillCatalogView error state', () => {
+  it('reports a retrieval failure instead of rendering an empty Catalog', async () => {
+    fetchMock.mockResolvedValue(mockErrorResponse('SKILL_CATALOG_FETCH_FAILED'));
+    render(<SkillCatalogView />);
+
+    expect(await screen.findByTestId('skill-catalog-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-catalog-empty')).not.toBeInTheDocument();
+    expect(screen.getByText(/SKILL_CATALOG_FETCH_FAILED/)).toBeInTheDocument();
+  });
+
+  it('surfaces a transport failure the same way, with a retry that refetches', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('network down'));
+    fetchMock.mockResolvedValueOnce(mockListResponse([makeSkill()]));
+    render(<SkillCatalogView />);
+
+    fireEvent.click(await screen.findByTestId('skill-catalog-retry'));
+
+    expect(await screen.findByTestId('skill-card-release-helper')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('SkillCatalogView empty state', () => {
+  it('distinguishes a genuinely empty Catalog from a failure', async () => {
+    fetchMock.mockResolvedValue(mockListResponse([]));
+    render(<SkillCatalogView />);
+
+    expect(await screen.findByTestId('skill-catalog-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-catalog-error')).not.toBeInTheDocument();
+  });
+});
+
+describe('SkillCatalogView freshness', () => {
+  it('announces a stale/offline snapshot with its reason rather than as current', async () => {
+    fetchMock.mockResolvedValue(
+      mockListResponse(
+        [makeSkill()],
+        makeCatalogMeta({
+          stale: true,
+          offline: true,
+          state: 'stale',
+          staleReason: 'SKILL_CATALOG_RATE_LIMITED',
+        })
+      )
+    );
+    render(<SkillCatalogView />);
+
+    const banner = await screen.findByTestId('skill-catalog-stale');
+    expect(banner).toHaveTextContent('skills.catalog.staleHeading');
+    expect(banner).toHaveTextContent('skills.catalog.offlineNotice');
+    expect(banner).toHaveTextContent('skills.catalog.reason.rateLimited');
+    expect(screen.queryByTestId('skill-catalog-fresh')).not.toBeInTheDocument();
+  });
+
+  it('marks a confirmed-current Catalog as such', async () => {
+    fetchMock.mockResolvedValue(mockListResponse([makeSkill()]));
+    render(<SkillCatalogView />);
+
+    expect(await screen.findByTestId('skill-catalog-fresh')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-catalog-stale')).not.toBeInTheDocument();
+  });
+});
+
+describe('SkillCatalogView list rendering', () => {
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(
+      mockListResponse([makeSkill(), makeIncompatibleSkill(), makeUnknownSkill()])
+    );
+  });
+
+  it('renders every entry with its compatibility and declared-risk badge', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+
+    expect(screen.getByTestId('skill-card-future-skill')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-card-mystery-skill')).toBeInTheDocument();
+    expect(screen.getAllByTestId('skill-compatibility-incompatible')).not.toHaveLength(0);
+    expect(screen.getAllByTestId('skill-declared-risk-high')).not.toHaveLength(0);
+  });
+
+  it('never labels an unknown verdict as compatible', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-mystery-skill');
+
+    const unknownBadge = screen.getByTestId('skill-compatibility-unknown');
+    expect(unknownBadge).toHaveTextContent('skills.compatibility.status.unknown');
+    expect(unknownBadge).not.toHaveTextContent('skills.compatibility.status.compatible');
+  });
+
+  it('links each card to its detail route', async () => {
+    render(<SkillCatalogView />);
+    const card = await screen.findByTestId('skill-card-release-helper');
+    expect(card).toHaveAttribute('href', '/skills/release-helper');
+  });
+
+  it('reports how many of the total are shown', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+    expect(screen.getByTestId('skill-result-count')).toHaveTextContent('shown=3,total=3');
+  });
+});
+
+describe('SkillCatalogView search and filters', () => {
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(
+      mockListResponse([makeSkill(), makeIncompatibleSkill(), makeUnknownSkill()])
+    );
+  });
+
+  it('narrows the list by free-text search', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+
+    fireEvent.change(screen.getByTestId('skill-search-input'), { target: { value: 'mystery' } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-card-release-helper')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('skill-card-mystery-skill')).toBeInTheDocument();
+  });
+
+  it('excludes unknown-compatibility entries from the compatible filter', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+
+    fireEvent.change(screen.getByTestId('skill-filter-compatibility'), {
+      target: { value: 'compatible' },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-card-mystery-skill')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('skill-card-future-skill')).not.toBeInTheDocument();
+    expect(screen.getByTestId('skill-card-release-helper')).toBeInTheDocument();
+  });
+
+  it('filters by declared risk', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+
+    fireEvent.change(screen.getByTestId('skill-filter-risk'), { target: { value: 'high' } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-card-release-helper')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('skill-card-future-skill')).toBeInTheDocument();
+  });
+
+  it('shows a no-match state that is not the empty-Catalog state', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+
+    fireEvent.change(screen.getByTestId('skill-search-input'), { target: { value: 'nothing' } });
+
+    expect(await screen.findByTestId('skill-catalog-no-results')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-catalog-empty')).not.toBeInTheDocument();
+  });
+
+  it('restores the full list when the filters are reset', async () => {
+    render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-release-helper');
+
+    fireEvent.change(screen.getByTestId('skill-search-input'), { target: { value: 'nothing' } });
+    await screen.findByTestId('skill-catalog-no-results');
+
+    fireEvent.click(screen.getByTestId('skill-filter-reset'));
+
+    expect(await screen.findByTestId('skill-card-release-helper')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-card-future-skill')).toBeInTheDocument();
+  });
+});
+
+describe('SkillCatalogView touch accessibility', () => {
+  it('never hides a badge or warning behind a hover-only class', async () => {
+    fetchMock.mockResolvedValue(mockListResponse([makeIncompatibleSkill()]));
+    const { container } = render(<SkillCatalogView />);
+    await screen.findByTestId('skill-card-future-skill');
+
+    expect(container.querySelectorAll('[class*="opacity-0"]')).toHaveLength(0);
+    expect(container.querySelectorAll('[class*="group-hover:opacity"]')).toHaveLength(0);
+  });
+});

--- a/tests/unit/components/skills/SkillDetailView.test.tsx
+++ b/tests/unit/components/skills/SkillDetailView.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * SkillDetailView (Issue #1232)
+ *
+ * These tests pin the statements the screen is not allowed to drop: that a
+ * declared risk is a claim, that permissions are not enforced, that `unknown`
+ * is not `compatible`, and that a Skill which cannot run here says why instead
+ * of offering an install.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace?: string) =>
+    (key: string, params?: Record<string, string | number>) => {
+      const full = namespace ? `${namespace}.${key}` : key;
+      if (!params) return full;
+      const rendered = Object.entries(params)
+        .map(([name, value]) => `${name}=${value}`)
+        .join(',');
+      return `${full}(${rendered})`;
+    },
+  useLocale: () => 'en',
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// The changelog renderer pulls in react-markdown and mermaid; the media-stripping
+// contract it enforces is covered directly in skill-vocabulary.test.ts.
+vi.mock('@/components/worktree/MarkdownPreview', () => ({
+  MarkdownPreview: ({ content }: { content: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
+import { SkillDetailView } from '@/components/skills/SkillDetailView';
+import { makeCatalogMeta, makeIncompatibleSkill, makeSkill, makeUnknownSkill } from './fixtures';
+import type { SkillDto } from '@/components/skills/types';
+
+function mockDetail(skill: SkillDto, catalog = makeCatalogMeta()) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ catalog, skill }),
+  } as unknown as Response;
+}
+
+function mockError(code: string, status: number) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ error: 'boom', code }),
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SkillDetailView required fields', () => {
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(mockDetail(makeSkill()));
+  });
+
+  it('renders every section a user needs before adopting a Skill', async () => {
+    render(<SkillDetailView skillId="release-helper" />);
+    await screen.findByTestId('skill-overview-section');
+
+    for (const section of [
+      'skill-install-section',
+      'skill-capabilities-section',
+      'skill-overview-section',
+      'skill-compatibility-section',
+      'skill-risk-section',
+      'skill-permissions-section',
+      'skill-requirements-section',
+      'skill-contents-section',
+      'skill-versions-section',
+    ]) {
+      expect(screen.getByTestId(section), section).toBeInTheDocument();
+    }
+  });
+
+  it('shows provider, license, versions, source and package identity', async () => {
+    render(<SkillDetailView skillId="release-helper" />);
+    const overview = await screen.findByTestId('skill-overview-section');
+
+    expect(overview).toHaveTextContent('CommandMate');
+    expect(overview).toHaveTextContent('MIT');
+    expect(overview).toHaveTextContent('1.2.0');
+    expect(overview).toHaveTextContent('release-helper');
+
+    const version = screen.getByTestId('skill-version-1.2.0');
+    expect(version).toHaveTextContent('Kewton/commandmate-skills');
+    expect(version).toHaveTextContent('a'.repeat(40));
+    expect(version).toHaveTextContent('b'.repeat(64));
+    expect(version).toHaveTextContent('release-helper-1.2.0.tar.gz');
+    expect(version).toHaveTextContent('2026-07-01T00:00:00Z');
+  });
+
+  it('renders the changelog through the shared sanitized preview', async () => {
+    render(<SkillDetailView skillId="release-helper" />);
+    expect(await screen.findByTestId('markdown-content')).toHaveTextContent(
+      'Adds the release checklist step.'
+    );
+  });
+
+  it('never exposes an artifact URL or an absolute install path', async () => {
+    const { container } = render(<SkillDetailView skillId="release-helper" />);
+    await screen.findByTestId('skill-overview-section');
+
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/releases\/download/);
+    expect(html).not.toMatch(/\/Users\//);
+    expect(html).not.toMatch(/\.agents\/skills/);
+  });
+
+  it('explains the Agent support vocabulary as a publisher claim', async () => {
+    render(<SkillDetailView skillId="release-helper" />);
+    const section = await screen.findByTestId('skill-compatibility-section');
+
+    expect(section).toHaveTextContent('skills.compatibility.agentsNotice');
+    expect(screen.getAllByTestId('skill-agent-claude-native')).not.toHaveLength(0);
+  });
+});
+
+describe('SkillDetailView risk and permission wording', () => {
+  it('separates the publisher declaration from the risk CommandMate computes', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeSkill()));
+    render(<SkillDetailView skillId="release-helper" />);
+    const section = await screen.findByTestId('skill-risk-section');
+
+    expect(section).toHaveTextContent('skills.risk.declaredNotice');
+    expect(screen.getByTestId('skill-computed-risk-unavailable')).toHaveTextContent(
+      'skills.risk.computedUnavailable'
+    );
+  });
+
+  it('states that a declared permission is not an enforcement', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeSkill()));
+    render(<SkillDetailView skillId="release-helper" />);
+
+    expect(await screen.findByTestId('skill-permission-declaration-notice')).toHaveTextContent(
+      'skills.permissions.declarationOnlyNotice'
+    );
+  });
+
+  it('warns visibly and in text when the publisher declares high risk', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeIncompatibleSkill()));
+    render(<SkillDetailView skillId="future-skill" />);
+
+    expect(await screen.findByTestId('skill-high-risk-warning')).toHaveTextContent(
+      'skills.risk.highWarning'
+    );
+    expect(screen.getAllByTestId('skill-declared-risk-high')).not.toHaveLength(0);
+  });
+
+  it('says the Catalog carries no file or script list rather than showing none', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeSkill()));
+    render(<SkillDetailView skillId="release-helper" />);
+
+    expect(await screen.findByTestId('skill-contents-section')).toHaveTextContent(
+      'skills.contents.unavailable'
+    );
+    expect(screen.getByTestId('skill-requirements-section')).toHaveTextContent(
+      'skills.requirements.unavailable'
+    );
+  });
+});
+
+describe('SkillDetailView install gating', () => {
+  it('disables the install path with the compatibility reason when incompatible', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeIncompatibleSkill()));
+    render(<SkillDetailView skillId="future-skill" />);
+
+    const action = await screen.findByTestId('skill-install-action');
+    expect(action).toBeDisabled();
+    expect(screen.getByTestId('skill-install-reason')).toHaveTextContent(
+      'skills.detail.install.blockedNoVersion'
+    );
+  });
+
+  it('reports an unknown verdict as unverified, never as compatible', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeUnknownSkill()));
+    render(<SkillDetailView skillId="mystery-skill" />);
+
+    await screen.findByTestId('skill-compatibility-section');
+    expect(screen.queryByTestId('skill-compatibility-compatible')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('skill-compatibility-unknown')).not.toHaveLength(0);
+    expect(screen.getByTestId('skill-compatibility-unknown-notice')).toHaveTextContent(
+      'skills.compatibility.unverifiedNotice'
+    );
+  });
+
+  it('blocks install on an unknown verdict, quoting the reason', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeUnknownSkill()));
+    render(<SkillDetailView skillId="mystery-skill" />);
+
+    const reason = await screen.findByTestId('skill-install-reason');
+    expect(reason).toHaveTextContent('skills.detail.install.blockedIncompatible');
+    expect(reason).toHaveTextContent('skills.compatibility.reason.rangeUnsupported');
+  });
+
+  it('keeps install disabled even when the Skill is compatible, since this screen only browses', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeSkill()));
+    render(<SkillDetailView skillId="release-helper" />);
+
+    expect(await screen.findByTestId('skill-install-action')).toBeDisabled();
+    expect(screen.getByTestId('skill-install-reason')).toHaveTextContent(
+      'skills.detail.install.unavailableYet'
+    );
+  });
+});
+
+describe('SkillDetailView failure states', () => {
+  it('distinguishes a missing Skill from a Catalog failure', async () => {
+    fetchMock.mockResolvedValue(mockError('SKILL_NOT_FOUND', 404));
+    render(<SkillDetailView skillId="ghost" />);
+
+    expect(await screen.findByTestId('skill-detail-not-found')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-detail-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('skill-detail-retry')).not.toBeInTheDocument();
+  });
+
+  it('offers a retry when the Catalog itself could not be loaded', async () => {
+    fetchMock.mockResolvedValue(mockError('SKILL_CATALOG_FETCH_FAILED', 503));
+    render(<SkillDetailView skillId="release-helper" />);
+
+    expect(await screen.findByTestId('skill-detail-error')).toHaveTextContent(
+      'SKILL_CATALOG_FETCH_FAILED'
+    );
+    expect(screen.getByTestId('skill-detail-retry')).toBeInTheDocument();
+  });
+
+  it('surfaces a stale Catalog on the detail screen too', async () => {
+    fetchMock.mockResolvedValue(
+      mockDetail(
+        makeSkill(),
+        makeCatalogMeta({
+          stale: true,
+          offline: false,
+          state: 'stale',
+          staleReason: 'SKILL_CATALOG_MALFORMED',
+        })
+      )
+    );
+    render(<SkillDetailView skillId="release-helper" />);
+
+    expect(await screen.findByTestId('skill-catalog-stale')).toHaveTextContent(
+      'skills.catalog.reason.malformed'
+    );
+  });
+});
+
+describe('SkillDetailView mobile layout', () => {
+  it('wraps long digests and commits so a 375px viewport has nothing to scroll sideways', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeSkill()));
+    render(<SkillDetailView skillId="release-helper" />);
+    const version = await screen.findByTestId('skill-version-1.2.0');
+
+    const digest = Array.from(version.querySelectorAll('dd')).find((node) =>
+      node.textContent?.includes('b'.repeat(64))
+    );
+    expect(digest?.className).toContain('break-all');
+  });
+
+  it('never places content behind a hover-only reveal', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeIncompatibleSkill()));
+    const { container } = render(<SkillDetailView skillId="future-skill" />);
+    await screen.findByTestId('skill-risk-section');
+
+    expect(container.querySelectorAll('[class*="opacity-0"]')).toHaveLength(0);
+    expect(container.querySelectorAll('[class*="group-hover:"]')).toHaveLength(0);
+  });
+});

--- a/tests/unit/components/skills/fixtures.ts
+++ b/tests/unit/components/skills/fixtures.ts
@@ -1,0 +1,151 @@
+/**
+ * Catalog API fixtures for the Skill Catalog UI tests (Issue #1232)
+ *
+ * Shaped from `lib/api/skills-api` so the tests break if the #1231 wire
+ * contract changes rather than passing against a stale hand-written shape.
+ */
+
+import type {
+  SkillCatalogMetaDto,
+  SkillDto,
+  SkillVersionDto,
+} from '@/components/skills/types';
+
+export function makeCatalogMeta(overrides: Partial<SkillCatalogMetaDto> = {}): SkillCatalogMetaDto {
+  return {
+    schemaVersion: 1,
+    fetchedAt: '2026-07-20T00:00:00Z',
+    revalidatedAt: '2026-07-20T00:05:00Z',
+    stale: false,
+    offline: false,
+    state: 'fresh',
+    staleReason: null,
+    source: { repository: 'Kewton/commandmate-skills', ref: 'main', revision: 'etag-1' },
+    ...overrides,
+  };
+}
+
+export function makeVersion(overrides: Partial<SkillVersionDto> = {}): SkillVersionDto {
+  return {
+    version: '1.2.0',
+    changelog: 'Adds the release checklist step.',
+    publishedAt: '2026-07-01T00:00:00Z',
+    declaredRisk: 'low',
+    prerelease: false,
+    source: {
+      repository: 'Kewton/commandmate-skills',
+      ref: 'v1.2.0',
+      commit: 'a'.repeat(40),
+    },
+    artifact: {
+      assetName: 'release-helper-1.2.0.tar.gz',
+      sha256: 'b'.repeat(64),
+      size: 20480,
+      format: 'tar.gz',
+    },
+    compatibility: {
+      commandmate: {
+        status: 'compatible',
+        reasonCode: 'SKILL_COMPAT_SATISFIED',
+        messageKey: 'skills.compatibility.reason.satisfied',
+        message: 'CommandMate 0.11.4 satisfies the required range ">=0.11.0".',
+        requiredRange: '>=0.11.0',
+        currentVersion: '0.11.4',
+      },
+      agents: [
+        {
+          agent: 'claude',
+          support: 'native',
+          labelKey: 'skills.compatibility.native',
+          evidence: 'Verified against the Agent Skills specification.',
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+export function makeSkill(overrides: Partial<SkillDto> = {}): SkillDto {
+  const versions = overrides.versions ?? [makeVersion()];
+  return {
+    id: 'release-helper',
+    name: 'Release Helper',
+    summary: 'Walks an agent through the release checklist.',
+    provider: { name: 'CommandMate', url: 'https://example.invalid/publisher' },
+    license: 'MIT',
+    homepage: 'https://example.invalid/release-helper',
+    keywords: ['release', 'checklist'],
+    latest: '1.2.0',
+    recommendedVersion: '1.2.0',
+    recommendedReason: 'SKILL_RECOMMEND_HIGHEST_COMPATIBLE',
+    compatibility: versions[0]?.compatibility.commandmate ?? null,
+    ...overrides,
+    versions,
+  };
+}
+
+/** An entry whose only version is out of range for the running CommandMate. */
+export function makeIncompatibleSkill(): SkillDto {
+  const version = makeVersion({
+    version: '2.0.0',
+    declaredRisk: 'high',
+    compatibility: {
+      commandmate: {
+        status: 'incompatible',
+        reasonCode: 'SKILL_COMPAT_HOST_VERSION_OUT_OF_RANGE',
+        messageKey: 'skills.compatibility.reason.hostVersionOutOfRange',
+        message: 'This Skill requires CommandMate ">=9.0.0", but CommandMate 0.11.4 is running.',
+        requiredRange: '>=9.0.0',
+        currentVersion: '0.11.4',
+      },
+      agents: [
+        {
+          agent: 'codex',
+          support: 'unknown',
+          labelKey: 'skills.compatibility.unknown',
+          evidence: 'Not verified.',
+        },
+      ],
+    },
+  });
+  return makeSkill({
+    id: 'future-skill',
+    name: 'Future Skill',
+    summary: 'Needs a CommandMate that is not released yet.',
+    latest: '2.0.0',
+    recommendedVersion: null,
+    recommendedReason: 'SKILL_RECOMMEND_NONE_COMPATIBLE',
+    compatibility: version.compatibility.commandmate,
+    versions: [version],
+  });
+}
+
+/** An entry CommandMate could not judge at all. */
+export function makeUnknownSkill(): SkillDto {
+  const version = makeVersion({
+    version: '0.9.0',
+    declaredRisk: 'moderate',
+    compatibility: {
+      commandmate: {
+        status: 'unknown',
+        reasonCode: 'SKILL_COMPAT_RANGE_UNSUPPORTED',
+        messageKey: 'skills.compatibility.reason.rangeUnsupported',
+        message: 'This Skill declares the unsupported CommandMate version range "latest".',
+        requiredRange: 'latest',
+        currentVersion: '0.11.4',
+      },
+      agents: [],
+    },
+  });
+  return makeSkill({
+    id: 'mystery-skill',
+    name: 'Mystery Skill',
+    summary: 'Declares a range CommandMate cannot interpret.',
+    keywords: ['mystery'],
+    latest: '0.9.0',
+    recommendedVersion: '0.9.0',
+    recommendedReason: 'SKILL_RECOMMEND_LATEST_UNVERIFIED',
+    compatibility: version.compatibility.commandmate,
+    versions: [version],
+  });
+}

--- a/tests/unit/components/skills/skill-vocabulary.test.ts
+++ b/tests/unit/components/skills/skill-vocabulary.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Skill Catalog display vocabulary (Issue #1232)
+ *
+ * The invariants here are the ones a rendered-output test cannot prove on its
+ * own: that `unknown` never borrows the compatible styling, and that Catalog
+ * text can never make the browser reach an external host.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  COMPATIBILITY_BADGE_VARIANT,
+  RISK_BADGE_VARIANT,
+  catalogReasonLabelKey,
+  collectAgentOptions,
+  filterSkills,
+  headlineDeclaredRisk,
+  matchesSkillQuery,
+  resolveSkillMessageKey,
+  stripRemoteMedia,
+  supportedAgents,
+  EMPTY_SKILL_FILTERS,
+} from '@/components/skills/skill-vocabulary';
+import { makeIncompatibleSkill, makeSkill, makeUnknownSkill, makeVersion } from './fixtures';
+
+describe('compatibility styling', () => {
+  it('never gives unknown the same variant as compatible', () => {
+    expect(COMPATIBILITY_BADGE_VARIANT.unknown).not.toBe(COMPATIBILITY_BADGE_VARIANT.compatible);
+  });
+
+  it('gives each of the three verdicts a distinct variant', () => {
+    const variants = Object.values(COMPATIBILITY_BADGE_VARIANT);
+    expect(new Set(variants).size).toBe(variants.length);
+  });
+
+  it('never renders a declared risk level as success', () => {
+    expect(Object.values(RISK_BADGE_VARIANT)).not.toContain('success');
+  });
+
+  it('distinguishes high risk from the lower levels', () => {
+    expect(RISK_BADGE_VARIANT.high).not.toBe(RISK_BADGE_VARIANT.low);
+    expect(RISK_BADGE_VARIANT.high).not.toBe(RISK_BADGE_VARIANT.moderate);
+  });
+});
+
+describe('resolveSkillMessageKey', () => {
+  it('strips the namespace off a contract-supplied key', () => {
+    expect(resolveSkillMessageKey('skills.compatibility.native')).toBe('compatibility.native');
+  });
+
+  it('leaves an already-relative key alone', () => {
+    expect(resolveSkillMessageKey('compatibility.native')).toBe('compatibility.native');
+  });
+});
+
+describe('catalogReasonLabelKey', () => {
+  it('maps each stale reason to its own label key', () => {
+    expect(catalogReasonLabelKey('SKILL_CATALOG_RATE_LIMITED')).toBe('catalog.reason.rateLimited');
+    expect(catalogReasonLabelKey('SKILL_CATALOG_INVALID_SCHEMA')).toBe(
+      'catalog.reason.invalidSchema'
+    );
+  });
+
+  it('falls back to an explicit unknown rather than an empty string', () => {
+    expect(catalogReasonLabelKey(null)).toBe('catalog.reason.unknown');
+    expect(catalogReasonLabelKey('SOMETHING_NEW')).toBe('catalog.reason.unknown');
+  });
+});
+
+describe('stripRemoteMedia', () => {
+  it('removes a markdown image but keeps its alt text', () => {
+    expect(stripRemoteMedia('before ![a pixel](https://tracker.invalid/p.gif) after')).toBe(
+      'before a pixel after'
+    );
+  });
+
+  it('removes raw media tags that would issue a request', () => {
+    const input = '<img src="https://tracker.invalid/p.gif"><iframe src="https://evil.invalid">x';
+    const output = stripRemoteMedia(input);
+    expect(output).not.toContain('tracker.invalid');
+    expect(output).not.toContain('<iframe');
+    expect(output).toContain('x');
+  });
+
+  it.each(['<video src="https://a.invalid/v.mp4">', '<audio src="https://a.invalid/a.mp3">', '<embed src="https://a.invalid/e">'])(
+    'removes %s',
+    (tag) => {
+      expect(stripRemoteMedia(tag)).not.toContain('a.invalid');
+    }
+  );
+
+  it('leaves ordinary markdown links intact, since they load nothing until clicked', () => {
+    const input = 'see [the docs](https://example.invalid/docs)';
+    expect(stripRemoteMedia(input)).toBe(input);
+  });
+
+  it('leaves text with no media untouched', () => {
+    expect(stripRemoteMedia('## Changes\n\n- fixed a thing')).toBe('## Changes\n\n- fixed a thing');
+  });
+});
+
+describe('matchesSkillQuery', () => {
+  const skill = makeSkill();
+
+  it.each(['release', 'RELEASE', 'checklist', 'CommandMate', 'release-helper'])(
+    'matches %s across name, summary, keywords, provider and id',
+    (query) => {
+      expect(matchesSkillQuery(skill, query)).toBe(true);
+    }
+  );
+
+  it('does not match an unrelated term', () => {
+    expect(matchesSkillQuery(skill, 'kubernetes')).toBe(false);
+  });
+
+  it('treats an empty query as no filter', () => {
+    expect(matchesSkillQuery(skill, '   ')).toBe(true);
+  });
+});
+
+describe('headlineDeclaredRisk / supportedAgents', () => {
+  it('reports the recommended version risk rather than the first listed one', () => {
+    const skill = makeSkill({
+      recommendedVersion: '1.0.0',
+      versions: [
+        makeVersion({ version: '2.0.0', declaredRisk: 'high' }),
+        makeVersion({ version: '1.0.0', declaredRisk: 'low' }),
+      ],
+    });
+    expect(headlineDeclaredRisk(skill)).toBe('low');
+  });
+
+  it('excludes agents that are only claimed as unsupported or unknown', () => {
+    expect(supportedAgents(makeIncompatibleSkill())).toEqual([]);
+    expect(supportedAgents(makeSkill())).toEqual(['claude']);
+  });
+});
+
+describe('filterSkills', () => {
+  const skills = [makeSkill(), makeIncompatibleSkill(), makeUnknownSkill()];
+
+  it('returns everything when nothing is filtered', () => {
+    expect(filterSkills(skills, EMPTY_SKILL_FILTERS)).toHaveLength(3);
+  });
+
+  it('never returns an unknown-compatibility Skill under the compatible filter', () => {
+    const result = filterSkills(skills, { ...EMPTY_SKILL_FILTERS, compatibility: 'compatible' });
+    expect(result.map((s) => s.id)).toEqual(['release-helper']);
+  });
+
+  it('filters by declared risk', () => {
+    const result = filterSkills(skills, { ...EMPTY_SKILL_FILTERS, risk: 'high' });
+    expect(result.map((s) => s.id)).toEqual(['future-skill']);
+  });
+
+  it('filters by agent support', () => {
+    const result = filterSkills(skills, { ...EMPTY_SKILL_FILTERS, agent: 'claude' });
+    expect(result.map((s) => s.id)).toEqual(['release-helper']);
+  });
+
+  it('combines search with filters', () => {
+    const result = filterSkills(skills, {
+      ...EMPTY_SKILL_FILTERS,
+      query: 'mystery',
+      compatibility: 'unknown',
+    });
+    expect(result.map((s) => s.id)).toEqual(['mystery-skill']);
+  });
+
+  it('collects every named agent for the filter options, including unsupported claims', () => {
+    expect(collectAgentOptions(skills)).toEqual(['claude', 'codex']);
+  });
+});

--- a/tests/unit/components/skills/skills-i18n-keys.test.ts
+++ b/tests/unit/components/skills/skills-i18n-keys.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Real-dictionary i18n guard for the `skills` namespace (Issue #1232)
+ *
+ * The next-intl mock echoes `skills.<key>`, so every component test here would
+ * still pass against a dictionary that never defined the key. Only asserting
+ * against the shipped JSON proves the screens render prose rather than key
+ * paths — `src/i18n.ts` has no message fallback, so a missing key reaches the
+ * user verbatim.
+ *
+ * Call-site keys are extracted from the source rather than listed by hand, so
+ * adding a `t('…')` without a dictionary entry fails here immediately.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import {
+  COMPATIBILITY_LABEL_KEY,
+  RECOMMENDATION_LABEL_KEY,
+  RISK_LABEL_KEY,
+  catalogReasonLabelKey,
+  resolveSkillMessageKey,
+} from '@/components/skills/skill-vocabulary';
+import { AGENT_SUPPORT_LABEL_KEYS, PERMISSION_DECLARATION_NOTICE_KEY } from '@/lib/skills/constants';
+import { SKILL_COMPATIBILITY_MESSAGE_KEYS } from '@/lib/skills/compatibility';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const LOCALES_DIR = path.join(ROOT, 'locales');
+const SOURCE_DIRS = [
+  path.join(ROOT, 'src/components/skills'),
+  path.join(ROOT, 'src/app/skills'),
+];
+
+function loadSkills(locale: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, locale, 'skills.json'), 'utf-8'));
+}
+
+function leafKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const full = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return leafKeys(value as Record<string, unknown>, full);
+    }
+    return [full];
+  });
+}
+
+function resolve(dict: Record<string, unknown>, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], dict);
+}
+
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+/** Literal `t('key')` arguments used by the Skill screens. */
+function callSiteKeys(): string[] {
+  const keys = new Set<string>();
+  for (const dir of SOURCE_DIRS) {
+    for (const file of sourceFiles(dir)) {
+      const content = fs.readFileSync(file, 'utf-8');
+      for (const match of content.matchAll(/\bt\('([a-zA-Z][\w.]*)'/g)) {
+        keys.add(match[1]);
+      }
+    }
+  }
+  return [...keys].sort();
+}
+
+/**
+ * Keys supplied by the `lib/skills` contract rather than written at a call
+ * site. `src/lib/skills` publishes them namespace-qualified so UI and CLI share
+ * one vocabulary; the screens strip the prefix before resolving them.
+ */
+function contractKeys(): string[] {
+  return [
+    ...Object.values(SKILL_COMPATIBILITY_MESSAGE_KEYS),
+    ...Object.values(AGENT_SUPPORT_LABEL_KEYS),
+    PERMISSION_DECLARATION_NOTICE_KEY,
+  ]
+    .map(resolveSkillMessageKey)
+    .concat(Object.values(RECOMMENDATION_LABEL_KEY))
+    .concat(Object.values(COMPATIBILITY_LABEL_KEY))
+    .concat(Object.values(RISK_LABEL_KEY))
+    .concat(
+      [
+        'SKILL_CATALOG_FETCH_FAILED',
+        'SKILL_CATALOG_RATE_LIMITED',
+        'SKILL_CATALOG_OVERSIZED',
+        'SKILL_CATALOG_MALFORMED',
+        'SKILL_CATALOG_INVALID_SCHEMA',
+        null,
+      ].map(catalogReasonLabelKey)
+    )
+    .sort();
+}
+
+/**
+ * Interpolated messages: a dropped placeholder renders the literal `{range}`
+ * to the user, which no key-parity check would catch.
+ */
+const PLACEHOLDERS: Record<string, string[]> = {
+  'search.resultCount': ['{shown}', '{total}'],
+  'compatibility.requiredRange': ['{range}'],
+  'compatibility.currentVersion': ['{version}'],
+  'compatibility.reason.satisfied': ['{range}', '{currentVersion}'],
+  'compatibility.reason.hostVersionOutOfRange': ['{range}', '{currentVersion}'],
+  'compatibility.reason.hostVersionUnknown': ['{range}'],
+  'compatibility.reason.rangeUnsupported': ['{range}'],
+  'risk.declaredLabel': ['{level}'],
+  'detail.packageBytes': ['{bytes}'],
+  'detail.install.blockedIncompatible': ['{reason}'],
+  'card.provider': ['{provider}'],
+  'state.errorCode': ['{code}'],
+  'catalog.fetchedAt': ['{timestamp}'],
+  'catalog.revalidatedAt': ['{timestamp}'],
+  'catalog.sourceLabel': ['{repository}', '{ref}'],
+};
+
+/**
+ * Labels that are the same string in both locales on purpose: they name a
+ * format or identifier, not a concept, and localizing them would misdescribe
+ * what the adjacent value literally is.
+ */
+const UNTRANSLATED_BY_DESIGN = ['detail.skillId', 'detail.sourceRef', 'detail.packageDigest'];
+
+describe('skills i18n keys (Issue #1232)', () => {
+  it.each(['en', 'ja'])('%s/skills.json has non-empty values for every leaf', (locale) => {
+    const dict = loadSkills(locale);
+    const keys = leafKeys(dict);
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(resolve(dict, key), `${locale}: ${key}`).toBeTruthy();
+    }
+  });
+
+  it('en and ja expose the identical set of keys (parity)', () => {
+    expect(leafKeys(loadSkills('en')).sort()).toEqual(leafKeys(loadSkills('ja')).sort());
+  });
+
+  it('finds the call sites it is meant to guard', () => {
+    expect(callSiteKeys().length).toBeGreaterThan(20);
+  });
+
+  it.each(['en', 'ja'])('%s defines every key the Skill screens resolve', (locale) => {
+    const dict = loadSkills(locale);
+    for (const key of [...callSiteKeys(), ...contractKeys()]) {
+      expect(resolve(dict, key), `${locale} missing ${key}`).toEqual(expect.any(String));
+    }
+  });
+
+  it('ships no dictionary entry the screens never resolve', () => {
+    const used = new Set([...callSiteKeys(), ...contractKeys()]);
+    const unused = leafKeys(loadSkills('en')).filter((key) => !used.has(key));
+    expect(unused).toEqual([]);
+  });
+
+  it('translates the Japanese dictionary rather than leaving it in English', () => {
+    const en = loadSkills('en');
+    const ja = loadSkills('ja');
+    const untranslated = leafKeys(en)
+      .filter((key) => !UNTRANSLATED_BY_DESIGN.includes(key))
+      .filter((key) => resolve(en, key) === resolve(ja, key));
+    expect(untranslated).toEqual([]);
+  });
+
+  it('keeps interpolation placeholders intact in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadSkills(locale);
+      for (const [key, placeholders] of Object.entries(PLACEHOLDERS)) {
+        const value = resolve(dict, key) as string;
+        for (const placeholder of placeholders) {
+          expect(value, `${locale}: ${key} lost ${placeholder}`).toContain(placeholder);
+        }
+      }
+    }
+  });
+
+  it('gives the three compatibility verdicts distinct labels in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadSkills(locale);
+      const labels = ['compatible', 'incompatible', 'unknown'].map((status) =>
+        resolve(dict, `compatibility.status.${status}`)
+      );
+      expect(new Set(labels).size, `${locale}: two verdicts share a label`).toBe(3);
+    }
+  });
+
+  it('gives the three risk levels distinct labels in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const dict = loadSkills(locale);
+      const labels = ['low', 'moderate', 'high'].map((level) =>
+        resolve(dict, `risk.level.${level}`)
+      );
+      expect(new Set(labels).size, `${locale}: two risk levels share a label`).toBe(3);
+    }
+  });
+
+  it('defines the shared Skills navigation label in both locales', () => {
+    for (const locale of ['en', 'ja']) {
+      const common = JSON.parse(
+        fs.readFileSync(path.join(LOCALES_DIR, locale, 'common.json'), 'utf-8')
+      );
+      expect(resolve(common, 'nav.skills'), `${locale} missing nav.skills`).toEqual(
+        expect.any(String)
+      );
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1232（Epic #1227 Phase 1 Wave 3）。`/skills` の Catalog 一覧と `/skills/[skillId]` の詳細画面を追加する。表示は #1231 の `GET /api/skills` 系のみを経由し、Catalog の fetch/parse を client 側へ重複させない。

## 主な変更

- `src/components/skills/` — 一覧（検索・compatibility / risk / agent filter）、詳細、badge、notice、Catalog freshness banner、API client、表示語彙（pure）
- 導線 — More 画面の Quick Links と Command Palette の Navigation 群に Skills を追加
- i18n — `locales/{en,ja}/skills.json` を新設し `src/i18n.ts` へ登録、`common.json` に `nav.skills` を追加

## 判定と警告

- 互換性は compatible / incompatible / **unknown** の 3 値を別々の badge variant で表示し、**unknown を compatible として描画しない**。install 導線は unknown でも disabled とし、contract の messageKey から理由文を出す
- publisher 宣言 risk は「宣言」であることを label と注記で明示し、CommandMate 算出 risk は別見出しで「Catalog からは取得できない」と述べる
- **permission は宣言であって enforcement ではない**旨を、#1228 の `PERMISSION_DECLARATION_NOTICE_KEY` を使って常時表示
- Catalog の stale / offline は理由コードと timestamp 付きで警告表示し、取得失敗は空 Catalog と別レンダリングにする

## セキュリティ

- artifact URL や絶対 install path は画面に出さない（#1231 の DTO にも含まれない）
- changelog は既存の rehype-sanitize 済み MarkdownPreview を利用するが、**共有 sanitize schema が `img[src]` の http(s) を許可するため**、描画前に `stripRemoteMedia()` で markdown image と img/iframe/video/audio/embed 等を除去し、Catalog 閲覧が外部ホストへリクエストを出さないようにした（sanitize だけでは publisher 管理下の changelog が tracking pixel を読み込めてしまう）。**ガードを壊す mutation test 4 件で失敗を確認済み**

## Issue 記載との差異

Issue 本文は書き換えていない。

1. Issue は詳細に「期待効果・要求 command/network・宣言権限・files/scripts」を表示するとしているが、**これらは Catalog ではなく package 内の `commandmate.skill.yaml` と #1230 の inspection にあり、#1231 の `SkillDto` には存在しない**。取得できない旨を明記する section として実装し、無言で省略も捏造もしていない
2. 同じ理由で「CommandMate 算出 risk」も Catalog からは出せない。宣言 risk のみ表示し、算出 risk は未取得であることを明示
3. 「SKILL.md preview」も SKILL.md が package 内にあるため Catalog から取得できない。MarkdownPreview は Catalog が返す changelog の描画に使用している
4. 受入条件「script 包含が視覚・アクセシビリティ上識別できる」は、**script 一覧が Catalog に無いため本 Issue の範囲では判定不能**。high risk については text + icon + badge variant で識別可能にしている
5. install 自体は Non-goal かつ #1242 未実装のため install 導線は常に disabled とし、理由（互換性 / version 不在 / 閲覧のみ）を表示

## その他

- page は barrel ではなく具体 module を import する。**barrel 経由だと一覧 route にも react-markdown/highlight.js が載り First Load JS が 227kB → 384kB に膨らむ**ため
- 新規 runtime 依存なし。fetch は global fetch
- `tests/unit/components/skills/` に 76 件追加。実辞書テストは call site の `t('...')` を静的抽出して照合するため、**key 追加漏れと未使用 key の双方を検出する**

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run test:unit` | worker 側 exit 0 / 617 files / 10654 tests |
| `npm run build` | worker 側 exit 0 |

`tests/integration/i18n-namespace-loading.test.ts` も namespace 追加に合わせて更新・通過。

## 未実施

実機ブラウザ確認は未実施。`Kewton/commandmate-skills` が private かつ Catalog 未作成のため、実画面は 503 の error state しか出せない。**#1238 で release pipeline が入り実 Catalog が公開された時点で実機確認が必要**。

Refs #1232, #1227