### PR TITLE
feat(security): Skill packageの完全照合・安全な検査・展開基盤 (#1230)

### DIFF
--- a/src/lib/skills/package-reader.ts
+++ b/src/lib/skills/package-reader.ts
@@ -1,0 +1,601 @@
+/**
+ * Strict tar.gz table reader for Skill packages (Issue #1230)
+ *
+ * Reads a verified artifact snapshot (#1229) into an in-memory entry table.
+ * Nothing is written to disk here and no archive library is used: a
+ * general-purpose extractor decides for itself what a symlink, a hardlink or a
+ * `..` component means, and those decisions are exactly the ones that have to
+ * be ours.
+ *
+ * The reader parses *every* entry before returning, so a package is judged as a
+ * whole. One forbidden entry rejects the package rather than being skipped,
+ * which is what stops a partially-trusted payload from reaching a consumer.
+ *
+ * Only `ustar` regular files and directories are accepted. Symlinks, hardlinks,
+ * devices, FIFOs, sockets, sparse/contiguous files and pax/GNU extension
+ * records are refused by type, before their content is looked at. Ownership,
+ * timestamps and permission metadata are read only to *reject* setuid/setgid/
+ * sticky entries; nothing from the archive is ever applied to the filesystem.
+ *
+ * @module lib/skills/package-reader
+ */
+
+import { gunzipSync } from 'zlib';
+import {
+  SKILL_FILE_MAX_SIZE,
+  SKILL_FILES_MAX_COUNT,
+  SKILL_MANIFEST_FILENAME,
+  foldSkillIdForCollision,
+  validateSkillPayloadPath,
+} from '@/lib/skills';
+import { computeSha256Hex } from '@/lib/skills/integrity';
+
+// =============================================================================
+// Limits
+// =============================================================================
+
+/** Fixed tar block size. */
+export const TAR_BLOCK_SIZE = 512;
+
+/** Hard cap on the decompressed archive, independent of the compressed size. */
+export const SKILL_PACKAGE_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+/** Maximum decompressed-to-compressed ratio tolerated above the floor below. */
+export const SKILL_PACKAGE_MAX_COMPRESSION_RATIO = 200;
+
+/**
+ * Ratio checking starts here.
+ *
+ * Tar pads every entry to 512 bytes and those pad bytes are zeros, so a small
+ * legitimate package compresses at a ratio a bomb would also show. Below this
+ * size the absolute caps are the meaningful guard.
+ */
+export const SKILL_PACKAGE_RATIO_FLOOR_BYTES = 1024 * 1024;
+
+/** Maximum number of archive entries, directories included. */
+export const SKILL_PACKAGE_MAX_ENTRIES = 1000;
+
+// =============================================================================
+// Error vocabulary
+// =============================================================================
+
+/**
+ * Stable reason codes for a rejected package.
+ *
+ * Shared with `package-validator` so a caller sees one vocabulary from
+ * decompression through materialization.
+ */
+export const SkillPackageErrorCode = {
+  /** Bytes are not a readable gzip/ustar stream. */
+  ARCHIVE_FORMAT: 'SKILL_PACKAGE_ARCHIVE_FORMAT',
+  /** Archive ends in the middle of an entry. */
+  ARCHIVE_TRUNCATED: 'SKILL_PACKAGE_ARCHIVE_TRUNCATED',
+  /** Entry is not a regular file or a directory. */
+  ENTRY_TYPE_FORBIDDEN: 'SKILL_PACKAGE_ENTRY_TYPE_FORBIDDEN',
+  /** Entry path escapes the package root or is otherwise unsafe. */
+  ENTRY_PATH_UNSAFE: 'SKILL_PACKAGE_ENTRY_PATH_UNSAFE',
+  /** The same path appears twice. */
+  ENTRY_DUPLICATE: 'SKILL_PACKAGE_ENTRY_DUPLICATE',
+  /** Two paths differ only by case or Unicode form. */
+  ENTRY_COLLISION: 'SKILL_PACKAGE_ENTRY_COLLISION',
+  /** Entry carries setuid, setgid or sticky bits. */
+  ENTRY_MODE_FORBIDDEN: 'SKILL_PACKAGE_ENTRY_MODE_FORBIDDEN',
+  /** Archive holds more entries than the contract allows. */
+  ENTRY_LIMIT_EXCEEDED: 'SKILL_PACKAGE_ENTRY_LIMIT_EXCEEDED',
+  /** A single file or the whole payload exceeds its size cap. */
+  SIZE_LIMIT_EXCEEDED: 'SKILL_PACKAGE_SIZE_LIMIT_EXCEEDED',
+  /** Decompression ratio is outside the tolerated band. */
+  COMPRESSION_RATIO_EXCEEDED: 'SKILL_PACKAGE_COMPRESSION_RATIO_EXCEEDED',
+  /** Root layout, required entries or the package root directory are wrong. */
+  LAYOUT_INVALID: 'SKILL_PACKAGE_LAYOUT_INVALID',
+  /** Manifest is absent, or a second manifest is smuggled in a subdirectory. */
+  MANIFEST_MISSING: 'SKILL_PACKAGE_MANIFEST_MISSING',
+  /** Manifest does not parse or does not satisfy the #1228 contract. */
+  MANIFEST_INVALID: 'SKILL_PACKAGE_MANIFEST_INVALID',
+  /** Manifest disagrees with the package or with the Catalog coordinates. */
+  MANIFEST_MISMATCH: 'SKILL_PACKAGE_MANIFEST_MISMATCH',
+  /** A payload file carries the executable bit without declaring it. */
+  UNDECLARED_EXECUTABLE: 'SKILL_PACKAGE_UNDECLARED_EXECUTABLE',
+  /** A payload file is a script without declaring it. */
+  UNDECLARED_SCRIPT: 'SKILL_PACKAGE_UNDECLARED_SCRIPT',
+  /** A payload file's digest differs from the declared one. */
+  DIGEST_MISMATCH: 'SKILL_PACKAGE_DIGEST_MISMATCH',
+  /** A payload file's size differs from the declared one. */
+  SIZE_MISMATCH: 'SKILL_PACKAGE_SIZE_MISMATCH',
+  /** SKILL.md frontmatter is missing or disagrees with the manifest. */
+  SKILL_MD_INVALID: 'SKILL_PACKAGE_SKILL_MD_INVALID',
+  /** Staging directory could not be created, written or verified. */
+  STAGING_IO: 'SKILL_PACKAGE_STAGING_IO',
+  /** Caller aborted before the package was complete. */
+  ABORTED: 'SKILL_PACKAGE_ABORTED',
+} as const;
+
+export type SkillPackageErrorCodeType =
+  (typeof SkillPackageErrorCode)[keyof typeof SkillPackageErrorCode];
+
+/** Coarse grouping a UI can branch on without knowing every code (UX-09). */
+export type SkillPackageErrorCategory =
+  | 'archive'
+  | 'path'
+  | 'limit'
+  | 'integrity'
+  | 'manifest'
+  | 'staging';
+
+const CATEGORIES: Record<SkillPackageErrorCodeType, SkillPackageErrorCategory> = {
+  [SkillPackageErrorCode.ARCHIVE_FORMAT]: 'archive',
+  [SkillPackageErrorCode.ARCHIVE_TRUNCATED]: 'archive',
+  [SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN]: 'path',
+  [SkillPackageErrorCode.ENTRY_PATH_UNSAFE]: 'path',
+  [SkillPackageErrorCode.ENTRY_DUPLICATE]: 'path',
+  [SkillPackageErrorCode.ENTRY_COLLISION]: 'path',
+  [SkillPackageErrorCode.ENTRY_MODE_FORBIDDEN]: 'path',
+  [SkillPackageErrorCode.ENTRY_LIMIT_EXCEEDED]: 'limit',
+  [SkillPackageErrorCode.SIZE_LIMIT_EXCEEDED]: 'limit',
+  [SkillPackageErrorCode.COMPRESSION_RATIO_EXCEEDED]: 'limit',
+  [SkillPackageErrorCode.LAYOUT_INVALID]: 'manifest',
+  [SkillPackageErrorCode.MANIFEST_MISSING]: 'manifest',
+  [SkillPackageErrorCode.MANIFEST_INVALID]: 'manifest',
+  [SkillPackageErrorCode.MANIFEST_MISMATCH]: 'manifest',
+  [SkillPackageErrorCode.UNDECLARED_EXECUTABLE]: 'manifest',
+  [SkillPackageErrorCode.UNDECLARED_SCRIPT]: 'manifest',
+  [SkillPackageErrorCode.DIGEST_MISMATCH]: 'integrity',
+  [SkillPackageErrorCode.SIZE_MISMATCH]: 'integrity',
+  [SkillPackageErrorCode.SKILL_MD_INVALID]: 'manifest',
+  [SkillPackageErrorCode.STAGING_IO]: 'staging',
+  [SkillPackageErrorCode.ABORTED]: 'staging',
+};
+
+const MESSAGES: Record<SkillPackageErrorCodeType, string> = {
+  [SkillPackageErrorCode.ARCHIVE_FORMAT]: 'Skill package is not a readable tar.gz archive',
+  [SkillPackageErrorCode.ARCHIVE_TRUNCATED]: 'Skill package archive is truncated',
+  [SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN]: 'Skill package contains a forbidden entry type',
+  [SkillPackageErrorCode.ENTRY_PATH_UNSAFE]: 'Skill package contains an unsafe entry path',
+  [SkillPackageErrorCode.ENTRY_DUPLICATE]: 'Skill package declares the same entry twice',
+  [SkillPackageErrorCode.ENTRY_COLLISION]: 'Skill package contains colliding entry paths',
+  [SkillPackageErrorCode.ENTRY_MODE_FORBIDDEN]: 'Skill package entry carries forbidden mode bits',
+  [SkillPackageErrorCode.ENTRY_LIMIT_EXCEEDED]: 'Skill package contains too many entries',
+  [SkillPackageErrorCode.SIZE_LIMIT_EXCEEDED]: 'Skill package exceeds a size limit',
+  [SkillPackageErrorCode.COMPRESSION_RATIO_EXCEEDED]:
+    'Skill package decompression ratio exceeds the limit',
+  [SkillPackageErrorCode.LAYOUT_INVALID]: 'Skill package layout does not match the contract',
+  [SkillPackageErrorCode.MANIFEST_MISSING]: 'Skill package manifest is missing or misplaced',
+  [SkillPackageErrorCode.MANIFEST_INVALID]: 'Skill package manifest is not valid',
+  [SkillPackageErrorCode.MANIFEST_MISMATCH]: 'Skill package manifest does not match the package',
+  [SkillPackageErrorCode.UNDECLARED_EXECUTABLE]: 'Skill package contains an undeclared executable',
+  [SkillPackageErrorCode.UNDECLARED_SCRIPT]: 'Skill package contains an undeclared script',
+  [SkillPackageErrorCode.DIGEST_MISMATCH]: 'Skill package file digest does not match the manifest',
+  [SkillPackageErrorCode.SIZE_MISMATCH]: 'Skill package file size does not match the manifest',
+  [SkillPackageErrorCode.SKILL_MD_INVALID]: 'Skill package SKILL.md is missing or inconsistent',
+  [SkillPackageErrorCode.STAGING_IO]: 'Skill package staging could not be prepared',
+  [SkillPackageErrorCode.ABORTED]: 'Skill package processing was aborted',
+};
+
+/** Bounded, non-sensitive context attached to a rejection. */
+export type SkillPackageErrorDetail = Record<string, string | number | boolean>;
+
+/** A rejected Skill package. Safe to surface to API clients and logs. */
+export class SkillPackageError extends Error {
+  readonly code: SkillPackageErrorCodeType;
+  readonly category: SkillPackageErrorCategory;
+  readonly detail?: SkillPackageErrorDetail;
+
+  constructor(code: SkillPackageErrorCodeType, detail?: SkillPackageErrorDetail) {
+    super(MESSAGES[code]);
+    this.name = 'SkillPackageError';
+    this.code = code;
+    this.category = CATEGORIES[code];
+    if (detail) this.detail = detail;
+  }
+}
+
+/** Narrow an unknown thrown value to a {@link SkillPackageError}. */
+export function isSkillPackageError(value: unknown): value is SkillPackageError {
+  return value instanceof SkillPackageError;
+}
+
+/**
+ * Render an archive-supplied path so it is safe to put in an error detail.
+ *
+ * Percent-encodes everything outside a conservative allow-list and truncates,
+ * so a crafted entry name cannot inject control characters into a log line or
+ * smuggle markup into a UI. Machine-absolute paths never reach this function:
+ * only archive-relative names do.
+ */
+export function encodeEntryPathForError(value: string): string {
+  const encoded = value.replace(/[^A-Za-z0-9._/-]/g, (ch) =>
+    [...ch]
+      .map((c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`)
+      .join('')
+  );
+  return encoded.length > 120 ? `${encoded.slice(0, 120)}…` : encoded;
+}
+
+function fail(
+  code: SkillPackageErrorCodeType,
+  detail?: SkillPackageErrorDetail
+): never {
+  throw new SkillPackageError(code, detail);
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** One regular payload file, as read from the archive. */
+export interface SkillPackageFileEntry {
+  /** POSIX path relative to the package root, after the root prefix is stripped. */
+  readonly path: string;
+  readonly size: number;
+  /** Lowercase hex SHA-256 over the file bytes. */
+  readonly sha256: string;
+  /** Whether the archive entry carried any executable bit. */
+  readonly executable: boolean;
+  readonly bytes: Uint8Array;
+}
+
+/** Everything the archive declared, parsed and bounded but not yet reconciled. */
+export interface SkillPackageTable {
+  /** Single top-level directory that was stripped, or null when there was none. */
+  readonly rootName: string | null;
+  readonly files: readonly SkillPackageFileEntry[];
+  /** Directory paths relative to the package root, root prefix stripped. */
+  readonly directories: readonly string[];
+  readonly compressedSize: number;
+  readonly decompressedSize: number;
+}
+
+/** Coordinates the package is expected to belong to, from the Catalog. */
+export interface SkillPackageReadOptions {
+  skillId: string;
+  version: string;
+}
+
+// =============================================================================
+// tar header decoding
+// =============================================================================
+
+/** A regular file is typeflag `0`; historic writers use NUL for the same thing. */
+const TYPEFLAG_REGULAR = new Set(['0', '\u0000']);
+const TYPEFLAG_DIRECTORY = '5';
+
+/**
+ * Read a NUL-terminated text field.
+ *
+ * Bytes after the terminator must be NUL: a name that continues past its own
+ * terminator is a header hand-built to be read differently by two parsers. The
+ * decoded text must also round-trip, so an invalid UTF-8 name cannot slip
+ * through as replacement characters.
+ */
+function readField(block: Uint8Array, offset: number, length: number): string {
+  const slice = block.subarray(offset, offset + length);
+  let end = slice.indexOf(0);
+  if (end === -1) end = slice.length;
+  for (let i = end; i < slice.length; i++) {
+    if (slice[i] !== 0) fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'padding' });
+  }
+  const raw = Buffer.from(slice.subarray(0, end));
+  const text = raw.toString('utf8');
+  if (!Buffer.from(text, 'utf8').equals(raw)) {
+    fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'encoding' });
+  }
+  return text;
+}
+
+/**
+ * Read an octal numeric field.
+ *
+ * Only octal digits, spaces and NULs are accepted; writers disagree about which
+ * padding they use, but none of them needs another character. GNU base-256
+ * encoding (high bit set) is refused rather than decoded: every value this
+ * reader cares about is bounded well below the point where base-256 is needed,
+ * so its presence only ever means a hand-built header.
+ */
+function readOctal(block: Uint8Array, offset: number, length: number): number {
+  if ((block[offset] & 0x80) !== 0) {
+    fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'numeric-encoding' });
+  }
+  let digits = '';
+  for (let i = offset; i < offset + length; i++) {
+    const byte = block[i];
+    if (byte === 0 || byte === 0x20) continue;
+    if (byte < 0x30 || byte > 0x37) {
+      fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'numeric' });
+    }
+    digits += String.fromCharCode(byte);
+  }
+  if (digits === '') return 0;
+  const value = parseInt(digits, 8);
+  if (!Number.isSafeInteger(value)) {
+    fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'numeric-range' });
+  }
+  return value;
+}
+
+function isZeroBlock(block: Uint8Array): boolean {
+  for (let i = 0; i < block.length; i++) if (block[i] !== 0) return false;
+  return true;
+}
+
+/** Verify the header checksum, accepting both the unsigned and signed sums. */
+function verifyChecksum(block: Uint8Array, declared: number): void {
+  let unsigned = 0;
+  let signed = 0;
+  for (let i = 0; i < TAR_BLOCK_SIZE; i++) {
+    const byte = i >= 148 && i < 156 ? 0x20 : block[i];
+    unsigned += byte;
+    signed += byte > 127 ? byte - 256 : byte;
+  }
+  if (declared !== unsigned && declared !== signed) {
+    fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'checksum' });
+  }
+}
+
+interface RawEntry {
+  name: string;
+  isDirectory: boolean;
+  mode: number;
+  size: number;
+  bytes: Uint8Array;
+}
+
+/** Decode the whole tar stream into raw entries, rejecting every other type. */
+function readTarEntries(tar: Uint8Array): RawEntry[] {
+  if (tar.byteLength === 0 || tar.byteLength % TAR_BLOCK_SIZE !== 0) {
+    fail(SkillPackageErrorCode.ARCHIVE_TRUNCATED, { field: 'alignment' });
+  }
+
+  const entries: RawEntry[] = [];
+  let offset = 0;
+
+  while (offset + TAR_BLOCK_SIZE <= tar.byteLength) {
+    const header = tar.subarray(offset, offset + TAR_BLOCK_SIZE);
+    if (isZeroBlock(header)) {
+      for (let i = offset; i < tar.byteLength; i++) {
+        if (tar[i] !== 0) fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'trailer' });
+      }
+      return entries;
+    }
+
+    verifyChecksum(header, readOctal(header, 148, 8));
+
+    // POSIX writes `ustar\0`, GNU writes `ustar ` — both are the same format here.
+    if (readField(header, 257, 6).trim() !== 'ustar') {
+      fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'magic' });
+    }
+
+    const typeflag = readField(header, 156, 1) || '\u0000';
+    const isDirectory = typeflag === TYPEFLAG_DIRECTORY;
+    if (!isDirectory && !TYPEFLAG_REGULAR.has(typeflag)) {
+      fail(SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN, { typeflag: encodeEntryPathForError(typeflag) });
+    }
+    if (readField(header, 157, 100) !== '') {
+      fail(SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN, { typeflag: 'link' });
+    }
+
+    const mode = readOctal(header, 100, 8);
+    if ((mode & 0o7000) !== 0) {
+      fail(SkillPackageErrorCode.ENTRY_MODE_FORBIDDEN, { bits: (mode & 0o7000).toString(8) });
+    }
+
+    const prefix = readField(header, 345, 155);
+    const name = readField(header, 0, 100);
+    const fullName = prefix === '' ? name : `${prefix}/${name}`;
+
+    const size = readOctal(header, 124, 12);
+    if (isDirectory && size !== 0) {
+      fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'directory-size' });
+    }
+    if (size > SKILL_FILE_MAX_SIZE) {
+      fail(SkillPackageErrorCode.SIZE_LIMIT_EXCEEDED, { limit: SKILL_FILE_MAX_SIZE });
+    }
+
+    const contentStart = offset + TAR_BLOCK_SIZE;
+    const contentEnd = contentStart + size;
+    if (contentEnd > tar.byteLength) fail(SkillPackageErrorCode.ARCHIVE_TRUNCATED);
+
+    entries.push({
+      name: fullName,
+      isDirectory,
+      mode,
+      size,
+      bytes: isDirectory ? new Uint8Array(0) : tar.subarray(contentStart, contentEnd),
+    });
+    if (entries.length > SKILL_PACKAGE_MAX_ENTRIES) {
+      fail(SkillPackageErrorCode.ENTRY_LIMIT_EXCEEDED, { limit: SKILL_PACKAGE_MAX_ENTRIES });
+    }
+
+    offset = contentStart + Math.ceil(size / TAR_BLOCK_SIZE) * TAR_BLOCK_SIZE;
+  }
+
+  // A well-formed archive ends with zero blocks; running off the end does not.
+  return fail(SkillPackageErrorCode.ARCHIVE_TRUNCATED, { field: 'trailer' });
+}
+
+// =============================================================================
+// Path normalization
+// =============================================================================
+
+/**
+ * Reduce an archive name to the form the root resolver and the payload-path
+ * validator expect: no `./` prefix, no trailing slash, never empty.
+ *
+ * Everything else — traversal, absolute and drive paths, control characters,
+ * depth and length — is left to `validateSkillPayloadPath`, which runs on the
+ * final root-relative path. Checking here as well would only add a guard no
+ * test could distinguish from the real one.
+ */
+function normalizeRawName(raw: string): { path: string; trailingSlash: boolean } {
+  let value = raw;
+  if (value.startsWith('./')) value = value.slice(2);
+  const trailingSlash = value.endsWith('/');
+  if (trailingSlash) value = value.slice(0, -1);
+  if (value === '') fail(SkillPackageErrorCode.ENTRY_PATH_UNSAFE, { reason: 'empty' });
+  return { path: value, trailingSlash };
+}
+
+/**
+ * Strip the single top-level directory a conventional tarball carries.
+ *
+ * Only `<skill-id>` and `<skill-id>-<version>` are accepted as that directory,
+ * so a package cannot install itself under a name the Catalog never named.
+ */
+function resolveRootName(paths: readonly string[], options: SkillPackageReadOptions): string | null {
+  const allowed = [options.skillId, `${options.skillId}-${options.version}`];
+  const firstSegments = new Set(paths.map((p) => p.split('/')[0]));
+  if (firstSegments.size !== 1) return null;
+
+  const candidate = [...firstSegments][0];
+  const hasNested = paths.some((p) => p.startsWith(`${candidate}/`));
+  if (!hasNested) return null;
+  if (!allowed.includes(candidate)) {
+    fail(SkillPackageErrorCode.LAYOUT_INVALID, {
+      reason: 'root-directory',
+      entry: encodeEntryPathForError(candidate),
+    });
+  }
+  return candidate;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Decompress and parse a Skill package into a bounded entry table.
+ *
+ * The caller is expected to have verified the artifact digest already (#1229);
+ * this step answers the separate question of whether the bytes are a package
+ * this build is willing to look at.
+ *
+ * @param artifact Verified artifact bytes from the snapshot store
+ * @param options Catalog coordinates the package must belong to
+ * @throws SkillPackageError for every rejection
+ */
+export function readSkillPackage(
+  artifact: Uint8Array,
+  options: SkillPackageReadOptions
+): SkillPackageTable {
+  if (artifact.byteLength < 2 || artifact[0] !== 0x1f || artifact[1] !== 0x8b) {
+    fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'gzip-magic' });
+  }
+
+  let tar: Buffer;
+  try {
+    tar = gunzipSync(artifact, { maxOutputLength: SKILL_PACKAGE_MAX_DECOMPRESSED_BYTES });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ERR_BUFFER_TOO_LARGE') {
+      fail(SkillPackageErrorCode.SIZE_LIMIT_EXCEEDED, {
+        limit: SKILL_PACKAGE_MAX_DECOMPRESSED_BYTES,
+      });
+    }
+    fail(SkillPackageErrorCode.ARCHIVE_FORMAT, { field: 'gzip' });
+  }
+
+  if (
+    tar.byteLength > SKILL_PACKAGE_RATIO_FLOOR_BYTES &&
+    tar.byteLength / artifact.byteLength > SKILL_PACKAGE_MAX_COMPRESSION_RATIO
+  ) {
+    fail(SkillPackageErrorCode.COMPRESSION_RATIO_EXCEEDED, {
+      limit: SKILL_PACKAGE_MAX_COMPRESSION_RATIO,
+    });
+  }
+
+  const raw = readTarEntries(tar);
+  const normalized = raw.map((entry) => ({ entry, ...normalizeRawName(entry.name) }));
+  const rootName = resolveRootName(
+    normalized.map((item) => item.path),
+    options
+  );
+
+  const files: SkillPackageFileEntry[] = [];
+  const directories: string[] = [];
+  const byPath = new Map<string, boolean>();
+  const byFold = new Map<string, string>();
+  let payloadBytes = 0;
+
+  for (const item of normalized) {
+    let relative = item.path;
+    if (rootName !== null) {
+      if (relative === rootName) continue;
+      relative = relative.slice(rootName.length + 1);
+    }
+
+    const isDirectory = item.entry.isDirectory || item.trailingSlash;
+    const pathResult = validateSkillPayloadPath(relative, '/entry');
+    if (!pathResult.ok) {
+      fail(SkillPackageErrorCode.ENTRY_PATH_UNSAFE, {
+        entry: encodeEntryPathForError(relative),
+        reason: pathResult.errors[0].message,
+      });
+    }
+
+    if (byPath.has(relative)) {
+      fail(SkillPackageErrorCode.ENTRY_DUPLICATE, { entry: encodeEntryPathForError(relative) });
+    }
+    const folded = relative
+      .split('/')
+      .map((segment) => foldSkillIdForCollision(segment))
+      .join('/');
+    const collidesWith = byFold.get(folded);
+    if (collidesWith !== undefined) {
+      fail(SkillPackageErrorCode.ENTRY_COLLISION, { entry: encodeEntryPathForError(relative) });
+    }
+    byPath.set(relative, isDirectory);
+    byFold.set(folded, relative);
+
+    if (isDirectory) {
+      directories.push(relative);
+      continue;
+    }
+
+    payloadBytes += item.entry.size;
+    if (payloadBytes > SKILL_PACKAGE_MAX_DECOMPRESSED_BYTES) {
+      fail(SkillPackageErrorCode.SIZE_LIMIT_EXCEEDED, {
+        limit: SKILL_PACKAGE_MAX_DECOMPRESSED_BYTES,
+      });
+    }
+    const bytes = new Uint8Array(item.entry.bytes);
+    files.push({
+      path: relative,
+      size: item.entry.size,
+      sha256: computeSha256Hex(bytes),
+      executable: (item.entry.mode & 0o111) !== 0,
+      bytes,
+    });
+  }
+
+  const payloadCount = files.filter((file) => file.path !== SKILL_MANIFEST_FILENAME).length;
+  if (payloadCount > SKILL_FILES_MAX_COUNT) {
+    fail(SkillPackageErrorCode.ENTRY_LIMIT_EXCEEDED, { limit: SKILL_FILES_MAX_COUNT });
+  }
+
+  // A file entry may not also be claimed as a directory by another entry.
+  for (const directory of directories) {
+    if (files.some((file) => file.path === directory)) {
+      fail(SkillPackageErrorCode.ENTRY_DUPLICATE, { entry: encodeEntryPathForError(directory) });
+    }
+  }
+  for (const file of files) {
+    const parents = file.path.split('/').slice(0, -1);
+    let walked = '';
+    for (const segment of parents) {
+      walked = walked === '' ? segment : `${walked}/${segment}`;
+      if (files.some((other) => other.path === walked)) {
+        fail(SkillPackageErrorCode.ENTRY_PATH_UNSAFE, {
+          entry: encodeEntryPathForError(file.path),
+          reason: 'parent-is-file',
+        });
+      }
+    }
+  }
+
+  return {
+    rootName,
+    files,
+    directories,
+    compressedSize: artifact.byteLength,
+    decompressedSize: tar.byteLength,
+  };
+}

--- a/src/lib/skills/package-validator.ts
+++ b/src/lib/skills/package-validator.ts
@@ -1,0 +1,589 @@
+/**
+ * Full package/manifest reconciliation and safe materialization (Issue #1230)
+ *
+ * Second half of the inspect-then-materialize boundary. `package-reader` decides
+ * whether the bytes are an archive we are willing to look at; this module
+ * decides whether the archive is *the package the manifest describes*, and only
+ * then writes it into an isolated staging directory.
+ *
+ * Reconciliation is exact in both directions. Every regular payload file except
+ * the manifest itself must be declared, every declaration must be present, and
+ * each one must agree on size, digest, kind, executable bit and script status.
+ * A partial match is a rejection: "mostly the manifest the user reviewed" is
+ * how an undeclared script gets installed.
+ *
+ * Nothing in the package is executed, at any point, by any code path here.
+ *
+ * @module lib/skills/package-validator
+ */
+
+import { randomBytes } from 'crypto';
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeSync,
+} from 'fs';
+import path from 'path';
+import { isSystemDirectory } from '@/config/system-directories';
+import {
+  REQUIRED_PACKAGE_ENTRIES,
+  SKILL_MANIFEST_FILENAME,
+  SKILL_MD_FILENAME,
+  computeSkillRisk,
+  resolveEffectiveSkillRisk,
+  validateManifestFileSet,
+  validateSkillIdentityConsistency,
+  validateSkillManifest,
+} from '@/lib/skills';
+import { computeSha256Hex, digestMatches } from '@/lib/skills/integrity';
+import {
+  SkillPackageError,
+  SkillPackageErrorCode,
+  encodeEntryPathForError,
+  readSkillPackage,
+  type SkillPackageErrorDetail,
+  type SkillPackageErrorCodeType,
+  type SkillPackageFileEntry,
+  type SkillPackageTable,
+} from '@/lib/skills/package-reader';
+import { isSkillYamlError, parseSkillFrontmatter, parseSkillYaml } from '@/lib/skills/safe-yaml';
+import type {
+  SkillFileKind,
+  SkillInstalledFile,
+  SkillManifest,
+  SkillPackageInspection,
+  SkillRiskLevel,
+} from '@/types/skills';
+
+// =============================================================================
+// Staging policy
+// =============================================================================
+
+/** Staging directories are private to the service account. */
+export const SKILL_STAGING_DIR_MODE = 0o700;
+
+/** Non-executable payload files land read/write for the owner only. */
+export const SKILL_STAGED_FILE_MODE = 0o600;
+
+/** Declared executables additionally get the owner execute bit. Nothing else. */
+export const SKILL_STAGED_EXECUTABLE_MODE = 0o700;
+
+/** Prefix of a staging directory, used to recognize orphans after a restart. */
+export const SKILL_STAGING_ENTRY_PREFIX = 'pkg-';
+
+const STAGING_ENTRY_PATTERN = /^pkg-[0-9a-f]{32}$/;
+
+/** `O_NOFOLLOW` is POSIX-only; on platforms without it the flag is a no-op. */
+const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
+
+// =============================================================================
+// Script classification
+// =============================================================================
+
+/**
+ * Extensions treated as scripts regardless of content.
+ *
+ * Classification is deliberately over-broad: a file wrongly called a script
+ * only forces the publisher to declare it, while a missed one would install an
+ * interpreted payload the user never saw listed.
+ */
+export const SKILL_SCRIPT_EXTENSIONS: readonly string[] = [
+  '.bash',
+  '.bat',
+  '.cjs',
+  '.cmd',
+  '.fish',
+  '.js',
+  '.lua',
+  '.mjs',
+  '.php',
+  '.pl',
+  '.ps1',
+  '.py',
+  '.rb',
+  '.sh',
+  '.ts',
+  '.zsh',
+];
+
+const INSTRUCTION_EXTENSIONS: readonly string[] = ['.md', '.markdown', '.rst', '.txt'];
+
+function extensionOf(filePath: string): string {
+  const base = filePath.slice(filePath.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot <= 0 ? '' : base.slice(dot).toLowerCase();
+}
+
+/** Whether a payload file is an interpreted script, by extension or shebang. */
+export function isSkillScriptPayload(filePath: string, bytes: Uint8Array): boolean {
+  if (SKILL_SCRIPT_EXTENSIONS.includes(extensionOf(filePath))) return true;
+  return bytes.length >= 2 && bytes[0] === 0x23 && bytes[1] === 0x21;
+}
+
+/** Role CommandMate derives for a payload file, independent of the declaration. */
+export function deriveSkillFileKind(filePath: string, bytes: Uint8Array): SkillFileKind {
+  if (filePath === SKILL_MD_FILENAME) return 'skill_md';
+  if (isSkillScriptPayload(filePath, bytes)) return 'script';
+  return INSTRUCTION_EXTENSIONS.includes(extensionOf(filePath)) ? 'instruction' : 'asset';
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A package that matched its manifest exactly.
+ *
+ * Immutable and path-free: consumers address files by their package-relative
+ * path, and {@link SkillPackageSnapshot.readFile} hands back a copy, so the
+ * bytes a plan was computed from cannot change under it (#1233).
+ */
+export interface SkillPackageSnapshot {
+  readonly skillId: string;
+  readonly version: string;
+  readonly manifest: SkillManifest;
+  /** Every regular payload file, manifest and SKILL.md included, sorted by path. */
+  readonly files: readonly SkillInstalledFile[];
+  readonly directories: readonly string[];
+  readonly inspection: SkillPackageInspection;
+  readonly declaredRisk: SkillRiskLevel;
+  readonly computedRisk: SkillRiskLevel;
+  readonly effectiveRisk: SkillRiskLevel;
+  /** Copy of one file's bytes. Throws for a path the package does not contain. */
+  readFile(filePath: string): Uint8Array;
+}
+
+/** Where and under what supervision a package may be written. */
+export interface SkillMaterializeOptions {
+  /** Service-owned directory the isolated staging directory is created under. */
+  stagingRoot: string;
+  signal?: AbortSignal;
+}
+
+/** A package written to an isolated staging directory. */
+export interface SkillStagedPackage {
+  readonly skillId: string;
+  readonly version: string;
+  /**
+   * Absolute path of the staging directory.
+   *
+   * Identifies the machine's data root: for the installer only, never for an
+   * API response, a log line or an error message.
+   *
+   * @internal
+   */
+  readonly stagingDir: string;
+  /** What landed, in the same order and shape a receipt will record. */
+  readonly inventory: readonly SkillInstalledFile[];
+  /** Remove the staging directory. Safe to call more than once. */
+  dispose(): void;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function fail(code: SkillPackageErrorCodeType, detail?: SkillPackageErrorDetail): never {
+  throw new SkillPackageError(code, detail);
+}
+
+function findFile(
+  table: SkillPackageTable,
+  filePath: string
+): SkillPackageFileEntry | undefined {
+  return table.files.find((file) => file.path === filePath);
+}
+
+// =============================================================================
+// Manifest reconciliation
+// =============================================================================
+
+function readManifest(table: SkillPackageTable): SkillManifest {
+  const manifestEntry = findFile(table, SKILL_MANIFEST_FILENAME);
+  if (!manifestEntry) fail(SkillPackageErrorCode.MANIFEST_MISSING, { reason: 'absent' });
+
+  for (const file of table.files) {
+    if (file.path !== SKILL_MANIFEST_FILENAME && file.path.endsWith(`/${SKILL_MANIFEST_FILENAME}`)) {
+      fail(SkillPackageErrorCode.LAYOUT_INVALID, {
+        reason: 'nested-manifest',
+        entry: encodeEntryPathForError(file.path),
+      });
+    }
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseSkillYaml(manifestEntry.bytes);
+  } catch (error) {
+    if (isSkillYamlError(error)) {
+      fail(SkillPackageErrorCode.MANIFEST_INVALID, { reason: error.code });
+    }
+    throw error;
+  }
+
+  const result = validateSkillManifest(parsed);
+  if (!result.ok) {
+    const first = result.errors[0];
+    fail(SkillPackageErrorCode.MANIFEST_INVALID, { reason: first.code, field: first.path });
+  }
+  return result.value;
+}
+
+function assertRequiredEntries(table: SkillPackageTable): void {
+  for (const required of REQUIRED_PACKAGE_ENTRIES) {
+    if (!findFile(table, required)) {
+      fail(SkillPackageErrorCode.LAYOUT_INVALID, {
+        reason: 'missing-required-entry',
+        entry: required,
+      });
+    }
+  }
+}
+
+function assertSkillMdConsistency(table: SkillPackageTable, manifest: SkillManifest): void {
+  const skillMd = findFile(table, SKILL_MD_FILENAME);
+  if (!skillMd) fail(SkillPackageErrorCode.SKILL_MD_INVALID, { reason: 'absent' });
+
+  let frontmatter: unknown;
+  try {
+    frontmatter = parseSkillFrontmatter(Buffer.from(skillMd.bytes).toString('utf8'));
+  } catch (error) {
+    if (isSkillYamlError(error)) {
+      fail(SkillPackageErrorCode.SKILL_MD_INVALID, { reason: error.code });
+    }
+    throw error;
+  }
+  if (frontmatter === null || typeof frontmatter !== 'object' || Array.isArray(frontmatter)) {
+    fail(SkillPackageErrorCode.SKILL_MD_INVALID, { reason: 'frontmatter-missing' });
+  }
+
+  const name = (frontmatter as Record<string, unknown>)['name'];
+  if (typeof name !== 'string') {
+    fail(SkillPackageErrorCode.SKILL_MD_INVALID, { reason: 'frontmatter-name-missing' });
+  }
+
+  const consistency = validateSkillIdentityConsistency({
+    directoryName: manifest.id,
+    skillMdName: name,
+    manifestId: manifest.id,
+    manifestName: manifest.name,
+  });
+  if (!consistency.ok) {
+    fail(SkillPackageErrorCode.SKILL_MD_INVALID, { reason: consistency.errors[0].code });
+  }
+}
+
+/**
+ * Both directions of the file-set comparison.
+ *
+ * Self-declaration and duplicate declarations are already refused by
+ * `validateSkillManifest` (#1228); what is left for this step is the package
+ * the manifest is being compared against.
+ */
+function assertFileSetMatches(table: SkillPackageTable, manifest: SkillManifest): void {
+  const result = validateManifestFileSet(
+    manifest,
+    table.files.map((file) => file.path)
+  );
+  if (!result.ok) {
+    const first = result.errors[0];
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, {
+      reason: first.message,
+      entry: encodeEntryPathForError(String(first.detail?.['path'] ?? '')),
+    });
+  }
+}
+
+/** Cross-check one payload file against its declaration on every axis. */
+function assertDeclarationMatches(entry: SkillPackageFileEntry, manifest: SkillManifest): void {
+  const declared = manifest.files.find((file) => file.path === entry.path);
+  if (!declared) {
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, {
+      reason: 'undeclared-file',
+      entry: encodeEntryPathForError(entry.path),
+    });
+  }
+  const detail = { entry: encodeEntryPathForError(entry.path) };
+
+  if (declared.size !== entry.size) fail(SkillPackageErrorCode.SIZE_MISMATCH, detail);
+  if (!digestMatches(declared.sha256, entry.sha256)) {
+    fail(SkillPackageErrorCode.DIGEST_MISMATCH, detail);
+  }
+
+  const derivedKind = deriveSkillFileKind(entry.path, entry.bytes);
+  const isScript = isSkillScriptPayload(entry.path, entry.bytes);
+
+  if (isScript && (!declared.script || declared.kind !== 'script')) {
+    fail(SkillPackageErrorCode.UNDECLARED_SCRIPT, detail);
+  }
+  if (declared.kind === 'script' && !declared.script) {
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, { ...detail, reason: 'kind-script-not-declared' });
+  }
+  if ((derivedKind === 'skill_md') !== (declared.kind === 'skill_md')) {
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, { ...detail, reason: 'kind-mismatch' });
+  }
+  if (entry.executable && !declared.executable) {
+    fail(SkillPackageErrorCode.UNDECLARED_EXECUTABLE, detail);
+  }
+  if (!entry.executable && declared.executable) {
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, { ...detail, reason: 'executable-not-present' });
+  }
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/**
+ * Reconcile a parsed package with its manifest and the Catalog coordinates.
+ *
+ * @param table Entry table from `readSkillPackage`
+ * @param options Coordinates the Catalog published this version under
+ * @returns An immutable snapshot, or throws before any consumer can see it
+ * @throws SkillPackageError for every rejection
+ */
+export function validateSkillPackage(
+  table: SkillPackageTable,
+  options: { skillId: string; version: string }
+): SkillPackageSnapshot {
+  assertRequiredEntries(table);
+  const manifest = readManifest(table);
+
+  if (manifest.id !== options.skillId) {
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, { reason: 'id' });
+  }
+  if (manifest.version !== options.version) {
+    fail(SkillPackageErrorCode.MANIFEST_MISMATCH, { reason: 'version' });
+  }
+
+  assertSkillMdConsistency(table, manifest);
+  assertFileSetMatches(table, manifest);
+
+  for (const entry of table.files) {
+    if (entry.path === SKILL_MANIFEST_FILENAME) continue;
+    assertDeclarationMatches(entry, manifest);
+  }
+
+  const executablePaths = manifest.files.filter((f) => f.executable).map((f) => f.path).sort();
+  const scriptPaths = manifest.files.filter((f) => f.script).map((f) => f.path).sort();
+  const inspection: SkillPackageInspection = {
+    executable_paths: executablePaths,
+    script_paths: scriptPaths,
+    network_hosts: [...manifest.requirements.network_hosts],
+    declared_permissions: [...manifest.declared_permissions],
+  };
+  const computedRisk = computeSkillRisk(inspection);
+
+  const byPath = new Map(table.files.map((file) => [file.path, file.bytes]));
+  const files: SkillInstalledFile[] = table.files
+    .map((file) => ({
+      path: file.path,
+      sha256: file.sha256,
+      size: file.size,
+      executable: file.executable,
+    }))
+    .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  return Object.freeze({
+    skillId: options.skillId,
+    version: options.version,
+    manifest,
+    files: Object.freeze(files),
+    directories: Object.freeze([...table.directories].sort()),
+    inspection: Object.freeze(inspection),
+    declaredRisk: manifest.declared_risk,
+    computedRisk,
+    effectiveRisk: resolveEffectiveSkillRisk(manifest.declared_risk, computedRisk),
+    readFile(filePath: string): Uint8Array {
+      const bytes = byPath.get(filePath);
+      if (!bytes) {
+        fail(SkillPackageErrorCode.MANIFEST_MISMATCH, {
+          reason: 'unknown-file',
+          entry: encodeEntryPathForError(filePath),
+        });
+      }
+      return new Uint8Array(bytes);
+    },
+  });
+}
+
+/**
+ * Read and reconcile an artifact in one step.
+ *
+ * The two halves are separately testable but must always run together: a table
+ * that was read but not reconciled is not a package, and nothing downstream
+ * should be able to obtain one.
+ *
+ * @throws SkillPackageError for every rejection
+ */
+export function inspectSkillPackage(
+  artifact: Uint8Array,
+  options: { skillId: string; version: string }
+): SkillPackageSnapshot {
+  return validateSkillPackage(readSkillPackage(artifact, options), options);
+}
+
+// =============================================================================
+// Materialization
+// =============================================================================
+
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) fail(SkillPackageErrorCode.ABORTED);
+}
+
+/** Create a directory that must not already exist and must not be a symlink. */
+function createDirectory(target: string): void {
+  try {
+    mkdirSync(target, { mode: SKILL_STAGING_DIR_MODE });
+  } catch {
+    fail(SkillPackageErrorCode.STAGING_IO, { reason: 'mkdir' });
+  }
+  const stats = lstatSync(target);
+  if (!stats.isDirectory()) fail(SkillPackageErrorCode.STAGING_IO, { reason: 'not-a-directory' });
+}
+
+/**
+ * Write one payload file.
+ *
+ * `O_CREAT|O_EXCL|O_NOFOLLOW` means the write either creates the file itself or
+ * fails: a symlink or an existing file planted between the directory scan and
+ * this call cannot be written through. The digest is re-read afterwards, so a
+ * file that changed underneath us never reaches the inventory.
+ */
+function writePayloadFile(
+  target: string,
+  snapshot: SkillPackageSnapshot,
+  file: SkillInstalledFile
+): void {
+  const bytes = snapshot.readFile(file.path);
+  const declared = snapshot.manifest.files.find((entry) => entry.path === file.path);
+  const mode = declared?.executable ? SKILL_STAGED_EXECUTABLE_MODE : SKILL_STAGED_FILE_MODE;
+
+  let fd: number;
+  try {
+    fd = openSync(
+      target,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | O_NOFOLLOW,
+      mode
+    );
+  } catch {
+    fail(SkillPackageErrorCode.STAGING_IO, { reason: 'open' });
+  }
+  try {
+    let written = 0;
+    while (written < bytes.byteLength) {
+      written += writeSync(fd, bytes, written, bytes.byteLength - written);
+    }
+  } catch {
+    closeSync(fd);
+    fail(SkillPackageErrorCode.STAGING_IO, { reason: 'write' });
+  }
+  closeSync(fd);
+
+  const stats = lstatSync(target);
+  if (!stats.isFile() || stats.nlink !== 1 || stats.size !== bytes.byteLength) {
+    fail(SkillPackageErrorCode.STAGING_IO, { reason: 'verify-stat' });
+  }
+  if (!digestMatches(computeSha256Hex(readFileSync(target)), file.sha256)) {
+    fail(SkillPackageErrorCode.DIGEST_MISMATCH, { reason: 'staged-readback' });
+  }
+}
+
+/**
+ * Write a validated package into a fresh, private staging directory.
+ *
+ * Nothing outside the new directory is touched and nothing from the archive
+ * (owner, timestamps, mode) is applied: directories and files get fixed modes,
+ * and only files the manifest declared executable get an execute bit.
+ *
+ * On any failure — including an abort — the whole staging directory is removed
+ * before the error propagates, so no consumer can ever observe a partial
+ * package.
+ *
+ * @throws SkillPackageError with `STAGING_IO`, `ABORTED` or `DIGEST_MISMATCH`
+ */
+export function materializeSkillPackage(
+  snapshot: SkillPackageSnapshot,
+  options: SkillMaterializeOptions
+): SkillStagedPackage {
+  const root = path.resolve(options.stagingRoot);
+  if (isSystemDirectory(root)) fail(SkillPackageErrorCode.STAGING_IO, { reason: 'system-directory' });
+
+  try {
+    mkdirSync(root, { recursive: true, mode: SKILL_STAGING_DIR_MODE });
+  } catch {
+    fail(SkillPackageErrorCode.STAGING_IO, { reason: 'mkdir-root' });
+  }
+
+  const stagingDir = path.join(
+    root,
+    `${SKILL_STAGING_ENTRY_PREFIX}${randomBytes(16).toString('hex')}`
+  );
+  createDirectory(stagingDir);
+
+  try {
+    assertNotAborted(options.signal);
+
+    const directories = new Set<string>(snapshot.directories);
+    for (const file of snapshot.files) {
+      const parents = file.path.split('/').slice(0, -1);
+      let walked = '';
+      for (const segment of parents) {
+        walked = walked === '' ? segment : `${walked}/${segment}`;
+        directories.add(walked);
+      }
+    }
+    for (const directory of [...directories].sort()) {
+      createDirectory(path.join(stagingDir, directory));
+    }
+
+    for (const file of snapshot.files) {
+      assertNotAborted(options.signal);
+      writePayloadFile(path.join(stagingDir, file.path), snapshot, file);
+    }
+  } catch (error) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    throw error;
+  }
+
+  let disposed = false;
+  return {
+    skillId: snapshot.skillId,
+    version: snapshot.version,
+    stagingDir,
+    inventory: snapshot.files,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      rmSync(stagingDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Remove staging directories left behind by a crashed or killed process.
+ *
+ * Only entries this module creates are removed, so pointing it at a directory
+ * that holds anything else cannot destroy that content.
+ *
+ * @returns Number of staging directories removed
+ */
+export function cleanupSkillStagingRoot(stagingRoot: string): number {
+  const root = path.resolve(stagingRoot);
+  if (isSystemDirectory(root) || !existsSync(root)) return 0;
+
+  let removed = 0;
+  for (const entry of readdirSync(root)) {
+    if (!STAGING_ENTRY_PATTERN.test(entry)) continue;
+    rmSync(path.join(root, entry), { recursive: true, force: true });
+    removed += 1;
+  }
+  return removed;
+}

--- a/src/lib/skills/safe-yaml.ts
+++ b/src/lib/skills/safe-yaml.ts
@@ -1,0 +1,641 @@
+/**
+ * Restricted YAML reader for Skill manifests (Issue #1230)
+ *
+ * `SKILL_YAML_SAFE_PROFILE` (#1228) fixed the limits a manifest parser must
+ * enforce but deliberately left the implementation open. This module closes it
+ * with a parser for a *subset* of YAML rather than a configured general-purpose
+ * one, for two reasons:
+ *
+ * - No dependency in the tree can enforce the profile. `js-yaml` (reachable
+ *   only transitively, through `gray-matter`) has no depth, node-count or
+ *   scalar-size bound and resolves anchors and merge keys by default, which is
+ *   exactly the parser-bomb surface the profile exists to remove.
+ * - A manifest is a closed document: schema_version 1 has no field that needs
+ *   anchors, tags, flow collections or multiple documents. Everything outside
+ *   the subset is therefore a rejection, not a parse.
+ *
+ * The subset is: one document, block mappings, block sequences, plain and
+ * quoted scalars, literal/folded block scalars, empty flow collections and
+ * comments. Anchors, aliases, merge keys, tags, non-empty flow collections,
+ * complex keys and additional documents are refused with their own code so a
+ * caller can tell "malicious" from "malformed".
+ *
+ * Parsed mappings have a null prototype: `__proto__` is rejected by the profile
+ * *and* is inert if that check is ever weakened.
+ *
+ * @module lib/skills/safe-yaml
+ */
+
+import { SKILL_YAML_SAFE_PROFILE } from '@/lib/skills';
+
+// =============================================================================
+// Error vocabulary
+// =============================================================================
+
+/** Stable, client-safe reason codes for a rejected YAML document. */
+export const SkillYamlErrorCode = {
+  /** Document is larger than the profile's byte budget. */
+  BYTES_LIMIT: 'SKILL_YAML_BYTES_LIMIT',
+  /** Nesting is deeper than the profile allows. */
+  DEPTH_LIMIT: 'SKILL_YAML_DEPTH_LIMIT',
+  /** Document has more nodes than the profile allows. */
+  NODE_LIMIT: 'SKILL_YAML_NODE_LIMIT',
+  /** A single scalar is longer than the profile allows. */
+  SCALAR_LIMIT: 'SKILL_YAML_SCALAR_LIMIT',
+  /** An anchor (`&`) or alias (`*`) was used. */
+  ALIAS_FORBIDDEN: 'SKILL_YAML_ALIAS_FORBIDDEN',
+  /** A merge key (`<<`) was used. */
+  MERGE_KEY_FORBIDDEN: 'SKILL_YAML_MERGE_KEY_FORBIDDEN',
+  /** An explicit tag (`!`/`!!`) was used. */
+  TAG_FORBIDDEN: 'SKILL_YAML_TAG_FORBIDDEN',
+  /** The same key appears twice in one mapping. */
+  DUPLICATE_KEY: 'SKILL_YAML_DUPLICATE_KEY',
+  /** A key on the profile's forbidden list (prototype pollution) was used. */
+  FORBIDDEN_KEY: 'SKILL_YAML_FORBIDDEN_KEY',
+  /** The stream carries more than one document. */
+  MULTIPLE_DOCUMENTS: 'SKILL_YAML_MULTIPLE_DOCUMENTS',
+  /** Bytes are not valid UTF-8, or carry a BOM or a control character. */
+  ENCODING: 'SKILL_YAML_ENCODING',
+  /** A construct outside the supported subset was used. */
+  UNSUPPORTED: 'SKILL_YAML_UNSUPPORTED',
+  /** The document does not parse as the supported subset. */
+  SYNTAX: 'SKILL_YAML_SYNTAX',
+} as const;
+
+export type SkillYamlErrorCodeType = (typeof SkillYamlErrorCode)[keyof typeof SkillYamlErrorCode];
+
+const MESSAGES: Record<SkillYamlErrorCodeType, string> = {
+  [SkillYamlErrorCode.BYTES_LIMIT]: 'YAML document exceeds the size limit',
+  [SkillYamlErrorCode.DEPTH_LIMIT]: 'YAML document is nested too deeply',
+  [SkillYamlErrorCode.NODE_LIMIT]: 'YAML document has too many nodes',
+  [SkillYamlErrorCode.SCALAR_LIMIT]: 'YAML scalar exceeds the length limit',
+  [SkillYamlErrorCode.ALIAS_FORBIDDEN]: 'YAML anchors and aliases are not accepted',
+  [SkillYamlErrorCode.MERGE_KEY_FORBIDDEN]: 'YAML merge keys are not accepted',
+  [SkillYamlErrorCode.TAG_FORBIDDEN]: 'YAML tags are not accepted',
+  [SkillYamlErrorCode.DUPLICATE_KEY]: 'YAML mapping declares the same key twice',
+  [SkillYamlErrorCode.FORBIDDEN_KEY]: 'YAML mapping uses a forbidden key',
+  [SkillYamlErrorCode.MULTIPLE_DOCUMENTS]: 'YAML stream carries more than one document',
+  [SkillYamlErrorCode.ENCODING]: 'YAML document is not valid UTF-8 text',
+  [SkillYamlErrorCode.UNSUPPORTED]: 'YAML document uses an unsupported construct',
+  [SkillYamlErrorCode.SYNTAX]: 'YAML document could not be parsed',
+};
+
+/**
+ * A rejected YAML document.
+ *
+ * Carries a line number but never the offending text: a manifest can embed
+ * anything, and echoing it back would turn the parser into a reflection gadget.
+ */
+export class SkillYamlError extends Error {
+  readonly code: SkillYamlErrorCodeType;
+  /** 1-based line the rejection was raised at, when known. */
+  readonly line?: number;
+
+  constructor(code: SkillYamlErrorCodeType, line?: number) {
+    super(MESSAGES[code]);
+    this.name = 'SkillYamlError';
+    this.code = code;
+    if (line !== undefined) this.line = line;
+  }
+}
+
+/** Narrow an unknown thrown value to a {@link SkillYamlError}. */
+export function isSkillYamlError(value: unknown): value is SkillYamlError {
+  return value instanceof SkillYamlError;
+}
+
+// =============================================================================
+// Profile
+// =============================================================================
+
+/** The bounds and refusals a parse run enforces. */
+export interface SkillYamlProfile {
+  readonly maxBytes: number;
+  readonly maxDepth: number;
+  readonly maxNodes: number;
+  readonly maxScalarLength: number;
+  readonly allowAliases: boolean;
+  readonly allowCustomTags: boolean;
+  readonly allowDuplicateKeys: boolean;
+  readonly forbiddenKeys: readonly string[];
+}
+
+// =============================================================================
+// Lexing
+// =============================================================================
+
+interface Line {
+  /** 1-based source line number. */
+  readonly number: number;
+  /** Raw text without the line terminator. */
+  readonly raw: string;
+  /** Leading space count. */
+  indent: number;
+  /** Text after the indent, comments still attached. */
+  content: string;
+  readonly significant: boolean;
+}
+
+const KEY_HEAD =
+  /^(?:"(?:[^"\\]|\\.)*"|'(?:[^']|'')*'|[A-Za-z_][A-Za-z0-9_.-]*)[ \t]*:(?:[ \t]|$)/;
+
+function decodeUtf8(input: string | Uint8Array, maxBytes: number): string {
+  const byteLength =
+    typeof input === 'string' ? Buffer.byteLength(input, 'utf8') : input.byteLength;
+  if (byteLength > maxBytes) throw new SkillYamlError(SkillYamlErrorCode.BYTES_LIMIT);
+  if (typeof input === 'string') return input;
+  try {
+    return new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(input);
+  } catch {
+    throw new SkillYamlError(SkillYamlErrorCode.ENCODING);
+  }
+}
+
+/** Split into lines, rejecting anything that is not plain UTF-8 text. */
+function toLines(text: string): Line[] {
+  if (text.includes('\uFEFF')) throw new SkillYamlError(SkillYamlErrorCode.ENCODING);
+  const normalized = text.replace(/\r\n/g, '\n');
+  if (normalized.includes('\r')) throw new SkillYamlError(SkillYamlErrorCode.ENCODING);
+
+  const lines: Line[] = [];
+  const rawLines = normalized.split('\n');
+  for (let i = 0; i < rawLines.length; i++) {
+    const raw = rawLines[i];
+    const number = i + 1;
+    for (let j = 0; j < raw.length; j++) {
+      const code = raw.charCodeAt(j);
+      if ((code < 0x20 && code !== 0x09) || code === 0x7f) {
+        throw new SkillYamlError(SkillYamlErrorCode.ENCODING, number);
+      }
+    }
+    let indent = 0;
+    while (indent < raw.length && raw[indent] === ' ') indent++;
+    if (raw[indent] === '\t') throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, number);
+    const content = raw.slice(indent);
+    lines.push({
+      number,
+      raw,
+      indent,
+      content,
+      significant: content.length > 0 && !content.startsWith('#'),
+    });
+  }
+  return lines;
+}
+
+/**
+ * Drop a trailing comment, honouring quotes.
+ *
+ * `summary: "a # b"` keeps its hash; `summary: a # b` does not.
+ */
+function stripComment(text: string): string {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (quote === '"') {
+      if (ch === '\\') i++;
+      else if (ch === '"') quote = null;
+    } else if (quote === "'") {
+      if (ch === "'") quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === '#' && (i === 0 || text[i - 1] === ' ' || text[i - 1] === '\t')) {
+      return text.slice(0, i);
+    }
+  }
+  return text;
+}
+
+// =============================================================================
+// Parser
+// =============================================================================
+
+class Parser {
+  private readonly lines: Line[];
+  private readonly profile: SkillYamlProfile;
+  private cursor = 0;
+  private nodes = 0;
+  private documentEnded = false;
+  private documentStarted = false;
+
+  constructor(lines: Line[], profile: SkillYamlProfile) {
+    this.lines = lines;
+    this.profile = profile;
+  }
+
+  parseDocument(): unknown {
+    const first = this.peek();
+    if (!first) return null;
+    if (first.indent !== 0) throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, first.number);
+    const value = this.parseNode(0, 1);
+    this.skipToSignificant();
+    const trailing = this.peek();
+    if (trailing) throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, trailing.number);
+    return value;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cursor
+  // ---------------------------------------------------------------------------
+
+  private skipToSignificant(): void {
+    while (this.cursor < this.lines.length) {
+      const line = this.lines[this.cursor];
+      if (!line.significant) {
+        this.cursor++;
+        continue;
+      }
+      const trimmed = line.content.trim();
+      if (trimmed === '...') {
+        this.documentEnded = true;
+        this.cursor++;
+        continue;
+      }
+      if (trimmed === '---') {
+        // Only the marker that opens the stream is a document start; a later one
+        // begins a second document, which this parser never accepts.
+        if (this.documentStarted) {
+          throw new SkillYamlError(SkillYamlErrorCode.MULTIPLE_DOCUMENTS, line.number);
+        }
+        this.documentStarted = true;
+        this.cursor++;
+        continue;
+      }
+      if (this.documentEnded) {
+        throw new SkillYamlError(SkillYamlErrorCode.MULTIPLE_DOCUMENTS, line.number);
+      }
+      this.documentStarted = true;
+      return;
+    }
+  }
+
+  private peek(): Line | null {
+    this.skipToSignificant();
+    return this.cursor < this.lines.length ? this.lines[this.cursor] : null;
+  }
+
+  private countNode(line: Line): void {
+    this.nodes++;
+    if (this.nodes > this.profile.maxNodes) {
+      throw new SkillYamlError(SkillYamlErrorCode.NODE_LIMIT, line.number);
+    }
+  }
+
+  private checkDepth(depth: number, line: Line): void {
+    if (depth > this.profile.maxDepth) {
+      throw new SkillYamlError(SkillYamlErrorCode.DEPTH_LIMIT, line.number);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Collections
+  // ---------------------------------------------------------------------------
+
+  private parseNode(indent: number, depth: number): unknown {
+    const line = this.peek();
+    if (!line) return null;
+    this.checkDepth(depth, line);
+    return this.isSequenceEntry(line.content)
+      ? this.parseSequence(indent, depth)
+      : this.parseMapping(indent, depth);
+  }
+
+  private isSequenceEntry(content: string): boolean {
+    return content === '-' || content.startsWith('- ');
+  }
+
+  private parseMapping(indent: number, depth: number): Record<string, unknown> {
+    const result = Object.create(null) as Record<string, unknown>;
+    const seen = new Set<string>();
+
+    for (;;) {
+      const line = this.peek();
+      if (!line || line.indent < indent) break;
+      if (line.indent > indent) throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+      if (this.isSequenceEntry(line.content)) {
+        throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+      }
+      this.countNode(line);
+
+      const key = this.readKey(line);
+      if (seen.has(key) && !this.profile.allowDuplicateKeys) {
+        throw new SkillYamlError(SkillYamlErrorCode.DUPLICATE_KEY, line.number);
+      }
+      seen.add(key);
+
+      const colon = line.content.indexOf(':', this.keyTokenLength(line.content));
+      const rest = stripComment(line.content.slice(colon + 1)).trim();
+      this.cursor++;
+      result[key] = this.parseValue(rest, indent, depth, line);
+    }
+    return result;
+  }
+
+  private parseSequence(indent: number, depth: number): unknown[] {
+    const result: unknown[] = [];
+
+    for (;;) {
+      const line = this.peek();
+      if (!line || line.indent < indent) break;
+      if (line.indent > indent) throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+      if (!this.isSequenceEntry(line.content)) break;
+      this.countNode(line);
+
+      const rest = line.content === '-' ? '' : line.content.slice(2);
+      const offset = line.content.length - rest.length;
+      const trimmedRest = stripComment(rest).trim();
+
+      if (trimmedRest === '') {
+        this.cursor++;
+        result.push(this.parseIndentedValue(indent, depth + 1, line));
+        continue;
+      }
+      if (this.isSequenceEntry(trimmedRest)) {
+        throw new SkillYamlError(SkillYamlErrorCode.UNSUPPORTED, line.number);
+      }
+      if (KEY_HEAD.test(rest.trimStart())) {
+        // Re-anchor `- key: value` as a mapping line at the item's own indent so
+        // its sibling keys on following lines line up with it.
+        const itemIndent = indent + offset + (rest.length - rest.trimStart().length);
+        line.indent = itemIndent;
+        line.content = rest.trimStart();
+        this.checkDepth(depth + 1, line);
+        result.push(this.parseMapping(itemIndent, depth + 1));
+        continue;
+      }
+      this.cursor++;
+      this.countNode(line);
+      result.push(this.parseScalar(trimmedRest, line));
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Keys and values
+  // ---------------------------------------------------------------------------
+
+  private keyTokenLength(content: string): number {
+    if (content.startsWith('"') || content.startsWith("'")) {
+      const quote = content[0];
+      for (let i = 1; i < content.length; i++) {
+        if (quote === '"' && content[i] === '\\') {
+          i++;
+          continue;
+        }
+        if (content[i] === quote) return i + 1;
+      }
+    }
+    return 0;
+  }
+
+  private readKey(line: Line): string {
+    const content = line.content;
+    if (content.startsWith('<<')) {
+      throw new SkillYamlError(SkillYamlErrorCode.MERGE_KEY_FORBIDDEN, line.number);
+    }
+    if (content.startsWith('&') || content.startsWith('*')) {
+      throw new SkillYamlError(SkillYamlErrorCode.ALIAS_FORBIDDEN, line.number);
+    }
+    if (content.startsWith('!')) {
+      throw new SkillYamlError(SkillYamlErrorCode.TAG_FORBIDDEN, line.number);
+    }
+    if (content.startsWith('?') || content.startsWith('[') || content.startsWith('{')) {
+      throw new SkillYamlError(SkillYamlErrorCode.UNSUPPORTED, line.number);
+    }
+    if (!KEY_HEAD.test(content)) {
+      throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+    }
+
+    const tokenLength = this.keyTokenLength(content);
+    const colon = content.indexOf(':', tokenLength);
+    const rawKey = content.slice(0, colon).trim();
+    const key =
+      rawKey.startsWith('"') || rawKey.startsWith("'")
+        ? this.parseQuoted(rawKey, line)
+        : rawKey;
+
+    if (key.length > this.profile.maxScalarLength) {
+      throw new SkillYamlError(SkillYamlErrorCode.SCALAR_LIMIT, line.number);
+    }
+    if (this.profile.forbiddenKeys.includes(key)) {
+      throw new SkillYamlError(SkillYamlErrorCode.FORBIDDEN_KEY, line.number);
+    }
+    return key;
+  }
+
+  private parseValue(rest: string, indent: number, depth: number, line: Line): unknown {
+    if (rest === '') {
+      const next = this.peek();
+      if (next && next.indent === indent && this.isSequenceEntry(next.content)) {
+        this.checkDepth(depth + 1, next);
+        return this.parseSequence(indent, depth + 1);
+      }
+      return this.parseIndentedValue(indent, depth + 1, line);
+    }
+    if (rest[0] === '|' || rest[0] === '>') {
+      return this.parseBlockScalar(rest, indent, line);
+    }
+    this.countNode(line);
+    return this.parseScalar(rest, line);
+  }
+
+  /** Read the nested block owned by a line, or null when there is none. */
+  private parseIndentedValue(indent: number, depth: number, owner: Line): unknown {
+    const next = this.peek();
+    if (!next || next.indent <= indent) {
+      this.countNode(owner);
+      return null;
+    }
+    this.checkDepth(depth, next);
+    return this.parseNode(next.indent, depth);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scalars
+  // ---------------------------------------------------------------------------
+
+  private parseScalar(raw: string, line: Line): unknown {
+    if (raw.startsWith('&') || raw.startsWith('*')) {
+      throw new SkillYamlError(SkillYamlErrorCode.ALIAS_FORBIDDEN, line.number);
+    }
+    if (raw.startsWith('!')) {
+      throw new SkillYamlError(SkillYamlErrorCode.TAG_FORBIDDEN, line.number);
+    }
+    if (raw === '[]') {
+      this.countNode(line);
+      return [];
+    }
+    if (raw === '{}') {
+      this.countNode(line);
+      return Object.create(null) as Record<string, unknown>;
+    }
+    if (raw.startsWith('[') || raw.startsWith('{') || raw.startsWith('%') || raw.startsWith('`')) {
+      throw new SkillYamlError(SkillYamlErrorCode.UNSUPPORTED, line.number);
+    }
+    if (raw.startsWith('"') || raw.startsWith("'")) {
+      const value = this.parseQuoted(raw, line);
+      this.checkScalarLength(value, line);
+      return value;
+    }
+    this.checkScalarLength(raw, line);
+    return this.resolvePlain(raw);
+  }
+
+  private checkScalarLength(value: string, line: Line): void {
+    if (value.length > this.profile.maxScalarLength) {
+      throw new SkillYamlError(SkillYamlErrorCode.SCALAR_LIMIT, line.number);
+    }
+  }
+
+  private resolvePlain(raw: string): unknown {
+    if (raw === '~' || raw === 'null' || raw === 'Null' || raw === 'NULL') return null;
+    if (raw === 'true' || raw === 'True' || raw === 'TRUE') return true;
+    if (raw === 'false' || raw === 'False' || raw === 'FALSE') return false;
+    if (/^-?(?:0|[1-9][0-9]*)$/.test(raw)) {
+      const parsed = Number(raw);
+      return Number.isSafeInteger(parsed) ? parsed : raw;
+    }
+    if (/^-?(?:0|[1-9][0-9]*)\.[0-9]+$/.test(raw)) return Number(raw);
+    return raw;
+  }
+
+  private parseQuoted(raw: string, line: Line): string {
+    const quote = raw[0];
+    if (raw.length < 2 || !raw.endsWith(quote)) {
+      throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+    }
+    const body = raw.slice(1, -1);
+
+    if (quote === "'") {
+      let out = '';
+      for (let i = 0; i < body.length; i++) {
+        if (body[i] === "'") {
+          if (body[i + 1] !== "'") throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+          i++;
+        }
+        out += body[i];
+      }
+      return out;
+    }
+
+    let out = '';
+    for (let i = 0; i < body.length; i++) {
+      const ch = body[i];
+      if (ch !== '\\') {
+        if (ch === '"') throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+        out += ch;
+        continue;
+      }
+      const escape = body[++i];
+      switch (escape) {
+        case '"':
+        case '\\':
+        case '/':
+          out += escape;
+          break;
+        case 'n':
+          out += '\n';
+          break;
+        case 't':
+          out += '\t';
+          break;
+        case 'r':
+          out += '\r';
+          break;
+        case 'u': {
+          const hex = body.slice(i + 1, i + 5);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+            throw new SkillYamlError(SkillYamlErrorCode.SYNTAX, line.number);
+          }
+          out += String.fromCharCode(parseInt(hex, 16));
+          i += 4;
+          break;
+        }
+        default:
+          throw new SkillYamlError(SkillYamlErrorCode.UNSUPPORTED, line.number);
+      }
+    }
+    return out;
+  }
+
+  /** Literal (`|`) and folded (`>`) block scalars with `-`/`+` chomping. */
+  private parseBlockScalar(header: string, indent: number, owner: Line): string {
+    const match = /^([|>])([-+]?)$/.exec(header.trim());
+    if (!match) throw new SkillYamlError(SkillYamlErrorCode.UNSUPPORTED, owner.number);
+    const [, style, chomp] = match;
+
+    const collected: string[] = [];
+    let blockIndent = -1;
+    while (this.cursor < this.lines.length) {
+      const line = this.lines[this.cursor];
+      const isBlank = line.raw.trim() === '';
+      if (!isBlank && line.indent <= indent) break;
+      if (!isBlank && blockIndent === -1) blockIndent = line.indent;
+      collected.push(isBlank ? '' : line.raw.slice(blockIndent));
+      this.cursor++;
+    }
+    while (collected.length > 0 && collected[collected.length - 1] === '') collected.pop();
+
+    this.countNode(owner);
+    let body: string;
+    if (style === '|') {
+      body = collected.join('\n');
+    } else {
+      body = collected.reduce((acc, current, index) => {
+        if (index === 0) return current;
+        const previous = collected[index - 1];
+        if (current === '' || previous === '') return `${acc}\n${current}`;
+        return `${acc} ${current}`;
+      }, '');
+    }
+    if (chomp !== '-' && collected.length > 0) body += '\n';
+    this.checkScalarLength(body, owner);
+    return body;
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Parse a YAML document under the safe profile.
+ *
+ * @param input Document bytes or text
+ * @param profile Bounds to enforce; defaults to {@link SKILL_YAML_SAFE_PROFILE}
+ * @returns The parsed value; mappings have a null prototype
+ * @throws SkillYamlError for every rejection, including plain syntax errors
+ */
+export function parseSkillYaml(
+  input: string | Uint8Array,
+  profile: SkillYamlProfile = SKILL_YAML_SAFE_PROFILE
+): unknown {
+  if (profile.allowAliases || profile.allowCustomTags) {
+    // The subset has no way to honour aliases or tags, so a profile that asks
+    // for them would silently under-enforce rather than parse them.
+    throw new SkillYamlError(SkillYamlErrorCode.UNSUPPORTED);
+  }
+  const text = decodeUtf8(input, profile.maxBytes);
+  return new Parser(toLines(text), profile).parseDocument();
+}
+
+/**
+ * Extract and parse the YAML frontmatter of a Markdown document.
+ *
+ * Used for `SKILL.md`, whose frontmatter must agree with the manifest. The
+ * frontmatter is parsed under the same profile as the manifest: it is authored
+ * by the same untrusted publisher.
+ *
+ * @returns The parsed frontmatter, or null when the document has none
+ * @throws SkillYamlError when frontmatter is present but violates the profile
+ */
+export function parseSkillFrontmatter(
+  markdown: string,
+  profile: SkillYamlProfile = SKILL_YAML_SAFE_PROFILE
+): unknown {
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  if (!normalized.startsWith('---\n')) return null;
+  const end = normalized.indexOf('\n---', 3);
+  if (end === -1) return null;
+  return parseSkillYaml(normalized.slice(4, end + 1), profile);
+}

--- a/tests/fixtures/skills/malicious-packages/index.ts
+++ b/tests/fixtures/skills/malicious-packages/index.ts
@@ -1,0 +1,529 @@
+/**
+ * Malicious Skill package corpus (Issue #1230)
+ *
+ * One case per attack the threat model names. Each is the benign baseline with
+ * a single property changed, and each is pinned to the error code the pipeline
+ * must fail closed with — so a guard that stops working shows up as a case that
+ * stopped rejecting, not as a silently weaker check.
+ */
+
+import { gzipSync } from 'zlib';
+import { SkillPackageErrorCode, type SkillPackageErrorCodeType } from '@/lib/skills/package-reader';
+import { SKILL_ID, buildPackage } from './package';
+import { TarType, buildTarGz, type TarEntryInput } from './tar';
+
+export { SKILL_ID, SKILL_VERSION, buildPackage, renderManifestYaml } from './package';
+export * from './tar';
+
+/** One corpus case: what it is, what it contains and how it must be refused. */
+export interface MaliciousPackageCase {
+  name: string;
+  /** The attack this case stands for. */
+  threat: string;
+  /** Built on demand: some cases allocate tens of megabytes. */
+  build: () => Uint8Array;
+  expectedCode: SkillPackageErrorCodeType;
+}
+
+const ROOT = `${SKILL_ID}/`;
+
+function baselineYaml(): string {
+  return buildPackage().manifestYaml;
+}
+
+/** Baseline manifest with one line rewritten, to build YAML-level attacks. */
+function manifestWith(replace: (yaml: string) => string): string {
+  return replace(baselineYaml());
+}
+
+function specialFile(name: string, type: TarEntryInput['type'], linkname?: string): Uint8Array {
+  return buildPackage({
+    extraEntries: [{ name: `${ROOT}${name}`, type, ...(linkname ? { linkname } : {}) }],
+  }).bytes;
+}
+
+function zeroFilePackage(size: number): Uint8Array {
+  return buildTarGz([
+    { name: ROOT, type: TarType.DIRECTORY },
+    { name: `${ROOT}payload.bin`, content: new Uint8Array(size) },
+  ]);
+}
+
+function manyEntries(count: number): Uint8Array {
+  const entries: TarEntryInput[] = [{ name: ROOT, type: TarType.DIRECTORY }];
+  for (let i = 0; i < count; i++) {
+    entries.push({ name: `${ROOT}f${i}.txt`, content: `${i}\n` });
+  }
+  return buildTarGz(entries);
+}
+
+// =============================================================================
+// Corpus
+// =============================================================================
+
+export const MALICIOUS_PACKAGES: readonly MaliciousPackageCase[] = [
+  // --- Path escape -----------------------------------------------------------
+  {
+    name: 'zip-slip-parent-traversal',
+    threat: 'Zip Slip: an entry walks out of the package root with `..`',
+    build: () => buildPackage({ extraEntries: [{ name: `${ROOT}../../etc/evil`, content: 'x' }] }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+  {
+    name: 'absolute-path',
+    threat: 'Absolute path writes outside any root',
+    build: () => buildPackage({ extraEntries: [{ name: '/etc/evil', content: 'x' }] }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+  {
+    name: 'windows-drive-path',
+    threat: 'Drive-qualified path escapes on Windows hosts',
+    build: () => buildPackage({ extraEntries: [{ name: 'C:/Windows/evil', content: 'x' }] }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+  {
+    name: 'backslash-separator',
+    threat: 'Backslash separator is a directory separator on Windows only',
+    build: () => buildPackage({ extraEntries: [{ name: `${ROOT}..\\evil`, content: 'x' }] }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+  {
+    name: 'nul-truncated-name',
+    threat: 'NUL in the name field makes two parsers read two different paths',
+    build: () => buildPackage({ extraEntries: [{ name: `${ROOT}ok.md\0../../evil`, content: 'x' }] })
+      .bytes,
+    expectedCode: SkillPackageErrorCode.ARCHIVE_FORMAT,
+  },
+  {
+    name: 'path-too-deep',
+    threat: 'Unbounded nesting defeats path-length assumptions downstream',
+    build: () => buildPackage({ extraEntries: [{ name: `${ROOT}a/b/c/d/e/f/g/h/i.md`, content: 'x' }] })
+      .bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+  {
+    name: 'path-segment-too-long',
+    threat: 'Over-long segment overflows filesystem name limits',
+    build: () =>
+      buildPackage({
+        extraEntries: [
+          { name: 'x.md', prefix: `${SKILL_ID}/${'a'.repeat(101)}`, content: 'x' },
+        ],
+      }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+  {
+    name: 'root-directory-mismatch',
+    threat: 'Package installs itself under a name the Catalog never published',
+    build: () => buildPackage({ rootDir: 'totally-other-skill' }).bytes,
+    expectedCode: SkillPackageErrorCode.LAYOUT_INVALID,
+  },
+
+  // --- Special files ---------------------------------------------------------
+  {
+    name: 'symlink-entry',
+    threat: 'Symlink escape: a link points at a path outside the package',
+    build: () => specialFile('link', TarType.SYMLINK, '../../../etc/passwd'),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'symlink-entry-without-target',
+    threat: 'Symlink typeflag with an empty link field, which a link-name check alone misses',
+    build: () => specialFile('link', TarType.SYMLINK),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'hardlink-entry',
+    threat: 'Hardlink escape: a link aliases a file outside the package',
+    build: () => specialFile('link', TarType.HARDLINK, 'SKILL.md'),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'character-device-entry',
+    threat: 'Device node materialized into the worktree',
+    build: () => specialFile('tty', TarType.CHAR_DEVICE),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'block-device-entry',
+    threat: 'Block device node materialized into the worktree',
+    build: () => specialFile('disk', TarType.BLOCK_DEVICE),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'fifo-entry',
+    threat: 'FIFO blocks a reader forever',
+    build: () => specialFile('pipe', TarType.FIFO),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'contiguous-file-entry',
+    threat: 'Non-regular file type smuggled past a type check that only lists two',
+    build: () => specialFile('sparse', TarType.CONTIGUOUS),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'pax-extended-header',
+    threat: 'pax record overrides the name of the entry that follows it',
+    build: () => specialFile('PaxHeaders/0', TarType.PAX_EXTENDED),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+  {
+    name: 'gnu-longname-header',
+    threat: 'GNU long-name record supplies a second, unchecked name',
+    build: () => specialFile('././@LongLink', TarType.GNU_LONGNAME),
+    expectedCode: SkillPackageErrorCode.ENTRY_TYPE_FORBIDDEN,
+  },
+
+  // --- Mode metadata ---------------------------------------------------------
+  {
+    name: 'setuid-bit',
+    threat: 'setuid binary lands with elevated privileges',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}tool`, content: 'x', mode: 0o4755 }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_MODE_FORBIDDEN,
+  },
+  {
+    name: 'setgid-bit',
+    threat: 'setgid binary lands with elevated group privileges',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}tool`, content: 'x', mode: 0o2755 }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_MODE_FORBIDDEN,
+  },
+  {
+    name: 'sticky-bit',
+    threat: 'Sticky bit carried over from the publisher machine',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}tool`, content: 'x', mode: 0o1755 }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_MODE_FORBIDDEN,
+  },
+
+  // --- Duplicates and collisions --------------------------------------------
+  {
+    name: 'duplicate-entry',
+    threat: 'Same path twice: the reviewed copy is overwritten by the second',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}reference/notes.md`, content: 'malicious replacement\n' }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_DUPLICATE,
+  },
+  {
+    name: 'case-collision',
+    threat: 'Case-insensitive filesystem collapses two entries into one',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}reference/NOTES.md`, content: 'shadow\n' }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_COLLISION,
+  },
+  {
+    name: 'unicode-collision',
+    threat: 'NFKC-equivalent name collides on a normalizing filesystem',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}reference/ﬁle.md`, content: 'shadow\n' }],
+      files: [{ path: 'reference/file.md', content: '# File\n' }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_COLLISION,
+  },
+  {
+    name: 'directory-shadows-file',
+    threat: 'A path is both a file and the parent of another file',
+    build: () => buildPackage({
+      files: [
+        { path: 'reference', content: 'not a directory\n' },
+        { path: 'reference/notes.md', content: '# Notes\n' },
+      ],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ENTRY_PATH_UNSAFE,
+  },
+
+  // --- Size and compression --------------------------------------------------
+  {
+    name: 'compression-ratio-bomb',
+    threat: 'Small artifact expands far beyond its compressed size',
+    build: () => zeroFilePackage(8 * 1024 * 1024),
+    expectedCode: SkillPackageErrorCode.COMPRESSION_RATIO_EXCEEDED,
+  },
+  {
+    name: 'decompressed-size-bomb',
+    threat: 'Artifact expands past the absolute decompression cap',
+    build: () => zeroFilePackage(68 * 1024 * 1024),
+    expectedCode: SkillPackageErrorCode.SIZE_LIMIT_EXCEEDED,
+  },
+  {
+    name: 'entry-count-flood',
+    threat: 'Entry flood exhausts inodes and review attention alike',
+    build: () => manyEntries(1200),
+    expectedCode: SkillPackageErrorCode.ENTRY_LIMIT_EXCEEDED,
+  },
+
+  // --- Archive framing -------------------------------------------------------
+  {
+    name: 'not-gzip',
+    threat: 'Format confusion: something other than the declared tar.gz',
+    build: () => Buffer.from('PK not a gzip stream'),
+    expectedCode: SkillPackageErrorCode.ARCHIVE_FORMAT,
+  },
+  {
+    name: 'broken-header-checksum',
+    threat: 'Header rewritten in place after the archive was built',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}tampered.md`, content: 'x', breakChecksum: true }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ARCHIVE_FORMAT,
+  },
+  {
+    name: 'foreign-archive-magic',
+    threat: 'Non-ustar variant parsed by a lenient extractor with other rules',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}other.md`, content: 'x', magic: 'xstar' }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ARCHIVE_FORMAT,
+  },
+  {
+    name: 'base256-size-field',
+    threat: 'GNU base-256 numeric field bypasses an octal-only size check',
+    build: () => buildPackage({
+      extraEntries: [{ name: `${ROOT}big.md`, content: 'x', base256Size: true }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ARCHIVE_FORMAT,
+  },
+  {
+    name: 'missing-trailer',
+    threat: 'Truncated archive leaves the last entry half-read',
+    build: () => buildPackage({ tarOptions: { omitTrailer: true } }).bytes,
+    expectedCode: SkillPackageErrorCode.ARCHIVE_TRUNCATED,
+  },
+  {
+    name: 'appended-after-trailer',
+    threat: 'Data past the end-of-archive marker is invisible to some readers',
+    build: () => buildPackage({
+      tarOptions: { trailingGarbage: Buffer.alloc(512, 0x41) },
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.ARCHIVE_FORMAT,
+  },
+
+  // --- YAML ------------------------------------------------------------------
+  {
+    name: 'yaml-anchor',
+    threat: 'Anchor/alias expansion is the classic YAML billion-laughs lever',
+    build: () => buildPackage({
+      manifestYaml: manifestWith((yaml) => yaml.replace('license: "MIT"', 'license: &lic "MIT"')),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-merge-key',
+    threat: 'Merge key pulls fields in from a node the reviewer never read',
+    build: () => buildPackage({
+      manifestYaml: manifestWith((yaml) => yaml.replace('provider:\n', 'provider:\n  <<: *base\n')),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-custom-tag',
+    threat: 'Custom tag reaches a type constructor in a permissive parser',
+    build: () => buildPackage({
+      manifestYaml: manifestWith((yaml) => yaml.replace('license: "MIT"', 'license: !!python/object x')),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-duplicate-key',
+    threat: 'Duplicate key: reviewer reads the first, parser keeps the second',
+    build: () => buildPackage({
+      manifestYaml: manifestWith((yaml) => `${yaml}declared_risk: "low"\n`),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-prototype-key',
+    threat: 'Prototype pollution through a parsed mapping key',
+    build: () => buildPackage({
+      manifestYaml: manifestWith((yaml) => `${yaml}__proto__: "polluted"\n`),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-deep-nesting',
+    threat: 'Deep nesting exhausts the parser stack',
+    build: () => buildPackage({
+      manifestYaml: Array.from({ length: 40 }, (_, i) => `${'  '.repeat(i)}k${i}:`).join('\n'),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-oversized-scalar',
+    threat: 'Single huge scalar drives allocation before any field check runs',
+    build: () => buildPackage({
+      manifestYaml: manifestWith((yaml) =>
+        yaml.replace(/^summary: .*$/m, `summary: "${'a'.repeat(9000)}"`)
+      ),
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-node-flood',
+    threat: 'Node flood turns a small document into a long parse',
+    build: () => buildPackage({
+      manifestYaml: `keywords:\n${Array.from({ length: 6000 }, (_, i) => `  - "k${i}"`).join('\n')}\n`,
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'yaml-oversized-document',
+    threat: 'Manifest larger than the parser is allowed to read',
+    build: () => buildPackage({
+      manifestYaml: `# ${'p'.repeat(70 * 1024)}\nschema_version: 1\n`,
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+
+  // --- Manifest reconciliation ----------------------------------------------
+  {
+    name: 'undeclared-executable',
+    threat: 'Executable bit on a file the manifest presents as inert data',
+    build: () => buildPackage({
+      files: [{ path: 'tools/helper', content: 'binary-ish\n', mode: 0o755, executable: false }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.UNDECLARED_EXECUTABLE,
+  },
+  {
+    name: 'undeclared-script',
+    threat: 'Script presented as an asset so it never appears in the plan',
+    build: () => buildPackage({
+      files: [{ path: 'tools/run.sh', content: '#!/bin/sh\necho hi\n', kind: 'asset', script: false }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.UNDECLARED_SCRIPT,
+  },
+  {
+    name: 'shebang-without-extension',
+    threat: 'Interpreted payload hidden behind a data-looking filename',
+    build: () => buildPackage({
+      files: [{ path: 'assets/data', content: '#!/bin/sh\ncurl evil\n', kind: 'asset', script: false }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.UNDECLARED_SCRIPT,
+  },
+  {
+    name: 'undeclared-file',
+    threat: 'Extra payload file absent from the reviewed manifest',
+    build: () => buildPackage({
+      files: [{ path: 'reference/notes.md', content: '# Notes\n', undeclared: true }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_MISMATCH,
+  },
+  {
+    name: 'declared-but-missing-file',
+    threat: 'Manifest advertises a file the archive does not carry',
+    build: () => buildPackage({
+      extraDeclarations: [
+        {
+          path: 'reference/ghost.md',
+          sha256: 'a'.repeat(64),
+          size: 10,
+          kind: 'instruction',
+          executable: false,
+          script: false,
+        },
+      ],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_MISMATCH,
+  },
+  {
+    name: 'digest-mismatch',
+    threat: 'File content swapped after the digest was published',
+    build: () => buildPackage({
+      files: [{ path: 'reference/notes.md', content: '# Notes\n', declaredSha256: 'b'.repeat(64) }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.DIGEST_MISMATCH,
+  },
+  {
+    name: 'size-mismatch',
+    threat: 'Declared size disagrees with the bytes actually shipped',
+    build: () => buildPackage({
+      files: [{ path: 'reference/notes.md', content: '# Notes\n', declaredSize: 99 }],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.SIZE_MISMATCH,
+  },
+  {
+    name: 'manifest-smuggling-nested',
+    threat: 'Second manifest in a subdirectory, read by a looser consumer',
+    build: () => buildPackage({
+      files: [
+        { path: 'reference/notes.md', content: '# Notes\n' },
+        { path: 'reference/commandmate.skill.yaml', content: 'schema_version: 1\n' },
+      ],
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.LAYOUT_INVALID,
+  },
+  {
+    name: 'manifest-declares-itself',
+    threat: 'Manifest lists its own digest so a self-check appears to pass',
+    build: () => buildPackage({
+      manifestPatch: (manifest) => {
+        manifest.files.push({
+          path: 'commandmate.skill.yaml',
+          sha256: 'c'.repeat(64),
+          size: 1,
+          kind: 'asset',
+          executable: false,
+          script: false,
+        });
+      },
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+  {
+    name: 'manifest-id-mismatch',
+    threat: 'Package claims an identity the Catalog did not publish',
+    build: () => buildPackage({ manifestPatch: (manifest) => void (manifest.id = 'other-skill') }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_MISMATCH,
+  },
+  {
+    name: 'manifest-version-mismatch',
+    threat: 'Package ships a different version than the one being installed',
+    build: () => buildPackage({ manifestPatch: (manifest) => void (manifest.version = '9.9.9') }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_MISMATCH,
+  },
+  {
+    name: 'skill-md-name-mismatch',
+    threat: 'SKILL.md advertises a different Skill than the manifest',
+    build: () => buildPackage({
+      skillMd: '---\nname: Something Else\ndescription: mismatched\n---\n\n# Nope\n',
+    }).bytes,
+    expectedCode: SkillPackageErrorCode.SKILL_MD_INVALID,
+  },
+  {
+    name: 'skill-md-without-frontmatter',
+    threat: 'No frontmatter means no identity to cross-check',
+    build: () => buildPackage({ skillMd: '# Demo Skill\n\nNo frontmatter here.\n' }).bytes,
+    expectedCode: SkillPackageErrorCode.SKILL_MD_INVALID,
+  },
+  {
+    name: 'missing-skill-md',
+    threat: 'Package without the standard authoring file',
+    build: () => buildPackage({ skillMd: null }).bytes,
+    expectedCode: SkillPackageErrorCode.LAYOUT_INVALID,
+  },
+  {
+    name: 'missing-manifest',
+    threat: 'Package with no distribution manifest at all',
+    build: () => buildPackage({ omitManifest: true }).bytes,
+    expectedCode: SkillPackageErrorCode.LAYOUT_INVALID,
+  },
+  {
+    name: 'manifest-not-yaml',
+    threat: 'Manifest bytes are not the document the contract describes',
+    build: () => buildPackage({ manifestYaml: gzipSync(Buffer.from('x')).toString('binary') }).bytes,
+    expectedCode: SkillPackageErrorCode.MANIFEST_INVALID,
+  },
+];
+
+/** Look a case up by name, for tests that assert on one specific attack. */
+export function maliciousCase(name: string): MaliciousPackageCase {
+  const found = MALICIOUS_PACKAGES.find((entry) => entry.name === name);
+  if (!found) throw new Error(`unknown malicious package case: ${name}`);
+  return found;
+}

--- a/tests/fixtures/skills/malicious-packages/package.ts
+++ b/tests/fixtures/skills/malicious-packages/package.ts
@@ -1,0 +1,266 @@
+/**
+ * Benign baseline package and the knobs the corpus turns (Issue #1230)
+ *
+ * Every malicious case is the baseline package with exactly one thing changed,
+ * so a test that fails tells you which property was load-bearing.
+ */
+
+import { createHash } from 'crypto';
+import type { SkillFileEntry, SkillFileKind, SkillManifest } from '@/types/skills';
+import { TarType, buildTarGz, type BuildTarOptions, type TarEntryInput } from './tar';
+
+export const SKILL_ID = 'demo-skill';
+export const SKILL_VERSION = '1.2.3';
+export const SKILL_NAME = 'Demo Skill';
+
+export const SKILL_MD = `---
+name: ${SKILL_NAME}
+description: A demo Skill used by the CommandMate package tests.
+---
+
+# ${SKILL_NAME}
+
+Steps go here.
+`;
+
+function sha256(content: string | Uint8Array): string {
+  return createHash('sha256')
+    .update(typeof content === 'string' ? Buffer.from(content, 'utf8') : content)
+    .digest('hex');
+}
+
+function byteLength(content: string | Uint8Array): number {
+  return typeof content === 'string' ? Buffer.byteLength(content, 'utf8') : content.byteLength;
+}
+
+// =============================================================================
+// Specs
+// =============================================================================
+
+/** One payload file, plus how the manifest should (mis)describe it. */
+export interface PackageFileSpec {
+  path: string;
+  content: string | Uint8Array;
+  /** Header mode written into the archive. */
+  mode?: number;
+  kind?: SkillFileKind;
+  script?: boolean;
+  /** Declared executable bit; defaults to whatever `mode` carries. */
+  executable?: boolean;
+  /** Leave the file out of `manifest.files`. */
+  undeclared?: boolean;
+  declaredSha256?: string;
+  declaredSize?: number;
+  /** Emit the tar entry with a different name than the declared path. */
+  archivePath?: string;
+  /** tar typeflag, for special-file cases. */
+  type?: TarEntryInput['type'];
+  linkname?: string;
+}
+
+export interface PackageOptions {
+  skillId?: string;
+  version?: string;
+  /** Top-level directory every entry is placed under. */
+  rootDir?: string | null;
+  files?: PackageFileSpec[];
+  skillMd?: string | null;
+  /** Replace the rendered manifest with raw bytes. */
+  manifestYaml?: string;
+  /** Mutate the manifest object after it is derived from the files. */
+  manifestPatch?: (manifest: SkillManifest) => void;
+  /** Declared entries with no file behind them. */
+  extraDeclarations?: SkillFileEntry[];
+  /** Raw tar entries appended after the generated ones. */
+  extraEntries?: TarEntryInput[];
+  omitManifest?: boolean;
+  directories?: string[];
+  tarOptions?: BuildTarOptions;
+}
+
+export const DEFAULT_FILES: readonly PackageFileSpec[] = [
+  { path: 'reference/notes.md', content: '# Notes\n\nBackground reading.\n' },
+  { path: 'assets/logo.svg', content: '<svg xmlns="http://www.w3.org/2000/svg"/>\n' },
+];
+
+// =============================================================================
+// Manifest rendering
+// =============================================================================
+
+function quote(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
+}
+
+function renderList(name: string, values: readonly string[], indent: string): string[] {
+  if (values.length === 0) return [`${indent}${name}: []`];
+  return [`${indent}${name}:`, ...values.map((value) => `${indent}  - ${quote(value)}`)];
+}
+
+/** Serialize a manifest in the subset `safe-yaml` accepts. */
+export function renderManifestYaml(manifest: SkillManifest): string {
+  const lines: string[] = [
+    `schema_version: ${manifest.schema_version}`,
+    `id: ${quote(manifest.id)}`,
+    `name: ${quote(manifest.name)}`,
+    `version: ${quote(manifest.version)}`,
+    `summary: ${quote(manifest.summary)}`,
+    `description: ${quote(manifest.description)}`,
+    ...renderList('capabilities', manifest.capabilities, ''),
+    ...renderList('expected_outcomes', manifest.expected_outcomes, ''),
+    'provider:',
+    `  name: ${quote(manifest.provider.name)}`,
+    `license: ${quote(manifest.license)}`,
+    'compatibility:',
+    `  commandmate: ${quote(manifest.compatibility.commandmate)}`,
+  ];
+
+  if (manifest.compatibility.agents.length === 0) {
+    lines.push('  agents: []');
+  } else {
+    lines.push('  agents:');
+    for (const agent of manifest.compatibility.agents) {
+      lines.push(
+        `    - agent: ${quote(agent.agent)}`,
+        `      support: ${quote(agent.support)}`,
+        `      evidence: ${quote(agent.evidence)}`
+      );
+    }
+  }
+
+  lines.push('requirements:');
+  if (manifest.requirements.commands.length === 0) {
+    lines.push('  commands: []');
+  } else {
+    lines.push('  commands:');
+    for (const command of manifest.requirements.commands) {
+      lines.push(`    - name: ${quote(command.name)}`);
+      if (command.version_range !== undefined) {
+        lines.push(`      version_range: ${quote(command.version_range)}`);
+      }
+    }
+  }
+  lines.push(...renderList('network_hosts', manifest.requirements.network_hosts, '  '));
+  lines.push(...renderList('declared_permissions', manifest.declared_permissions, ''));
+  lines.push(`declared_risk: ${quote(manifest.declared_risk)}`);
+  lines.push(`risk_rationale: ${quote(manifest.risk_rationale)}`);
+
+  if (manifest.files.length === 0) {
+    lines.push('files: []');
+  } else {
+    lines.push('files:');
+    for (const file of manifest.files) {
+      lines.push(
+        `  - path: ${quote(file.path)}`,
+        `    sha256: ${quote(file.sha256)}`,
+        `    size: ${file.size}`,
+        `    kind: ${quote(file.kind)}`,
+        `    executable: ${file.executable}`,
+        `    script: ${file.script}`
+      );
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+const SCRIPT_EXTENSIONS = ['.sh', '.py', '.js', '.rb', '.ps1'];
+
+function deriveKind(spec: PackageFileSpec): SkillFileKind {
+  if (spec.kind) return spec.kind;
+  if (spec.path === 'SKILL.md') return 'skill_md';
+  if (SCRIPT_EXTENSIONS.some((extension) => spec.path.endsWith(extension))) return 'script';
+  return spec.path.endsWith('.md') ? 'instruction' : 'asset';
+}
+
+function declarationFor(spec: PackageFileSpec): SkillFileEntry {
+  const kind = deriveKind(spec);
+  return {
+    path: spec.path,
+    sha256: spec.declaredSha256 ?? sha256(spec.content),
+    size: spec.declaredSize ?? byteLength(spec.content),
+    kind,
+    executable: spec.executable ?? ((spec.mode ?? 0o644) & 0o111) !== 0,
+    script: spec.script ?? kind === 'script',
+  };
+}
+
+// =============================================================================
+// Package assembly
+// =============================================================================
+
+export interface BuiltPackage {
+  bytes: Buffer;
+  manifest: SkillManifest;
+  manifestYaml: string;
+  skillId: string;
+  version: string;
+}
+
+/** Build a package: benign by default, malicious via one option. */
+export function buildPackage(options: PackageOptions = {}): BuiltPackage {
+  const skillId = options.skillId ?? SKILL_ID;
+  const version = options.version ?? SKILL_VERSION;
+  const rootDir = options.rootDir === undefined ? skillId : options.rootDir;
+  const skillMd = options.skillMd === undefined ? SKILL_MD : options.skillMd;
+
+  const payload: PackageFileSpec[] = [
+    ...(skillMd === null ? [] : [{ path: 'SKILL.md', content: skillMd } as PackageFileSpec]),
+    ...(options.files ?? DEFAULT_FILES).map((file) => ({ ...file })),
+  ];
+
+  const manifest: SkillManifest = {
+    schema_version: 1,
+    id: skillId,
+    name: SKILL_NAME,
+    version,
+    summary: 'A demo Skill used by the CommandMate package tests.',
+    description: 'Longer description of the demo Skill used by the package tests.',
+    capabilities: ['Read the reference notes'],
+    expected_outcomes: ['You know what the demo Skill does'],
+    provider: { name: 'CommandMate' },
+    license: 'MIT',
+    compatibility: {
+      commandmate: '>=0.11.0',
+      agents: [{ agent: 'claude', support: 'native', evidence: 'verified by the package tests' }],
+    },
+    requirements: { commands: [], network_hosts: [] },
+    declared_permissions: ['filesystem_read'],
+    declared_risk: 'low',
+    risk_rationale: 'Reads bundled reference material only.',
+    files: [
+      ...payload.filter((spec) => !spec.undeclared).map(declarationFor),
+      ...(options.extraDeclarations ?? []),
+    ],
+  };
+  options.manifestPatch?.(manifest);
+
+  const manifestYaml = options.manifestYaml ?? renderManifestYaml(manifest);
+  const withRoot = (entryPath: string): string =>
+    rootDir === null ? entryPath : `${rootDir}/${entryPath}`;
+
+  const entries: TarEntryInput[] = [];
+  if (rootDir !== null) entries.push({ name: `${rootDir}/`, type: TarType.DIRECTORY });
+  for (const directory of options.directories ?? []) {
+    entries.push({ name: `${withRoot(directory)}/`, type: TarType.DIRECTORY });
+  }
+  if (!options.omitManifest) {
+    entries.push({ name: withRoot('commandmate.skill.yaml'), content: manifestYaml, mode: 0o644 });
+  }
+  for (const spec of payload) {
+    entries.push({
+      name: withRoot(spec.archivePath ?? spec.path),
+      content: spec.content,
+      mode: spec.mode ?? 0o644,
+      ...(spec.type ? { type: spec.type } : {}),
+      ...(spec.linkname ? { linkname: spec.linkname } : {}),
+    });
+  }
+  entries.push(...(options.extraEntries ?? []));
+
+  return {
+    bytes: buildTarGz(entries, options.tarOptions),
+    manifest,
+    manifestYaml,
+    skillId,
+    version,
+  };
+}

--- a/tests/fixtures/skills/malicious-packages/tar.ts
+++ b/tests/fixtures/skills/malicious-packages/tar.ts
@@ -1,0 +1,126 @@
+/**
+ * Hand-rolled tar/gzip writer for the malicious package corpus (Issue #1230)
+ *
+ * `tar(1)` refuses to produce most of what this corpus needs — a device node
+ * owned by nobody, a duplicate entry, a broken checksum, a name with a `..`
+ * component — and checking binary blobs into the repository would hide what
+ * each case actually contains. Everything is therefore built in code, so a
+ * reviewer can read the attack instead of unpacking it.
+ */
+
+import { gzipSync } from 'zlib';
+
+export const TAR_BLOCK_SIZE = 512;
+
+/** tar typeflags, including the ones a Skill package may never contain. */
+export const TarType = {
+  REGULAR: '0',
+  HARDLINK: '1',
+  SYMLINK: '2',
+  CHAR_DEVICE: '3',
+  BLOCK_DEVICE: '4',
+  DIRECTORY: '5',
+  FIFO: '6',
+  CONTIGUOUS: '7',
+  PAX_EXTENDED: 'x',
+  PAX_GLOBAL: 'g',
+  GNU_LONGNAME: 'L',
+} as const;
+
+export type TarTypeValue = (typeof TarType)[keyof typeof TarType];
+
+export interface TarEntryInput {
+  name: string;
+  type?: TarTypeValue | '\0';
+  /** Permission bits written to the header. Defaults to 0o644 / 0o755. */
+  mode?: number;
+  content?: Uint8Array | string;
+  linkname?: string;
+  /** Written to the 155-byte prefix field, joined to `name` with a slash. */
+  prefix?: string;
+  /** Override the `ustar` magic, for format-rejection cases. */
+  magic?: string;
+  /** Override the declared size without changing the payload. */
+  declaredSize?: number;
+  /** Corrupt the header checksum. */
+  breakChecksum?: boolean;
+  /** Write the size field in GNU base-256 encoding. */
+  base256Size?: boolean;
+}
+
+function toBytes(content: Uint8Array | string | undefined): Uint8Array {
+  if (content === undefined) return new Uint8Array(0);
+  return typeof content === 'string' ? Buffer.from(content, 'utf8') : content;
+}
+
+function writeText(block: Buffer, offset: number, length: number, value: string): void {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.byteLength > length) throw new Error(`tar field overflow at offset ${offset}`);
+  bytes.copy(block, offset);
+}
+
+function writeOctal(block: Buffer, offset: number, length: number, value: number): void {
+  writeText(block, offset, length, value.toString(8).padStart(length - 1, '0'));
+}
+
+function buildHeader(entry: TarEntryInput, size: number): Buffer {
+  const block = Buffer.alloc(TAR_BLOCK_SIZE);
+  const type = entry.type ?? TarType.REGULAR;
+  const isDirectory = type === TarType.DIRECTORY;
+
+  writeText(block, 0, 100, entry.name);
+  writeOctal(block, 100, 8, entry.mode ?? (isDirectory ? 0o755 : 0o644));
+  writeOctal(block, 108, 8, 0);
+  writeOctal(block, 116, 8, 0);
+  if (entry.base256Size) {
+    block[124] = 0x80;
+    block.writeUInt32BE(size, 132);
+  } else {
+    writeOctal(block, 124, 12, entry.declaredSize ?? size);
+  }
+  writeOctal(block, 136, 12, 0);
+  writeText(block, 156, 1, type);
+  if (entry.linkname) writeText(block, 157, 100, entry.linkname);
+  writeText(block, 257, 6, entry.magic ?? 'ustar');
+  writeText(block, 263, 2, '00');
+  if (entry.prefix) writeText(block, 345, 155, entry.prefix);
+
+  block.fill(0x20, 148, 156);
+  let checksum = 0;
+  for (let i = 0; i < TAR_BLOCK_SIZE; i++) checksum += block[i];
+  writeOctal(block, 148, 7, entry.breakChecksum ? checksum + 1 : checksum);
+  block[155] = 0x20;
+  return block;
+}
+
+export interface BuildTarOptions {
+  /** Leave off the two zero blocks that mark the end of the archive. */
+  omitTrailer?: boolean;
+  /** Append bytes after the trailer. */
+  trailingGarbage?: Uint8Array;
+}
+
+/** Assemble raw tar bytes. */
+export function buildTar(entries: readonly TarEntryInput[], options: BuildTarOptions = {}): Buffer {
+  const blocks: Buffer[] = [];
+  for (const entry of entries) {
+    const content = toBytes(entry.content);
+    blocks.push(buildHeader(entry, content.byteLength));
+    if (content.byteLength > 0) {
+      const padded = Buffer.alloc(Math.ceil(content.byteLength / TAR_BLOCK_SIZE) * TAR_BLOCK_SIZE);
+      Buffer.from(content).copy(padded);
+      blocks.push(padded);
+    }
+  }
+  if (!options.omitTrailer) blocks.push(Buffer.alloc(TAR_BLOCK_SIZE * 2));
+  if (options.trailingGarbage) blocks.push(Buffer.from(options.trailingGarbage));
+  return Buffer.concat(blocks);
+}
+
+/** Assemble a gzipped tar, the only artifact format schema_version 1 accepts. */
+export function buildTarGz(
+  entries: readonly TarEntryInput[],
+  options: BuildTarOptions = {}
+): Buffer {
+  return gzipSync(buildTar(entries, options), { level: 9 });
+}

--- a/tests/unit/lib/skills/package-reader.test.ts
+++ b/tests/unit/lib/skills/package-reader.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for src/lib/skills/package-reader.ts
+ * Issue #1230: strict tar.gz table parsing with fail-closed entry rules
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash, randomBytes } from 'crypto';
+import {
+  SKILL_PACKAGE_MAX_COMPRESSION_RATIO,
+  SkillPackageError,
+  encodeEntryPathForError,
+  isSkillPackageError,
+  readSkillPackage,
+} from '@/lib/skills/package-reader';
+import {
+  MALICIOUS_PACKAGES,
+  SKILL_ID,
+  SKILL_VERSION,
+  TarType,
+  buildPackage,
+  buildTarGz,
+  maliciousCase,
+} from '@tests/fixtures/skills/malicious-packages';
+
+const COORDINATES = { skillId: SKILL_ID, version: SKILL_VERSION };
+
+function read(bytes: Uint8Array) {
+  return readSkillPackage(bytes, COORDINATES);
+}
+
+describe('readSkillPackage — well-formed packages', () => {
+  it('strips the conventional top-level directory and reports every entry', () => {
+    const table = read(buildPackage().bytes);
+
+    expect(table.rootName).toBe(SKILL_ID);
+    expect(table.files.map((file) => file.path).sort()).toEqual([
+      'SKILL.md',
+      'assets/logo.svg',
+      'commandmate.skill.yaml',
+      'reference/notes.md',
+    ]);
+    expect(table.compressedSize).toBeGreaterThan(0);
+    expect(table.decompressedSize % 512).toBe(0);
+  });
+
+  it('accepts `<skill-id>-<version>` as the root directory too', () => {
+    const table = read(buildPackage({ rootDir: `${SKILL_ID}-${SKILL_VERSION}` }).bytes);
+    expect(table.rootName).toBe(`${SKILL_ID}-${SKILL_VERSION}`);
+    expect(table.files.some((file) => file.path === 'SKILL.md')).toBe(true);
+  });
+
+  it('accepts a package with no root directory at all', () => {
+    const table = read(buildPackage({ rootDir: null }).bytes);
+    expect(table.rootName).toBeNull();
+    expect(table.files.some((file) => file.path === 'SKILL.md')).toBe(true);
+  });
+
+  it('digests every file and reports the archive executable bit', () => {
+    const content = '#!/bin/sh\necho hi\n';
+    const table = read(
+      buildPackage({ files: [{ path: 'tools/run.sh', content, mode: 0o755 }] }).bytes
+    );
+
+    const script = table.files.find((file) => file.path === 'tools/run.sh');
+    expect(script?.executable).toBe(true);
+    expect(script?.sha256).toBe(createHash('sha256').update(content).digest('hex'));
+    expect(table.files.find((file) => file.path === 'SKILL.md')?.executable).toBe(false);
+  });
+
+  it('records directory entries separately from files', () => {
+    const table = read(buildPackage({ directories: ['reference'] }).bytes);
+    expect(table.directories).toContain('reference');
+    expect(table.files.some((file) => file.path === 'reference')).toBe(false);
+  });
+
+  it('reads a large but incompressible payload, which the ratio guard must allow', () => {
+    // The acceptance side of the check the compression-bomb case rejects: past
+    // the ratio floor, real content still has to get through.
+    const table = read(
+      buildTarGz([
+        { name: `${SKILL_ID}/`, type: TarType.DIRECTORY },
+        { name: `${SKILL_ID}/payload.bin`, content: randomBytes(2 * 1024 * 1024) },
+      ])
+    );
+    expect(table.decompressedSize / table.compressedSize).toBeLessThan(
+      SKILL_PACKAGE_MAX_COMPRESSION_RATIO
+    );
+  });
+});
+
+describe('readSkillPackage — fail-closed rejections', () => {
+  it.each([
+    ['zip-slip-parent-traversal'],
+    ['absolute-path'],
+    ['windows-drive-path'],
+    ['backslash-separator'],
+    ['nul-truncated-name'],
+    ['path-too-deep'],
+    ['path-segment-too-long'],
+    ['symlink-entry'],
+    ['symlink-entry-without-target'],
+    ['hardlink-entry'],
+    ['character-device-entry'],
+    ['block-device-entry'],
+    ['fifo-entry'],
+    ['contiguous-file-entry'],
+    ['pax-extended-header'],
+    ['gnu-longname-header'],
+    ['setuid-bit'],
+    ['setgid-bit'],
+    ['sticky-bit'],
+    ['duplicate-entry'],
+    ['case-collision'],
+    ['unicode-collision'],
+    ['directory-shadows-file'],
+    ['compression-ratio-bomb'],
+    ['decompressed-size-bomb'],
+    ['entry-count-flood'],
+    ['not-gzip'],
+    ['broken-header-checksum'],
+    ['foreign-archive-magic'],
+    ['base256-size-field'],
+    ['missing-trailer'],
+    ['appended-after-trailer'],
+    ['root-directory-mismatch'],
+  ])('rejects %s at the archive layer', (name) => {
+    const entry = maliciousCase(name);
+    try {
+      read(entry.build());
+      throw new Error(`${entry.name} was accepted: ${entry.threat}`);
+    } catch (error) {
+      expect(isSkillPackageError(error)).toBe(true);
+      expect((error as SkillPackageError).code).toBe(entry.expectedCode);
+    }
+  });
+
+  it('never leaks a machine path or raw entry name in a rejection message', () => {
+    for (const entry of MALICIOUS_PACKAGES) {
+      let error: unknown;
+      try {
+        read(entry.build());
+        continue;
+      } catch (caught) {
+        error = caught;
+      }
+      if (!isSkillPackageError(error)) continue;
+      expect(error.message).not.toContain('/Users');
+      expect(error.message).not.toMatch(/\.\./);
+      for (const value of Object.values(error.detail ?? {})) {
+        expect(String(value)).not.toContain('\n');
+      }
+    }
+  });
+
+  it('classifies every rejection into a category the UI can branch on', () => {
+    const categories = new Set<string>();
+    for (const entry of MALICIOUS_PACKAGES) {
+      try {
+        read(entry.build());
+      } catch (error) {
+        if (isSkillPackageError(error)) categories.add(error.category);
+      }
+    }
+    expect([...categories].sort()).toEqual(['archive', 'limit', 'manifest', 'path']);
+  });
+});
+
+describe('encodeEntryPathForError', () => {
+  it('percent-encodes anything that could reshape a log line', () => {
+    expect(encodeEntryPathForError('a/b.md')).toBe('a/b.md');
+    expect(encodeEntryPathForError('a\nb')).toBe('a%0Ab');
+    expect(encodeEntryPathForError('<script>')).toBe('%3Cscript%3E');
+  });
+
+  it('truncates an over-long name', () => {
+    expect(encodeEntryPathForError('a'.repeat(500))).toHaveLength(121);
+  });
+});

--- a/tests/unit/lib/skills/package-validator.test.ts
+++ b/tests/unit/lib/skills/package-validator.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for src/lib/skills/package-validator.ts
+ * Issue #1230: exact manifest reconciliation and safe staging materialization
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+
+/**
+ * Hooks into the two filesystem calls materialization depends on.
+ *
+ * A staging directory has a random name, so the only way to plant a symlink in
+ * the window a real race would use is to act the instant the directory appears.
+ * Both hooks are inert unless a test installs one.
+ */
+const fsHooks = vi.hoisted(() => ({
+  afterMkdir: null as ((target: string) => void) | null,
+  beforeWrite: null as (() => void) | null,
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: actual,
+    mkdirSync: ((...args: Parameters<typeof actual.mkdirSync>) => {
+      const result = actual.mkdirSync(...args);
+      fsHooks.afterMkdir?.(String(args[0]));
+      return result;
+    }) as typeof actual.mkdirSync,
+    writeSync: ((...args: Parameters<typeof actual.writeSync>) => {
+      fsHooks.beforeWrite?.();
+      return actual.writeSync(...args);
+    }) as typeof actual.writeSync,
+  };
+});
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import path from 'path';
+import {
+  SkillPackageError,
+  SkillPackageErrorCode,
+  isSkillPackageError,
+  readSkillPackage,
+} from '@/lib/skills/package-reader';
+import {
+  SKILL_STAGED_EXECUTABLE_MODE,
+  SKILL_STAGED_FILE_MODE,
+  SKILL_STAGING_DIR_MODE,
+  cleanupSkillStagingRoot,
+  deriveSkillFileKind,
+  inspectSkillPackage,
+  isSkillScriptPayload,
+  materializeSkillPackage,
+  validateSkillPackage,
+} from '@/lib/skills/package-validator';
+import {
+  MALICIOUS_PACKAGES,
+  SKILL_ID,
+  SKILL_VERSION,
+  buildPackage,
+  maliciousCase,
+} from '@tests/fixtures/skills/malicious-packages';
+
+const COORDINATES = { skillId: SKILL_ID, version: SKILL_VERSION };
+
+/**
+ * The staging root refuses system directories, and os.tmpdir() resolves under
+ * /var on macOS, so test roots live in the repo-local (gitignored) temp dir.
+ */
+const TEST_ROOT_PARENT = path.join(process.cwd(), 'temp');
+
+let stagingRoot: string;
+
+function inspect(bytes: Uint8Array) {
+  return inspectSkillPackage(bytes, COORDINATES);
+}
+
+function modeOf(target: string): number {
+  return lstatSync(target).mode & 0o7777;
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_ROOT_PARENT, { recursive: true });
+  stagingRoot = mkdtempSync(path.join(TEST_ROOT_PARENT, 'skill-staging-'));
+});
+
+afterEach(() => {
+  fsHooks.afterMkdir = null;
+  fsHooks.beforeWrite = null;
+  rmSync(stagingRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+// =============================================================================
+// Classification
+// =============================================================================
+
+describe('script classification', () => {
+  it('treats known extensions and shebangs as scripts', () => {
+    expect(isSkillScriptPayload('tools/run.sh', new Uint8Array())).toBe(true);
+    expect(isSkillScriptPayload('tools/run.PY', new Uint8Array())).toBe(true);
+    expect(isSkillScriptPayload('assets/data', Buffer.from('#!/bin/sh\n'))).toBe(true);
+    expect(isSkillScriptPayload('assets/logo.svg', Buffer.from('<svg/>'))).toBe(false);
+  });
+
+  it('derives a kind independent of what the manifest claims', () => {
+    expect(deriveSkillFileKind('SKILL.md', Buffer.from('# x'))).toBe('skill_md');
+    expect(deriveSkillFileKind('tools/run.sh', Buffer.from(''))).toBe('script');
+    expect(deriveSkillFileKind('reference/notes.md', Buffer.from('# x'))).toBe('instruction');
+    expect(deriveSkillFileKind('assets/logo.svg', Buffer.from('<svg/>'))).toBe('asset');
+  });
+});
+
+// =============================================================================
+// Reconciliation
+// =============================================================================
+
+describe('validateSkillPackage — accepted packages', () => {
+  it('returns an immutable snapshot of everything the package contains', () => {
+    const snapshot = inspect(buildPackage().bytes);
+
+    expect(snapshot.skillId).toBe(SKILL_ID);
+    expect(snapshot.version).toBe(SKILL_VERSION);
+    expect(snapshot.manifest.name).toBe('Demo Skill');
+    expect(snapshot.files.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'assets/logo.svg',
+      'commandmate.skill.yaml',
+      'reference/notes.md',
+    ]);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+
+  it('hands out copies, so a consumer cannot mutate the reviewed bytes', () => {
+    const snapshot = inspect(buildPackage().bytes);
+    const first = snapshot.readFile('SKILL.md');
+    first[0] = 0;
+    expect(snapshot.readFile('SKILL.md')[0]).not.toBe(0);
+  });
+
+  it('refuses to read a path the package does not contain', () => {
+    const snapshot = inspect(buildPackage().bytes);
+    expect(() => snapshot.readFile('../escape')).toThrow(SkillPackageError);
+  });
+
+  it('computes risk from the package, not from the publisher claim', () => {
+    const inert = inspect(buildPackage().bytes);
+    expect(inert.computedRisk).toBe('low');
+    expect(inert.effectiveRisk).toBe('low');
+
+    const scripted = inspect(
+      buildPackage({ files: [{ path: 'tools/run.sh', content: '#!/bin/sh\necho hi\n' }] }).bytes
+    );
+    expect(scripted.declaredRisk).toBe('low');
+    expect(scripted.computedRisk).toBe('moderate');
+    expect(scripted.effectiveRisk).toBe('moderate');
+
+    const executable = inspect(
+      buildPackage({
+        files: [{ path: 'tools/run.sh', content: '#!/bin/sh\necho hi\n', mode: 0o755 }],
+      }).bytes
+    );
+    expect(executable.computedRisk).toBe('high');
+    expect(executable.effectiveRisk).toBe('high');
+  });
+
+  it('returns an inventory a plan can list every file and script from (UX-09)', () => {
+    const snapshot = inspect(
+      buildPackage({
+        files: [
+          { path: 'tools/run.sh', content: '#!/bin/sh\necho hi\n', mode: 0o755 },
+          { path: 'reference/notes.md', content: '# Notes\n' },
+        ],
+      }).bytes
+    );
+    expect(snapshot.inspection.executable_paths).toEqual(['tools/run.sh']);
+    expect(snapshot.inspection.script_paths).toEqual(['tools/run.sh']);
+    expect(snapshot.inspection.declared_permissions).toEqual(['filesystem_read']);
+  });
+});
+
+describe('validateSkillPackage — fail-closed rejections', () => {
+  it.each(MALICIOUS_PACKAGES.map((entry) => [entry.name] as const))(
+    'rejects the whole package for %s',
+    (name) => {
+      const entry = maliciousCase(name);
+      try {
+        inspect(entry.build());
+        throw new Error(`${entry.name} was accepted: ${entry.threat}`);
+      } catch (error) {
+        expect(isSkillPackageError(error)).toBe(true);
+        expect((error as SkillPackageError).code).toBe(entry.expectedCode);
+      }
+    }
+  );
+
+  it('rejects a package whose archive carries no entries at all', () => {
+    const table = readSkillPackage(buildPackage({ omitManifest: true, skillMd: null }).bytes, COORDINATES);
+    expect(() => validateSkillPackage(table, COORDINATES)).toThrow(SkillPackageError);
+  });
+});
+
+// =============================================================================
+// Materialization
+// =============================================================================
+
+describe('materializeSkillPackage', () => {
+  it('writes the package into a private staging directory with fixed modes', () => {
+    const snapshot = inspect(
+      buildPackage({
+        files: [
+          { path: 'tools/run.sh', content: '#!/bin/sh\necho hi\n', mode: 0o755 },
+          { path: 'reference/notes.md', content: '# Notes\n' },
+        ],
+      }).bytes
+    );
+    const staged = materializeSkillPackage(snapshot, { stagingRoot });
+
+    expect(modeOf(staged.stagingDir)).toBe(SKILL_STAGING_DIR_MODE);
+    expect(modeOf(path.join(staged.stagingDir, 'tools'))).toBe(SKILL_STAGING_DIR_MODE);
+    expect(modeOf(path.join(staged.stagingDir, 'tools/run.sh'))).toBe(
+      SKILL_STAGED_EXECUTABLE_MODE
+    );
+    expect(modeOf(path.join(staged.stagingDir, 'reference/notes.md'))).toBe(
+      SKILL_STAGED_FILE_MODE
+    );
+    expect(readFileSync(path.join(staged.stagingDir, 'reference/notes.md'), 'utf8')).toBe(
+      '# Notes\n'
+    );
+    expect(staged.inventory.map((file) => file.path)).toEqual(
+      snapshot.files.map((file) => file.path)
+    );
+    staged.dispose();
+  });
+
+  it('never sets an execute bit on a file the manifest did not declare executable', () => {
+    const snapshot = inspect(
+      buildPackage({ files: [{ path: 'tools/run.sh', content: '#!/bin/sh\necho hi\n' }] }).bytes
+    );
+    const staged = materializeSkillPackage(snapshot, { stagingRoot });
+
+    for (const file of staged.inventory) {
+      expect(modeOf(path.join(staged.stagingDir, file.path)) & 0o111).toBe(0);
+    }
+    staged.dispose();
+  });
+
+  it('gives concurrent materializations of the same package separate directories', () => {
+    const snapshot = inspect(buildPackage().bytes);
+    const first = materializeSkillPackage(snapshot, { stagingRoot });
+    const second = materializeSkillPackage(snapshot, { stagingRoot });
+
+    expect(first.stagingDir).not.toBe(second.stagingDir);
+    expect(readdirSync(stagingRoot)).toHaveLength(2);
+    first.dispose();
+    second.dispose();
+  });
+
+  it('removes the staging directory on dispose, and tolerates a second call', () => {
+    const staged = materializeSkillPackage(inspect(buildPackage().bytes), { stagingRoot });
+    staged.dispose();
+    staged.dispose();
+    expect(existsSync(staged.stagingDir)).toBe(false);
+  });
+
+  it('publishes nothing when the caller aborts', () => {
+    const snapshot = inspect(buildPackage().bytes);
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      materializeSkillPackage(snapshot, { stagingRoot, signal: controller.signal });
+      throw new Error('expected an abort');
+    } catch (error) {
+      expect(isSkillPackageError(error)).toBe(true);
+      expect((error as SkillPackageError).code).toBe(SkillPackageErrorCode.ABORTED);
+    }
+    expect(readdirSync(stagingRoot)).toEqual([]);
+  });
+
+  it('leaves no partial package behind when a write fails midway', () => {
+    const snapshot = inspect(buildPackage().bytes);
+    let writes = 0;
+    fsHooks.beforeWrite = () => {
+      writes += 1;
+      if (writes > 1) throw new Error('disk full');
+    };
+
+    expect(() => materializeSkillPackage(snapshot, { stagingRoot })).toThrow(SkillPackageError);
+    expect(readdirSync(stagingRoot)).toEqual([]);
+  });
+
+  it('refuses a staging root that is a system directory', () => {
+    expect(() => materializeSkillPackage(inspect(buildPackage().bytes), { stagingRoot: '/' })).toThrow(
+      SkillPackageError
+    );
+  });
+
+  it('does not write through a symlink planted at a target path', () => {
+    const snapshot = inspect(buildPackage().bytes);
+    const decoy = path.join(stagingRoot, 'decoy.txt');
+    writeFileSync(decoy, 'original\n');
+
+    fsHooks.afterMkdir = (target) => {
+      if (path.basename(target).startsWith('pkg-')) {
+        symlinkSync(decoy, path.join(target, 'SKILL.md'));
+      }
+    };
+
+    expect(() => materializeSkillPackage(snapshot, { stagingRoot })).toThrow(SkillPackageError);
+    expect(readFileSync(decoy, 'utf8')).toBe('original\n');
+  });
+});
+
+describe('cleanupSkillStagingRoot', () => {
+  it('removes orphaned staging directories and nothing else', () => {
+    const staged = materializeSkillPackage(inspect(buildPackage().bytes), { stagingRoot });
+    const keeper = path.join(stagingRoot, 'not-a-staging-dir');
+    writeFileSync(keeper, 'keep me\n');
+
+    expect(cleanupSkillStagingRoot(stagingRoot)).toBe(1);
+    expect(existsSync(staged.stagingDir)).toBe(false);
+    expect(existsSync(keeper)).toBe(true);
+  });
+
+  it('is a no-op for a root that does not exist', () => {
+    expect(cleanupSkillStagingRoot(path.join(stagingRoot, 'missing'))).toBe(0);
+  });
+});

--- a/tests/unit/lib/skills/safe-yaml.test.ts
+++ b/tests/unit/lib/skills/safe-yaml.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for src/lib/skills/safe-yaml.ts
+ * Issue #1230: manifest YAML parsed under SKILL_YAML_SAFE_PROFILE
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SKILL_YAML_SAFE_PROFILE } from '@/lib/skills';
+import {
+  SkillYamlError,
+  SkillYamlErrorCode,
+  isSkillYamlError,
+  parseSkillFrontmatter,
+  parseSkillYaml,
+  type SkillYamlProfile,
+} from '@/lib/skills/safe-yaml';
+
+function expectRejection(yaml: string | Uint8Array, code: string, profile?: SkillYamlProfile): void {
+  try {
+    parseSkillYaml(yaml, profile);
+    throw new Error(`expected a rejection with ${code}`);
+  } catch (error) {
+    if (!isSkillYamlError(error)) throw error;
+    expect(error.code).toBe(code);
+  }
+}
+
+describe('parseSkillYaml — supported subset', () => {
+  it('parses nested mappings and sequences', () => {
+    const parsed = parseSkillYaml(
+      [
+        'schema_version: 1',
+        'id: demo-skill',
+        'provider:',
+        '  name: CommandMate',
+        '  url: https://example.test/a',
+        'files:',
+        '  - path: SKILL.md',
+        '    size: 12',
+        '    executable: false',
+        '  - path: run.sh',
+        '    size: 34',
+        '    executable: true',
+      ].join('\n')
+    ) as Record<string, unknown>;
+
+    expect(parsed['schema_version']).toBe(1);
+    expect(parsed['id']).toBe('demo-skill');
+    expect(parsed['provider']).toMatchObject({
+      name: 'CommandMate',
+      url: 'https://example.test/a',
+    });
+    expect(parsed['files']).toEqual([
+      { path: 'SKILL.md', size: 12, executable: false },
+      { path: 'run.sh', size: 34, executable: true },
+    ]);
+  });
+
+  it('accepts a sequence indented at the same level as its key', () => {
+    const parsed = parseSkillYaml('keywords:\n- alpha\n- beta\n') as Record<string, unknown>;
+    expect(parsed['keywords']).toEqual(['alpha', 'beta']);
+  });
+
+  it('resolves plain scalars to the JSON core types only', () => {
+    const parsed = parseSkillYaml(
+      [
+        'a: true',
+        'b: false',
+        'c: null',
+        'd: ~',
+        'e: 42',
+        'f: -1.5',
+        'g: 1.2.3',
+        'h: yes',
+        'i: 0755',
+      ].join('\n')
+    ) as Record<string, unknown>;
+
+    expect(parsed).toMatchObject({ a: true, b: false, c: null, d: null, e: 42, f: -1.5 });
+    // A version, a YAML 1.1 boolean and a leading-zero number all stay strings:
+    // guessing at them is how `version: 1.0` silently becomes a float.
+    expect(parsed['g']).toBe('1.2.3');
+    expect(parsed['h']).toBe('yes');
+    expect(parsed['i']).toBe('0755');
+  });
+
+  it('keeps a hash inside quotes and drops a trailing comment', () => {
+    const parsed = parseSkillYaml('a: "keep # this"  # drop this\nb: plain # gone\n') as Record<
+      string,
+      unknown
+    >;
+    expect(parsed['a']).toBe('keep # this');
+    expect(parsed['b']).toBe('plain');
+  });
+
+  it('reads literal and folded block scalars with chomping', () => {
+    const parsed = parseSkillYaml(
+      ['literal: |', '  line one', '  line two', 'folded: >-', '  a', '  b', 'tail: 1'].join('\n')
+    ) as Record<string, unknown>;
+    expect(parsed['literal']).toBe('line one\nline two\n');
+    expect(parsed['folded']).toBe('a b');
+    expect(parsed['tail']).toBe(1);
+  });
+
+  it('unescapes double-quoted and single-quoted scalars', () => {
+    const parsed = parseSkillYaml(
+      ['a: "tab\\there"', 'b: "quote\\"inside"', "c: 'it''s fine'"].join('\n')
+    ) as Record<string, unknown>;
+    expect(parsed['a']).toBe('tab\there');
+    expect(parsed['b']).toBe('quote"inside');
+    expect(parsed['c']).toBe("it's fine");
+  });
+
+  it('accepts empty flow collections, which the manifest needs for empty lists', () => {
+    const parsed = parseSkillYaml('commands: []\nextras: {}\n') as Record<string, unknown>;
+    expect(parsed['commands']).toEqual([]);
+    expect(parsed['extras']).toEqual({});
+  });
+
+  it('skips comments, blank lines and the document start marker', () => {
+    const parsed = parseSkillYaml('---\n# leading\n\na: 1\n\n# trailing\n') as Record<
+      string,
+      unknown
+    >;
+    expect(parsed).toEqual({ a: 1 });
+  });
+
+  it('produces mappings with a null prototype', () => {
+    const parsed = parseSkillYaml('a:\n  b: 1\n') as Record<string, Record<string, unknown>>;
+    expect(Object.getPrototypeOf(parsed)).toBeNull();
+    expect(Object.getPrototypeOf(parsed['a'])).toBeNull();
+  });
+});
+
+describe('parseSkillYaml — profile enforcement', () => {
+  it('rejects anchors and aliases', () => {
+    expectRejection('a: &anchor 1\n', SkillYamlErrorCode.ALIAS_FORBIDDEN);
+    expectRejection('a: *alias\n', SkillYamlErrorCode.ALIAS_FORBIDDEN);
+    expectRejection('&anchor a: 1\n', SkillYamlErrorCode.ALIAS_FORBIDDEN);
+  });
+
+  it('rejects merge keys', () => {
+    expectRejection('a:\n  <<: *base\n  b: 1\n', SkillYamlErrorCode.MERGE_KEY_FORBIDDEN);
+  });
+
+  it('rejects explicit tags', () => {
+    expectRejection('a: !!str 1\n', SkillYamlErrorCode.TAG_FORBIDDEN);
+    expectRejection('!tag a: 1\n', SkillYamlErrorCode.TAG_FORBIDDEN);
+  });
+
+  it('rejects duplicate keys', () => {
+    expectRejection('a: 1\na: 2\n', SkillYamlErrorCode.DUPLICATE_KEY);
+  });
+
+  it('rejects every forbidden prototype key', () => {
+    for (const key of SKILL_YAML_SAFE_PROFILE.forbiddenKeys) {
+      expectRejection(`${key}: 1\n`, SkillYamlErrorCode.FORBIDDEN_KEY);
+    }
+  });
+
+  it('rejects a second document', () => {
+    expectRejection('a: 1\n---\nb: 2\n', SkillYamlErrorCode.MULTIPLE_DOCUMENTS);
+    expectRejection('a: 1\n...\nb: 2\n', SkillYamlErrorCode.MULTIPLE_DOCUMENTS);
+  });
+
+  it('rejects non-empty flow collections and complex keys', () => {
+    expectRejection('a: [1, 2]\n', SkillYamlErrorCode.UNSUPPORTED);
+    expectRejection('a: {b: 1}\n', SkillYamlErrorCode.UNSUPPORTED);
+    expectRejection('? a\n: 1\n', SkillYamlErrorCode.UNSUPPORTED);
+  });
+
+  it('rejects a document over the byte budget', () => {
+    expectRejection(`a: "${'x'.repeat(SKILL_YAML_SAFE_PROFILE.maxBytes)}"\n`, SkillYamlErrorCode.BYTES_LIMIT);
+  });
+
+  it('rejects nesting past the depth limit', () => {
+    const deep = Array.from(
+      { length: SKILL_YAML_SAFE_PROFILE.maxDepth + 4 },
+      (_, i) => `${'  '.repeat(i)}k${i}:`
+    ).join('\n');
+    expectRejection(deep, SkillYamlErrorCode.DEPTH_LIMIT);
+  });
+
+  it('rejects more nodes than the profile allows', () => {
+    const flood = `a:\n${Array.from({ length: SKILL_YAML_SAFE_PROFILE.maxNodes + 10 }, (_, i) => `  - ${i}`).join('\n')}`;
+    expectRejection(flood, SkillYamlErrorCode.NODE_LIMIT);
+  });
+
+  it('rejects an oversized scalar', () => {
+    const long = 'x'.repeat(SKILL_YAML_SAFE_PROFILE.maxScalarLength + 1);
+    expectRejection(`a: "${long}"\n`, SkillYamlErrorCode.SCALAR_LIMIT);
+    expectRejection(`a: |\n  ${long}\n`, SkillYamlErrorCode.SCALAR_LIMIT);
+  });
+
+  it('rejects text that is not plain UTF-8', () => {
+    expectRejection(Uint8Array.from([0xff, 0xfe, 0x41]), SkillYamlErrorCode.ENCODING);
+    expectRejection('\uFEFFa: 1\n', SkillYamlErrorCode.ENCODING);
+    expectRejection('a: 1\rb: 2\n', SkillYamlErrorCode.ENCODING);
+    expectRejection('a: \u0000\n', SkillYamlErrorCode.ENCODING);
+  });
+
+  it('rejects tab indentation and malformed lines', () => {
+    expectRejection('a:\n\tb: 1\n', SkillYamlErrorCode.SYNTAX);
+    expectRejection('not a mapping\n', SkillYamlErrorCode.SYNTAX);
+    expectRejection('a: "unterminated\n', SkillYamlErrorCode.SYNTAX);
+  });
+
+  it('refuses a profile that would relax the parser it cannot relax', () => {
+    const relaxed = { ...SKILL_YAML_SAFE_PROFILE, allowAliases: true };
+    expectRejection('a: 1\n', SkillYamlErrorCode.UNSUPPORTED, relaxed);
+  });
+
+  it('reports the offending line without echoing its content', () => {
+    try {
+      parseSkillYaml('a: 1\nb: &secret-anchor 2\n');
+      throw new Error('expected a rejection');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SkillYamlError);
+      const yamlError = error as SkillYamlError;
+      expect(yamlError.line).toBe(2);
+      expect(yamlError.message).not.toContain('secret-anchor');
+    }
+  });
+});
+
+describe('parseSkillFrontmatter', () => {
+  it('parses the frontmatter block of a Markdown document', () => {
+    const parsed = parseSkillFrontmatter('---\nname: Demo Skill\n---\n\n# Body\n') as Record<
+      string,
+      unknown
+    >;
+    expect(parsed['name']).toBe('Demo Skill');
+  });
+
+  it('returns null when there is no frontmatter', () => {
+    expect(parseSkillFrontmatter('# Body only\n')).toBeNull();
+    expect(parseSkillFrontmatter('---\nname: unterminated\n')).toBeNull();
+  });
+
+  it('applies the same profile as the manifest', () => {
+    expect(() => parseSkillFrontmatter('---\nname: &a Demo\n---\n')).toThrow(SkillYamlError);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1230（Epic #1227 Phase 1 Wave 3）。#1229 の検証済み snapshot を read-only 入力とし、全 entry を先に解析してから #1228 の package 契約と完全一致した場合だけ隔離 staging へ materialize する。**検査・展開のいずれでも archive 内 script を実行しない。**

## 追加 module

- **`safe-yaml.ts`** — `SKILL_YAML_SAFE_PROFILE` を満たす YAML 部分集合 parser。maxBytes / maxDepth / maxNodes / maxScalarLength を強制し、anchor / alias / merge key / custom tag / duplicate key / prototype key / 複数 document / 非空 flow collection を個別 code で拒否。mapping は null prototype で生成。SKILL.md frontmatter も同 profile
- **`package-reader.ts`** — tar.gz を自前解析し entry table を構築。regular file/directory 以外（symlink / hardlink / device / FIFO / contiguous / pax / GNU 拡張）を **typeflag と link field の二重 guard** で拒否。setuid/setgid/sticky を拒否、uid/gid/mtime は破棄。path・duplicate・case/Unicode collision・file 数・単体/総展開 size・compression ratio を全 entry へ適用。error path は percent-encode / truncate
- **`package-validator.ts`** — manifest と package を path/size/digest/kind/executable/script の全軸で**双方向**完全照合し、未宣言 file/script/executable を拒否。inspection・computed risk・effective risk を返す immutable snapshot を発行し、0700 staging へ `O_EXCL|O_NOFOLLOW` で materialize。固定 mode（dir 0700 / file 0600 / 宣言済み executable のみ 0700）を適用し、**write 後に digest を再検証**。失敗・abort 時は staging 全体を削除して partial package を公開しない。restart 用 orphan cleanup も提供

## テスト

`tests/fixtures/skills/malicious-packages/` に **59 件の悪性 corpus を code で構築**（binary blob を置かず attack が diff で読める形にした）。Zip Slip / absolute / drive / backslash / NUL / 深すぎる path / symlink / hardlink / device / FIFO / contiguous / pax / GNU longname / setuid / setgid / sticky / duplicate / case・Unicode collision / 圧縮爆弾 / entry flood / checksum・magic・trailer 破壊 / YAML bomb 各種 / 未宣言 executable・script / manifest smuggling / digest・size mismatch を全件 fail closed で拒否することを固定。

## ガード破壊（mutation）実行結果 — 12 件中 12 件をテストが検知

| # | 破壊した guard | 結果 |
|---|---|---|
| M1 | reader: symlink/hardlink typeflag を許可 | DETECTED (1 test) |
| M2 | reader: 正規化後 path の検証を skip | DETECTED (6 tests) |
| M3 | reader: setuid/setgid/sticky 拒否を削除 | DETECTED (3 tests) |
| M4 | reader: case/Unicode collision 検出を削除 | DETECTED (2 tests) |
| M5 | yaml: anchor/alias を許可 | DETECTED (4 tests) |
| M6 | yaml: duplicate key 検出を削除 | DETECTED (1 test) |
| M7 | yaml: node 数上限を削除 | DETECTED (1 test) |
| M8 | validator: executable bit 照合を削除 | DETECTED (1 test) |
| M9 | validator: script 分類照合を削除 | DETECTED (2 tests) |
| M10 | validator: 全 staged ファイルへ実行 bit 付与 | DETECTED (2 tests) |
| M11 | validator: 失敗時の staging 削除を削除 | DETECTED (2 tests) |
| M12 | validator: digest 照合を削除 | DETECTED (1 test) |

**M1 と M2 は初回 NOT DETECTED だった。** 原因と対応:

- **M1**: 悪性 corpus の symlink/hardlink が全て link field 有りで、typeflag guard を壊しても link field guard が拾っていた。**link field 空の symlink case を追加**して typeflag guard 単独を観測可能にした
- **M2**: `normalizeRawName` 内の生 path `..` check は `validateSkillPayloadPath`（#1228）と完全に重複しており、壊してもテストが緑のままだった。**テストで区別できない guard は負債**なので当該 check を削除し、正規化後 path の検証を破壊する mutation へ差し替えて検知を確認した

## Issue 記載への訂正

Issue 本文は書き換えていない。

1. Issue は「extract 前の central directory/header 検査」と記述しているが、**#1228 が固定した artifact format は tar.gz で central directory を持たない**。「書き込み前に全 entry を in-memory で解析し、write 時に `O_EXCL|O_NOFOLLOW` で再検証」として実装
2. Issue は「setuid/setgid/sticky を破棄」としつつ悪性 corpus での拒否も求めている。**fail closed 側を採り**、setuid/setgid/sticky は拒否、uid/gid/mtime は破棄とした
3. `manifest.files` の self-declaration と duplicate declaration は既に #1228 の `validateSkillManifest` が拒否済み。#1230 側で二重 check せず、corpus の期待 code を `MANIFEST_INVALID` として固定
4. **#1228 は「archive root directory」の具体形を定義していない。** top-level directory は省略可、置く場合は `<skill-id>` または `<skill-id>-<version>` のみ許可（Catalog が公開していない名前での install を塞ぐ）として確定させた
5. YAML parser は新規依存を足さず自前実装。**js-yaml は gray-matter 経由の推移依存でしか届かず、depth/node/scalar bound を持たず anchor と merge key を既定で解決するため profile を満たせない**

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run test:unit` / `build` | worker 側 exit 0 |

Refs #1230, #1227