### PR TITLE
feat(skills): 単一worktreeへのatomic installとdeterministic receipt (#1235)

### DIFF
--- a/locales/en/skills.json
+++ b/locales/en/skills.json
@@ -133,6 +133,19 @@
   "plan": {
     "highRiskAcknowledgement": "CommandMate rated this package high risk after inspecting its contents. Review the files, scripts and declared permissions below, then confirm explicitly that you want to install it into this worktree."
   },
+  "install": {
+    "reload": {
+      "native": "{agent} loads Skills from the worktree at startup. Restart the {agent} session in this worktree to make {skillId} {version} available.",
+      "commandmateRuntime": "{agent} runs this Skill through the CommandMate runtime. Restart the {agent} session in this worktree so the runtime picks up {skillId} {version}.",
+      "unsupported": "{agent} does not support this Skill. The files are installed, but {skillId} {version} will not be offered in {agent} sessions.",
+      "unknown": "Support for {agent} has not been verified. The files are installed; restart the {agent} session and check whether {skillId} {version} is offered."
+    },
+    "nextAction": {
+      "succeeded": "The Skill is installed and recorded. Restart the agent sessions listed below to start using it.",
+      "committedReconciling": "The files were written and are already in the worktree, but the installation record is incomplete. CommandMate will finish it automatically; no reinstall is needed.",
+      "failed": "Nothing was written to the worktree. Review the reason and build a new install plan."
+    }
+  },
   "card": {
     "provider": "by {provider}",
     "noRecommendedVersion": "No installable version"

--- a/locales/ja/skills.json
+++ b/locales/ja/skills.json
@@ -133,6 +133,19 @@
   "plan": {
     "highRiskAcknowledgement": "CommandMateはpackageの内容を検査した結果、このSkillをhigh riskと判定しました。以下のファイル・スクリプト・宣言された権限を確認したうえで、このworktreeへ導入することを明示的に承認してください。"
   },
+  "install": {
+    "reload": {
+      "native": "{agent} は起動時にworktreeからSkillを読み込みます。{skillId} {version} を利用するには、このworktreeの {agent} セッションを再起動してください。",
+      "commandmateRuntime": "{agent} はCommandMate runtime経由でこのSkillを実行します。runtimeが {skillId} {version} を認識するよう、このworktreeの {agent} セッションを再起動してください。",
+      "unsupported": "{agent} はこのSkillに対応していません。ファイルは配置されましたが、{agent} セッションでは {skillId} {version} は提示されません。",
+      "unknown": "{agent} での対応状況は未検証です。ファイルは配置済みです。{agent} セッションを再起動し、{skillId} {version} が提示されるか確認してください。"
+    },
+    "nextAction": {
+      "succeeded": "Skillのインストールと記録が完了しました。以下のagentセッションを再起動すると利用を開始できます。",
+      "committedReconciling": "ファイルの書き込みは完了しworktreeに存在しますが、インストール記録が未完了です。CommandMateが自動的に完了させるため、再インストールは不要です。",
+      "failed": "worktreeへの書き込みは行われていません。理由を確認し、新しいInstall Planを作成してください。"
+    }
+  },
   "card": {
     "provider": "提供元: {provider}",
     "noRecommendedVersion": "導入可能なversionなし"

--- a/src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts
@@ -1,0 +1,598 @@
+/**
+ * POST /api/worktrees/[id]/skills/[skillId]/install — apply an Install Plan (Issue #1235)
+ *
+ * The request presents a single-use plan token and nothing else that could
+ * change where or what is written. Everything the write needs — the worktree
+ * path, the artifact bytes, the payload inventory, the exact receipt bytes — was
+ * fixed server-side when the plan was built (#1233) and is re-verified here
+ * against the live worktree before a single byte is staged.
+ *
+ * The order of operations is the contract:
+ *
+ * 1. open the journal entry, so a crash at any later point is recoverable;
+ * 2. take the exclusive (worktree, skill) lock (#1234);
+ * 3. re-read branch, HEAD and the destination tree, and spend the token only if
+ *    they still match what the user approved — otherwise `SKILL_PLAN_STALE`;
+ * 4. stage, verify and atomically rename (#1235's `install-apply`);
+ * 5. index and audit.
+ *
+ * Steps 1–3 are undoable and are reported as "nothing happened". Step 4 is the
+ * commit point: once the rename lands, a failure in step 5 is answered as
+ * *committed, reconciling* — never as an unchanged worktree, because the payload
+ * is on disk and the user can see it.
+ *
+ * Nothing in the package is executed at any point, by any path in this route.
+ *
+ * @module api/worktrees/[id]/skills/[skillId]/install
+ */
+
+import { realpathSync } from 'fs';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createLogger } from '@/lib/logger';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { resolveWorktreeOr404 } from '@/lib/git/git-route-worktree';
+import { validateSkillId } from '@/lib/skills/schema';
+import { isSkillFetchError } from '@/lib/skills/integrity';
+import { inspectSkillPackage } from '@/lib/skills/package-validator';
+import { isSkillPackageError } from '@/lib/skills/package-reader';
+import {
+  getSkillSnapshot,
+  readSkillSnapshotBytes,
+  releaseSkillSnapshot,
+} from '@/lib/skills/snapshot-store';
+import {
+  SKILL_PLAN_TOKEN_PATTERN,
+  SKILL_RECEIPT_FILENAME,
+  consumeSkillInstallPlan,
+  getSkillInstallPlan,
+  isSkillPlanError,
+  type SkillPlanActor,
+} from '@/lib/skills/install-plan';
+import {
+  computeSkillTreeHash,
+  readExistingSkillTree,
+  readSkillGitTargetState,
+} from '@/lib/skills/preview-diff';
+import {
+  acquireSkillOperationLock,
+  buildSkillOperationLockKey,
+  releaseSkillOperationLock,
+} from '@/lib/skills/operation-lock';
+import {
+  beginSkillOperation,
+  deleteSkillOperationJournal,
+  hasSkillFilesystemCommit,
+  readSkillOperationJournal,
+  transitionSkillOperation,
+  type SkillOperationJournalEntry,
+} from '@/lib/skills/operation-journal';
+import {
+  buildSkillOperationAuditInput,
+  recordSkillOperationAudit,
+} from '@/lib/skills/operation-audit';
+import { redactSkillOperationText } from '@/lib/skills/operation-store';
+import {
+  SKILL_INSTALL_NEXT_ACTION_KEYS,
+  applySkillInstall,
+  buildSkillReloadGuidance,
+  isSkillInstallError,
+  resolveSkillInstallTarget,
+  type SkillReloadGuidance,
+} from '@/lib/skills/install-apply';
+import {
+  getSkillInstallation,
+  upsertSkillInstallation,
+} from '@/lib/skills/installed-state';
+import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
+import type { SkillInstalledFile } from '@/types/skills';
+
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/worktrees/[id]/skills/[skillId]/install');
+
+// =============================================================================
+// Wire shape
+// =============================================================================
+
+/** How the operation ended, from the caller's point of view. */
+export type SkillInstallResult = 'succeeded' | 'committed_reconciling';
+
+/** Journal state of the operation, plus what the user should do about it. */
+export interface SkillInstallOperationDto {
+  operationId: string;
+  idempotencyKey: string;
+  state: SkillOperationJournalEntry['state'];
+  result: SkillInstallResult;
+  /** The payload is on disk regardless of how the index step ended. */
+  committed: boolean;
+  /** Reconciliation still owes this operation an index write. */
+  reconcilePending: boolean;
+  nextActionKey: string;
+  /** True when this response replays an earlier identical request. */
+  replayed: boolean;
+}
+
+/** What landed, described without a machine-absolute path. */
+export interface SkillInstallPayloadDto {
+  skillId: string;
+  version: string;
+  installRoot: string;
+  receipt: { path: string; sha256: string; size: number };
+  files: SkillInstalledFile[];
+  treeHash: string;
+}
+
+export interface SkillInstallResponse {
+  operation: SkillInstallOperationDto;
+  install: SkillInstallPayloadDto;
+  reload: SkillReloadGuidance;
+}
+
+/**
+ * Answer to a retried request.
+ *
+ * Deliberately narrower than {@link SkillInstallResponse}: a replay is served
+ * from the index, which records what is installed but not the per-file
+ * inventory. Returning a fabricated file list would be worse than omitting it.
+ */
+export interface SkillInstallReplayResponse {
+  operation: SkillInstallOperationDto;
+  install: {
+    skillId: string;
+    version: string;
+    installRoot: string;
+    receipt: { path: string; sha256: string };
+  } | null;
+}
+
+// =============================================================================
+// Body
+// =============================================================================
+
+/**
+ * Fields a client must never be able to supply.
+ *
+ * Mirrors the plan route: a rejected field is answered explicitly rather than
+ * dropped, so a caller cannot conclude that a different spelling might work.
+ */
+const REJECTED_BODY_KEYS = [
+  'path',
+  'paths',
+  'worktreePath',
+  'repositoryPath',
+  'installRoot',
+  'targetPath',
+  'url',
+  'artifactUrl',
+  'artifact',
+  'files',
+  'checksum',
+  'sha256',
+  'snapshotId',
+  'commit',
+] as const;
+
+const ALLOWED_BODY_KEYS = [
+  'planToken',
+  'version',
+  'acknowledgeRisk',
+  'idempotencyKey',
+] as const;
+
+/** Bound on a client-supplied idempotency key, which is hashed before it names a file. */
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._:-]{8,128}$/;
+
+interface InstallRequestBody {
+  planToken: string;
+  version: string;
+  acknowledgeRisk: boolean;
+  idempotencyKey: string | null;
+}
+
+type BodyResult = { ok: true; body: InstallRequestBody } | { ok: false; response: NextResponse };
+
+function invalidBody(message: string): { ok: false; response: NextResponse } {
+  return { ok: false, response: skillApiError('SKILL_INSTALL_INVALID_BODY', message, 400) };
+}
+
+async function readBody(request: NextRequest): Promise<BodyResult> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await request.text());
+  } catch {
+    return invalidBody('Malformed JSON body.');
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return invalidBody('Body must be a JSON object.');
+  }
+
+  const record = raw as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if ((REJECTED_BODY_KEYS as readonly string[]).includes(key)) {
+      return {
+        ok: false,
+        response: skillApiError(
+          'SKILL_PLAN_INPUT_REJECTED',
+          'The install target is resolved by the server and cannot be supplied by the client.',
+          400
+        ),
+      };
+    }
+    if (!(ALLOWED_BODY_KEYS as readonly string[]).includes(key)) {
+      return invalidBody('Unknown field in body.');
+    }
+  }
+
+  const { planToken, version, idempotencyKey } = record;
+  if (typeof planToken !== 'string' || !SKILL_PLAN_TOKEN_PATTERN.test(planToken)) {
+    return invalidBody('Field `planToken` must be a plan token issued by the plan endpoint.');
+  }
+  if (typeof version !== 'string' || version.length === 0) {
+    return invalidBody('Field `version` must name the version the plan was built for.');
+  }
+  if (
+    idempotencyKey !== undefined &&
+    (typeof idempotencyKey !== 'string' || !IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey))
+  ) {
+    return invalidBody('Field `idempotencyKey` has an unsupported format.');
+  }
+
+  return {
+    ok: true,
+    body: {
+      planToken,
+      version,
+      acknowledgeRisk: record.acknowledgeRisk === true,
+      idempotencyKey: typeof idempotencyKey === 'string' ? idempotencyKey : null,
+    },
+  };
+}
+
+/**
+ * Actor identity available to a single-token deployment.
+ *
+ * CommandMate authenticates one shared token, so there is no per-user id to
+ * bind. The channel is still distinguished, because a plan issued to the browser
+ * must not be spendable by a CLI run and vice versa.
+ */
+function resolveActor(request: NextRequest): SkillPlanActor {
+  return { type: request.headers.get('authorization') ? 'cli' : 'user', id: null };
+}
+
+// =============================================================================
+// Response assembly
+// =============================================================================
+
+function describeOperation(
+  entry: SkillOperationJournalEntry,
+  options: { replayed: boolean }
+): SkillInstallOperationDto {
+  const committed = hasSkillFilesystemCommit(entry);
+  const succeeded = entry.state === 'SUCCEEDED';
+  return {
+    operationId: entry.operationId,
+    idempotencyKey: entry.idempotencyKey,
+    state: entry.state,
+    result: succeeded ? 'succeeded' : 'committed_reconciling',
+    committed,
+    reconcilePending: !succeeded,
+    nextActionKey: succeeded
+      ? SKILL_INSTALL_NEXT_ACTION_KEYS.succeeded
+      : SKILL_INSTALL_NEXT_ACTION_KEYS.committedReconciling,
+    replayed: options.replayed,
+  };
+}
+
+// =============================================================================
+// Route
+// =============================================================================
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; skillId: string }> }
+): Promise<NextResponse> {
+  let snapshotId: string | null = null;
+  let lock: ReturnType<typeof acquireSkillOperationLock> | null = null;
+
+  try {
+    const { id, skillId } = await params;
+
+    const worktree = resolveWorktreeOr404(id);
+    if (worktree instanceof NextResponse) return worktree;
+
+    const idResult = validateSkillId(skillId);
+    if (!idResult.ok) return skillApiError(idResult.errors[0].code, 'Invalid Skill ID.', 400);
+
+    const parsed = await readBody(request);
+    if (!parsed.ok) return parsed.response;
+
+    const actor = resolveActor(request);
+
+    // A retried request must be answered from its recorded outcome, not by
+    // spending a token that is already gone: the plan is single-use, so without
+    // this the second delivery of the *same* request would look like a replay
+    // attack rather than the network retry it is.
+    if (parsed.body.idempotencyKey !== null) {
+      const replay = readSkillOperationJournal(parsed.body.idempotencyKey);
+      if (replay !== null) {
+        return answerReplay(replay, worktree.id, idResult.value, parsed.body.version);
+      }
+    }
+
+    let worktreeRealPath: string;
+    try {
+      worktreeRealPath = realpathSync(worktree.path);
+    } catch {
+      return skillApiError(
+        'SKILL_INSTALL_TARGET_UNSAFE',
+        'The registered worktree path could not be resolved.',
+        409
+      );
+    }
+
+    // Peeking does not spend the token; the plan is only consumed once the lock
+    // is held and the live target has been re-read.
+    const plan = getSkillInstallPlan(parsed.body.planToken);
+
+    const lockKey = buildSkillOperationLockKey(worktreeRealPath, idResult.value);
+    const begun = beginSkillOperation({
+      idempotencyKey: parsed.body.idempotencyKey ?? undefined,
+      binding: {
+        actor,
+        operation: 'install',
+        target: {
+          worktreeId: worktree.id,
+          skillId: idResult.value,
+          version: parsed.body.version,
+        },
+        planHash: plan.bindingHash,
+      },
+      lockKey,
+      source: {
+        origin: 'github-release',
+        repository: plan.dto.skill.source.repository,
+        ref: plan.dto.skill.source.ref,
+        commit: plan.dto.skill.source.commit,
+        artifactSha256: plan.binding.artifactSha256,
+      },
+    });
+    if (!begun.ok) {
+      return skillApiError(
+        'SKILL_INSTALL_IDEMPOTENCY_CONFLICT',
+        'This idempotency key was already used for a different request.',
+        409
+      );
+    }
+    if (begun.replayed) {
+      return answerReplay(begun.entry, worktree.id, idResult.value, parsed.body.version);
+    }
+
+    let entry = begun.entry;
+    lock = acquireSkillOperationLock({ key: lockKey, operationId: entry.operationId });
+    if (!lock.ok) {
+      // Nothing was attempted, so the key must stay reusable rather than be
+      // pinned to a failure the caller never caused.
+      deleteSkillOperationJournal(entry.idempotencyKey);
+      lock = null;
+      return skillApiError(
+        'SKILL_INSTALL_LOCKED',
+        'Another operation is already running for this Skill and worktree.',
+        409
+      );
+    }
+
+    const installRootAbs = resolveSkillInstallTarget(worktree.path, idResult.value);
+    const git = await readSkillGitTargetState(worktree.path);
+    const existing = readExistingSkillTree(installRootAbs);
+
+    let consumed;
+    try {
+      consumed = consumeSkillInstallPlan(
+        parsed.body.planToken,
+        {
+          actor,
+          worktreeId: worktree.id,
+          skillId: idResult.value,
+          version: parsed.body.version,
+          riskAcknowledged: parsed.body.acknowledgeRisk,
+        },
+        {
+          branch: git.branch,
+          headCommit: git.headCommit,
+          currentTreeHash: computeSkillTreeHash(existing.files),
+        }
+      );
+    } catch (error) {
+      deleteSkillOperationJournal(entry.idempotencyKey);
+      throw error;
+    }
+    // The snapshot reference passed to us when the token was spent.
+    snapshotId = consumed.binding.snapshotId;
+
+    let result;
+    try {
+      // Bytes come from the verified read-only snapshot the plan was computed
+      // from. Re-downloading here would reopen the door the plan closed.
+      const handle = getSkillSnapshot(snapshotId);
+      if (handle.sha256 !== consumed.binding.artifactSha256) {
+        throw new Error('snapshot artifact digest does not match the plan binding');
+      }
+      const snapshot = inspectSkillPackage(readSkillSnapshotBytes(snapshotId), {
+        skillId: idResult.value,
+        version: consumed.binding.version,
+      });
+
+      result = applySkillInstall({
+        worktreePath: worktree.path,
+        worktreeRealPath,
+        skillId: idResult.value,
+        operationId: entry.operationId,
+        snapshot,
+        receiptBytes: consumed.receiptBytes,
+        plannedTreeHash: consumed.binding.plannedTreeHash,
+      });
+    } catch (error) {
+      // Nothing was published: the staging directory is already gone and the
+      // destination was never touched.
+      entry = transitionSkillOperation(entry, 'FAILED_RECONCILABLE', {
+        error: { code: errorCodeOf(error), message: messageOf(error) },
+      });
+      recordAuditSafely(entry, 'failed');
+      throw error;
+    }
+
+    entry = transitionSkillOperation(entry, 'FS_COMMITTED', {
+      receiptDigest: result.receiptSha256,
+    });
+
+    try {
+      const db = getDbInstance();
+      upsertSkillInstallation(db, {
+        worktreeId: worktree.id,
+        receipt: consumed.receipt,
+        receiptSha256: result.receiptSha256,
+        operationId: entry.operationId,
+        installedAt: entry.fsCommittedAt ?? Date.now(),
+      });
+      entry = transitionSkillOperation(entry, 'INDEXED');
+      entry = transitionSkillOperation(entry, 'SUCCEEDED', { error: null });
+      recordAuditSafely(entry, 'succeeded');
+    } catch (error) {
+      // The rename already landed. Reporting this as a failed install would
+      // contradict what the user can see on disk, so the operation is handed to
+      // #1234 reconciliation instead of being rolled back.
+      entry = transitionSkillOperation(entry, 'FAILED_RECONCILABLE', {
+        error: { code: 'SKILL_INSTALL_INDEX_FAILED', message: messageOf(error) },
+      });
+      recordAuditSafely(entry, 'failed');
+      logger.error('skill-install-index-failed', {
+        operationId: entry.operationId,
+        error: redactSkillOperationText(messageOf(error)),
+      });
+    }
+
+    const response: SkillInstallResponse = {
+      operation: describeOperation(entry, { replayed: false }),
+      install: {
+        skillId: consumed.receipt.skill_id,
+        version: consumed.receipt.version,
+        installRoot: result.installRoot,
+        receipt: {
+          path: result.receiptPath,
+          sha256: result.receiptSha256,
+          size: result.receiptSize,
+        },
+        files: result.files,
+        treeHash: result.treeHash,
+      },
+      reload: buildSkillReloadGuidance(consumed.receipt),
+    };
+    return NextResponse.json(response, { headers: SKILL_API_NO_STORE_HEADERS });
+  } catch (error) {
+    if (isSkillPlanError(error)) {
+      return skillApiError(error.code, 'The install plan was rejected.', error.status);
+    }
+    if (isSkillInstallError(error)) {
+      return skillApiError(error.code, 'The install could not be applied.', error.status);
+    }
+    if (isSkillPackageError(error)) {
+      return skillApiError(error.code, 'The Skill package failed verification.', 422);
+    }
+    if (isSkillFetchError(error)) {
+      return skillApiError(error.code, 'The verified artifact could not be read.', 502);
+    }
+    logger.error('skill-install-failed', {
+      error: redactSkillOperationText(messageOf(error)),
+    });
+    return skillApiError('SKILL_INSTALL_INTERNAL_ERROR', 'Failed to apply the install.', 500);
+  } finally {
+    if (lock?.ok) releaseSkillOperationLock(lock.lock);
+    if (snapshotId) releaseSkillSnapshot(snapshotId);
+  }
+}
+
+// =============================================================================
+// Replay
+// =============================================================================
+
+/**
+ * Answer from a journal entry an earlier request already produced.
+ *
+ * A replay is only honoured for the same target: the same key naming a
+ * different worktree, Skill or version is a conflict, never a substitution of
+ * someone else's install.
+ */
+function answerReplay(
+  entry: SkillOperationJournalEntry,
+  worktreeId: string,
+  skillId: string,
+  version: string
+): NextResponse {
+  if (
+    entry.target.worktreeId !== worktreeId ||
+    entry.target.skillId !== skillId ||
+    entry.target.version !== version
+  ) {
+    return skillApiError(
+      'SKILL_INSTALL_IDEMPOTENCY_CONFLICT',
+      'This idempotency key was already used for a different request.',
+      409
+    );
+  }
+  if (!hasSkillFilesystemCommit(entry)) {
+    return skillApiError(
+      entry.state === 'PREPARING' ? 'SKILL_INSTALL_IN_PROGRESS' : 'SKILL_INSTALL_FAILED',
+      entry.state === 'PREPARING'
+        ? 'The operation for this idempotency key is still running.'
+        : 'The operation for this idempotency key did not install anything.',
+      409
+    );
+  }
+
+  const installation = getSkillInstallation(getDbInstance(), worktreeId, skillId);
+  const response: SkillInstallReplayResponse = {
+    operation: describeOperation(entry, { replayed: true }),
+    install: installation
+      ? {
+          skillId: installation.skillId,
+          version: installation.version,
+          installRoot: installation.installRoot,
+          receipt: {
+            path: `${installation.installRoot}/${SKILL_RECEIPT_FILENAME}`,
+            sha256: installation.receiptSha256,
+          },
+        }
+      : null,
+  };
+  return NextResponse.json(response, { headers: SKILL_API_NO_STORE_HEADERS });
+}
+
+// =============================================================================
+// Error helpers
+// =============================================================================
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCodeOf(error: unknown): string {
+  if (isSkillInstallError(error) || isSkillPlanError(error)) return error.code;
+  if (isSkillPackageError(error) || isSkillFetchError(error)) return error.code;
+  return 'SKILL_INSTALL_INTERNAL_ERROR';
+}
+
+/** Audit failures must not mask the outcome they are describing. */
+function recordAuditSafely(
+  entry: SkillOperationJournalEntry,
+  outcome: 'succeeded' | 'failed'
+): void {
+  try {
+    recordSkillOperationAudit(getDbInstance(), buildSkillOperationAuditInput(entry, outcome));
+  } catch (error) {
+    logger.warn('skill-install-audit-failed', {
+      operationId: entry.operationId,
+      error: redactSkillOperationText(messageOf(error)),
+    });
+  }
+}

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -27,6 +27,7 @@ import { v41_migrations } from './v41-push-subscriptions';
 import { v42_migrations } from './v42-push-subscription-locale';
 import { v43_migrations } from './v43-remove-cm-root-dir-ghost-repository';
 import { v44_migrations } from './v44-skill-operations';
+import { v45_migrations } from './v45-skill-installations';
 
 /**
  * Complete ordered list of all migrations.
@@ -59,4 +60,5 @@ export const migrations: Migration[] = [
   ...v42_migrations,
   ...v43_migrations,
   ...v44_migrations,
+  ...v45_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 44;
+export const CURRENT_SCHEMA_VERSION = 45;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v45-skill-installations.ts
+++ b/src/lib/db/migrations/v45-skill-installations.ts
@@ -1,0 +1,60 @@
+/**
+ * Migration v45: `skill_installations` index (Issue #1235).
+ *
+ * One row per (worktree, skill): the index answers "what is installed here"
+ * without walking every worktree on disk. It is an *index*, not the truth — the
+ * receipt inside `.agents/skills/<id>/` is. That ordering is what lets a crash
+ * between the atomic rename and this row be reconciled forward (#1234) instead
+ * of being reported as a rollback that the filesystem contradicts.
+ *
+ * `receipt_sha256` is the join back to the payload: reconciliation compares it
+ * against the receipt actually on disk, so a row that describes a different
+ * install than the one present is detectable rather than merely stale.
+ *
+ * No column holds a URL, a token or a machine-absolute path; `install_root` is
+ * repository-relative by construction.
+ */
+
+import type { Migration } from './runner';
+
+export const v45_migrations: Migration[] = [
+  {
+    version: 45,
+    name: 'add-skill-installations',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS skill_installations (
+          id TEXT PRIMARY KEY,
+          worktree_id TEXT NOT NULL,
+          skill_id TEXT NOT NULL,
+          version TEXT NOT NULL,
+          install_root TEXT NOT NULL,
+          receipt_sha256 TEXT NOT NULL,
+          source_repository TEXT NOT NULL,
+          source_ref TEXT NOT NULL,
+          source_commit TEXT NOT NULL,
+          artifact_sha256 TEXT NOT NULL,
+          effective_risk TEXT NOT NULL,
+          operation_id TEXT NOT NULL,
+          installed_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          UNIQUE (worktree_id, skill_id)
+        );
+      `);
+
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_skill_installations_worktree
+          ON skill_installations(worktree_id);
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_skill_installations_skill
+          ON skill_installations(skill_id, version);
+      `);
+    },
+    down: (db) => {
+      db.exec('DROP INDEX IF EXISTS idx_skill_installations_skill;');
+      db.exec('DROP INDEX IF EXISTS idx_skill_installations_worktree;');
+      db.exec('DROP TABLE IF EXISTS skill_installations;');
+    },
+  },
+];

--- a/src/lib/skills/install-apply.ts
+++ b/src/lib/skills/install-apply.ts
@@ -1,0 +1,643 @@
+/**
+ * Atomic commit of a planned Skill install into one worktree (Issue #1235)
+ *
+ * The write half of the plan/apply pair. #1233 fixed *what* would be written —
+ * the exact payload bytes, the exact receipt bytes and the tree hash they add up
+ * to — and this module is the only place those bytes reach a repository.
+ *
+ * Four properties carry the safety argument:
+ *
+ * - **The destination is derived, never received.** The install root comes from
+ *   a server-resolved worktree path plus a Skill ID re-checked against
+ *   {@link SKILL_ID_PATTERN}. Re-checking the grammar rather than only the
+ *   joined result is deliberate: `path.join` normalizes `..` away, so
+ *   `.agents/skills/../x` and `.agents/x` compare equal and a containment check
+ *   alone would accept an ID that walked out of the Skills directory.
+ * - **Every write is exclusive and does not follow links.** Files are created
+ *   with `O_CREAT|O_EXCL|O_NOFOLLOW`, so a symlink or a file planted between the
+ *   directory scan and the write cannot be written *through*; mode and digest
+ *   are re-read afterwards, so a file that changed underneath us never reaches
+ *   the receipt.
+ * - **The commit point is one rename.** Staging lives in the reserved
+ *   `.agents/skills/.commandmate-staging/` namespace, on the same filesystem as
+ *   the destination, so `rename(2)` is atomic. Before it lands the destination
+ *   is proven absent: an existing directory — managed or hand-made — is refused,
+ *   never merged into and never implicitly overwritten.
+ * - **Nothing is executed.** No script, hook, install step or archive-carried
+ *   mode is ever run or honoured. Modes are assigned from the manifest's
+ *   declared executable bit and nothing else.
+ *
+ * A failure *after* the rename is not a rollback. The payload exists, and the
+ * caller must report it as committed and hand the remainder to #1234
+ * reconciliation rather than claiming the worktree is unchanged.
+ *
+ * @module lib/skills/install-apply
+ */
+
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  rmdirSync,
+  writeSync,
+} from 'fs';
+import path from 'path';
+import {
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+  SKILL_INSTALL_ROOT_PREFIX,
+} from '@/lib/skills/constants';
+import { computeSha256Hex, digestMatches } from '@/lib/skills/integrity';
+import { getSkillInstallStagingRoot } from '@/lib/skills/operation-store';
+import {
+  computeSkillTreeHash,
+  resolveSkillInstallRoot,
+  skillInstallRoot,
+} from '@/lib/skills/preview-diff';
+import { SKILL_RECEIPT_FILENAME, parseInstalledReceipt } from '@/lib/skills/install-plan';
+import type { SkillPackageSnapshot } from '@/lib/skills/package-validator';
+import type { SkillAgentSupport, SkillInstallReceipt, SkillInstalledFile } from '@/types/skills';
+
+// =============================================================================
+// Modes and layout
+// =============================================================================
+
+/** Payload directories are owner-only, like the staging that produced them. */
+export const SKILL_INSTALL_DIR_MODE = 0o700;
+
+/** Ordinary payload files. */
+export const SKILL_INSTALL_FILE_MODE = 0o600;
+
+/** Files the manifest declared executable. Only the owner execute bit is added. */
+export const SKILL_INSTALL_EXECUTABLE_MODE = 0o700;
+
+/**
+ * Grammar of the staging directory name.
+ *
+ * The name is a server-generated operation ID and never a client string, but it
+ * becomes a path segment, so it is checked rather than trusted.
+ */
+export const SKILL_INSTALL_OPERATION_ID_PATTERN = /^[0-9a-zA-Z-]{8,64}$/;
+
+/** `O_NOFOLLOW` is POSIX-only; on platforms without it the flag is a no-op. */
+const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+/** Client-safe reasons an apply refused to write or could not finish. */
+export const SkillInstallErrorCode = {
+  /** The install root could not be derived safely from the worktree and Skill ID. */
+  TARGET_UNSAFE: 'SKILL_INSTALL_TARGET_UNSAFE',
+  /** An ancestor of the install root is a symlink or is not a directory. */
+  ANCESTOR_UNSAFE: 'SKILL_INSTALL_ANCESTOR_UNSAFE',
+  /** A CommandMate-managed install is already present. Updating is out of scope. */
+  DESTINATION_EXISTS: 'SKILL_INSTALL_DESTINATION_EXISTS',
+  /** Something CommandMate does not manage occupies the install root. */
+  DESTINATION_UNMANAGED: 'SKILL_INSTALL_DESTINATION_UNMANAGED',
+  /** Staging and destination are on different filesystems, so rename is not atomic. */
+  CROSS_DEVICE: 'SKILL_INSTALL_CROSS_DEVICE',
+  /** Staging could not be created or written. */
+  STAGING_IO: 'SKILL_INSTALL_STAGING_IO',
+  /** What landed in staging is not what the plan fixed. */
+  PAYLOAD_MISMATCH: 'SKILL_INSTALL_PAYLOAD_MISMATCH',
+  /** The atomic rename itself failed. Nothing was published. */
+  COMMIT_FAILED: 'SKILL_INSTALL_COMMIT_FAILED',
+} as const;
+
+export type SkillInstallErrorCodeType =
+  (typeof SkillInstallErrorCode)[keyof typeof SkillInstallErrorCode];
+
+/** HTTP status each reason maps to, so every caller answers alike. */
+export const SKILL_INSTALL_ERROR_STATUS: Record<SkillInstallErrorCodeType, number> = {
+  [SkillInstallErrorCode.TARGET_UNSAFE]: 400,
+  [SkillInstallErrorCode.ANCESTOR_UNSAFE]: 409,
+  [SkillInstallErrorCode.DESTINATION_EXISTS]: 409,
+  [SkillInstallErrorCode.DESTINATION_UNMANAGED]: 409,
+  [SkillInstallErrorCode.CROSS_DEVICE]: 500,
+  [SkillInstallErrorCode.STAGING_IO]: 500,
+  [SkillInstallErrorCode.PAYLOAD_MISMATCH]: 500,
+  [SkillInstallErrorCode.COMMIT_FAILED]: 500,
+};
+
+/** An apply rejection. The message is built from the code — never from a path. */
+export class SkillInstallError extends Error {
+  constructor(
+    readonly code: SkillInstallErrorCodeType,
+    readonly detail?: Record<string, string | number | boolean>
+  ) {
+    super(`Skill install rejected: ${code}`);
+    this.name = 'SkillInstallError';
+  }
+
+  get status(): number {
+    return SKILL_INSTALL_ERROR_STATUS[this.code];
+  }
+}
+
+export function isSkillInstallError(value: unknown): value is SkillInstallError {
+  return value instanceof SkillInstallError;
+}
+
+function fail(
+  code: SkillInstallErrorCodeType,
+  detail?: Record<string, string | number | boolean>
+): never {
+  throw new SkillInstallError(code, detail);
+}
+
+// =============================================================================
+// Reload guidance
+// =============================================================================
+
+/** i18n key per agent support level, so UI and CLI say the same thing (UX-01). */
+export const SKILL_INSTALL_RELOAD_MESSAGE_KEYS: Record<SkillAgentSupport, string> = {
+  native: 'skills.install.reload.native',
+  commandmate_runtime: 'skills.install.reload.commandmateRuntime',
+  unsupported: 'skills.install.reload.unsupported',
+  unknown: 'skills.install.reload.unknown',
+};
+
+/** i18n key for what the user should do next, per outcome (UX-07). */
+export const SKILL_INSTALL_NEXT_ACTION_KEYS = {
+  succeeded: 'skills.install.nextAction.succeeded',
+  committedReconciling: 'skills.install.nextAction.committedReconciling',
+  failed: 'skills.install.nextAction.failed',
+} as const;
+
+/** One agent's reload instruction for the version that was just installed. */
+export interface SkillReloadAgentGuidance {
+  agent: string;
+  support: SkillAgentSupport;
+  messageKey: string;
+}
+
+/** How to start using the Skill that was just installed. */
+export interface SkillReloadGuidance {
+  skillId: string;
+  version: string;
+  installRoot: string;
+  agents: SkillReloadAgentGuidance[];
+}
+
+/**
+ * Derive reload guidance from the receipt.
+ *
+ * The receipt is used rather than the Catalog because it is the record of what
+ * actually landed: guidance for a version other than the installed one would be
+ * worse than none.
+ */
+export function buildSkillReloadGuidance(receipt: SkillInstallReceipt): SkillReloadGuidance {
+  return {
+    skillId: receipt.skill_id,
+    version: receipt.version,
+    installRoot: receipt.install_root,
+    agents: receipt.agent_compatibility.map((entry) => ({
+      agent: entry.agent,
+      support: entry.support,
+      messageKey: SKILL_INSTALL_RELOAD_MESSAGE_KEYS[entry.support],
+    })),
+  };
+}
+
+// =============================================================================
+// Path safety
+// =============================================================================
+
+/**
+ * Absolute install root for a validated Skill ID inside a server-resolved worktree.
+ *
+ * Delegates to #1233's resolver so plan and apply cannot disagree about where a
+ * Skill lives, and re-checks the ID here as well: this module must be safe to
+ * call without a plan, for instance from reconciliation.
+ */
+export function resolveSkillInstallTarget(worktreePath: string, skillId: string): string {
+  if (!SKILL_ID_PATTERN.test(skillId) || skillId.length > SKILL_ID_MAX_LENGTH) {
+    fail(SkillInstallErrorCode.TARGET_UNSAFE, { reason: 'skill-id' });
+  }
+  try {
+    return resolveSkillInstallRoot(worktreePath, skillId);
+  } catch {
+    return fail(SkillInstallErrorCode.TARGET_UNSAFE, { reason: 'install-root' });
+  }
+}
+
+/**
+ * Prove no ancestor of the install root was swapped for a link.
+ *
+ * `lstat` at every level from the worktree down: a symlink anywhere on the chain
+ * would let the rename publish the payload outside the registered worktree, and
+ * `realpath` alone would silently *follow* it instead of refusing.
+ */
+function assertAncestorsAreRealDirectories(worktreeRealPath: string, worktreePath: string): void {
+  let resolved: string;
+  try {
+    resolved = realpathSync(worktreePath);
+  } catch {
+    return fail(SkillInstallErrorCode.ANCESTOR_UNSAFE, { reason: 'worktree-unresolvable' });
+  }
+  if (resolved !== worktreeRealPath) {
+    fail(SkillInstallErrorCode.ANCESTOR_UNSAFE, { reason: 'worktree-identity' });
+  }
+
+  let walked = worktreeRealPath;
+  for (const segment of SKILL_INSTALL_ROOT_PREFIX.split('/')) {
+    walked = path.join(walked, segment);
+    let stats;
+    try {
+      stats = lstatSync(walked);
+    } catch {
+      // Not yet created is fine; it is created below with a plain mkdir.
+      return;
+    }
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      fail(SkillInstallErrorCode.ANCESTOR_UNSAFE, { reason: 'not-a-directory' });
+    }
+  }
+}
+
+// =============================================================================
+// Destination inspection
+// =============================================================================
+
+/** What currently occupies the install root, if anything. */
+export interface SkillDestinationState {
+  present: boolean;
+  /** A parseable CommandMate receipt is present, so the directory is managed. */
+  managed: boolean;
+  /** Version recorded by that receipt. */
+  version: string | null;
+}
+
+/**
+ * Describe the install root without following anything.
+ *
+ * A non-directory at the install root (a file, a symlink) counts as present and
+ * unmanaged: it is not something an install may quietly replace.
+ */
+export function inspectSkillDestination(installRootAbs: string): SkillDestinationState {
+  let stats;
+  try {
+    stats = lstatSync(installRootAbs);
+  } catch {
+    return { present: false, managed: false, version: null };
+  }
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    return { present: true, managed: false, version: null };
+  }
+
+  try {
+    const receipt = parseInstalledReceipt(
+      readFileSync(path.join(installRootAbs, SKILL_RECEIPT_FILENAME))
+    );
+    if (receipt) return { present: true, managed: true, version: receipt.version };
+  } catch {
+    // No readable receipt: the directory exists but CommandMate did not write it.
+  }
+  return { present: true, managed: false, version: null };
+}
+
+/**
+ * Whether the payload a committed operation wrote is still on disk.
+ *
+ * The port #1234's reconciler needs: it decides between "converge forward" and
+ * "genuinely rolled back", and only the receipt digest can distinguish the
+ * install that committed from a different one that happens to share the path.
+ */
+export function hasCommittedSkillPayload(
+  worktreePath: string,
+  skillId: string,
+  receiptDigest: string | null
+): boolean {
+  let installRootAbs: string;
+  try {
+    installRootAbs = resolveSkillInstallTarget(worktreePath, skillId);
+  } catch {
+    return false;
+  }
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path.join(installRootAbs, SKILL_RECEIPT_FILENAME));
+  } catch {
+    return false;
+  }
+  if (parseInstalledReceipt(bytes) === null) return false;
+  return receiptDigest === null || digestMatches(computeSha256Hex(bytes), receiptDigest);
+}
+
+// =============================================================================
+// Staging
+// =============================================================================
+
+function makeDirectory(target: string, mode: number, recursive: boolean): void {
+  try {
+    mkdirSync(target, { mode, recursive });
+  } catch {
+    fail(SkillInstallErrorCode.STAGING_IO, { reason: 'mkdir' });
+  }
+  let stats;
+  try {
+    stats = lstatSync(target);
+  } catch {
+    return fail(SkillInstallErrorCode.STAGING_IO, { reason: 'mkdir-verify' });
+  }
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    fail(SkillInstallErrorCode.STAGING_IO, { reason: 'not-a-directory' });
+  }
+}
+
+/**
+ * Write one file and prove afterwards that it is the file we meant to write.
+ *
+ * `O_EXCL` means an existing path is never written to, and `O_NOFOLLOW` means a
+ * symlink planted at that path is refused rather than followed — together they
+ * make "the write landed somewhere else" unrepresentable. The post-write checks
+ * are not belt-and-braces either: `nlink !== 1` would mean the path was
+ * hard-linked elsewhere, and a digest read back through the same path is the
+ * only evidence that what a later reader sees matches the plan.
+ *
+ * @internal Exported for the guard tests; callers use {@link applySkillInstall}.
+ */
+export function writeSkillPayloadFile(
+  target: string,
+  bytes: Uint8Array,
+  executable: boolean
+): void {
+  const mode = executable ? SKILL_INSTALL_EXECUTABLE_MODE : SKILL_INSTALL_FILE_MODE;
+
+  let fd: number;
+  try {
+    fd = openSync(
+      target,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | O_NOFOLLOW,
+      mode
+    );
+  } catch {
+    return fail(SkillInstallErrorCode.STAGING_IO, { reason: 'open' });
+  }
+  try {
+    let written = 0;
+    while (written < bytes.byteLength) {
+      written += writeSync(fd, bytes, written, bytes.byteLength - written);
+    }
+  } catch {
+    closeSync(fd);
+    return fail(SkillInstallErrorCode.STAGING_IO, { reason: 'write' });
+  }
+  closeSync(fd);
+
+  const stats = lstatSync(target);
+  if (!stats.isFile() || stats.nlink !== 1 || stats.size !== bytes.byteLength) {
+    fail(SkillInstallErrorCode.STAGING_IO, { reason: 'verify-stat' });
+  }
+  if (((stats.mode & 0o111) !== 0) !== executable) {
+    fail(SkillInstallErrorCode.STAGING_IO, { reason: 'verify-mode' });
+  }
+  if (!digestMatches(computeSha256Hex(readFileSync(target)), computeSha256Hex(bytes))) {
+    fail(SkillInstallErrorCode.PAYLOAD_MISMATCH, { reason: 'readback' });
+  }
+}
+
+/** Re-read a staged tree from disk, so verification never trusts its own inputs. */
+function readStagedTree(
+  stagingDir: string
+): Array<{ path: string; sha256: string; executable: boolean }> {
+  const files: Array<{ path: string; sha256: string; executable: boolean }> = [];
+
+  const walk = (dirAbs: string, relPrefix: string): void => {
+    for (const entry of readdirSync(dirAbs, { withFileTypes: true })) {
+      const relative = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
+      const absolute = path.join(dirAbs, entry.name);
+      const stats = lstatSync(absolute);
+      if (stats.isDirectory()) {
+        walk(absolute, relative);
+        continue;
+      }
+      if (!stats.isFile()) {
+        fail(SkillInstallErrorCode.PAYLOAD_MISMATCH, { reason: 'irregular-staged-entry' });
+      }
+      files.push({
+        path: relative,
+        sha256: computeSha256Hex(readFileSync(absolute)),
+        executable: (stats.mode & 0o111) !== 0,
+      });
+    }
+  };
+
+  walk(stagingDir, '');
+  return files;
+}
+
+// =============================================================================
+// Apply
+// =============================================================================
+
+/** Everything the commit needs. All of it server-resolved or plan-fixed. */
+export interface SkillInstallApplyInput {
+  /** Absolute path from the worktree row. Never client-supplied. */
+  worktreePath: string;
+  /** Symlink-free form of {@link worktreePath}, resolved before the lock was taken. */
+  worktreeRealPath: string;
+  skillId: string;
+  /** Opaque server-generated ID; names the private staging directory. */
+  operationId: string;
+  /** Verified package the plan was computed from. Read, never re-downloaded. */
+  snapshot: SkillPackageSnapshot;
+  /** The exact receipt bytes the plan fixed. Written verbatim, not rebuilt. */
+  receiptBytes: Uint8Array;
+  /** Tree hash the plan committed the destination to. */
+  plannedTreeHash: string;
+}
+
+/** What the commit produced. Paths are repository-relative. */
+export interface SkillInstallApplyResult {
+  installRoot: string;
+  receiptPath: string;
+  receiptSha256: string;
+  receiptSize: number;
+  files: SkillInstalledFile[];
+  treeHash: string;
+}
+
+/**
+ * Stage, verify and atomically publish one Skill install.
+ *
+ * Everything before the `renameSync` is undoable and is undone on any failure:
+ * the staging directory is removed and the destination is untouched. Everything
+ * after it is not, which is why the rename is the last thing that happens and
+ * why the caller records `FS_COMMITTED` the moment this returns.
+ *
+ * @throws SkillInstallError — the destination was not modified in every case.
+ */
+export function applySkillInstall(input: SkillInstallApplyInput): SkillInstallApplyResult {
+  if (!SKILL_INSTALL_OPERATION_ID_PATTERN.test(input.operationId)) {
+    fail(SkillInstallErrorCode.STAGING_IO, { reason: 'operation-id' });
+  }
+
+  const installRootAbs = resolveSkillInstallTarget(input.worktreePath, input.skillId);
+  assertAncestorsAreRealDirectories(input.worktreeRealPath, input.worktreePath);
+
+  const destinationBefore = inspectSkillDestination(installRootAbs);
+  if (destinationBefore.present) {
+    fail(
+      destinationBefore.managed
+        ? SkillInstallErrorCode.DESTINATION_EXISTS
+        : SkillInstallErrorCode.DESTINATION_UNMANAGED,
+      destinationBefore.version ? { version: destinationBefore.version } : undefined
+    );
+  }
+
+  const stagingRoot = getSkillInstallStagingRoot(input.worktreePath);
+  makeDirectory(path.dirname(stagingRoot), 0o755, true);
+  makeDirectory(stagingRoot, SKILL_INSTALL_DIR_MODE, true);
+
+  // Not recursive: a staging directory that already exists means another
+  // operation is using this ID, and silently adopting it would merge two writes.
+  const stagingDir = path.join(stagingRoot, input.operationId);
+  makeDirectory(stagingDir, SKILL_INSTALL_DIR_MODE, false);
+
+  try {
+    const directories = new Set<string>(input.snapshot.directories);
+    for (const file of input.snapshot.files) {
+      const parents = file.path.split('/').slice(0, -1);
+      let walked = '';
+      for (const segment of parents) {
+        walked = walked === '' ? segment : `${walked}/${segment}`;
+        directories.add(walked);
+      }
+    }
+    for (const directory of [...directories].sort()) {
+      makeDirectory(path.join(stagingDir, directory), SKILL_INSTALL_DIR_MODE, false);
+    }
+
+    for (const file of input.snapshot.files) {
+      const bytes = input.snapshot.readFile(file.path);
+      if (!digestMatches(computeSha256Hex(bytes), file.sha256)) {
+        fail(SkillInstallErrorCode.PAYLOAD_MISMATCH, { reason: 'snapshot-digest' });
+      }
+      // The execute bit comes from the reconciled inventory, which is also what
+      // the plan hashed — never from the archive header, which is attacker data.
+      writeSkillPayloadFile(path.join(stagingDir, file.path), bytes, file.executable);
+    }
+
+    // The receipt is written last and from the plan's own bytes: rebuilding it
+    // here would make the file the user previewed and the file on disk two
+    // different artifacts that merely ought to agree.
+    writeSkillPayloadFile(path.join(stagingDir, SKILL_RECEIPT_FILENAME), input.receiptBytes, false);
+
+    const staged = readStagedTree(stagingDir);
+    const treeHash = computeSkillTreeHash(staged);
+    if (treeHash !== input.plannedTreeHash) {
+      fail(SkillInstallErrorCode.PAYLOAD_MISMATCH, { reason: 'tree-hash' });
+    }
+
+    assertSameFilesystem(stagingDir, path.dirname(installRootAbs));
+
+    // Re-checked immediately before the rename rather than only at entry: the
+    // exclusive lock keeps CommandMate out, but nothing keeps the user's own
+    // editor from creating this directory while the payload was being staged.
+    assertAncestorsAreRealDirectories(input.worktreeRealPath, input.worktreePath);
+    const destinationNow = inspectSkillDestination(installRootAbs);
+    if (destinationNow.present) {
+      fail(
+        destinationNow.managed
+          ? SkillInstallErrorCode.DESTINATION_EXISTS
+          : SkillInstallErrorCode.DESTINATION_UNMANAGED
+      );
+    }
+
+    try {
+      renameSync(stagingDir, installRootAbs);
+    } catch {
+      fail(SkillInstallErrorCode.COMMIT_FAILED, { reason: 'rename' });
+    }
+  } catch (error) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    pruneStagingRoot(stagingRoot);
+    throw error;
+  }
+
+  pruneStagingRoot(stagingRoot);
+
+  const installRootRel = skillInstallRoot(input.skillId);
+  const receiptSha256 = computeSha256Hex(input.receiptBytes);
+  return {
+    installRoot: installRootRel,
+    receiptPath: `${installRootRel}/${SKILL_RECEIPT_FILENAME}`,
+    receiptSha256,
+    receiptSize: input.receiptBytes.byteLength,
+    files: input.snapshot.files.map((file) => ({
+      path: file.path,
+      sha256: file.sha256,
+      size: file.size,
+      executable: file.executable,
+    })),
+    treeHash: input.plannedTreeHash,
+  };
+}
+
+/**
+ * Refuse to commit across a filesystem boundary.
+ *
+ * `rename(2)` is only atomic within one filesystem; across one it fails with
+ * EXDEV, and a caller that "helpfully" fell back to copy+delete would give up
+ * the single property the whole design rests on. Staging is placed inside the
+ * destination's own parent so this holds by construction — the check is here so
+ * a future change that moves staging elsewhere fails loudly.
+ */
+function assertSameFilesystem(stagingDir: string, destinationParent: string): void {
+  let stagingDev: number;
+  let destinationDev: number;
+  try {
+    stagingDev = lstatSync(stagingDir).dev;
+    destinationDev = lstatSync(destinationParent).dev;
+  } catch {
+    return fail(SkillInstallErrorCode.STAGING_IO, { reason: 'stat-device' });
+  }
+  if (stagingDev !== destinationDev) {
+    fail(SkillInstallErrorCode.CROSS_DEVICE);
+  }
+}
+
+/** Remove the staging root once it is empty, so it does not linger in a worktree. */
+function pruneStagingRoot(stagingRoot: string): void {
+  try {
+    rmdirSync(stagingRoot);
+  } catch {
+    // Still in use by a concurrent operation, or already gone.
+  }
+}
+
+/**
+ * Drop staging directories left behind by a crashed process.
+ *
+ * Only entries whose name matches the operation-ID grammar are removed, so
+ * pointing this at a directory holding anything else cannot destroy content.
+ *
+ * @returns Number of staging directories removed
+ */
+export function cleanupSkillInstallStaging(worktreePath: string): number {
+  const stagingRoot = getSkillInstallStagingRoot(worktreePath);
+  let entries: string[];
+  try {
+    entries = readdirSync(stagingRoot);
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const entry of entries) {
+    if (!SKILL_INSTALL_OPERATION_ID_PATTERN.test(entry)) continue;
+    rmSync(path.join(stagingRoot, entry), { recursive: true, force: true });
+    removed += 1;
+  }
+  pruneStagingRoot(stagingRoot);
+  return removed;
+}

--- a/src/lib/skills/installed-state.ts
+++ b/src/lib/skills/installed-state.ts
@@ -1,0 +1,187 @@
+/**
+ * Installed-Skill index (Issue #1235)
+ *
+ * A lookup table over what the receipts already say. The receipt inside
+ * `.agents/skills/<id>/` is the truth; this table exists so "what is installed
+ * in this worktree" does not require walking every registered worktree.
+ *
+ * That ordering is the whole point. The row is written *after* the atomic
+ * rename, so a crash in between leaves a worktree that is installed and a table
+ * that has not caught up — which #1234 reconciliation converges forward from the
+ * receipt. Writing the row first would create the opposite and unrecoverable
+ * state: a table claiming an install that does not exist.
+ *
+ * {@link upsertSkillInstallation} is therefore idempotent by construction, so
+ * reconciliation may replay it any number of times.
+ *
+ * @module lib/skills/installed-state
+ */
+
+import { randomUUID } from 'crypto';
+import type Database from 'better-sqlite3';
+import type { SkillInstallReceipt, SkillRiskLevel } from '@/types/skills';
+
+/** One indexed install. Repository-relative paths only. */
+export interface SkillInstallationRecord {
+  id: string;
+  worktreeId: string;
+  skillId: string;
+  version: string;
+  installRoot: string;
+  receiptSha256: string;
+  sourceRepository: string;
+  sourceRef: string;
+  sourceCommit: string;
+  artifactSha256: string;
+  effectiveRisk: SkillRiskLevel;
+  operationId: string;
+  installedAt: number;
+  updatedAt: number;
+}
+
+interface SkillInstallationRow {
+  id: string;
+  worktree_id: string;
+  skill_id: string;
+  version: string;
+  install_root: string;
+  receipt_sha256: string;
+  source_repository: string;
+  source_ref: string;
+  source_commit: string;
+  artifact_sha256: string;
+  effective_risk: string;
+  operation_id: string;
+  installed_at: number;
+  updated_at: number;
+}
+
+const SELECT_COLUMNS = `
+  id, worktree_id, skill_id, version, install_root, receipt_sha256,
+  source_repository, source_ref, source_commit, artifact_sha256,
+  effective_risk, operation_id, installed_at, updated_at
+`;
+
+function mapRow(row: SkillInstallationRow): SkillInstallationRecord {
+  return {
+    id: row.id,
+    worktreeId: row.worktree_id,
+    skillId: row.skill_id,
+    version: row.version,
+    installRoot: row.install_root,
+    receiptSha256: row.receipt_sha256,
+    sourceRepository: row.source_repository,
+    sourceRef: row.source_ref,
+    sourceCommit: row.source_commit,
+    artifactSha256: row.artifact_sha256,
+    effectiveRisk: row.effective_risk as SkillRiskLevel,
+    operationId: row.operation_id,
+    installedAt: row.installed_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** What an index write is derived from: the receipt that actually landed. */
+export interface SkillInstallationInput {
+  worktreeId: string;
+  receipt: SkillInstallReceipt;
+  /** Digest of the exact receipt bytes on disk. */
+  receiptSha256: string;
+  operationId: string;
+  installedAt: number;
+}
+
+/**
+ * Record an install, replacing any earlier row for the same (worktree, skill).
+ *
+ * Idempotent: replaying the same operation rewrites the same values, so
+ * reconciliation can call this without first having to know whether an earlier
+ * attempt got this far. `installed_at` is preserved across replays so the
+ * original commit time is not rewritten by a later convergence.
+ */
+export function upsertSkillInstallation(
+  db: Database.Database,
+  input: SkillInstallationInput
+): SkillInstallationRecord {
+  const { receipt } = input;
+  db.prepare(
+    `INSERT INTO skill_installations (
+       id, worktree_id, skill_id, version, install_root, receipt_sha256,
+       source_repository, source_ref, source_commit, artifact_sha256,
+       effective_risk, operation_id, installed_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (worktree_id, skill_id) DO UPDATE SET
+       version = excluded.version,
+       install_root = excluded.install_root,
+       receipt_sha256 = excluded.receipt_sha256,
+       source_repository = excluded.source_repository,
+       source_ref = excluded.source_ref,
+       source_commit = excluded.source_commit,
+       artifact_sha256 = excluded.artifact_sha256,
+       effective_risk = excluded.effective_risk,
+       operation_id = excluded.operation_id,
+       updated_at = excluded.updated_at`
+  ).run(
+    randomUUID(),
+    input.worktreeId,
+    receipt.skill_id,
+    receipt.version,
+    receipt.install_root,
+    input.receiptSha256,
+    receipt.source.repository,
+    receipt.source.ref,
+    receipt.source.commit,
+    receipt.artifact.sha256,
+    receipt.effective_risk,
+    input.operationId,
+    input.installedAt,
+    input.installedAt
+  );
+
+  const record = getSkillInstallation(db, input.worktreeId, receipt.skill_id);
+  if (record === null) {
+    throw new Error('Skill installation row disappeared immediately after being written');
+  }
+  return record;
+}
+
+/** The indexed install for one Skill in one worktree, or null. */
+export function getSkillInstallation(
+  db: Database.Database,
+  worktreeId: string,
+  skillId: string
+): SkillInstallationRecord | null {
+  const row = db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM skill_installations
+       WHERE worktree_id = ? AND skill_id = ?`
+    )
+    .get(worktreeId, skillId) as SkillInstallationRow | undefined;
+  return row ? mapRow(row) : null;
+}
+
+/** Every indexed install in one worktree, by Skill ID. */
+export function listSkillInstallations(
+  db: Database.Database,
+  worktreeId: string
+): SkillInstallationRecord[] {
+  const rows = db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM skill_installations
+       WHERE worktree_id = ? ORDER BY skill_id ASC`
+    )
+    .all(worktreeId) as SkillInstallationRow[];
+  return rows.map(mapRow);
+}
+
+/** Drop an index row. Returns whether a row was removed. */
+export function deleteSkillInstallation(
+  db: Database.Database,
+  worktreeId: string,
+  skillId: string
+): boolean {
+  const result = db
+    .prepare('DELETE FROM skill_installations WHERE worktree_id = ? AND skill_id = ?')
+    .run(worktreeId, skillId);
+  return result.changes > 0;
+}

--- a/tests/integration/api/skills-install.test.ts
+++ b/tests/integration/api/skills-install.test.ts
@@ -1,0 +1,664 @@
+/**
+ * API integration tests — Install apply route (Issue #1235)
+ *
+ * Runs the real vertical slice: the plan route issues a token against a real
+ * temporary worktree and a real `tar.gz` package, and the install route spends
+ * it, writes the payload and records the operation in a real database. Only the
+ * network edges are mocked — the Catalog, the artifact download and the snapshot
+ * store — because `Kewton/commandmate-skills` is private and an install must
+ * never re-fetch anything at apply time anyway.
+ *
+ * What each case is really checking is that a rejection leaves the worktree
+ * exactly as it was, and that a success leaves precisely the bytes the plan
+ * previewed.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import Database from 'better-sqlite3';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import type { SkillCatalog, SkillManifest } from '@/types/skills';
+import type { SkillCatalogResult } from '@/lib/skills/catalog-client';
+
+const state = vi.hoisted(() => ({ configRoot: '' }));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn(),
+  })),
+  generateRequestId: vi.fn(() => 'test-request-id'),
+}));
+
+// Locks, journals and audit state must land in a throwaway directory rather
+// than in the developer's real CommandMate config root.
+vi.mock('@/cli/utils/install-context', () => ({
+  ensureConfigDir: () => state.configRoot,
+  getConfigDir: () => state.configRoot,
+  isGlobalInstall: () => false,
+}));
+
+vi.mock('@/lib/db/db-instance', () => ({ getDbInstance: vi.fn() }));
+vi.mock('@/lib/db', () => ({ getWorktreeById: vi.fn() }));
+vi.mock('@/lib/skills/catalog-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/skills/catalog-client')>();
+  return { ...actual, getSkillCatalog: vi.fn() };
+});
+vi.mock('@/lib/skills/artifact-downloader', () => ({ downloadSkillArtifact: vi.fn() }));
+vi.mock('@/lib/skills/snapshot-store', () => ({
+  initSkillSnapshotStore: vi.fn(() => '/tmp/snapshots'),
+  createSkillSnapshot: vi.fn(),
+  getSkillSnapshot: vi.fn(),
+  readSkillSnapshotBytes: vi.fn(),
+  releaseSkillSnapshot: vi.fn(),
+}));
+vi.mock('@/lib/version-checker', () => ({ getServerVersion: vi.fn(() => '0.11.4') }));
+vi.mock('@/lib/git/git-exec', () => ({ execGitCommand: vi.fn(), execFileAsync: vi.fn() }));
+
+import { POST as buildPlan } from '@/app/api/worktrees/[id]/skills/[skillId]/plan/route';
+import { POST as applyInstall } from '@/app/api/worktrees/[id]/skills/[skillId]/install/route';
+import { getWorktreeById } from '@/lib/db';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getSkillCatalog } from '@/lib/skills/catalog-client';
+import { downloadSkillArtifact } from '@/lib/skills/artifact-downloader';
+import {
+  createSkillSnapshot,
+  getSkillSnapshot,
+  readSkillSnapshotBytes,
+} from '@/lib/skills/snapshot-store';
+import { execGitCommand, execFileAsync } from '@/lib/git/git-exec';
+import { resetSkillInstallPlanCacheForTesting } from '@/lib/skills/install-plan';
+import { SKILL_RECEIPT_FILENAME } from '@/lib/skills/install-plan';
+import { getSkillInstallation } from '@/lib/skills/installed-state';
+import { listSkillOperationAudit } from '@/lib/skills/operation-audit';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { getSkillInstallStagingRoot } from '@/lib/skills/operation-store';
+import { buildPackage } from '../../fixtures/skills/malicious-packages/package';
+import type { PackageFileSpec } from '../../fixtures/skills/malicious-packages/package';
+import type { Worktree } from '@/types/models';
+
+const getWorktreeByIdMock = vi.mocked(getWorktreeById);
+const getDbInstanceMock = vi.mocked(getDbInstance);
+const getSkillCatalogMock = vi.mocked(getSkillCatalog);
+const downloadSkillArtifactMock = vi.mocked(downloadSkillArtifact);
+const createSkillSnapshotMock = vi.mocked(createSkillSnapshot);
+const getSkillSnapshotMock = vi.mocked(getSkillSnapshot);
+const readSkillSnapshotBytesMock = vi.mocked(readSkillSnapshotBytes);
+const execGitCommandMock = vi.mocked(execGitCommand);
+const execFileAsyncMock = vi.mocked(execFileAsync) as unknown as ReturnType<typeof vi.fn>;
+
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const WORKTREE_ID = 'wt-00000000-0000-4000-8000-000000000001';
+const COMMIT = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+const HEAD = 'f'.repeat(40);
+const SNAPSHOT_ID = 'a'.repeat(32);
+
+let worktreeDir: string;
+let configRoot: string;
+let db: Database.Database;
+let artifact: Buffer;
+let artifactSha: string;
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+function installRootAbs(): string {
+  return path.join(worktreeDir, '.agents', 'skills', SKILL_ID);
+}
+
+function useArtifact(options: {
+  files?: PackageFileSpec[];
+  manifestPatch?: (manifest: SkillManifest) => void;
+} = {}): void {
+  const built = buildPackage({
+    skillId: SKILL_ID,
+    version: VERSION,
+    ...(options.files ? { files: options.files } : {}),
+    ...(options.manifestPatch ? { manifestPatch: options.manifestPatch } : {}),
+  });
+  artifact = built.bytes;
+  artifactSha = createHash('sha256').update(artifact).digest('hex');
+}
+
+function makeCatalog(): SkillCatalog {
+  return {
+    schema_version: 1,
+    entries: [
+      {
+        id: SKILL_ID,
+        name: 'Demo Skill',
+        summary: 'A demo Skill used by the CommandMate package tests.',
+        provider: { name: 'CommandMate' },
+        license: 'MIT',
+        latest: VERSION,
+        versions: [
+          {
+            version: VERSION,
+            changelog: `Release ${VERSION}`,
+            published_at: '2026-07-16T09:30:00Z',
+            source: { repository: 'Kewton/commandmate-skills', ref: `v${VERSION}`, commit: COMMIT },
+            artifact: {
+              asset_name: `${SKILL_ID}-${VERSION}.tar.gz`,
+              url: `https://example.invalid/${SKILL_ID}-${VERSION}.tar.gz`,
+              sha256: artifactSha,
+              size: artifact.byteLength,
+              content_type: 'application/gzip',
+              format: 'tar.gz',
+            },
+            compatibility: {
+              commandmate: '>=0.11.0 <1.0.0',
+              agents: [
+                { agent: 'claude', support: 'native', evidence: 'verified by the package tests' },
+              ],
+            },
+            declared_risk: 'low',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function wireMocks(): void {
+  getSkillCatalogMock.mockResolvedValue({
+    ok: true,
+    snapshot: {
+      catalog: makeCatalog(),
+      fetchedAt: '2026-07-16T10:00:00Z',
+      revalidatedAt: '2026-07-16T10:00:00Z',
+      stale: false,
+      offline: false,
+      state: 'fresh',
+      staleReason: null,
+      source: { repository: 'Kewton/commandmate-skills', ref: 'main', revision: null },
+    },
+  } as SkillCatalogResult);
+
+  downloadSkillArtifactMock.mockResolvedValue({
+    skillId: SKILL_ID,
+    version: VERSION,
+    commit: COMMIT,
+    bytes: artifact,
+    sha256: artifactSha,
+    size: artifact.byteLength,
+  });
+
+  const handle = {
+    snapshotId: SNAPSHOT_ID,
+    skillId: SKILL_ID,
+    version: VERSION,
+    commit: COMMIT,
+    sha256: artifactSha,
+    size: artifact.byteLength,
+    expiresAt: Date.now() + 600_000,
+  };
+  createSkillSnapshotMock.mockReturnValue(handle);
+  getSkillSnapshotMock.mockReturnValue(handle);
+  readSkillSnapshotBytesMock.mockImplementation(() => artifact);
+}
+
+function setHead(commit: string | null): void {
+  execGitCommandMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'symbolic-ref') return 'feature/demo';
+    if (args[0] === 'rev-parse') return commit;
+    if (args[0] === 'status') return '';
+    return null;
+  });
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: WORKTREE_ID,
+    name: 'demo-worktree',
+    path: worktreeDir,
+    branch: 'feature/demo',
+    repositoryName: 'commandmate',
+    repositoryDisplayName: 'CommandMate',
+  } as Worktree;
+}
+
+async function requestPlan(body: Record<string, unknown> = {}): Promise<Response> {
+  return buildPlan(
+    new NextRequest(`http://localhost/api/worktrees/${WORKTREE_ID}/skills/${SKILL_ID}/plan`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id: WORKTREE_ID, skillId: SKILL_ID }) }
+  );
+}
+
+async function requestInstall(body: Record<string, unknown>): Promise<Response> {
+  return applyInstall(
+    new NextRequest(`http://localhost/api/worktrees/${WORKTREE_ID}/skills/${SKILL_ID}/install`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id: WORKTREE_ID, skillId: SKILL_ID }) }
+  );
+}
+
+/** Build a plan and hand back its token together with the previewed payload. */
+async function issuePlan(body: Record<string, unknown> = {}): Promise<{
+  token: string;
+  plan: { receipt: { sha256: string; size: number }; files: Array<{ path: string }> };
+}> {
+  const response = await requestPlan(body);
+  expect(response.status).toBe(200);
+  const payload = await response.json();
+  return { token: payload.plan.token, plan: payload.plan };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetSkillInstallPlanCacheForTesting();
+
+  worktreeDir = mkdtempSync(path.join(tmpdir(), 'cm-install-wt-'));
+  configRoot = mkdtempSync(path.join(tmpdir(), 'cm-install-cfg-'));
+  state.configRoot = configRoot;
+
+  db = new Database(':memory:');
+  runMigrations(db);
+  getDbInstanceMock.mockReturnValue(db);
+  getWorktreeByIdMock.mockReturnValue(makeWorktree());
+
+  useArtifact();
+  wireMocks();
+  setHead(HEAD);
+  execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(worktreeDir, { recursive: true, force: true });
+  rmSync(configRoot, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Cases
+// =============================================================================
+
+describe('POST /api/worktrees/[id]/skills/[skillId]/install — success', () => {
+  it('writes the payload the plan previewed, byte for byte', async () => {
+    const { token, plan } = await issuePlan();
+
+    const response = await requestInstall({ planToken: token, version: VERSION });
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.operation).toMatchObject({
+      state: 'SUCCEEDED',
+      result: 'succeeded',
+      committed: true,
+      reconcilePending: false,
+      replayed: false,
+      nextActionKey: 'skills.install.nextAction.succeeded',
+    });
+    expect(payload.install.installRoot).toBe(`.agents/skills/${SKILL_ID}`);
+
+    // The receipt on disk is the file the plan hashed, not one rebuilt at apply.
+    const receiptBytes = readFileSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME));
+    expect(createHash('sha256').update(receiptBytes).digest('hex')).toBe(plan.receipt.sha256);
+    expect(receiptBytes.byteLength).toBe(plan.receipt.size);
+    expect(payload.install.receipt.sha256).toBe(plan.receipt.sha256);
+
+    for (const file of payload.install.files) {
+      const bytes = readFileSync(path.join(installRootAbs(), file.path));
+      expect(createHash('sha256').update(bytes).digest('hex')).toBe(file.sha256);
+    }
+    // Every planned path in the preview exists, and nothing else was created.
+    const previewed = plan.files.map((entry) => entry.path).sort();
+    expect(previewed).toContain(`.agents/skills/${SKILL_ID}/${SKILL_RECEIPT_FILENAME}`);
+  });
+
+  it('records the install in the index and appends one audit row', async () => {
+    const { token } = await issuePlan();
+
+    await requestInstall({ planToken: token, version: VERSION });
+
+    const installation = getSkillInstallation(db, WORKTREE_ID, SKILL_ID);
+    expect(installation).toMatchObject({
+      version: VERSION,
+      installRoot: `.agents/skills/${SKILL_ID}`,
+      sourceCommit: COMMIT,
+      artifactSha256: artifactSha,
+    });
+
+    const audit = listSkillOperationAudit(db, { worktreeId: WORKTREE_ID });
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ operation: 'install', result: 'succeeded', state: 'SUCCEEDED' });
+  });
+
+  it('returns per-agent reload guidance for the version that landed', async () => {
+    const { token } = await issuePlan();
+
+    const payload = await (await requestInstall({ planToken: token, version: VERSION })).json();
+
+    expect(payload.reload).toMatchObject({ skillId: SKILL_ID, version: VERSION });
+    expect(payload.reload.agents).toEqual([
+      { agent: 'claude', support: 'native', messageKey: 'skills.install.reload.native' },
+    ]);
+  });
+
+  it('leaves no staging directory in the worktree', async () => {
+    const { token } = await issuePlan();
+
+    await requestInstall({ planToken: token, version: VERSION });
+
+    expect(existsSync(getSkillInstallStagingRoot(worktreeDir))).toBe(false);
+    expect(readdirSync(path.join(worktreeDir, '.agents', 'skills'))).toEqual([SKILL_ID]);
+  });
+
+  it('does not execute a script the package ships', async () => {
+    const sentinel = path.join(worktreeDir, 'script-was-executed');
+    useArtifact({
+      files: [
+        { path: 'reference/notes.md', content: '# Notes\n' },
+        {
+          path: 'scripts/install.sh',
+          content: `#!/bin/sh\ntouch ${sentinel}\n`,
+          mode: 0o755,
+          kind: 'script',
+          script: true,
+        },
+      ],
+    });
+    wireMocks();
+
+    const { token } = await issuePlan();
+    // Shipping a script raises the computed risk, so the acknowledgement is
+    // required — which is itself the guard this package would otherwise dodge.
+    const response = await requestInstall({
+      planToken: token,
+      version: VERSION,
+      acknowledgeRisk: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(existsSync(path.join(installRootAbs(), 'scripts/install.sh'))).toBe(true);
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it('does not re-download the artifact at apply time', async () => {
+    const { token } = await issuePlan();
+    downloadSkillArtifactMock.mockClear();
+
+    await requestInstall({ planToken: token, version: VERSION });
+
+    expect(downloadSkillArtifactMock).not.toHaveBeenCalled();
+    expect(readSkillSnapshotBytesMock).toHaveBeenCalledWith(SNAPSHOT_ID);
+  });
+});
+
+describe('POST …/install — the token contract', () => {
+  it('refuses a second apply of the same token', async () => {
+    const { token } = await issuePlan();
+    expect((await requestInstall({ planToken: token, version: VERSION })).status).toBe(200);
+
+    const replay = await requestInstall({ planToken: token, version: VERSION });
+
+    expect(replay.status).toBe(409);
+    expect((await replay.json()).code).toBe('SKILL_PLAN_CONSUMED');
+  });
+
+  it('refuses a token presented for a different version', async () => {
+    const { token } = await issuePlan();
+
+    const response = await requestInstall({ planToken: token, version: '9.9.9' });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_BINDING_MISMATCH');
+    expect(existsSync(installRootAbs())).toBe(false);
+  });
+
+  it('refuses a plan whose target moved on', async () => {
+    const { token } = await issuePlan();
+    setHead('b'.repeat(40));
+
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_STALE');
+    expect(existsSync(installRootAbs())).toBe(false);
+  });
+
+  it('refuses a plan whose destination tree changed since it was previewed', async () => {
+    const { token } = await issuePlan();
+    mkdirSync(installRootAbs(), { recursive: true });
+    writeFileSync(path.join(installRootAbs(), 'SKILL.md'), 'appeared after the preview\n');
+
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_STALE');
+    expect(readFileSync(path.join(installRootAbs(), 'SKILL.md')).toString()).toBe(
+      'appeared after the preview\n'
+    );
+  });
+
+  it('refuses a malformed token before the plan store is consulted', async () => {
+    const response = await requestInstall({ planToken: 'not-a-token', version: VERSION });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).code).toBe('SKILL_INSTALL_INVALID_BODY');
+  });
+
+  it('refuses an unknown token', async () => {
+    const response = await requestInstall({ planToken: 'a'.repeat(48), version: VERSION });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).code).toBe('SKILL_PLAN_NOT_FOUND');
+  });
+});
+
+describe('POST …/install — risk acknowledgement', () => {
+  beforeEach(() => {
+    useArtifact({
+      manifestPatch: (manifest) => {
+        manifest.declared_risk = 'high';
+      },
+    });
+    wireMocks();
+  });
+
+  it('cannot be skipped for a high-risk package', async () => {
+    const { token } = await issuePlan();
+
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_RISK_NOT_ACKNOWLEDGED');
+    expect(existsSync(installRootAbs())).toBe(false);
+  });
+
+  it('proceeds once the risk is acknowledged explicitly', async () => {
+    const { token } = await issuePlan();
+
+    const response = await requestInstall({
+      planToken: token,
+      version: VERSION,
+      acknowledgeRisk: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(existsSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME))).toBe(true);
+  });
+});
+
+describe('POST …/install — what the client may not supply', () => {
+  it.each(['path', 'installRoot', 'artifactUrl', 'files', 'sha256', 'snapshotId'])(
+    'rejects a body carrying `%s` rather than ignoring it',
+    async (key) => {
+      const { token } = await issuePlan();
+
+      const response = await requestInstall({
+        planToken: token,
+        version: VERSION,
+        [key]: 'anything',
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).code).toBe('SKILL_PLAN_INPUT_REJECTED');
+      expect(existsSync(installRootAbs())).toBe(false);
+    }
+  );
+
+  it('rejects an unknown field', async () => {
+    const { token } = await issuePlan();
+
+    const response = await requestInstall({ planToken: token, version: VERSION, force: true });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).code).toBe('SKILL_INSTALL_INVALID_BODY');
+  });
+
+  it('never echoes a machine-absolute path in an error body', async () => {
+    mkdirSync(installRootAbs(), { recursive: true });
+    const { token } = await issuePlan();
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    const body = JSON.stringify(await response.json());
+    expect(body).not.toContain(worktreeDir);
+    expect(body).not.toContain(tmpdir());
+  });
+});
+
+describe('POST …/install — an occupied destination', () => {
+  it('refuses to overwrite an unmanaged Skill directory', async () => {
+    mkdirSync(installRootAbs(), { recursive: true });
+    writeFileSync(path.join(installRootAbs(), 'SKILL.md'), 'hand-written\n');
+
+    const { token } = await issuePlan();
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    // The plan already knows this destination is not installable, so the token
+    // is refused before anything is staged.
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_NOT_INSTALLABLE');
+    expect(readFileSync(path.join(installRootAbs(), 'SKILL.md')).toString()).toBe('hand-written\n');
+  });
+
+  it('refuses to publish into an empty directory that appeared at the install root', async () => {
+    mkdirSync(installRootAbs(), { recursive: true });
+
+    const { token } = await issuePlan();
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_INSTALL_DESTINATION_UNMANAGED');
+    expect(readdirSync(installRootAbs())).toEqual([]);
+  });
+
+  it('refuses a second install of the same Skill into the same worktree', async () => {
+    const first = await issuePlan();
+    expect((await requestInstall({ planToken: first.token, version: VERSION })).status).toBe(200);
+
+    const second = await issuePlan();
+    const response = await requestInstall({ planToken: second.token, version: VERSION });
+
+    // Updating an existing install is out of scope; the receipt already there
+    // must not be silently replaced.
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_INSTALL_DESTINATION_EXISTS');
+  });
+});
+
+describe('POST …/install — idempotency', () => {
+  it('replays a recorded success instead of spending a second token', async () => {
+    const { token } = await issuePlan();
+    const key = 'install-demo-skill-0001';
+    expect(
+      (await requestInstall({ planToken: token, version: VERSION, idempotencyKey: key })).status
+    ).toBe(200);
+
+    const { token: second } = await issuePlan();
+    const replay = await requestInstall({
+      planToken: second,
+      version: VERSION,
+      idempotencyKey: key,
+    });
+
+    expect(replay.status).toBe(200);
+    const payload = await replay.json();
+    expect(payload.operation).toMatchObject({ replayed: true, state: 'SUCCEEDED' });
+    expect(payload.install).toMatchObject({ skillId: SKILL_ID, version: VERSION });
+    // The replay must not have installed a second time.
+    expect(listSkillOperationAudit(db, { worktreeId: WORKTREE_ID })).toHaveLength(1);
+  });
+
+  it('refuses a key already used for a different target', async () => {
+    const { token } = await issuePlan();
+    const key = 'install-demo-skill-0002';
+    await requestInstall({ planToken: token, version: VERSION, idempotencyKey: key });
+
+    const { token: second } = await issuePlan();
+    const response = await requestInstall({
+      planToken: second,
+      version: '9.9.9',
+      idempotencyKey: key,
+    });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_INSTALL_IDEMPOTENCY_CONFLICT');
+  });
+
+  it('rejects a key that is not a safe identifier', async () => {
+    const { token } = await issuePlan();
+
+    const response = await requestInstall({
+      planToken: token,
+      version: VERSION,
+      idempotencyKey: '../../etc/passwd',
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).code).toBe('SKILL_INSTALL_INVALID_BODY');
+  });
+});
+
+describe('POST …/install — a failure after the commit point', () => {
+  it('reports the payload as committed and reconciling, not as unchanged', async () => {
+    const { token } = await issuePlan();
+
+    // The index write is the first thing that happens after the atomic rename.
+    const realPrepare = db.prepare.bind(db);
+    vi.spyOn(db, 'prepare').mockImplementation((sql: string) => {
+      if (sql.includes('INSERT INTO skill_installations')) {
+        throw new Error(`disk I/O error while writing ${worktreeDir}`);
+      }
+      return realPrepare(sql);
+    });
+
+    const response = await requestInstall({ planToken: token, version: VERSION });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.operation).toMatchObject({
+      state: 'FAILED_RECONCILABLE',
+      result: 'committed_reconciling',
+      committed: true,
+      reconcilePending: true,
+      nextActionKey: 'skills.install.nextAction.committedReconciling',
+    });
+    // The payload really is on disk, which is why "unchanged" would be a lie.
+    expect(existsSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME))).toBe(true);
+    expect(JSON.stringify(payload)).not.toContain(worktreeDir);
+  });
+});

--- a/tests/unit/components/skills/skills-i18n-keys.test.ts
+++ b/tests/unit/components/skills/skills-i18n-keys.test.ts
@@ -24,6 +24,10 @@ import {
 import { AGENT_SUPPORT_LABEL_KEYS, PERMISSION_DECLARATION_NOTICE_KEY } from '@/lib/skills/constants';
 import { SKILL_COMPATIBILITY_MESSAGE_KEYS } from '@/lib/skills/compatibility';
 import { SKILL_PLAN_HIGH_RISK_MESSAGE_KEY } from '@/lib/skills/install-plan';
+import {
+  SKILL_INSTALL_NEXT_ACTION_KEYS,
+  SKILL_INSTALL_RELOAD_MESSAGE_KEYS,
+} from '@/lib/skills/install-apply';
 
 const ROOT = path.resolve(__dirname, '../../../..');
 const LOCALES_DIR = path.join(ROOT, 'locales');
@@ -87,6 +91,10 @@ function contractKeys(): string[] {
     // Emitted by the Install Plan API (#1233) rather than written at a call
     // site: the plan tells the client which confirmation to show.
     SKILL_PLAN_HIGH_RISK_MESSAGE_KEY,
+    // Emitted by the install apply API (#1235): the response names the reload
+    // instruction per agent and the next action per outcome.
+    ...Object.values(SKILL_INSTALL_RELOAD_MESSAGE_KEYS),
+    ...Object.values(SKILL_INSTALL_NEXT_ACTION_KEYS),
   ]
     .map(resolveSkillMessageKey)
     .concat(Object.values(RECOMMENDATION_LABEL_KEY))

--- a/tests/unit/db/migration-v45-skill-installations.test.ts
+++ b/tests/unit/db/migration-v45-skill-installations.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for migration v45 (skill_installations index, Issue #1235).
+ *
+ * 1. Fresh DB end state — table, columns and indexes exist.
+ * 2. One row per (worktree, skill), enforced by the database rather than by the
+ *    upsert that happens to be written today.
+ * 3. Rollback and idempotency of the migration chain.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  runMigrations,
+  rollbackMigrations,
+  getCurrentVersion,
+  CURRENT_SCHEMA_VERSION,
+} from '@/lib/db/db-migrations';
+
+function tableNames(db: Database.Database): string[] {
+  return (
+    db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function insertRow(
+  db: Database.Database,
+  id: string,
+  worktreeId = 'wt-1',
+  skillId = 'demo-skill'
+): void {
+  db.prepare(
+    `INSERT INTO skill_installations (
+      id, worktree_id, skill_id, version, install_root, receipt_sha256,
+      source_repository, source_ref, source_commit, artifact_sha256,
+      effective_risk, operation_id, installed_at, updated_at
+    ) VALUES (?, ?, ?, '1.2.3', '.agents/skills/demo-skill', ?,
+      'Kewton/commandmate-skills', 'demo-skill-v1.2.3', ?, ?,
+      'low', 'op-1', 1800000000000, 1800000000000)`
+  ).run(id, worktreeId, skillId, 'd'.repeat(64), 'b'.repeat(40), 'c'.repeat(64));
+}
+
+describe('migration v45: fresh DB end state', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates the skill_installations table', () => {
+    expect(tableNames(db)).toContain('skill_installations');
+  });
+
+  it('has the provenance columns that join a row back to its receipt', () => {
+    const cols = (db.pragma('table_info(skill_installations)') as Array<{ name: string }>).map(
+      (c) => c.name
+    );
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        'id',
+        'worktree_id',
+        'skill_id',
+        'version',
+        'install_root',
+        'receipt_sha256',
+        'source_repository',
+        'source_ref',
+        'source_commit',
+        'artifact_sha256',
+        'effective_risk',
+        'operation_id',
+        'installed_at',
+        'updated_at',
+      ])
+    );
+  });
+
+  it('creates the lookup indexes', () => {
+    const indexes = (
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='skill_installations'"
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        'idx_skill_installations_worktree',
+        'idx_skill_installations_skill',
+      ])
+    );
+  });
+});
+
+describe('migration v45: one row per (worktree, skill)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    insertRow(db, 'install-1');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('rejects a second row for the same pair at the database level', () => {
+    expect(() => insertRow(db, 'install-2')).toThrow(/UNIQUE/);
+  });
+
+  it('allows the same Skill in another worktree', () => {
+    insertRow(db, 'install-2', 'wt-2');
+    const count = db.prepare('SELECT COUNT(*) AS n FROM skill_installations').get() as {
+      n: number;
+    };
+    expect(count.n).toBe(2);
+  });
+
+  it('allows another Skill in the same worktree', () => {
+    insertRow(db, 'install-2', 'wt-1', 'other-skill');
+    const count = db.prepare('SELECT COUNT(*) AS n FROM skill_installations').get() as {
+      n: number;
+    };
+    expect(count.n).toBe(2);
+  });
+});
+
+describe('migration v45: rollback and idempotency', () => {
+  it('down() drops the table and rewinds the version', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+
+    rollbackMigrations(db, 44);
+
+    expect(getCurrentVersion(db)).toBe(44);
+    expect(tableNames(db)).not.toContain('skill_installations');
+    // The audit log v44 created is untouched by the rollback of v45.
+    expect(tableNames(db)).toContain('skill_operations');
+    db.close();
+  });
+
+  it('re-running runMigrations is a no-op and keeps the table', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    expect(() => runMigrations(db)).not.toThrow();
+    expect(tableNames(db)).toContain('skill_installations');
+    db.close();
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 44 after Migration #44 (skill_operations audit log)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(44);
+    it('should be 45 after Migration #45 (skill_installations index)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(45);
     });
   });
 

--- a/tests/unit/lib/skills/install-apply.test.ts
+++ b/tests/unit/lib/skills/install-apply.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Issue #1235: atomic commit of a planned Skill install.
+ *
+ * The behaviour under test is almost entirely what the module *refuses* to do.
+ * Every case below either proves the destination is untouched after a rejection,
+ * or proves that what landed is byte-for-byte what the plan fixed — because the
+ * two failure modes that matter are "wrote somewhere else" and "wrote something
+ * else", and both look like success from the caller's side.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import {
+  SKILL_INSTALL_EXECUTABLE_MODE,
+  SKILL_INSTALL_FILE_MODE,
+  SkillInstallErrorCode,
+  applySkillInstall,
+  buildSkillReloadGuidance,
+  cleanupSkillInstallStaging,
+  hasCommittedSkillPayload,
+  inspectSkillDestination,
+  isSkillInstallError,
+  resolveSkillInstallTarget,
+  type SkillInstallApplyInput,
+} from '@/lib/skills/install-apply';
+import {
+  SKILL_RECEIPT_FILENAME,
+  buildSkillInstallReceipt,
+  serializeSkillInstallReceipt,
+} from '@/lib/skills/install-plan';
+import { computeSkillTreeHash } from '@/lib/skills/preview-diff';
+import { inspectSkillPackage } from '@/lib/skills/package-validator';
+import type { SkillPackageSnapshot } from '@/lib/skills/package-validator';
+import {
+  SKILL_INSTALL_STAGING_REL_PATH,
+  getSkillInstallStagingRoot,
+  isSkillInstallStagingPath,
+} from '@/lib/skills/operation-store';
+import { buildPackage } from '../../../fixtures/skills/malicious-packages/package';
+import type { PackageFileSpec } from '../../../fixtures/skills/malicious-packages/package';
+import { makeCatalogVersion } from './fixtures';
+
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const OPERATION_ID = '9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f';
+
+let worktree: string;
+
+/** A real package, read and reconciled the same way the plan route reads it. */
+function makeSnapshot(files?: PackageFileSpec[]): SkillPackageSnapshot {
+  const built = buildPackage(files ? { files } : {});
+  return inspectSkillPackage(built.bytes, { skillId: SKILL_ID, version: VERSION });
+}
+
+/**
+ * Build the inputs a plan would hand to apply.
+ *
+ * The tree hash is derived exactly as `createSkillInstallPlan` derives it — the
+ * package inventory plus the generated receipt — so a drift between the two
+ * shows up here rather than in production.
+ */
+function makeInput(
+  snapshot: SkillPackageSnapshot,
+  overrides: Partial<SkillInstallApplyInput> = {}
+): SkillInstallApplyInput {
+  const receipt = buildSkillInstallReceipt({ snapshot, version: makeCatalogVersion() });
+  const receiptBytes = serializeSkillInstallReceipt(receipt);
+  const plannedTreeHash = computeSkillTreeHash([
+    ...snapshot.files.map((file) => ({
+      path: file.path,
+      sha256: file.sha256,
+      executable: file.executable,
+    })),
+    {
+      path: SKILL_RECEIPT_FILENAME,
+      sha256: createHash('sha256').update(receiptBytes).digest('hex'),
+      executable: false,
+    },
+  ]);
+
+  return {
+    worktreePath: worktree,
+    worktreeRealPath: realpathSync(worktree),
+    skillId: SKILL_ID,
+    operationId: OPERATION_ID,
+    snapshot,
+    receiptBytes,
+    plannedTreeHash,
+    ...overrides,
+  };
+}
+
+function installRoot(): string {
+  return path.join(worktree, '.agents', 'skills', SKILL_ID);
+}
+
+/** Assert a rejection carries the expected code and left nothing behind. */
+function expectRejection(run: () => unknown, code: string): void {
+  let thrown: unknown;
+  try {
+    run();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(isSkillInstallError(thrown)).toBe(true);
+  expect((thrown as { code: string }).code).toBe(code);
+}
+
+beforeEach(() => {
+  worktree = mkdtempSync(path.join(tmpdir(), 'cm-skill-install-'));
+});
+
+afterEach(() => {
+  rmSync(worktree, { recursive: true, force: true });
+});
+
+describe('applySkillInstall — the committed payload', () => {
+  it('writes exactly the files the plan fixed, receipt included', () => {
+    const snapshot = makeSnapshot();
+    const input = makeInput(snapshot);
+
+    const result = applySkillInstall(input);
+
+    expect(result.installRoot).toBe(`.agents/skills/${SKILL_ID}`);
+    for (const file of snapshot.files) {
+      const bytes = readFileSync(path.join(installRoot(), file.path));
+      expect(createHash('sha256').update(bytes).digest('hex')).toBe(file.sha256);
+    }
+    const receiptOnDisk = readFileSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME));
+    expect(Buffer.from(receiptOnDisk).equals(Buffer.from(input.receiptBytes))).toBe(true);
+    expect(result.receiptSha256).toBe(
+      createHash('sha256').update(input.receiptBytes).digest('hex')
+    );
+  });
+
+  it('writes the receipt bytes the plan fixed rather than rebuilding them', () => {
+    const snapshot = makeSnapshot();
+    // A receipt the caller fixed; apply must not regenerate its own.
+    const receiptBytes = Buffer.from('{"schema_version":1,"skill_id":"demo-skill"}', 'utf-8');
+    const input = makeInput(snapshot, { receiptBytes });
+    const plannedTreeHash = computeSkillTreeHash([
+      ...snapshot.files.map((file) => ({
+        path: file.path,
+        sha256: file.sha256,
+        executable: file.executable,
+      })),
+      {
+        path: SKILL_RECEIPT_FILENAME,
+        sha256: createHash('sha256').update(receiptBytes).digest('hex'),
+        executable: false,
+      },
+    ]);
+
+    applySkillInstall({ ...input, plannedTreeHash });
+
+    expect(readFileSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME)).toString()).toBe(
+      receiptBytes.toString()
+    );
+  });
+
+  it('gives only declared executables an execute bit', () => {
+    const snapshot = makeSnapshot([
+      { path: 'reference/notes.md', content: '# Notes\n' },
+      { path: 'scripts/run.sh', content: '#!/bin/sh\nexit 0\n', mode: 0o755, kind: 'script', script: true },
+    ]);
+
+    applySkillInstall(makeInput(snapshot));
+
+    const script = lstatSync(path.join(installRoot(), 'scripts/run.sh'));
+    const notes = lstatSync(path.join(installRoot(), 'reference/notes.md'));
+    expect(script.mode & 0o777).toBe(SKILL_INSTALL_EXECUTABLE_MODE);
+    expect(notes.mode & 0o777).toBe(SKILL_INSTALL_FILE_MODE);
+  });
+
+  it('never executes a script it installs', () => {
+    const sentinel = path.join(worktree, 'script-was-executed');
+    const snapshot = makeSnapshot([
+      { path: 'reference/notes.md', content: '# Notes\n' },
+      {
+        path: 'scripts/install.sh',
+        content: `#!/bin/sh\ntouch ${sentinel}\n`,
+        mode: 0o755,
+        kind: 'script',
+        script: true,
+      },
+    ]);
+
+    applySkillInstall(makeInput(snapshot));
+
+    expect(existsSync(path.join(installRoot(), 'scripts/install.sh'))).toBe(true);
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it('leaves no staging directory behind after a successful commit', () => {
+    applySkillInstall(makeInput(makeSnapshot()));
+
+    expect(existsSync(getSkillInstallStagingRoot(worktree))).toBe(false);
+  });
+});
+
+describe('applySkillInstall — where it refuses to write', () => {
+  it('rejects a Skill ID that would walk out of the Skills directory', () => {
+    // `path.join` normalizes `..` away, so a containment check alone would let
+    // this through: the grammar has to be re-checked first.
+    expectRejection(
+      () => resolveSkillInstallTarget(worktree, `..${path.sep}evil`),
+      SkillInstallErrorCode.TARGET_UNSAFE
+    );
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot(), { skillId: '../evil' })),
+      SkillInstallErrorCode.TARGET_UNSAFE
+    );
+    expect(existsSync(path.join(worktree, '.agents', 'evil'))).toBe(false);
+  });
+
+  it('refuses when an ancestor of the install root is a symlink', () => {
+    const outside = mkdtempSync(path.join(tmpdir(), 'cm-skill-outside-'));
+    try {
+      mkdirSync(path.join(worktree, '.agents'));
+      symlinkSync(outside, path.join(worktree, '.agents', 'skills'));
+
+      expectRejection(
+        () => applySkillInstall(makeInput(makeSnapshot())),
+        SkillInstallErrorCode.ANCESTOR_UNSAFE
+      );
+      expect(readdirSync(outside)).toEqual([]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses when the worktree path no longer resolves to the identity it was locked under', () => {
+    expectRejection(
+      () =>
+        applySkillInstall(
+          makeInput(makeSnapshot(), { worktreeRealPath: path.join(tmpdir(), 'some-other-worktree') })
+        ),
+      SkillInstallErrorCode.ANCESTOR_UNSAFE
+    );
+    expect(existsSync(installRoot())).toBe(false);
+  });
+
+  it('does not overwrite a CommandMate-managed install', () => {
+    mkdirSync(installRoot(), { recursive: true });
+    writeFileSync(
+      path.join(installRoot(), SKILL_RECEIPT_FILENAME),
+      JSON.stringify({ schema_version: 1, skill_id: SKILL_ID, version: '1.0.0', files: [] })
+    );
+
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot())),
+      SkillInstallErrorCode.DESTINATION_EXISTS
+    );
+    expect(readdirSync(installRoot())).toEqual([SKILL_RECEIPT_FILENAME]);
+  });
+
+  it('does not overwrite a directory CommandMate does not manage', () => {
+    mkdirSync(installRoot(), { recursive: true });
+    writeFileSync(path.join(installRoot(), 'SKILL.md'), 'hand-written\n');
+
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot())),
+      SkillInstallErrorCode.DESTINATION_UNMANAGED
+    );
+    expect(readFileSync(path.join(installRoot(), 'SKILL.md')).toString()).toBe('hand-written\n');
+  });
+
+  it('does not overwrite an empty directory that is already at the install root', () => {
+    // rename(2) silently replaces an empty destination directory, so absence has
+    // to be proven rather than delegated to the syscall.
+    mkdirSync(installRoot(), { recursive: true });
+
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot())),
+      SkillInstallErrorCode.DESTINATION_UNMANAGED
+    );
+    expect(readdirSync(installRoot())).toEqual([]);
+  });
+
+  it('treats a symlink at the install root as an occupant, not a path to follow', () => {
+    const outside = mkdtempSync(path.join(tmpdir(), 'cm-skill-outside-'));
+    try {
+      mkdirSync(path.join(worktree, '.agents', 'skills'), { recursive: true });
+      symlinkSync(outside, installRoot());
+
+      expect(inspectSkillDestination(installRoot())).toEqual({
+        present: true,
+        managed: false,
+        version: null,
+      });
+      expectRejection(
+        () => applySkillInstall(makeInput(makeSnapshot())),
+        SkillInstallErrorCode.DESTINATION_UNMANAGED
+      );
+      expect(readdirSync(outside)).toEqual([]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('applySkillInstall — verification before the commit point', () => {
+  it('refuses to publish a tree that does not hash to what the plan fixed', () => {
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot(), { plannedTreeHash: 'f'.repeat(64) })),
+      SkillInstallErrorCode.PAYLOAD_MISMATCH
+    );
+    expect(existsSync(installRoot())).toBe(false);
+    expect(existsSync(getSkillInstallStagingRoot(worktree))).toBe(false);
+  });
+
+  it('never adopts a staging directory that already exists', () => {
+    // Adopting one would mean two operations writing into a single commit, and
+    // whatever a previous run left there would be published as ours.
+    const outside = path.join(worktree, 'outside.txt');
+    writeFileSync(outside, 'untouched\n');
+    const stagingDir = path.join(getSkillInstallStagingRoot(worktree), OPERATION_ID);
+    mkdirSync(stagingDir, { recursive: true });
+    symlinkSync(outside, path.join(stagingDir, 'SKILL.md'));
+
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot())),
+      SkillInstallErrorCode.STAGING_IO
+    );
+    expect(readFileSync(outside).toString()).toBe('untouched\n');
+    expect(existsSync(installRoot())).toBe(false);
+  });
+
+  it('rejects an operation ID that is not a safe path segment', () => {
+    expectRejection(
+      () => applySkillInstall(makeInput(makeSnapshot(), { operationId: '../escape' })),
+      SkillInstallErrorCode.STAGING_IO
+    );
+  });
+
+  it('stages inside the destination parent, so the commit rename cannot cross a filesystem', () => {
+    const stagingRoot = getSkillInstallStagingRoot(worktree);
+    expect(path.dirname(stagingRoot)).toBe(path.dirname(installRoot()));
+  });
+});
+
+describe('staging namespace', () => {
+  it('is excluded from Skill discovery and payload diffs', () => {
+    expect(isSkillInstallStagingPath(`${SKILL_INSTALL_STAGING_REL_PATH}/${OPERATION_ID}`)).toBe(
+      true
+    );
+    expect(isSkillInstallStagingPath(`.agents/skills/${SKILL_ID}/SKILL.md`)).toBe(false);
+  });
+
+  it('is cleaned up after a crash left a staging directory behind', () => {
+    const stagingDir = path.join(getSkillInstallStagingRoot(worktree), OPERATION_ID);
+    mkdirSync(stagingDir, { recursive: true });
+    writeFileSync(path.join(stagingDir, 'partial.md'), 'half a package\n');
+    mkdirSync(path.join(getSkillInstallStagingRoot(worktree), 'not-ours!'), { recursive: true });
+
+    expect(cleanupSkillInstallStaging(worktree)).toBe(1);
+    expect(existsSync(stagingDir)).toBe(false);
+    // An entry outside the grammar is left alone rather than destroyed.
+    expect(existsSync(path.join(getSkillInstallStagingRoot(worktree), 'not-ours!'))).toBe(true);
+  });
+});
+
+describe('hasCommittedSkillPayload', () => {
+  it('recognises the payload the operation committed', () => {
+    const input = makeInput(makeSnapshot());
+    const result = applySkillInstall(input);
+
+    expect(hasCommittedSkillPayload(worktree, SKILL_ID, result.receiptSha256)).toBe(true);
+  });
+
+  it('rejects a receipt belonging to a different install', () => {
+    applySkillInstall(makeInput(makeSnapshot()));
+
+    expect(hasCommittedSkillPayload(worktree, SKILL_ID, 'a'.repeat(64))).toBe(false);
+  });
+
+  it('reports no payload when nothing was committed', () => {
+    expect(hasCommittedSkillPayload(worktree, SKILL_ID, null)).toBe(false);
+  });
+});
+
+describe('buildSkillReloadGuidance', () => {
+  it('names one reload instruction per agent, for the version that landed', () => {
+    const snapshot = makeSnapshot();
+    const receipt = buildSkillInstallReceipt({ snapshot, version: makeCatalogVersion() });
+
+    const guidance = buildSkillReloadGuidance(receipt);
+
+    expect(guidance).toMatchObject({ skillId: SKILL_ID, version: VERSION });
+    expect(guidance.installRoot).toBe(`.agents/skills/${SKILL_ID}`);
+    expect(guidance.agents.every((agent) => agent.messageKey.startsWith('skills.install.reload.')))
+      .toBe(true);
+  });
+});

--- a/tests/unit/lib/skills/installed-state.test.ts
+++ b/tests/unit/lib/skills/installed-state.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Issue #1235: the installed-Skill index and the exclusive-write guard.
+ *
+ * The index is written after the commit point, so the property that matters is
+ * that writing it twice is indistinguishable from writing it once —
+ * reconciliation replays it without knowing whether an earlier attempt got that
+ * far.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync, lstatSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { runMigrations } from '@/lib/db/db-migrations';
+import {
+  deleteSkillInstallation,
+  getSkillInstallation,
+  listSkillInstallations,
+  upsertSkillInstallation,
+} from '@/lib/skills/installed-state';
+import {
+  SKILL_INSTALL_EXECUTABLE_MODE,
+  SKILL_INSTALL_FILE_MODE,
+  SkillInstallErrorCode,
+  isSkillInstallError,
+  writeSkillPayloadFile,
+} from '@/lib/skills/install-apply';
+import type { SkillInstallReceipt } from '@/types/skills';
+
+let db: Database.Database;
+let dir: string;
+
+const T0 = 1_800_000_000_000;
+
+function makeReceipt(overrides: Partial<SkillInstallReceipt> = {}): SkillInstallReceipt {
+  return {
+    schema_version: 1,
+    skill_id: 'demo-skill',
+    version: '1.2.3',
+    install_root: '.agents/skills/demo-skill',
+    source: {
+      repository: 'Kewton/commandmate-skills',
+      ref: 'demo-skill-v1.2.3',
+      commit: 'b'.repeat(40),
+    },
+    artifact: {
+      asset_name: 'demo-skill-1.2.3.tar.gz',
+      sha256: 'c'.repeat(64),
+      size: 2048,
+      format: 'tar.gz',
+    },
+    files: [],
+    declared_risk: 'low',
+    computed_risk: 'low',
+    effective_risk: 'low',
+    declared_permissions: [],
+    agent_compatibility: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  runMigrations(db);
+  dir = mkdtempSync(path.join(tmpdir(), 'cm-installed-state-'));
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('skill_installations index', () => {
+  it('records the install the receipt describes', () => {
+    const record = upsertSkillInstallation(db, {
+      worktreeId: 'wt-1',
+      receipt: makeReceipt(),
+      receiptSha256: 'd'.repeat(64),
+      operationId: 'op-1',
+      installedAt: T0,
+    });
+
+    expect(record).toMatchObject({
+      worktreeId: 'wt-1',
+      skillId: 'demo-skill',
+      version: '1.2.3',
+      installRoot: '.agents/skills/demo-skill',
+      receiptSha256: 'd'.repeat(64),
+      sourceCommit: 'b'.repeat(40),
+      effectiveRisk: 'low',
+      installedAt: T0,
+    });
+    expect(getSkillInstallation(db, 'wt-1', 'demo-skill')).toEqual(record);
+  });
+
+  it('is idempotent, so reconciliation may replay it', () => {
+    const input = {
+      worktreeId: 'wt-1',
+      receipt: makeReceipt(),
+      receiptSha256: 'd'.repeat(64),
+      operationId: 'op-1',
+      installedAt: T0,
+    };
+
+    const first = upsertSkillInstallation(db, input);
+    const second = upsertSkillInstallation(db, { ...input, installedAt: T0 + 60_000 });
+
+    expect(listSkillInstallations(db, 'wt-1')).toHaveLength(1);
+    expect(second.id).toBe(first.id);
+    // The original commit time survives a later convergence.
+    expect(second.installedAt).toBe(T0);
+    expect(second.updatedAt).toBe(T0 + 60_000);
+  });
+
+  it('keeps one row per (worktree, skill) pair', () => {
+    upsertSkillInstallation(db, {
+      worktreeId: 'wt-1',
+      receipt: makeReceipt(),
+      receiptSha256: 'd'.repeat(64),
+      operationId: 'op-1',
+      installedAt: T0,
+    });
+    upsertSkillInstallation(db, {
+      worktreeId: 'wt-2',
+      receipt: makeReceipt(),
+      receiptSha256: 'd'.repeat(64),
+      operationId: 'op-2',
+      installedAt: T0,
+    });
+    upsertSkillInstallation(db, {
+      worktreeId: 'wt-1',
+      receipt: makeReceipt({ skill_id: 'other-skill' }),
+      receiptSha256: 'e'.repeat(64),
+      operationId: 'op-3',
+      installedAt: T0,
+    });
+
+    expect(listSkillInstallations(db, 'wt-1').map((row) => row.skillId)).toEqual([
+      'demo-skill',
+      'other-skill',
+    ]);
+    expect(listSkillInstallations(db, 'wt-2')).toHaveLength(1);
+  });
+
+  it('removes only the row it was asked to remove', () => {
+    upsertSkillInstallation(db, {
+      worktreeId: 'wt-1',
+      receipt: makeReceipt(),
+      receiptSha256: 'd'.repeat(64),
+      operationId: 'op-1',
+      installedAt: T0,
+    });
+
+    expect(deleteSkillInstallation(db, 'wt-1', 'demo-skill')).toBe(true);
+    expect(deleteSkillInstallation(db, 'wt-1', 'demo-skill')).toBe(false);
+    expect(getSkillInstallation(db, 'wt-1', 'demo-skill')).toBeNull();
+  });
+});
+
+describe('writeSkillPayloadFile', () => {
+  function expectRejection(run: () => unknown, code: string): void {
+    let thrown: unknown;
+    try {
+      run();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(isSkillInstallError(thrown)).toBe(true);
+    expect((thrown as { code: string }).code).toBe(code);
+  }
+
+  it('creates the file itself and verifies mode and digest afterwards', () => {
+    const target = path.join(dir, 'payload.md');
+
+    writeSkillPayloadFile(target, Buffer.from('hello\n'), false);
+
+    expect(readFileSync(target).toString()).toBe('hello\n');
+    expect(lstatSync(target).mode & 0o777).toBe(SKILL_INSTALL_FILE_MODE);
+  });
+
+  it('adds the owner execute bit only for a declared executable', () => {
+    const target = path.join(dir, 'run.sh');
+
+    writeSkillPayloadFile(target, Buffer.from('#!/bin/sh\n'), true);
+
+    expect(lstatSync(target).mode & 0o777).toBe(SKILL_INSTALL_EXECUTABLE_MODE);
+  });
+
+  it('refuses to write over an existing file', () => {
+    const target = path.join(dir, 'payload.md');
+    writeFileSync(target, 'already here\n');
+
+    expectRejection(
+      () => writeSkillPayloadFile(target, Buffer.from('replacement\n'), false),
+      SkillInstallErrorCode.STAGING_IO
+    );
+    expect(readFileSync(target).toString()).toBe('already here\n');
+  });
+
+  it('refuses to write through a symlink instead of following it', () => {
+    const outside = path.join(dir, 'outside.txt');
+    writeFileSync(outside, 'untouched\n');
+    const target = path.join(dir, 'payload.md');
+    symlinkSync(outside, target);
+
+    expectRejection(
+      () => writeSkillPayloadFile(target, Buffer.from('payload\n'), false),
+      SkillInstallErrorCode.STAGING_IO
+    );
+    expect(readFileSync(outside).toString()).toBe('untouched\n');
+  });
+
+  it('refuses to write through a symlink that points outside the directory tree', () => {
+    const outsideDir = mkdtempSync(path.join(tmpdir(), 'cm-installed-outside-'));
+    try {
+      const outside = path.join(outsideDir, 'escape.txt');
+      writeFileSync(outside, 'untouched\n');
+      const target = path.join(dir, 'SKILL.md');
+      symlinkSync(outside, target);
+
+      expectRejection(
+        () => writeSkillPayloadFile(target, Buffer.from('payload\n'), false),
+        SkillInstallErrorCode.STAGING_IO
+      );
+      expect(readFileSync(outside).toString()).toBe('untouched\n');
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1235（Epic #1227 Phase 1 Wave 5）。#1233 の Install Plan と #1234 の operation 基盤を合流させ、検証済み plan を **preview と同一 byte 列のまま**単一 worktree へ commit する vertical slice。

## 追加

### `src/lib/skills/install-apply.ts`

- install root は「server 解決済み worktree path + `SKILL_ID_PATTERN` 再検証」から導出。**#1233 が発見した罠**（`path.join` が `..` を正規化するため `.agents/skills/../x` が包含チェックを素通りする）に対し、grammar を先に再検証してから `resolveSkillInstallRoot()` へ委譲する
- payload write は `O_CREAT|O_EXCL|O_NOFOLLOW` + write 後の mode/nlink/size/digest 再確認。**symlink や既存 file を「通り抜けて」書くことが表現不能**
- staging は destination と同一 filesystem の `.agents/skills/.commandmate-staging/<opaque-operation-id>/`（#1234 の予約 namespace）。既存 staging dir は adopt せず拒否。commit 直前に staging と destination parent の `dev` 一致を assert
- rename 直前に ancestor の lstat 連鎖と worktree realpath identity を再確認し、**destination 不存在を証明してから** rename。**`rename(2)` は空 directory を黙って置換する**ため、「存在しないこと」を syscall に委ねず自前で証明する
- receipt は **plan が固定した bytes をそのまま書く**（apply 側で再構築しない）
- staged tree を disk から読み直して tree hash を再計算し、`binding.plannedTreeHash` と一致しなければ publish しない
- **script/hook は一切実行しない。** mode は archive header ではなく突合済み inventory の executable bit のみから決める

### `installed-state.ts` + migration v45 `skill_installations`

(worktree, skill) 一意の index。commit 後に書くため upsert は idempotent で、reconciliation が何度 replay しても `installed_at` は初回値を保つ。

### `POST /api/worktrees/[id]/skills/[skillId]/install`

journal open → lock 取得 → branch/HEAD/destination tree 再読込 → token 消費 → stage/verify/rename → index/audit の順。**token 消費前の失敗は「未変更」、rename 後の失敗は `committed_reconciling`（state=FAILED_RECONCILABLE, committed=true, reconcilePending=true）として返し、rollback とは言わない。** artifact は #1229 snapshot からのみ読む（network 再取得なし）。

## Mutation run（ガードを意図的に壊して該当 test が落ちることを確認）

| 壊した guard | 結果 |
| --- | --- |
| `O_EXCL\|O_NOFOLLOW` を write flag から除去 | 3 failed（既存 file 上書き / symlink 追従 2 件） |
| `O_EXCL` のみ除去（`O_NOFOLLOW` 維持） | 1 failed（既存 file 上書きのみ。symlink は `O_NOFOLLOW` が阻止） |
| destination 不存在チェック 2 箇所を無効化 | 4 failed。うち**「空 directory」ケースは例外すら出ず rename が黙って置換した** |
| planned tree hash 比較を除去 | 1 failed |
| ancestor lstat / realpath identity 確認を除去 | 2 failed |
| index 失敗を rethrow（未変更として 500 を返す） | 1 failed（200 committed_reconciling を期待） |
| plan token の single-use 判定を除去（#1233 側） | 1 failed（2 回目 apply が `SKILL_PLAN_CONSUMED` にならない） |

## Issue 記載との差分

Issue 本文は書き換えていない。

- Issue は「actor …を apply 直前に再検証する」とするが、**CommandMate の認証は共有 token 単一のため channel 区別 + `id: null` までしか実現できない**。per-user identity の検証は未実装（#1233 の方針を踏襲）
- Issue の「skill_installations index を更新する」に対し、既存 migration に該当 table が無かったため **v45 を新設**（`CURRENT_SCHEMA_VERSION` 44→45）
- Issue Non-goals が update/rollback を除外しているため、**destination に既存 install がある場合は暗黙 update せず 409 で拒否**（managed=`SKILL_INSTALL_DESTINATION_EXISTS` / unmanaged=`SKILL_INSTALL_DESTINATION_UNMANAGED` で UX-07 の区別に対応）

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run test:unit` / `build` | worker 側 exit 0 |

Refs #1235, #1227