### PR TITLE
feat(skills): 安全なuninstallとunmanaged・local change保護 (#1236)

### DIFF
--- a/locales/en/skills.json
+++ b/locales/en/skills.json
@@ -146,6 +146,33 @@
       "failed": "Nothing was written to the worktree. Review the reason and build a new install plan."
     }
   },
+  "uninstall": {
+    "reason": {
+      "managedUnchanged": "Installed by CommandMate and unchanged since, so it can be removed safely.",
+      "localModification": "This file has been edited since it was installed. CommandMate will not delete your changes.",
+      "receiptOrphan": "The install record lists this file but it is no longer in the worktree, so what is on disk is no longer the installation CommandMate recorded.",
+      "unmanagedFile": "This file is inside the Skill directory but was not installed by CommandMate, so it is not CommandMate's to delete.",
+      "notARegularFile": "This path is a symbolic link or another non-regular entry. CommandMate will not follow it to decide what to delete.",
+      "notInstalled": "No CommandMate-managed installation of this Skill exists in this worktree.",
+      "receiptMissing": "The Skill directory has no CommandMate install record, so nothing proves which files belong to the Skill.",
+      "receiptUnreadable": "The install record could not be read, so file ownership cannot be established.",
+      "receiptForeign": "The install record in this directory describes a different Skill.",
+      "treeScanTruncated": "The Skill directory is too large or too deep to inspect completely, so CommandMate cannot rule out files it does not own."
+    },
+    "nextAction": {
+      "removable": "Every file in this directory was installed by CommandMate and is unchanged. Confirm to remove them.",
+      "blocked": "Nothing has been deleted. Move or restore the files listed below, then build a new uninstall plan.",
+      "succeeded": "The Skill was removed and its record cleared. Restart the agent sessions listed below so they stop offering it.",
+      "committedReconciling": "Files were already being removed when the operation stopped. The install record is still in place for diagnosis; CommandMate will finish automatically.",
+      "failed": "Nothing was deleted from the worktree. Review the reason and build a new uninstall plan."
+    },
+    "reload": {
+      "native": "{agent} loads Skills from the worktree at startup. Restart the {agent} session in this worktree so it stops offering {skillId}.",
+      "commandmateRuntime": "{agent} ran this Skill through the CommandMate runtime. Restart the {agent} session in this worktree so the runtime drops {skillId}.",
+      "unsupported": "{agent} did not support this Skill, so removing {skillId} changes nothing for {agent} sessions.",
+      "unknown": "Support for {agent} was never verified. The files are removed; restart the {agent} session if {skillId} is still offered."
+    }
+  },
   "card": {
     "provider": "by {provider}",
     "noRecommendedVersion": "No installable version"

--- a/locales/ja/skills.json
+++ b/locales/ja/skills.json
@@ -146,6 +146,33 @@
       "failed": "worktreeへの書き込みは行われていません。理由を確認し、新しいInstall Planを作成してください。"
     }
   },
+  "uninstall": {
+    "reason": {
+      "managedUnchanged": "CommandMateが配置し、その後変更されていないため安全に削除できます。",
+      "localModification": "インストール後に編集されています。CommandMateは変更内容を削除しません。",
+      "receiptOrphan": "インストール記録に載っているファイルがworktreeに存在しません。ディスク上の状態は記録されたインストールと一致していません。",
+      "unmanagedFile": "Skillディレクトリ内にありますが、CommandMateが配置したファイルではないため削除対象にしません。",
+      "notARegularFile": "このパスはシンボリックリンクなど通常ファイル以外です。CommandMateは削除対象の判定でリンクをたどりません。",
+      "notInstalled": "このworktreeにはCommandMate管理下のインストールがありません。",
+      "receiptMissing": "SkillディレクトリにCommandMateのインストール記録がないため、どのファイルがSkillのものか証明できません。",
+      "receiptUnreadable": "インストール記録を読み取れないため、ファイルの所有関係を確定できません。",
+      "receiptForeign": "このディレクトリのインストール記録は別のSkillを指しています。",
+      "treeScanTruncated": "Skillディレクトリが大きすぎるか深すぎて完全に検査できないため、管理外ファイルがないと確認できません。"
+    },
+    "nextAction": {
+      "removable": "このディレクトリのファイルはすべてCommandMateが配置し、変更されていません。確認のうえ削除してください。",
+      "blocked": "何も削除していません。以下のファイルを退避または復元してから、新しいUninstall Planを作成してください。",
+      "succeeded": "Skillを削除し、記録を消去しました。以下のagentセッションを再起動すると提示されなくなります。",
+      "committedReconciling": "削除の途中で処理が停止しました。診断のためインストール記録は残しています。CommandMateが自動的に完了させます。",
+      "failed": "worktreeからは何も削除していません。理由を確認し、新しいUninstall Planを作成してください。"
+    },
+    "reload": {
+      "native": "{agent} は起動時にworktreeからSkillを読み込みます。{skillId} が提示されなくなるよう、このworktreeの {agent} セッションを再起動してください。",
+      "commandmateRuntime": "{agent} はCommandMate runtime経由でこのSkillを実行していました。runtimeが {skillId} を解放するよう、このworktreeの {agent} セッションを再起動してください。",
+      "unsupported": "{agent} はこのSkillに対応していなかったため、{skillId} の削除による {agent} セッションへの影響はありません。",
+      "unknown": "{agent} での対応状況は未検証でした。ファイルは削除済みです。{skillId} がまだ提示される場合は {agent} セッションを再起動してください。"
+    }
+  },
   "card": {
     "provider": "提供元: {provider}",
     "noRecommendedVersion": "導入可能なversionなし"

--- a/src/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route.ts
@@ -1,0 +1,151 @@
+/**
+ * POST /api/worktrees/[id]/skills/[skillId]/uninstall-plan — preview a removal (Issue #1236)
+ *
+ * The request names *what* to uninstall and nothing else. The worktree ID is
+ * resolved against the database to a trusted path and the install root is
+ * derived from it, so — exactly as in #1233 — a body carrying a filesystem path
+ * or a file list is rejected outright rather than ignored.
+ *
+ * A blocked plan is still a plan. The user asked to remove a Skill and is
+ * entitled to see *which* file stops that from being safe: a locally edited
+ * SKILL.md, a note they left in the directory, a symlink that appeared. Apply
+ * (see the sibling `uninstall` route) refuses to spend such a token, so the
+ * preview can never turn into a delete by accident.
+ *
+ * @module api/worktrees/[id]/skills/[skillId]/uninstall-plan
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createLogger } from '@/lib/logger';
+import { resolveWorktreeOr404 } from '@/lib/git/git-route-worktree';
+import { validateSkillId } from '@/lib/skills/schema';
+import { isSkillPlanError, type SkillPlanActor } from '@/lib/skills/install-plan';
+import { readSkillGitTargetState } from '@/lib/skills/preview-diff';
+import {
+  createSkillUninstallPlan,
+  type SkillUninstallPlanDto,
+} from '@/lib/skills/uninstall-plan';
+import {
+  isSkillUninstallError,
+  resolveSkillUninstallTarget,
+} from '@/lib/skills/uninstall-apply';
+import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
+
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/worktrees/[id]/skills/[skillId]/uninstall-plan');
+
+export interface SkillUninstallPlanResponse {
+  plan: SkillUninstallPlanDto;
+}
+
+/** Fields a client must never be able to supply. Mirrors the install plan route. */
+const REJECTED_BODY_KEYS = [
+  'path',
+  'paths',
+  'worktreePath',
+  'repositoryPath',
+  'installRoot',
+  'targetPath',
+  'files',
+  'checksum',
+  'sha256',
+  'receipt',
+  'receiptDigest',
+  /** There is no force in the MVP; naming it explicitly beats ignoring it. */
+  'force',
+] as const;
+
+/**
+ * Actor identity available to a single-token deployment.
+ *
+ * CommandMate authenticates one shared token, so there is no per-user id to
+ * bind. The channel is still distinguished, because a plan issued to the browser
+ * must not be spendable by a CLI run and vice versa.
+ */
+function resolveActor(request: NextRequest): SkillPlanActor {
+  return { type: request.headers.get('authorization') ? 'cli' : 'user', id: null };
+}
+
+async function rejectUnsupportedBody(request: NextRequest): Promise<NextResponse | null> {
+  let raw: unknown = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) raw = JSON.parse(text);
+  } catch {
+    return skillApiError('SKILL_UNINSTALL_INVALID_BODY', 'Malformed JSON body.', 400);
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return skillApiError('SKILL_UNINSTALL_INVALID_BODY', 'Body must be a JSON object.', 400);
+  }
+  const keys = Object.keys(raw as Record<string, unknown>);
+  if (keys.some((key) => (REJECTED_BODY_KEYS as readonly string[]).includes(key))) {
+    return skillApiError(
+      'SKILL_PLAN_INPUT_REJECTED',
+      'The uninstall target is resolved by the server and cannot be supplied by the client.',
+      400
+    );
+  }
+  // The plan takes no parameters at all: what to remove is fully determined by
+  // the route, so any other field is a misunderstanding worth reporting.
+  if (keys.length > 0) {
+    return skillApiError('SKILL_UNINSTALL_INVALID_BODY', 'Unknown field in body.', 400);
+  }
+  return null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; skillId: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id, skillId } = await params;
+
+    const worktree = resolveWorktreeOr404(id);
+    if (worktree instanceof NextResponse) return worktree;
+
+    const idResult = validateSkillId(skillId);
+    if (!idResult.ok) return skillApiError(idResult.errors[0].code, 'Invalid Skill ID.', 400);
+
+    const rejected = await rejectUnsupportedBody(request);
+    if (rejected) return rejected;
+
+    const installRootAbs = resolveSkillUninstallTarget(worktree.path, idResult.value);
+    const git = await readSkillGitTargetState(worktree.path);
+
+    const record = createSkillUninstallPlan({
+      actor: resolveActor(request),
+      worktree: {
+        id: worktree.id,
+        name: worktree.name,
+        path: worktree.path,
+        repositoryName: worktree.repositoryDisplayName ?? worktree.repositoryName,
+      },
+      skillId: idResult.value,
+      installRootAbs,
+      git,
+    });
+
+    return NextResponse.json({ plan: record.dto }, { headers: SKILL_API_NO_STORE_HEADERS });
+  } catch (error) {
+    if (isSkillUninstallError(error)) {
+      return skillApiError(error.code, 'The uninstall target was rejected.', error.status);
+    }
+    if (isSkillPlanError(error)) {
+      return skillApiError(
+        error.code === 'SKILL_PLAN_NOT_FOUND' ? 'SKILL_UNINSTALL_NOT_INSTALLED' : error.code,
+        'No installed Skill was found to uninstall.',
+        error.code === 'SKILL_PLAN_NOT_FOUND' ? 404 : error.status
+      );
+    }
+    logger.error('skill-uninstall-plan-failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return skillApiError(
+      'SKILL_UNINSTALL_PLAN_INTERNAL_ERROR',
+      'Failed to build the uninstall plan.',
+      500
+    );
+  }
+}

--- a/src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts
@@ -1,0 +1,576 @@
+/**
+ * POST /api/worktrees/[id]/skills/[skillId]/uninstall — apply an Uninstall Plan (Issue #1236)
+ *
+ * The mirror of #1235's install route, with the order of operations kept
+ * deliberately identical so the two are auditable side by side:
+ *
+ * 1. open the journal entry, so a crash at any later point is recoverable;
+ * 2. take the exclusive (worktree, skill) lock (#1234);
+ * 3. re-read branch, HEAD, the receipt digest and the destination tree, and
+ *    spend the token only if they still match what the user approved —
+ *    otherwise `SKILL_PLAN_STALE`;
+ * 4. re-assess the install root and delete only provably managed, unchanged
+ *    files, receipt last;
+ * 5. drop the index row and audit.
+ *
+ * Where install and uninstall differ is the commit point. Install has an atomic
+ * rename to hang it on; a delete does not, so step 4 reports its own commit
+ * point through a callback, immediately before the first `unlink`. Everything
+ * before it leaves the worktree untouched and is answered as "nothing happened".
+ * Everything after it is answered as *committed, reconciling* — the payload is
+ * partly gone and the user can see that.
+ *
+ * The refusal path matters as much as the success path: if a single file is
+ * modified, unknown, missing or irregular, this route deletes nothing at all and
+ * says which path stopped it (UX-07).
+ *
+ * @module api/worktrees/[id]/skills/[skillId]/uninstall
+ */
+
+import { realpathSync } from 'fs';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createLogger } from '@/lib/logger';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { resolveWorktreeOr404 } from '@/lib/git/git-route-worktree';
+import { validateSkillId } from '@/lib/skills/schema';
+import { isSkillPlanError, type SkillPlanActor } from '@/lib/skills/install-plan';
+import {
+  computeSkillTreeHash,
+  readExistingSkillTree,
+  readSkillGitTargetState,
+} from '@/lib/skills/preview-diff';
+import {
+  acquireSkillOperationLock,
+  buildSkillOperationLockKey,
+  releaseSkillOperationLock,
+} from '@/lib/skills/operation-lock';
+import {
+  beginSkillOperation,
+  deleteSkillOperationJournal,
+  hasSkillFilesystemCommit,
+  readSkillOperationJournal,
+  transitionSkillOperation,
+  type SkillOperationJournalEntry,
+} from '@/lib/skills/operation-journal';
+import {
+  buildSkillOperationAuditInput,
+  recordSkillOperationAudit,
+} from '@/lib/skills/operation-audit';
+import { redactSkillOperationText } from '@/lib/skills/operation-store';
+import {
+  SKILL_UNINSTALL_NEXT_ACTION_KEYS,
+  SKILL_UNINSTALL_RELOAD_MESSAGE_KEYS,
+  consumeSkillUninstallPlan,
+  getSkillUninstallPlan,
+  readSkillReceiptDigest,
+  type SkillUninstallBlocker,
+} from '@/lib/skills/uninstall-plan';
+import {
+  applySkillUninstall,
+  isSkillUninstallError,
+  resolveSkillUninstallTarget,
+  type SkillUninstallRemovedFile,
+  type SkillUninstallRetainedPath,
+} from '@/lib/skills/uninstall-apply';
+import { deleteSkillInstallation } from '@/lib/skills/installed-state';
+import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
+import type { SkillAgentSupport } from '@/types/skills';
+
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/worktrees/[id]/skills/[skillId]/uninstall');
+
+// =============================================================================
+// Wire shape
+// =============================================================================
+
+/** How the operation ended, from the caller's point of view. */
+export type SkillUninstallResult = 'succeeded' | 'committed_reconciling';
+
+/** Journal state of the operation, plus what the user should do about it. */
+export interface SkillUninstallOperationDto {
+  operationId: string;
+  idempotencyKey: string;
+  state: SkillOperationJournalEntry['state'];
+  result: SkillUninstallResult;
+  /** Files were already being removed when the operation ended. */
+  committed: boolean;
+  reconcilePending: boolean;
+  nextActionKey: string;
+  /** True when this response replays an earlier identical request. */
+  replayed: boolean;
+}
+
+/** What was removed, described without a machine-absolute path. */
+export interface SkillUninstallPayloadDto {
+  skillId: string;
+  version: string;
+  installRoot: string;
+  removedFiles: SkillUninstallRemovedFile[];
+  removedDirectories: string[];
+  /** Anything still on disk, with the reason it stayed (UX-07). */
+  retained: SkillUninstallRetainedPath[];
+  receiptRemoved: boolean;
+  fullyRemoved: boolean;
+}
+
+/** How to stop using the Skill that was just removed. */
+export interface SkillUninstallReloadGuidance {
+  skillId: string;
+  version: string;
+  installRoot: string;
+  agents: Array<{ agent: string; support: SkillAgentSupport; messageKey: string }>;
+}
+
+export interface SkillUninstallResponse {
+  operation: SkillUninstallOperationDto;
+  uninstall: SkillUninstallPayloadDto;
+  reload: SkillUninstallReloadGuidance;
+}
+
+/** Answer to a retried request. Narrower: the index row is already gone. */
+export interface SkillUninstallReplayResponse {
+  operation: SkillUninstallOperationDto;
+  uninstall: { skillId: string; version: string | null } | null;
+}
+
+/** Body of a refusal that names the paths responsible. */
+export interface SkillUninstallBlockedResponse {
+  error: string;
+  code: string;
+  nextActionKey: string;
+  blockers: SkillUninstallBlocker[];
+}
+
+// =============================================================================
+// Body
+// =============================================================================
+
+/**
+ * Fields a client must never be able to supply.
+ *
+ * `force` is listed rather than merely absent: the MVP has no force delete
+ * (Non-goal), and a caller who tries one deserves to be told so instead of
+ * having the flag silently dropped and concluding it worked.
+ */
+const REJECTED_BODY_KEYS = [
+  'path',
+  'paths',
+  'worktreePath',
+  'repositoryPath',
+  'installRoot',
+  'targetPath',
+  'files',
+  'checksum',
+  'sha256',
+  'receipt',
+  'receiptDigest',
+  'force',
+  'recursive',
+] as const;
+
+const ALLOWED_BODY_KEYS = ['planToken', 'idempotencyKey'] as const;
+
+/** Bound on a client-supplied idempotency key, which is hashed before it names a file. */
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._:-]{8,128}$/;
+
+/** Token grammar, checked before the plan store is consulted. */
+const PLAN_TOKEN_PATTERN = /^[0-9a-f]{48}$/;
+
+interface UninstallRequestBody {
+  planToken: string;
+  idempotencyKey: string | null;
+}
+
+type BodyResult = { ok: true; body: UninstallRequestBody } | { ok: false; response: NextResponse };
+
+function invalidBody(message: string): { ok: false; response: NextResponse } {
+  return { ok: false, response: skillApiError('SKILL_UNINSTALL_INVALID_BODY', message, 400) };
+}
+
+async function readBody(request: NextRequest): Promise<BodyResult> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await request.text());
+  } catch {
+    return invalidBody('Malformed JSON body.');
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return invalidBody('Body must be a JSON object.');
+  }
+
+  const record = raw as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if ((REJECTED_BODY_KEYS as readonly string[]).includes(key)) {
+      return {
+        ok: false,
+        response: skillApiError(
+          'SKILL_PLAN_INPUT_REJECTED',
+          'The uninstall target is resolved by the server and cannot be supplied by the client.',
+          400
+        ),
+      };
+    }
+    if (!(ALLOWED_BODY_KEYS as readonly string[]).includes(key)) {
+      return invalidBody('Unknown field in body.');
+    }
+  }
+
+  const { planToken, idempotencyKey } = record;
+  if (typeof planToken !== 'string' || !PLAN_TOKEN_PATTERN.test(planToken)) {
+    return invalidBody(
+      'Field `planToken` must be a plan token issued by the uninstall-plan endpoint.'
+    );
+  }
+  if (
+    idempotencyKey !== undefined &&
+    (typeof idempotencyKey !== 'string' || !IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey))
+  ) {
+    return invalidBody('Field `idempotencyKey` has an unsupported format.');
+  }
+
+  return {
+    ok: true,
+    body: {
+      planToken,
+      idempotencyKey: typeof idempotencyKey === 'string' ? idempotencyKey : null,
+    },
+  };
+}
+
+function resolveActor(request: NextRequest): SkillPlanActor {
+  return { type: request.headers.get('authorization') ? 'cli' : 'user', id: null };
+}
+
+// =============================================================================
+// Response assembly
+// =============================================================================
+
+function describeOperation(
+  entry: SkillOperationJournalEntry,
+  options: { replayed: boolean }
+): SkillUninstallOperationDto {
+  const succeeded = entry.state === 'SUCCEEDED';
+  return {
+    operationId: entry.operationId,
+    idempotencyKey: entry.idempotencyKey,
+    state: entry.state,
+    result: succeeded ? 'succeeded' : 'committed_reconciling',
+    committed: hasSkillFilesystemCommit(entry),
+    reconcilePending: !succeeded,
+    nextActionKey: succeeded
+      ? SKILL_UNINSTALL_NEXT_ACTION_KEYS.succeeded
+      : SKILL_UNINSTALL_NEXT_ACTION_KEYS.committedReconciling,
+    replayed: options.replayed,
+  };
+}
+
+/** A refusal that carries the offending paths, so the UI can explain them. */
+function blockedResponse(
+  code: string,
+  message: string,
+  status: number,
+  blockers: readonly SkillUninstallBlocker[]
+): NextResponse<SkillUninstallBlockedResponse> {
+  return NextResponse.json(
+    {
+      error: message,
+      code,
+      nextActionKey: SKILL_UNINSTALL_NEXT_ACTION_KEYS.blocked,
+      blockers: [...blockers],
+    },
+    { status, headers: SKILL_API_NO_STORE_HEADERS }
+  );
+}
+
+// =============================================================================
+// Route
+// =============================================================================
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; skillId: string }> }
+): Promise<NextResponse> {
+  let lock: ReturnType<typeof acquireSkillOperationLock> | null = null;
+
+  try {
+    const { id, skillId } = await params;
+
+    const worktree = resolveWorktreeOr404(id);
+    if (worktree instanceof NextResponse) return worktree;
+
+    const idResult = validateSkillId(skillId);
+    if (!idResult.ok) return skillApiError(idResult.errors[0].code, 'Invalid Skill ID.', 400);
+
+    const parsed = await readBody(request);
+    if (!parsed.ok) return parsed.response;
+
+    const actor = resolveActor(request);
+
+    // A retried request must be answered from its recorded outcome, not by
+    // spending a token that is already gone.
+    if (parsed.body.idempotencyKey !== null) {
+      const replay = readSkillOperationJournal(parsed.body.idempotencyKey);
+      if (replay !== null) return answerReplay(replay, worktree.id, idResult.value);
+    }
+
+    let worktreeRealPath: string;
+    try {
+      worktreeRealPath = realpathSync(worktree.path);
+    } catch {
+      return skillApiError(
+        'SKILL_UNINSTALL_TARGET_UNSAFE',
+        'The registered worktree path could not be resolved.',
+        409
+      );
+    }
+
+    // Peeking does not spend the token; the plan is only consumed once the lock
+    // is held and the live target has been re-read.
+    const plan = getSkillUninstallPlan(parsed.body.planToken);
+    // A blocked plan is refused before any operation is opened, and without
+    // spending the token: the user has to resolve the named paths and re-plan,
+    // and burning the token would only cost them the preview they are reading.
+    if (!plan.dto.removable) {
+      return blockedResponse(
+        'SKILL_UNINSTALL_BLOCKED',
+        'The uninstall was refused; nothing was deleted.',
+        409,
+        plan.dto.blockers
+      );
+    }
+
+    const lockKey = buildSkillOperationLockKey(worktreeRealPath, idResult.value);
+    const begun = beginSkillOperation({
+      idempotencyKey: parsed.body.idempotencyKey ?? undefined,
+      binding: {
+        actor,
+        operation: 'uninstall',
+        target: {
+          worktreeId: worktree.id,
+          skillId: idResult.value,
+          // The version comes from the receipt, not from the request: binding
+          // the key to it is what makes a replay provably about *this* install.
+          version: plan.binding.version,
+        },
+        planHash: plan.bindingHash,
+      },
+      lockKey,
+      source: {
+        origin: 'github-release',
+        repository: plan.receipt.source.repository,
+        ref: plan.receipt.source.ref,
+        commit: plan.receipt.source.commit,
+        artifactSha256: plan.receipt.artifact.sha256,
+      },
+    });
+    if (!begun.ok) {
+      return skillApiError(
+        'SKILL_UNINSTALL_IDEMPOTENCY_CONFLICT',
+        'This idempotency key was already used for a different request.',
+        409
+      );
+    }
+    if (begun.replayed) return answerReplay(begun.entry, worktree.id, idResult.value);
+
+    let entry = begun.entry;
+    lock = acquireSkillOperationLock({ key: lockKey, operationId: entry.operationId });
+    if (!lock.ok) {
+      // Nothing was attempted, so the key must stay reusable.
+      deleteSkillOperationJournal(entry.idempotencyKey);
+      lock = null;
+      return skillApiError(
+        'SKILL_UNINSTALL_LOCKED',
+        'Another operation is already running for this Skill and worktree.',
+        409
+      );
+    }
+
+    const installRootAbs = resolveSkillUninstallTarget(worktree.path, idResult.value);
+    const git = await readSkillGitTargetState(worktree.path);
+    const existing = readExistingSkillTree(installRootAbs);
+
+    let consumed;
+    try {
+      consumed = consumeSkillUninstallPlan(
+        parsed.body.planToken,
+        { actor, worktreeId: worktree.id, skillId: idResult.value },
+        {
+          branch: git.branch,
+          headCommit: git.headCommit,
+          currentTreeHash: computeSkillTreeHash(existing.files),
+          receiptDigest: readSkillReceiptDigest(existing),
+        }
+      );
+    } catch (error) {
+      deleteSkillOperationJournal(entry.idempotencyKey);
+      throw error;
+    }
+
+    let committed = false;
+    let result;
+    try {
+      result = applySkillUninstall({
+        worktreePath: worktree.path,
+        worktreeRealPath,
+        skillId: idResult.value,
+        expectedReceiptDigest: consumed.binding.receiptDigest,
+        expectedTreeHash: consumed.binding.currentTreeHash,
+        onCommitPoint: () => {
+          committed = true;
+          entry = transitionSkillOperation(entry, 'FS_COMMITTED', {
+            receiptDigest: consumed.binding.receiptDigest,
+          });
+        },
+      });
+    } catch (error) {
+      entry = transitionSkillOperation(entry, 'FAILED_RECONCILABLE', {
+        error: { code: errorCodeOf(error), message: messageOf(error) },
+      });
+      recordAuditSafely(entry, 'failed');
+      if (!committed) throw error;
+
+      // Deletion had already begun, so the receipt and the surviving files are
+      // the diagnostic record; reconciliation converges from there.
+      logger.error('skill-uninstall-partial', {
+        operationId: entry.operationId,
+        error: redactSkillOperationText(messageOf(error)),
+      });
+      throw error;
+    }
+
+    try {
+      deleteSkillInstallation(getDbInstance(), worktree.id, idResult.value);
+      entry = transitionSkillOperation(entry, 'INDEXED');
+      entry = transitionSkillOperation(entry, 'SUCCEEDED', { error: null });
+      recordAuditSafely(entry, 'succeeded');
+    } catch (error) {
+      // The files are gone. Reporting this as a failed uninstall would
+      // contradict what the user can see on disk.
+      entry = transitionSkillOperation(entry, 'FAILED_RECONCILABLE', {
+        error: { code: 'SKILL_UNINSTALL_INDEX_FAILED', message: messageOf(error) },
+      });
+      recordAuditSafely(entry, 'failed');
+      logger.error('skill-uninstall-index-failed', {
+        operationId: entry.operationId,
+        error: redactSkillOperationText(messageOf(error)),
+      });
+    }
+
+    const response: SkillUninstallResponse = {
+      operation: describeOperation(entry, { replayed: false }),
+      uninstall: {
+        skillId: idResult.value,
+        version: result.version,
+        installRoot: result.installRoot,
+        removedFiles: result.removedFiles,
+        removedDirectories: result.removedDirectories,
+        retained: result.retained,
+        receiptRemoved: result.receiptRemoved,
+        fullyRemoved: result.fullyRemoved,
+      },
+      reload: {
+        skillId: idResult.value,
+        version: result.version,
+        installRoot: result.installRoot,
+        agents: consumed.receipt.agent_compatibility.map((agent) => ({
+          agent: agent.agent,
+          support: agent.support,
+          messageKey: SKILL_UNINSTALL_RELOAD_MESSAGE_KEYS[agent.support],
+        })),
+      },
+    };
+    return NextResponse.json(response, { headers: SKILL_API_NO_STORE_HEADERS });
+  } catch (error) {
+    if (isSkillUninstallError(error)) {
+      // A 5xx is the only case where deletion may already have started, so it
+      // is the only one that must not claim the worktree is untouched.
+      return blockedResponse(
+        error.code,
+        error.status >= 500
+          ? 'The uninstall did not complete. The receipt and the remaining files are still in place.'
+          : 'The uninstall was refused; nothing was deleted.',
+        error.status,
+        error.blockers
+      );
+    }
+    if (isSkillPlanError(error)) {
+      return skillApiError(error.code, 'The uninstall plan was rejected.', error.status);
+    }
+    logger.error('skill-uninstall-failed', {
+      error: redactSkillOperationText(messageOf(error)),
+    });
+    return skillApiError('SKILL_UNINSTALL_INTERNAL_ERROR', 'Failed to apply the uninstall.', 500);
+  } finally {
+    if (lock?.ok) releaseSkillOperationLock(lock.lock);
+  }
+}
+
+// =============================================================================
+// Replay
+// =============================================================================
+
+/**
+ * Answer from a journal entry an earlier request already produced.
+ *
+ * A replay is only honoured for the same target: the same key naming a
+ * different worktree or Skill is a conflict, never a substitution of someone
+ * else's uninstall.
+ */
+function answerReplay(
+  entry: SkillOperationJournalEntry,
+  worktreeId: string,
+  skillId: string
+): NextResponse {
+  if (entry.target.worktreeId !== worktreeId || entry.target.skillId !== skillId) {
+    return skillApiError(
+      'SKILL_UNINSTALL_IDEMPOTENCY_CONFLICT',
+      'This idempotency key was already used for a different request.',
+      409
+    );
+  }
+  if (!hasSkillFilesystemCommit(entry)) {
+    return skillApiError(
+      entry.state === 'PREPARING' ? 'SKILL_UNINSTALL_IN_PROGRESS' : 'SKILL_UNINSTALL_FAILED',
+      entry.state === 'PREPARING'
+        ? 'The operation for this idempotency key is still running.'
+        : 'The operation for this idempotency key did not remove anything.',
+      409
+    );
+  }
+
+  const response: SkillUninstallReplayResponse = {
+    operation: describeOperation(entry, { replayed: true }),
+    uninstall: { skillId, version: entry.target.version },
+  };
+  return NextResponse.json(response, { headers: SKILL_API_NO_STORE_HEADERS });
+}
+
+// =============================================================================
+// Error helpers
+// =============================================================================
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCodeOf(error: unknown): string {
+  if (isSkillUninstallError(error) || isSkillPlanError(error)) return error.code;
+  return 'SKILL_UNINSTALL_INTERNAL_ERROR';
+}
+
+/** Audit failures must not mask the outcome they are describing. */
+function recordAuditSafely(
+  entry: SkillOperationJournalEntry,
+  outcome: 'succeeded' | 'failed'
+): void {
+  try {
+    recordSkillOperationAudit(getDbInstance(), buildSkillOperationAuditInput(entry, outcome));
+  } catch (error) {
+    logger.warn('skill-uninstall-audit-failed', {
+      operationId: entry.operationId,
+      error: redactSkillOperationText(messageOf(error)),
+    });
+  }
+}

--- a/src/lib/skills/uninstall-apply.ts
+++ b/src/lib/skills/uninstall-apply.ts
@@ -1,0 +1,531 @@
+/**
+ * Deleting exactly the files CommandMate wrote, and nothing else (Issue #1236)
+ *
+ * The delete half of the plan/apply pair, and the only module in the codebase
+ * that removes Skill payload from a repository. #1235's install could rely on a
+ * single atomic rename for its safety argument; deletion has no such primitive,
+ * so the argument here is built from four rules instead:
+ *
+ * - **Zero-delete on ambiguity.** The whole install root is re-assessed before
+ *   the first `unlink`. One modified, unknown, missing or irregular path and the
+ *   operation stops having deleted nothing. There is no partial uninstall —
+ *   "removed seven of eight files" is a corrupted Skill reported as a success.
+ * - **The destination is derived, never received.** The install root comes from
+ *   the server-resolved worktree path plus a Skill ID re-checked against
+ *   {@link SKILL_ID_PATTERN}, using #1233's resolver — the same derivation
+ *   install uses, because a delete that resolved its target differently from the
+ *   write that created it would eventually resolve it somewhere else entirely.
+ * - **Nothing is followed.** Every path component from the install root down is
+ *   `lstat`ed immediately before the file it leads to is unlinked, so a symlink
+ *   swapped in after the scan is refused rather than traversed. `unlink` itself
+ *   never follows its final component, so the directory chain is the exposure.
+ * - **Directories go only when empty.** `rmdir(2)` is used, never a recursive
+ *   remove, and only on directories the receipt's own file list implies. An
+ *   empty directory the user made is not ours to collect.
+ *
+ * The receipt is deleted **last**. Until it is gone the directory still explains
+ * itself: a crash mid-delete leaves a worktree that #1234 reconciliation — and a
+ * human reading `.commandmate-receipt.json` — can still make sense of.
+ *
+ * @module lib/skills/uninstall-apply
+ */
+
+import { lstatSync, readFileSync, readdirSync, realpathSync, rmdirSync, unlinkSync } from 'fs';
+import path from 'path';
+import {
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+  SKILL_INSTALL_ROOT_PREFIX,
+} from '@/lib/skills/constants';
+import { computeSha256Hex, digestMatches } from '@/lib/skills/integrity';
+import { SKILL_RECEIPT_FILENAME } from '@/lib/skills/install-plan';
+import { readExistingSkillTree, resolveSkillInstallRoot } from '@/lib/skills/preview-diff';
+import {
+  assessSkillUninstall,
+  type SkillUninstallAssessment,
+  type SkillUninstallBlocker,
+} from '@/lib/skills/uninstall-plan';
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+/** Client-safe reasons an uninstall refused to delete or could not finish. */
+export const SkillUninstallErrorCode = {
+  /** The install root could not be derived safely from the worktree and Skill ID. */
+  TARGET_UNSAFE: 'SKILL_UNINSTALL_TARGET_UNSAFE',
+  /** An ancestor of the install root is a symlink or is not a directory. */
+  ANCESTOR_UNSAFE: 'SKILL_UNINSTALL_ANCESTOR_UNSAFE',
+  /** There is nothing to uninstall at the target. */
+  NOT_INSTALLED: 'SKILL_UNINSTALL_NOT_INSTALLED',
+  /** At least one path is not provably managed and unchanged. Nothing was deleted. */
+  BLOCKED: 'SKILL_UNINSTALL_BLOCKED',
+  /** The install root changed between the plan and this apply. Nothing was deleted. */
+  DRIFT: 'SKILL_UNINSTALL_DRIFT',
+  /** A file changed between the re-assessment and its own delete. */
+  FILE_CHANGED: 'SKILL_UNINSTALL_FILE_CHANGED',
+  /** A path or one of its ancestors is not what it was when it was scanned. */
+  PATH_UNSAFE: 'SKILL_UNINSTALL_PATH_UNSAFE',
+  /** The delete syscall itself failed. */
+  DELETE_FAILED: 'SKILL_UNINSTALL_DELETE_FAILED',
+} as const;
+
+export type SkillUninstallErrorCodeType =
+  (typeof SkillUninstallErrorCode)[keyof typeof SkillUninstallErrorCode];
+
+/** HTTP status each reason maps to, so every caller answers alike. */
+export const SKILL_UNINSTALL_ERROR_STATUS: Record<SkillUninstallErrorCodeType, number> = {
+  [SkillUninstallErrorCode.TARGET_UNSAFE]: 400,
+  [SkillUninstallErrorCode.ANCESTOR_UNSAFE]: 409,
+  [SkillUninstallErrorCode.NOT_INSTALLED]: 404,
+  [SkillUninstallErrorCode.BLOCKED]: 409,
+  [SkillUninstallErrorCode.DRIFT]: 409,
+  [SkillUninstallErrorCode.FILE_CHANGED]: 409,
+  [SkillUninstallErrorCode.PATH_UNSAFE]: 409,
+  [SkillUninstallErrorCode.DELETE_FAILED]: 500,
+};
+
+/** An uninstall rejection. The message is built from the code — never from a path. */
+export class SkillUninstallError extends Error {
+  constructor(
+    readonly code: SkillUninstallErrorCodeType,
+    readonly detail?: Record<string, string | number | boolean>,
+    /** Repository-relative paths that blocked the operation, for UX-07. */
+    readonly blockers: readonly SkillUninstallBlocker[] = []
+  ) {
+    super(`Skill uninstall rejected: ${code}`);
+    this.name = 'SkillUninstallError';
+  }
+
+  get status(): number {
+    return SKILL_UNINSTALL_ERROR_STATUS[this.code];
+  }
+}
+
+export function isSkillUninstallError(value: unknown): value is SkillUninstallError {
+  return value instanceof SkillUninstallError;
+}
+
+function fail(
+  code: SkillUninstallErrorCodeType,
+  detail?: Record<string, string | number | boolean>,
+  blockers: readonly SkillUninstallBlocker[] = []
+): never {
+  throw new SkillUninstallError(code, detail, blockers);
+}
+
+// =============================================================================
+// Path safety
+// =============================================================================
+
+/**
+ * Absolute install root for a validated Skill ID inside a server-resolved worktree.
+ *
+ * Delegates to #1233's resolver — the same one {@link resolveSkillInstallTarget}
+ * uses — and re-checks the ID grammar here as well, because `path.join`
+ * normalizes `..` away and a containment check alone would accept an ID that
+ * walked out of the Skills directory.
+ */
+export function resolveSkillUninstallTarget(worktreePath: string, skillId: string): string {
+  if (!SKILL_ID_PATTERN.test(skillId) || skillId.length > SKILL_ID_MAX_LENGTH) {
+    fail(SkillUninstallErrorCode.TARGET_UNSAFE, { reason: 'skill-id' });
+  }
+  try {
+    return resolveSkillInstallRoot(worktreePath, skillId);
+  } catch {
+    return fail(SkillUninstallErrorCode.TARGET_UNSAFE, { reason: 'install-root' });
+  }
+}
+
+/**
+ * Prove no ancestor of the install root was swapped for a link.
+ *
+ * `lstat` at every level from the worktree down. `realpath` alone would silently
+ * *follow* a swapped ancestor and delete under whatever it pointed at, which is
+ * precisely the failure this whole module exists to make unrepresentable.
+ */
+export function assertSkillUninstallAncestors(
+  worktreeRealPath: string,
+  worktreePath: string
+): void {
+  let resolved: string;
+  try {
+    resolved = realpathSync(worktreePath);
+  } catch {
+    return fail(SkillUninstallErrorCode.ANCESTOR_UNSAFE, { reason: 'worktree-unresolvable' });
+  }
+  if (resolved !== worktreeRealPath) {
+    fail(SkillUninstallErrorCode.ANCESTOR_UNSAFE, { reason: 'worktree-identity' });
+  }
+
+  let walked = worktreeRealPath;
+  for (const segment of SKILL_INSTALL_ROOT_PREFIX.split('/')) {
+    walked = path.join(walked, segment);
+    let stats;
+    try {
+      stats = lstatSync(walked);
+    } catch {
+      // Absent is fine: there is then nothing under it to delete.
+      return;
+    }
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      fail(SkillUninstallErrorCode.ANCESTOR_UNSAFE, { reason: 'not-a-directory' });
+    }
+  }
+}
+
+/**
+ * Reject a receipt-recorded path that is not a plain relative path.
+ *
+ * The receipt is a file inside a repository, so it is data the user could have
+ * edited even though CommandMate wrote it. Its `files` entries name what gets
+ * unlinked, and are therefore validated here rather than trusted.
+ */
+function assertSafeRelativePath(relativePath: string): void {
+  if (
+    relativePath.length === 0 ||
+    relativePath.includes('\0') ||
+    relativePath.includes('\\') ||
+    path.posix.isAbsolute(relativePath) ||
+    path.win32.isAbsolute(relativePath)
+  ) {
+    fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'grammar' });
+  }
+  for (const segment of relativePath.split('/')) {
+    if (segment === '' || segment === '.' || segment === '..') {
+      fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'segment' });
+    }
+  }
+}
+
+/**
+ * `lstat` every directory from the install root down to the file's parent.
+ *
+ * Run immediately before each `unlink`, not once per operation: the exclusive
+ * lock keeps CommandMate out, but nothing stops the user's own tooling from
+ * replacing a directory with a link while the deletes are running.
+ */
+function assertDirectoryChainIsReal(installRootAbs: string, relativePath: string): void {
+  let walked = installRootAbs;
+  const segments = relativePath.split('/').slice(0, -1);
+  for (let index = 0; index <= segments.length; index += 1) {
+    if (index > 0) walked = path.join(walked, segments[index - 1]);
+    let stats;
+    try {
+      stats = lstatSync(walked);
+    } catch {
+      return fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'ancestor-missing' });
+    }
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'ancestor-not-a-directory' });
+    }
+  }
+}
+
+// =============================================================================
+// File removal
+// =============================================================================
+
+/** What the receipt says a file should be at the moment it is deleted. */
+export interface SkillUninstallExpectedFile {
+  sha256: string;
+  executable: boolean;
+}
+
+/**
+ * Delete one receipt-owned file, having just proved it is still that file.
+ *
+ * The digest is re-read here even though the assessment already checked it, for
+ * the same reason install re-reads what it wrote: the assessment is evidence
+ * about a moment that has passed, and the only claim worth making about a delete
+ * is one established immediately before the syscall.
+ *
+ * @internal Exported for the guard tests; callers use {@link applySkillUninstall}.
+ * @throws SkillUninstallError — the file was not deleted in every case.
+ */
+export function removeReceiptOwnedFile(
+  installRootAbs: string,
+  relativePath: string,
+  expected: SkillUninstallExpectedFile
+): number {
+  assertSafeRelativePath(relativePath);
+  assertDirectoryChainIsReal(installRootAbs, relativePath);
+
+  const absolute = path.join(installRootAbs, relativePath);
+  if (path.relative(installRootAbs, absolute) !== relativePath.split('/').join(path.sep)) {
+    fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'containment' });
+  }
+
+  let stats;
+  try {
+    stats = lstatSync(absolute);
+  } catch {
+    return fail(SkillUninstallErrorCode.FILE_CHANGED, { reason: 'vanished' });
+  }
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'not-a-regular-file' });
+  }
+  // A hard link means the same inode is reachable from somewhere we did not
+  // scan, so the receipt cannot claim sole ownership of this content.
+  if (stats.nlink !== 1) {
+    fail(SkillUninstallErrorCode.PATH_UNSAFE, { reason: 'hard-linked' });
+  }
+  if (((stats.mode & 0o111) !== 0) !== expected.executable) {
+    fail(SkillUninstallErrorCode.FILE_CHANGED, { reason: 'mode' });
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(absolute);
+  } catch {
+    return fail(SkillUninstallErrorCode.FILE_CHANGED, { reason: 'unreadable' });
+  }
+  if (!digestMatches(computeSha256Hex(bytes), expected.sha256)) {
+    fail(SkillUninstallErrorCode.FILE_CHANGED, { reason: 'digest' });
+  }
+
+  try {
+    unlinkSync(absolute);
+  } catch {
+    return fail(SkillUninstallErrorCode.DELETE_FAILED, { reason: 'unlink' });
+  }
+  return bytes.byteLength;
+}
+
+/**
+ * Remove a directory only if it is empty.
+ *
+ * `rmdir(2)` refuses a non-empty directory, so the emptiness check and the
+ * removal are one indivisible step rather than a scan followed by a delete that
+ * could act on a directory something was written into meanwhile.
+ *
+ * @returns whether the directory was removed
+ */
+function removeIfEmpty(directoryAbs: string): boolean {
+  let stats;
+  try {
+    stats = lstatSync(directoryAbs);
+  } catch {
+    return false;
+  }
+  if (stats.isSymbolicLink() || !stats.isDirectory()) return false;
+  try {
+    rmdirSync(directoryAbs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Directories the receipt's file list implies, deepest first.
+ *
+ * Derived from the receipt rather than from a directory walk on purpose: an
+ * empty directory the user created inside the install root is not something the
+ * install put there, and collecting it would be a deletion nobody asked for.
+ */
+function directoriesImpliedByReceipt(relativePaths: readonly string[]): string[] {
+  const directories = new Set<string>();
+  for (const relative of relativePaths) {
+    const segments = relative.split('/').slice(0, -1);
+    let walked = '';
+    for (const segment of segments) {
+      walked = walked === '' ? segment : `${walked}/${segment}`;
+      directories.add(walked);
+    }
+  }
+  return [...directories].sort(
+    (a, b) => b.split('/').length - a.split('/').length || (a < b ? 1 : -1)
+  );
+}
+
+// =============================================================================
+// Apply
+// =============================================================================
+
+/** Everything the delete needs. All of it server-resolved or plan-fixed. */
+export interface SkillUninstallApplyInput {
+  /** Absolute path from the worktree row. Never client-supplied. */
+  worktreePath: string;
+  /** Symlink-free form of {@link worktreePath}, resolved before the lock was taken. */
+  worktreeRealPath: string;
+  skillId: string;
+  /** Digest of the receipt bytes the plan was built against. */
+  expectedReceiptDigest: string;
+  /** Tree hash the plan recorded for the install root. */
+  expectedTreeHash: string;
+  /**
+   * Called once, after every check has passed and before the first `unlink`.
+   *
+   * This is the uninstall's commit point. Unlike install there is no single
+   * atomic syscall to hang it on, so the caller records it here and treats any
+   * later failure as reconcilable rather than as an untouched worktree.
+   */
+  onCommitPoint?: () => void;
+}
+
+/** One file that was deleted. Paths are repository-relative. */
+export interface SkillUninstallRemovedFile {
+  path: string;
+  sha256: string;
+  size: number;
+}
+
+/** Something that is still on disk, and why. */
+export interface SkillUninstallRetainedPath {
+  path: string;
+  reason: string;
+  messageKey: string;
+}
+
+/** What the delete produced. */
+export interface SkillUninstallApplyResult {
+  installRoot: string;
+  version: string;
+  removedFiles: SkillUninstallRemovedFile[];
+  /** Repository-relative directories removed because they became empty. */
+  removedDirectories: string[];
+  /** Directories that could not be collected, so the user knows what is left. */
+  retained: SkillUninstallRetainedPath[];
+  receiptRemoved: boolean;
+  /** The install root itself is gone. */
+  fullyRemoved: boolean;
+}
+
+/**
+ * Verify and delete one Skill install.
+ *
+ * Everything before {@link SkillUninstallApplyInput.onCommitPoint} is a read:
+ * on any rejection the worktree is byte-for-byte what it was. After it, files
+ * are gone and a failure is reported as *committed, reconciling* — the receipt
+ * survives until last precisely so that state remains explainable.
+ *
+ * @throws SkillUninstallError
+ */
+export function applySkillUninstall(
+  input: SkillUninstallApplyInput
+): SkillUninstallApplyResult {
+  const installRootAbs = resolveSkillUninstallTarget(input.worktreePath, input.skillId);
+  assertSkillUninstallAncestors(input.worktreeRealPath, input.worktreePath);
+
+  const assessment: SkillUninstallAssessment = assessSkillUninstall(
+    installRootAbs,
+    input.skillId,
+    { existing: readExistingSkillTree(installRootAbs) }
+  );
+  if (!assessment.present) {
+    fail(SkillUninstallErrorCode.NOT_INSTALLED, undefined, assessment.blockers);
+  }
+  if (!assessment.removable || assessment.receipt === null) {
+    fail(SkillUninstallErrorCode.BLOCKED, undefined, assessment.blockers);
+  }
+  if (assessment.currentTreeHash !== input.expectedTreeHash) {
+    fail(SkillUninstallErrorCode.DRIFT, { reason: 'tree-hash' });
+  }
+  const receipt = assessment.receipt;
+  const receiptDigest = assessment.receiptDigest;
+  if (receiptDigest === null || !digestMatches(receiptDigest, input.expectedReceiptDigest)) {
+    fail(SkillUninstallErrorCode.DRIFT, { reason: 'receipt-digest' });
+  }
+
+  const payload = assessment.entries.filter(
+    (entry) => entry.disposition === 'remove' && !entry.generated
+  );
+
+  input.onCommitPoint?.();
+
+  const removedFiles: SkillUninstallRemovedFile[] = [];
+  for (const entry of payload) {
+    const size = removeReceiptOwnedFile(installRootAbs, entry.relativePath, {
+      sha256: entry.recordedSha256 as string,
+      executable: entry.executable,
+    });
+    removedFiles.push({ path: entry.path, sha256: entry.recordedSha256 as string, size });
+  }
+
+  const removedDirectories: string[] = [];
+  for (const relative of directoriesImpliedByReceipt(
+    payload.map((entry) => entry.relativePath)
+  )) {
+    if (removeIfEmpty(path.join(installRootAbs, relative))) {
+      removedDirectories.push(`${assessment.installRoot}/${relative}`);
+    }
+  }
+
+  // Last, so that up to this point the directory still says what it is.
+  const receiptEntry = assessment.entries.find((entry) => entry.generated);
+  if (receiptEntry) {
+    const size = removeReceiptOwnedFile(installRootAbs, SKILL_RECEIPT_FILENAME, {
+      sha256: receiptDigest,
+      executable: false,
+    });
+    removedFiles.push({
+      path: `${assessment.installRoot}/${SKILL_RECEIPT_FILENAME}`,
+      sha256: receiptDigest,
+      size,
+    });
+  }
+
+  const fullyRemoved = removeIfEmpty(installRootAbs);
+  const retained: SkillUninstallRetainedPath[] = fullyRemoved
+    ? []
+    : listRetainedPaths(installRootAbs, assessment.installRoot);
+
+  return {
+    installRoot: assessment.installRoot,
+    version: receipt.version,
+    removedFiles,
+    removedDirectories,
+    retained,
+    receiptRemoved: receiptEntry !== undefined,
+    fullyRemoved,
+  };
+}
+
+/**
+ * Name what is still inside the install root.
+ *
+ * Only reached when the root would not collect, which after a fail-closed
+ * assessment means something appeared during the delete. The user is told the
+ * paths rather than that "uninstall partially failed" (UX-07).
+ */
+function listRetainedPaths(installRootAbs: string, installRoot: string): SkillUninstallRetainedPath[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(installRootAbs);
+  } catch {
+    return [];
+  }
+  return entries.map((name) => ({
+    path: `${installRoot}/${name}`,
+    reason: 'SKILL_UNINSTALL_UNMANAGED_FILE',
+    messageKey: 'skills.uninstall.reason.unmanagedFile',
+  }));
+}
+
+/**
+ * Whether the payload a committed uninstall removed is really gone.
+ *
+ * The uninstall counterpart of `hasCommittedSkillPayload`: #1234's reconciler
+ * asks whether the filesystem side of an operation landed, and for a delete
+ * that means the receipt no longer names this install.
+ */
+export function hasRemovedSkillPayload(
+  worktreePath: string,
+  skillId: string,
+  receiptDigest: string | null
+): boolean {
+  let installRootAbs: string;
+  try {
+    installRootAbs = resolveSkillUninstallTarget(worktreePath, skillId);
+  } catch {
+    return true;
+  }
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path.join(installRootAbs, SKILL_RECEIPT_FILENAME));
+  } catch {
+    return true;
+  }
+  return receiptDigest !== null && !digestMatches(computeSha256Hex(bytes), receiptDigest);
+}

--- a/src/lib/skills/uninstall-plan.ts
+++ b/src/lib/skills/uninstall-plan.ts
@@ -1,0 +1,704 @@
+/**
+ * Uninstall Plan: proving a Skill directory is safe to remove (Issue #1236)
+ *
+ * The inverse of #1233's install plan, and deliberately not its mirror image.
+ * An install may write into an empty destination; an uninstall must delete, and
+ * deletion is the one operation a user cannot undo from CommandMate. So this
+ * module answers a narrower question: *is every single file under the install
+ * root provably one that CommandMate wrote and that nobody has touched since?*
+ *
+ * Anything else — a locally edited file, a file the receipt never recorded, a
+ * recorded file that has gone missing, a symlink, an unreadable receipt, a scan
+ * that hit its bound — makes the plan non-removable. There is no partial
+ * uninstall: "delete the seven files we are sure about and leave the eighth"
+ * would silently destroy a Skill the user had customised while telling them the
+ * operation succeeded.
+ *
+ * The token contract is #1233's, reused rather than re-derived: the same TTL,
+ * the same single-use semantics, the same LRU bound, and the same
+ * {@link SkillPlanError} codes, so a drifting or replayed uninstall token is
+ * answered exactly like a drifting or replayed install token.
+ *
+ * Apply is {@link module:lib/skills/uninstall-apply}. This module never deletes.
+ *
+ * @module lib/skills/uninstall-plan
+ */
+
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import { SKILL_ID_MAX_LENGTH, SKILL_ID_PATTERN } from '@/lib/skills/constants';
+import { computeSha256Hex, digestMatches } from '@/lib/skills/integrity';
+import {
+  SKILL_PLAN_MAX_ENTRIES,
+  SKILL_PLAN_TTL_MS,
+  SKILL_RECEIPT_FILENAME,
+  SkillPlanError,
+  SkillPlanErrorCode,
+  parseInstalledReceipt,
+  type SkillPlanActor,
+} from '@/lib/skills/install-plan';
+import {
+  computeSkillTreeHash,
+  readExistingSkillTree,
+  skillInstallRoot,
+  type SkillExistingTree,
+  type SkillGitTargetState,
+} from '@/lib/skills/preview-diff';
+import type { SkillAgentSupport, SkillInstallReceipt } from '@/types/skills';
+
+// =============================================================================
+// Vocabulary
+// =============================================================================
+
+/** What uninstall would do to one path under the install root. */
+export type SkillUninstallDisposition =
+  /** Recorded by the receipt, byte-identical to it, and safe to delete. */
+  | 'remove'
+  /** Recorded by the receipt but its bytes or mode no longer match. */
+  | 'modified'
+  /** Recorded by the receipt and no longer on disk. */
+  | 'missing'
+  /** Present under the install root with no receipt recording it. */
+  | 'unknown'
+  /** Present but not a regular file: a symlink, a device, an oversized blob. */
+  | 'irregular';
+
+/** Stable machine reasons, one per disposition plus the plan-level failures. */
+export const SkillUninstallReason = {
+  /** Recorded, unchanged, and therefore deletable. */
+  MANAGED_UNCHANGED: 'SKILL_UNINSTALL_MANAGED_UNCHANGED',
+  /** Recorded but locally edited. Deleting it would destroy the user's work. */
+  LOCAL_MODIFICATION: 'SKILL_UNINSTALL_LOCAL_MODIFICATION',
+  /** Recorded but absent, so the install is no longer the one the receipt describes. */
+  RECEIPT_ORPHAN: 'SKILL_UNINSTALL_RECEIPT_ORPHAN',
+  /** Present but unrecorded: a user file, or another tool's output. */
+  UNMANAGED_FILE: 'SKILL_UNINSTALL_UNMANAGED_FILE',
+  /** Present as a symlink, a directory entry or another non-regular entry. */
+  NOT_A_REGULAR_FILE: 'SKILL_UNINSTALL_NOT_A_REGULAR_FILE',
+  /** No install root exists at all. */
+  NOT_INSTALLED: 'SKILL_UNINSTALL_NOT_INSTALLED',
+  /** The install root exists but carries no CommandMate receipt. */
+  RECEIPT_MISSING: 'SKILL_UNINSTALL_RECEIPT_MISSING',
+  /** A receipt file exists but cannot be parsed. */
+  RECEIPT_UNREADABLE: 'SKILL_UNINSTALL_RECEIPT_UNREADABLE',
+  /** The receipt describes a different Skill than the one being uninstalled. */
+  RECEIPT_FOREIGN: 'SKILL_UNINSTALL_RECEIPT_FOREIGN',
+  /** The directory walk hit a bound, so absence of unknown files is unproven. */
+  TREE_SCAN_TRUNCATED: 'SKILL_UNINSTALL_TREE_SCAN_TRUNCATED',
+} as const;
+
+export type SkillUninstallReasonCode =
+  (typeof SkillUninstallReason)[keyof typeof SkillUninstallReason];
+
+/** i18n key explaining why one path cannot be removed (UX-07). */
+export const SKILL_UNINSTALL_REASON_MESSAGE_KEYS: Record<SkillUninstallReasonCode, string> = {
+  [SkillUninstallReason.MANAGED_UNCHANGED]: 'skills.uninstall.reason.managedUnchanged',
+  [SkillUninstallReason.LOCAL_MODIFICATION]: 'skills.uninstall.reason.localModification',
+  [SkillUninstallReason.RECEIPT_ORPHAN]: 'skills.uninstall.reason.receiptOrphan',
+  [SkillUninstallReason.UNMANAGED_FILE]: 'skills.uninstall.reason.unmanagedFile',
+  [SkillUninstallReason.NOT_A_REGULAR_FILE]: 'skills.uninstall.reason.notARegularFile',
+  [SkillUninstallReason.NOT_INSTALLED]: 'skills.uninstall.reason.notInstalled',
+  [SkillUninstallReason.RECEIPT_MISSING]: 'skills.uninstall.reason.receiptMissing',
+  [SkillUninstallReason.RECEIPT_UNREADABLE]: 'skills.uninstall.reason.receiptUnreadable',
+  [SkillUninstallReason.RECEIPT_FOREIGN]: 'skills.uninstall.reason.receiptForeign',
+  [SkillUninstallReason.TREE_SCAN_TRUNCATED]: 'skills.uninstall.reason.treeScanTruncated',
+};
+
+/** i18n key for what the user should do next, per outcome (UX-07). */
+export const SKILL_UNINSTALL_NEXT_ACTION_KEYS = {
+  /** Every file checked out; the plan can be applied. */
+  removable: 'skills.uninstall.nextAction.removable',
+  /** Something is ambiguous, so nothing will be deleted until the user resolves it. */
+  blocked: 'skills.uninstall.nextAction.blocked',
+  succeeded: 'skills.uninstall.nextAction.succeeded',
+  committedReconciling: 'skills.uninstall.nextAction.committedReconciling',
+  failed: 'skills.uninstall.nextAction.failed',
+} as const;
+
+/** i18n key per agent support level, so UI and CLI say the same thing (UX-01). */
+export const SKILL_UNINSTALL_RELOAD_MESSAGE_KEYS: Record<SkillAgentSupport, string> = {
+  native: 'skills.uninstall.reload.native',
+  commandmate_runtime: 'skills.uninstall.reload.commandmateRuntime',
+  unsupported: 'skills.uninstall.reload.unsupported',
+  unknown: 'skills.uninstall.reload.unknown',
+};
+
+// =============================================================================
+// Assessment
+// =============================================================================
+
+/** One path under the install root, and what uninstall would do to it. */
+export interface SkillUninstallFileEntry {
+  /** Repository-relative POSIX path. Never absolute. */
+  path: string;
+  /** Path relative to the install root, as the receipt records it. */
+  relativePath: string;
+  disposition: SkillUninstallDisposition;
+  reason: SkillUninstallReasonCode;
+  /** The receipt itself, which records every file but not itself. */
+  generated: boolean;
+  /** Digest the receipt recorded, or null when the file is unrecorded. */
+  recordedSha256: string | null;
+  /** Digest of what is on disk now, or null when the path is gone. */
+  currentSha256: string | null;
+  size: number | null;
+  executable: boolean;
+}
+
+/** Why a plan refuses to delete anything. Paths are repository-relative. */
+export interface SkillUninstallBlocker {
+  code: SkillUninstallReasonCode;
+  path: string | null;
+  messageKey: string;
+}
+
+export interface SkillUninstallStats {
+  removable: number;
+  modified: number;
+  missing: number;
+  unknown: number;
+  irregular: number;
+}
+
+/** The complete verdict on one install root. Produced without writing anything. */
+export interface SkillUninstallAssessment {
+  /** Repository-relative install root, always `.agents/skills/<skill-id>`. */
+  installRoot: string;
+  present: boolean;
+  receipt: SkillInstallReceipt | null;
+  /** Digest of the receipt bytes on disk; identifies *which* install this is. */
+  receiptDigest: string | null;
+  entries: SkillUninstallFileEntry[];
+  blockers: SkillUninstallBlocker[];
+  /** True only when every path under the root is recorded and unchanged. */
+  removable: boolean;
+  /** Tree hash of the install root as it is now, for drift detection. */
+  currentTreeHash: string;
+  stats: SkillUninstallStats;
+}
+
+function blocker(code: SkillUninstallReasonCode, path: string | null): SkillUninstallBlocker {
+  return { code, path, messageKey: SKILL_UNINSTALL_REASON_MESSAGE_KEYS[code] };
+}
+
+type ScannedDisposition = Exclude<SkillUninstallDisposition, 'irregular'>;
+
+const DISPOSITION_REASON: Record<ScannedDisposition, SkillUninstallReasonCode> = {
+  remove: SkillUninstallReason.MANAGED_UNCHANGED,
+  modified: SkillUninstallReason.LOCAL_MODIFICATION,
+  missing: SkillUninstallReason.RECEIPT_ORPHAN,
+  unknown: SkillUninstallReason.UNMANAGED_FILE,
+};
+
+/** Stat bucket each disposition counts towards. */
+const DISPOSITION_STAT: Record<ScannedDisposition, keyof SkillUninstallStats> = {
+  remove: 'removable',
+  modified: 'modified',
+  missing: 'missing',
+  unknown: 'unknown',
+};
+
+/**
+ * Decide what uninstall would do to every path under the install root.
+ *
+ * The receipt is the ownership record, and it is read from the directory it
+ * describes rather than from the database: the index can be rebuilt from the
+ * receipt but never the other way round, and a delete that trusted the index
+ * would act on a claim instead of on evidence.
+ *
+ * The receipt does not list itself, so it is folded in here under its own
+ * on-disk digest. Without that it would read as an unmanaged file and every
+ * uninstall would block on the very file that authorises it.
+ */
+export function assessSkillUninstall(
+  installRootAbs: string,
+  skillId: string,
+  options: { existing?: SkillExistingTree } = {}
+): SkillUninstallAssessment {
+  const installRoot = skillInstallRoot(skillId);
+  const existing = options.existing ?? readExistingSkillTree(installRootAbs);
+  const currentTreeHash = computeSkillTreeHash(existing.files);
+
+  const empty: SkillUninstallAssessment = {
+    installRoot,
+    present: existing.present,
+    receipt: null,
+    receiptDigest: null,
+    entries: [],
+    blockers: [],
+    removable: false,
+    currentTreeHash,
+    stats: { removable: 0, modified: 0, missing: 0, unknown: 0, irregular: 0 },
+  };
+
+  if (!existing.present) {
+    return { ...empty, blockers: [blocker(SkillUninstallReason.NOT_INSTALLED, installRoot)] };
+  }
+
+  const blockers: SkillUninstallBlocker[] = [];
+  if (existing.truncated) {
+    blockers.push(blocker(SkillUninstallReason.TREE_SCAN_TRUNCATED, installRoot));
+  }
+
+  const receiptFile = existing.files.find((file) => file.path === SKILL_RECEIPT_FILENAME);
+  const receipt = receiptFile ? parseInstalledReceipt(receiptFile.bytes) : null;
+  if (!receiptFile) {
+    blockers.push(
+      blocker(SkillUninstallReason.RECEIPT_MISSING, `${installRoot}/${SKILL_RECEIPT_FILENAME}`)
+    );
+  } else if (receipt === null) {
+    blockers.push(
+      blocker(SkillUninstallReason.RECEIPT_UNREADABLE, `${installRoot}/${SKILL_RECEIPT_FILENAME}`)
+    );
+  } else if (receipt.skill_id !== skillId) {
+    blockers.push(
+      blocker(SkillUninstallReason.RECEIPT_FOREIGN, `${installRoot}/${SKILL_RECEIPT_FILENAME}`)
+    );
+  }
+
+  // A receipt that cannot be trusted makes ownership unknowable for every path,
+  // so nothing below could promote a file to `remove` anyway.
+  const trustedReceipt =
+    receiptFile && receipt !== null && receipt.skill_id === skillId ? receipt : null;
+
+  const recorded = new Map<string, { sha256: string; executable: boolean; size: number | null }>();
+  if (trustedReceipt && receiptFile) {
+    for (const file of trustedReceipt.files) {
+      recorded.set(file.path, {
+        sha256: file.sha256,
+        executable: file.executable,
+        size: file.size,
+      });
+    }
+    recorded.set(SKILL_RECEIPT_FILENAME, {
+      sha256: receiptFile.sha256,
+      executable: false,
+      size: receiptFile.size,
+    });
+  }
+
+  const existingByPath = new Map(existing.files.map((file) => [file.path, file]));
+  const entries: SkillUninstallFileEntry[] = [];
+  const stats: SkillUninstallStats = {
+    removable: 0,
+    modified: 0,
+    missing: 0,
+    unknown: 0,
+    irregular: 0,
+  };
+
+  for (const relative of [...new Set([...recorded.keys(), ...existingByPath.keys()])].sort()) {
+    const owned = recorded.get(relative) ?? null;
+    const onDisk = existingByPath.get(relative) ?? null;
+
+    let disposition: ScannedDisposition;
+    if (owned === null) disposition = 'unknown';
+    else if (onDisk === null) disposition = 'missing';
+    else if (
+      digestMatches(onDisk.sha256, owned.sha256) &&
+      onDisk.executable === owned.executable
+    ) {
+      disposition = 'remove';
+    } else disposition = 'modified';
+
+    const reason = DISPOSITION_REASON[disposition];
+    entries.push({
+      path: `${installRoot}/${relative}`,
+      relativePath: relative,
+      disposition,
+      reason,
+      generated: relative === SKILL_RECEIPT_FILENAME,
+      recordedSha256: owned?.sha256 ?? null,
+      currentSha256: onDisk?.sha256 ?? null,
+      size: onDisk?.size ?? owned?.size ?? null,
+      executable: onDisk?.executable ?? owned?.executable ?? false,
+    });
+    stats[DISPOSITION_STAT[disposition]] += 1;
+    if (disposition !== 'remove') {
+      blockers.push(blocker(reason, `${installRoot}/${relative}`));
+    }
+  }
+
+  for (const irregular of existing.irregularPaths) {
+    const repoPath = irregular ? `${installRoot}/${irregular}` : installRoot;
+    entries.push({
+      path: repoPath,
+      relativePath: irregular,
+      disposition: 'irregular',
+      reason: SkillUninstallReason.NOT_A_REGULAR_FILE,
+      generated: false,
+      recordedSha256: recorded.get(irregular)?.sha256 ?? null,
+      currentSha256: null,
+      size: null,
+      executable: false,
+    });
+    stats.irregular += 1;
+    blockers.push(blocker(SkillUninstallReason.NOT_A_REGULAR_FILE, repoPath));
+  }
+
+  return {
+    installRoot,
+    present: true,
+    receipt: trustedReceipt,
+    receiptDigest: receiptFile?.sha256 ?? null,
+    entries: entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0)),
+    blockers,
+    removable: trustedReceipt !== null && blockers.length === 0,
+    currentTreeHash,
+    stats,
+  };
+}
+
+// =============================================================================
+// Plan shape
+// =============================================================================
+
+/** The uninstall target, described without a machine-absolute path. */
+export interface SkillUninstallTargetDto {
+  worktreeId: string;
+  worktreeName: string;
+  repositoryName: string;
+  branch: string | null;
+  headState: SkillGitTargetState['headState'];
+  headCommit: string | null;
+  workingTreeDirty: boolean;
+  installRoot: string;
+  currentTreeHash: string;
+}
+
+/** Identity and provenance of the install being removed, taken from its receipt. */
+export interface SkillUninstallSkillDto {
+  id: string;
+  version: string;
+  source: { repository: string; ref: string; commit: string };
+  artifact: { assetName: string; sha256: string };
+  effectiveRisk: SkillInstallReceipt['effective_risk'];
+  agents: Array<{ agent: string; support: SkillAgentSupport; messageKey: string }>;
+}
+
+/** The uninstall plan as served to a client. Contains no path outside the repository. */
+export interface SkillUninstallPlanDto {
+  token: string;
+  /** RFC 3339 UTC instant after which the token is refused. */
+  expiresAt: string;
+  /** Every path under the install root is recorded and unchanged. */
+  removable: boolean;
+  blockers: SkillUninstallBlocker[];
+  nextActionKey: string;
+  target: SkillUninstallTargetDto;
+  skill: SkillUninstallSkillDto;
+  receipt: { path: string; sha256: string; size: number };
+  /** Everything the uninstall would delete. */
+  removals: SkillUninstallFileEntry[];
+  /** Everything that would stay behind, with the reason it stays. */
+  retained: SkillUninstallFileEntry[];
+  stats: SkillUninstallStats;
+}
+
+/** Everything a token is bound to. Mirrors #1233's install binding. */
+export interface SkillUninstallPlanBinding {
+  actor: SkillPlanActor;
+  operation: 'uninstall';
+  worktreeId: string;
+  skillId: string;
+  version: string;
+  /** Digest of the receipt bytes on disk when the plan was built. */
+  receiptDigest: string;
+  branch: string | null;
+  headCommit: string | null;
+  currentTreeHash: string;
+}
+
+/** Server-side plan record. Never serialized. */
+export interface SkillUninstallPlanRecord {
+  token: string;
+  binding: SkillUninstallPlanBinding;
+  bindingHash: string;
+  createdAt: number;
+  expiresAt: number;
+  consumedAt: number | null;
+  /** Server-resolved worktree path. Apply's only source of truth for where to delete. */
+  worktreePath: string;
+  receipt: SkillInstallReceipt;
+  assessment: SkillUninstallAssessment;
+  dto: SkillUninstallPlanDto;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
+}
+
+/** Digest of a binding, used to compare two of them without leaking either. */
+export function computeSkillUninstallBindingHash(binding: SkillUninstallPlanBinding): string {
+  return createHash('sha256').update(canonicalJson(binding)).digest('hex');
+}
+
+// =============================================================================
+// Plan cache
+// =============================================================================
+
+interface UninstallPlanCacheState {
+  records: Map<string, SkillUninstallPlanRecord>;
+}
+
+declare global {
+  // eslint-disable-next-line no-var -- globalThis cache pattern for hot-reload persistence (install-plan.ts precedent)
+  var __skillUninstallPlans: UninstallPlanCacheState | undefined;
+}
+
+const cache: UninstallPlanCacheState =
+  globalThis.__skillUninstallPlans ??
+  (globalThis.__skillUninstallPlans = { records: new Map() });
+
+/** Token grammar. Anything else is rejected before the store is consulted. */
+export const SKILL_UNINSTALL_PLAN_TOKEN_PATTERN = /^[0-9a-f]{48}$/;
+
+const SKILL_UNINSTALL_PLAN_TOKEN_BYTES = 24;
+
+function sweep(now: number): void {
+  for (const record of [...cache.records.values()]) {
+    if (now >= record.expiresAt) cache.records.delete(record.token);
+  }
+  while (cache.records.size >= SKILL_PLAN_MAX_ENTRIES) {
+    const oldest = [...cache.records.values()].sort((a, b) => a.createdAt - b.createdAt)[0];
+    if (!oldest) break;
+    cache.records.delete(oldest.token);
+  }
+}
+
+function requireRecord(token: string, now: number): SkillUninstallPlanRecord {
+  if (!SKILL_UNINSTALL_PLAN_TOKEN_PATTERN.test(token)) {
+    throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
+  }
+  const record = cache.records.get(token);
+  if (!record) throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
+
+  const presented = Buffer.from(token, 'utf-8');
+  const stored = Buffer.from(record.token, 'utf-8');
+  if (presented.length !== stored.length || !timingSafeEqual(presented, stored)) {
+    throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
+  }
+  if (now >= record.expiresAt) {
+    cache.records.delete(record.token);
+    throw new SkillPlanError(SkillPlanErrorCode.EXPIRED);
+  }
+  if (record.consumedAt !== null) throw new SkillPlanError(SkillPlanErrorCode.CONSUMED);
+  return record;
+}
+
+/** Read a stored plan. Does not spend the token. */
+export function getSkillUninstallPlan(
+  token: string,
+  options: { now?: number } = {}
+): SkillUninstallPlanRecord {
+  return requireRecord(token, options.now ?? Date.now());
+}
+
+/** Facts apply must observe again before it is allowed to delete. */
+export interface SkillUninstallObservation {
+  branch: string | null;
+  headCommit: string | null;
+  currentTreeHash: string;
+  receiptDigest: string | null;
+}
+
+/**
+ * Spend a token.
+ *
+ * Binding equality is checked before staleness, so a token presented for the
+ * wrong target is never told anything about the right one. The receipt digest
+ * is part of the observation as well as of the binding: branch and tree hash
+ * would already catch a content change, but the digest is what proves this is
+ * still *the same install* rather than a reinstall that happens to be identical.
+ */
+export function consumeSkillUninstallPlan(
+  token: string,
+  expected: { actor: SkillPlanActor; worktreeId: string; skillId: string },
+  observed: SkillUninstallObservation,
+  options: { now?: number } = {}
+): SkillUninstallPlanRecord {
+  const now = options.now ?? Date.now();
+  const record = requireRecord(token, now);
+  const { binding } = record;
+
+  const sameActor =
+    binding.actor.type === expected.actor.type && binding.actor.id === expected.actor.id;
+  if (
+    !sameActor ||
+    binding.worktreeId !== expected.worktreeId ||
+    binding.skillId !== expected.skillId
+  ) {
+    throw new SkillPlanError(SkillPlanErrorCode.BINDING_MISMATCH);
+  }
+  if (!record.dto.removable) throw new SkillPlanError(SkillPlanErrorCode.NOT_INSTALLABLE);
+
+  if (
+    observed.branch !== binding.branch ||
+    observed.headCommit !== binding.headCommit ||
+    observed.currentTreeHash !== binding.currentTreeHash ||
+    observed.receiptDigest === null ||
+    !digestMatches(observed.receiptDigest, binding.receiptDigest)
+  ) {
+    throw new SkillPlanError(SkillPlanErrorCode.STALE);
+  }
+
+  record.consumedAt = now;
+  return record;
+}
+
+/** Drop a plan. Safe to call twice. */
+export function discardSkillUninstallPlan(token: string): void {
+  cache.records.delete(token);
+}
+
+/** @internal */
+export function resetSkillUninstallPlanCacheForTesting(): void {
+  cache.records.clear();
+}
+
+/** @internal Number of plans currently held. */
+export function getSkillUninstallPlanCount(): number {
+  return cache.records.size;
+}
+
+// =============================================================================
+// Plan construction
+// =============================================================================
+
+/** Everything the uninstall plan builder needs. All of it server-resolved. */
+export interface CreateSkillUninstallPlanInput {
+  actor: SkillPlanActor;
+  worktree: {
+    id: string;
+    name: string;
+    /** Server-resolved absolute path from the worktree row. Never client-supplied. */
+    path: string;
+    repositoryName: string;
+  };
+  skillId: string;
+  /** Absolute install root, derived server-side from the worktree and Skill ID. */
+  installRootAbs: string;
+  git: SkillGitTargetState;
+  now?: number;
+}
+
+/**
+ * Assess the install root and register a plan under a fresh token.
+ *
+ * A non-removable assessment still produces a plan: the user is entitled to see
+ * *which* file is blocking and why, and #1233 established that a plan the apply
+ * step will refuse is more useful than an opaque error. Apply declines to spend
+ * such a token, so the preview cannot become a delete by accident.
+ *
+ * @throws SkillPlanError — `NOT_FOUND` when nothing is installed at the target.
+ */
+export function createSkillUninstallPlan(
+  input: CreateSkillUninstallPlanInput
+): SkillUninstallPlanRecord {
+  if (!SKILL_ID_PATTERN.test(input.skillId) || input.skillId.length > SKILL_ID_MAX_LENGTH) {
+    throw new SkillPlanError(SkillPlanErrorCode.TARGET_UNSAFE);
+  }
+
+  const now = input.now ?? Date.now();
+  const assessment = assessSkillUninstall(input.installRootAbs, input.skillId);
+  if (!assessment.present) {
+    throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
+  }
+
+  const token = randomBytes(SKILL_UNINSTALL_PLAN_TOKEN_BYTES).toString('hex');
+  const expiresAt = now + SKILL_PLAN_TTL_MS;
+  const receipt = assessment.receipt;
+  const receiptEntry = assessment.entries.find((entry) => entry.generated) ?? null;
+
+  const binding: SkillUninstallPlanBinding = {
+    actor: input.actor,
+    operation: 'uninstall',
+    worktreeId: input.worktree.id,
+    skillId: input.skillId,
+    version: receipt?.version ?? '',
+    receiptDigest: assessment.receiptDigest ?? '',
+    branch: input.git.branch,
+    headCommit: input.git.headCommit,
+    currentTreeHash: assessment.currentTreeHash,
+  };
+
+  const dto: SkillUninstallPlanDto = {
+    token,
+    expiresAt: new Date(expiresAt).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    removable: assessment.removable,
+    blockers: assessment.blockers,
+    nextActionKey: assessment.removable
+      ? SKILL_UNINSTALL_NEXT_ACTION_KEYS.removable
+      : SKILL_UNINSTALL_NEXT_ACTION_KEYS.blocked,
+    target: {
+      worktreeId: input.worktree.id,
+      worktreeName: input.worktree.name,
+      repositoryName: input.worktree.repositoryName,
+      branch: input.git.branch,
+      headState: input.git.headState,
+      headCommit: input.git.headCommit,
+      workingTreeDirty: input.git.dirty,
+      installRoot: assessment.installRoot,
+      currentTreeHash: assessment.currentTreeHash,
+    },
+    skill: {
+      id: input.skillId,
+      version: receipt?.version ?? '',
+      source: receipt
+        ? { ...receipt.source }
+        : { repository: '', ref: '', commit: '' },
+      artifact: {
+        assetName: receipt?.artifact.asset_name ?? '',
+        sha256: receipt?.artifact.sha256 ?? '',
+      },
+      effectiveRisk: receipt?.effective_risk ?? 'low',
+      agents: (receipt?.agent_compatibility ?? []).map((entry) => ({
+        agent: entry.agent,
+        support: entry.support,
+        messageKey: SKILL_UNINSTALL_RELOAD_MESSAGE_KEYS[entry.support],
+      })),
+    },
+    receipt: {
+      path: `${assessment.installRoot}/${SKILL_RECEIPT_FILENAME}`,
+      sha256: assessment.receiptDigest ?? '',
+      size: receiptEntry?.size ?? 0,
+    },
+    removals: assessment.entries.filter((entry) => entry.disposition === 'remove'),
+    retained: assessment.entries.filter((entry) => entry.disposition !== 'remove'),
+    stats: assessment.stats,
+  };
+
+  const record: SkillUninstallPlanRecord = {
+    token,
+    binding,
+    bindingHash: computeSkillUninstallBindingHash(binding),
+    createdAt: now,
+    expiresAt,
+    consumedAt: null,
+    worktreePath: input.worktree.path,
+    // A blocked plan has no trusted receipt; apply refuses it before this is read.
+    receipt: receipt ?? ({} as SkillInstallReceipt),
+    assessment,
+    dto,
+  };
+
+  sweep(now);
+  cache.records.set(token, record);
+  return record;
+}
+
+/**
+ * Digest of the receipt currently on disk, or null when there is none.
+ *
+ * Apply re-reads this immediately before spending the token, so a reinstall
+ * between plan and apply is drift rather than a silent substitution.
+ */
+export function readSkillReceiptDigest(existing: SkillExistingTree): string | null {
+  const file = existing.files.find((entry) => entry.path === SKILL_RECEIPT_FILENAME);
+  if (!file) return null;
+  return parseInstalledReceipt(file.bytes) === null ? null : computeSha256Hex(file.bytes);
+}

--- a/tests/integration/api/skills-uninstall.test.ts
+++ b/tests/integration/api/skills-uninstall.test.ts
@@ -1,0 +1,596 @@
+/**
+ * API integration tests — Uninstall plan and apply routes (Issue #1236)
+ *
+ * Runs the real vertical slice both ways: the #1235 install route puts a real
+ * package into a real temporary worktree and records it in a real database, and
+ * then the uninstall routes take it back out again. Only the network edges are
+ * mocked — the Catalog, the artifact download and the snapshot store — because
+ * `Kewton/commandmate-skills` is private and an uninstall touches the network at
+ * no point anyway.
+ *
+ * The assertions to read closely are the negative ones. For every way a Skill
+ * directory can become ambiguous, the check is not that the API returned 409 but
+ * that the files are still there afterwards.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import Database from 'better-sqlite3';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import type { SkillCatalog } from '@/types/skills';
+import type { SkillCatalogResult } from '@/lib/skills/catalog-client';
+
+const state = vi.hoisted(() => ({ configRoot: '' }));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn(),
+  })),
+  generateRequestId: vi.fn(() => 'test-request-id'),
+}));
+
+// Locks, journals and audit state must land in a throwaway directory rather
+// than in the developer's real CommandMate config root.
+vi.mock('@/cli/utils/install-context', () => ({
+  ensureConfigDir: () => state.configRoot,
+  getConfigDir: () => state.configRoot,
+  isGlobalInstall: () => false,
+}));
+
+vi.mock('@/lib/db/db-instance', () => ({ getDbInstance: vi.fn() }));
+vi.mock('@/lib/db', () => ({ getWorktreeById: vi.fn() }));
+vi.mock('@/lib/skills/catalog-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/skills/catalog-client')>();
+  return { ...actual, getSkillCatalog: vi.fn() };
+});
+vi.mock('@/lib/skills/artifact-downloader', () => ({ downloadSkillArtifact: vi.fn() }));
+vi.mock('@/lib/skills/snapshot-store', () => ({
+  initSkillSnapshotStore: vi.fn(() => '/tmp/snapshots'),
+  createSkillSnapshot: vi.fn(),
+  getSkillSnapshot: vi.fn(),
+  readSkillSnapshotBytes: vi.fn(),
+  releaseSkillSnapshot: vi.fn(),
+}));
+vi.mock('@/lib/version-checker', () => ({ getServerVersion: vi.fn(() => '0.11.4') }));
+vi.mock('@/lib/git/git-exec', () => ({ execGitCommand: vi.fn(), execFileAsync: vi.fn() }));
+
+import { POST as buildInstallPlan } from '@/app/api/worktrees/[id]/skills/[skillId]/plan/route';
+import { POST as applyInstall } from '@/app/api/worktrees/[id]/skills/[skillId]/install/route';
+import { POST as buildUninstallPlan } from '@/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route';
+import { POST as applyUninstall } from '@/app/api/worktrees/[id]/skills/[skillId]/uninstall/route';
+import { getWorktreeById } from '@/lib/db';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getSkillCatalog } from '@/lib/skills/catalog-client';
+import { downloadSkillArtifact } from '@/lib/skills/artifact-downloader';
+import {
+  createSkillSnapshot,
+  getSkillSnapshot,
+  readSkillSnapshotBytes,
+} from '@/lib/skills/snapshot-store';
+import { execGitCommand, execFileAsync } from '@/lib/git/git-exec';
+import {
+  SKILL_RECEIPT_FILENAME,
+  resetSkillInstallPlanCacheForTesting,
+} from '@/lib/skills/install-plan';
+import { resetSkillUninstallPlanCacheForTesting } from '@/lib/skills/uninstall-plan';
+import { getSkillInstallation } from '@/lib/skills/installed-state';
+import { listSkillOperationAudit } from '@/lib/skills/operation-audit';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { buildPackage } from '../../fixtures/skills/malicious-packages/package';
+import type { PackageFileSpec } from '../../fixtures/skills/malicious-packages/package';
+import type { Worktree } from '@/types/models';
+
+const getWorktreeByIdMock = vi.mocked(getWorktreeById);
+const getDbInstanceMock = vi.mocked(getDbInstance);
+const getSkillCatalogMock = vi.mocked(getSkillCatalog);
+const downloadSkillArtifactMock = vi.mocked(downloadSkillArtifact);
+const createSkillSnapshotMock = vi.mocked(createSkillSnapshot);
+const getSkillSnapshotMock = vi.mocked(getSkillSnapshot);
+const readSkillSnapshotBytesMock = vi.mocked(readSkillSnapshotBytes);
+const execGitCommandMock = vi.mocked(execGitCommand);
+const execFileAsyncMock = vi.mocked(execFileAsync) as unknown as ReturnType<typeof vi.fn>;
+
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const WORKTREE_ID = 'wt-00000000-0000-4000-8000-000000000001';
+const COMMIT = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+const HEAD = 'f'.repeat(40);
+const SNAPSHOT_ID = 'a'.repeat(32);
+
+let worktreeDir: string;
+let configRoot: string;
+let db: Database.Database;
+let artifact: Buffer;
+let artifactSha: string;
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+function installRootAbs(): string {
+  return path.join(worktreeDir, '.agents', 'skills', SKILL_ID);
+}
+
+function makeCatalog(): SkillCatalog {
+  return {
+    schema_version: 1,
+    entries: [
+      {
+        id: SKILL_ID,
+        name: 'Demo Skill',
+        summary: 'A demo Skill used by the CommandMate package tests.',
+        provider: { name: 'CommandMate' },
+        license: 'MIT',
+        latest: VERSION,
+        versions: [
+          {
+            version: VERSION,
+            changelog: `Release ${VERSION}`,
+            published_at: '2026-07-16T09:30:00Z',
+            source: { repository: 'Kewton/commandmate-skills', ref: `v${VERSION}`, commit: COMMIT },
+            artifact: {
+              asset_name: `${SKILL_ID}-${VERSION}.tar.gz`,
+              url: `https://example.invalid/${SKILL_ID}-${VERSION}.tar.gz`,
+              sha256: artifactSha,
+              size: artifact.byteLength,
+              content_type: 'application/gzip',
+              format: 'tar.gz',
+            },
+            compatibility: {
+              commandmate: '>=0.11.0 <1.0.0',
+              agents: [
+                { agent: 'claude', support: 'native', evidence: 'verified by the package tests' },
+              ],
+            },
+            declared_risk: 'low',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function wireMocks(): void {
+  getSkillCatalogMock.mockResolvedValue({
+    ok: true,
+    snapshot: {
+      catalog: makeCatalog(),
+      fetchedAt: '2026-07-16T10:00:00Z',
+      revalidatedAt: '2026-07-16T10:00:00Z',
+      stale: false,
+      offline: false,
+      state: 'fresh',
+      staleReason: null,
+      source: { repository: 'Kewton/commandmate-skills', ref: 'main', revision: null },
+    },
+  } as SkillCatalogResult);
+
+  downloadSkillArtifactMock.mockResolvedValue({
+    skillId: SKILL_ID,
+    version: VERSION,
+    commit: COMMIT,
+    bytes: artifact,
+    sha256: artifactSha,
+    size: artifact.byteLength,
+  });
+
+  const handle = {
+    snapshotId: SNAPSHOT_ID,
+    skillId: SKILL_ID,
+    version: VERSION,
+    commit: COMMIT,
+    sha256: artifactSha,
+    size: artifact.byteLength,
+    expiresAt: Date.now() + 600_000,
+  };
+  createSkillSnapshotMock.mockReturnValue(handle);
+  getSkillSnapshotMock.mockReturnValue(handle);
+  readSkillSnapshotBytesMock.mockImplementation(() => artifact);
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: WORKTREE_ID,
+    name: 'demo-worktree',
+    path: worktreeDir,
+    branch: 'feature/demo',
+    repositoryName: 'commandmate',
+    repositoryDisplayName: 'CommandMate',
+  } as Worktree;
+}
+
+function post(
+  handler: (request: NextRequest, ctx: { params: Promise<{ id: string; skillId: string }> }) => Promise<Response>,
+  segment: string,
+  body: Record<string, unknown> | null,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return handler(
+    new NextRequest(
+      `http://localhost/api/worktrees/${WORKTREE_ID}/skills/${SKILL_ID}/${segment}`,
+      {
+        method: 'POST',
+        headers,
+        ...(body === null ? {} : { body: JSON.stringify(body) }),
+      }
+    ),
+    { params: Promise.resolve({ id: WORKTREE_ID, skillId: SKILL_ID }) }
+  );
+}
+
+/** Rebuild the mocked artifact, so a re-install can carry different bytes. */
+function useArtifact(files?: PackageFileSpec[]): void {
+  const built = buildPackage({ skillId: SKILL_ID, version: VERSION, ...(files ? { files } : {}) });
+  artifact = built.bytes;
+  artifactSha = createHash('sha256').update(artifact).digest('hex');
+  wireMocks();
+}
+
+/**
+ * Put a real install into the worktree through the real install route.
+ *
+ * The idempotency key is explicit because the mocked snapshot ID is a constant:
+ * without it two installs of the same bytes derive the same key and the second
+ * would be answered as a replay rather than actually writing anything.
+ */
+async function installSkill(idempotencyKey = 'install-key-00000001'): Promise<void> {
+  const planResponse = await post(buildInstallPlan, 'plan', {});
+  expect(planResponse.status).toBe(200);
+  const { plan } = await planResponse.json();
+  const installed = await post(applyInstall, 'install', {
+    planToken: plan.token,
+    version: VERSION,
+    idempotencyKey,
+  });
+  expect(installed.status).toBe(200);
+}
+
+/** Build an uninstall plan and hand back its token and DTO. */
+async function issueUninstallPlan(
+  headers: Record<string, string> = {}
+): Promise<{ token: string; plan: Record<string, never> & Record<string, unknown> }> {
+  const response = await post(buildUninstallPlan, 'uninstall-plan', null, headers);
+  expect(response.status).toBe(200);
+  const payload = await response.json();
+  return { token: payload.plan.token, plan: payload.plan };
+}
+
+/** Payload files are written 0600, so an edit needs the bit put back first. */
+function overwrite(relative: string, content: string): void {
+  const target = path.join(installRootAbs(), relative);
+  chmodSync(target, 0o600);
+  writeFileSync(target, content);
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  resetSkillInstallPlanCacheForTesting();
+  resetSkillUninstallPlanCacheForTesting();
+
+  worktreeDir = mkdtempSync(path.join(tmpdir(), 'cm-uninstall-wt-'));
+  configRoot = mkdtempSync(path.join(tmpdir(), 'cm-uninstall-cfg-'));
+  state.configRoot = configRoot;
+
+  db = new Database(':memory:');
+  runMigrations(db);
+  getDbInstanceMock.mockReturnValue(db);
+  getWorktreeByIdMock.mockReturnValue(makeWorktree());
+
+  useArtifact();
+  execGitCommandMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'symbolic-ref') return 'feature/demo';
+    if (args[0] === 'rev-parse') return HEAD;
+    if (args[0] === 'status') return '';
+    return null;
+  });
+  execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+  await installSkill();
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(worktreeDir, { recursive: true, force: true });
+  rmSync(configRoot, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Plan
+// =============================================================================
+
+describe('POST …/uninstall-plan', () => {
+  it('lists what would be removed, receipt included', async () => {
+    const { plan } = await issueUninstallPlan();
+
+    expect(plan.removable).toBe(true);
+    expect(plan.nextActionKey).toBe('skills.uninstall.nextAction.removable');
+    expect((plan.removals as Array<{ path: string }>).map((entry) => entry.path)).toContain(
+      `.agents/skills/${SKILL_ID}/${SKILL_RECEIPT_FILENAME}`
+    );
+    expect(plan.retained).toEqual([]);
+    expect(plan.skill).toMatchObject({ id: SKILL_ID, version: VERSION });
+  });
+
+  it('explains which file blocks removal instead of offering a partial delete', async () => {
+    overwrite('reference/notes.md', '# Notes\n\nmine now\n');
+
+    const { plan } = await issueUninstallPlan();
+
+    expect(plan.removable).toBe(false);
+    expect(plan.nextActionKey).toBe('skills.uninstall.nextAction.blocked');
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({
+        code: 'SKILL_UNINSTALL_LOCAL_MODIFICATION',
+        path: `.agents/skills/${SKILL_ID}/reference/notes.md`,
+        messageKey: 'skills.uninstall.reason.localModification',
+      })
+    );
+  });
+
+  it('reports nothing installed for a Skill that is not there', async () => {
+    rmSync(installRootAbs(), { recursive: true });
+
+    const response = await post(buildUninstallPlan, 'uninstall-plan', null);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).code).toBe('SKILL_UNINSTALL_NOT_INSTALLED');
+  });
+
+  it('refuses a body that tries to name the target itself', async () => {
+    const response = await post(buildUninstallPlan, 'uninstall-plan', {
+      installRoot: '/etc',
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).code).toBe('SKILL_PLAN_INPUT_REJECTED');
+  });
+});
+
+// =============================================================================
+// Apply — success
+// =============================================================================
+
+describe('POST …/uninstall — success', () => {
+  it('removes the payload, the directories and the receipt', async () => {
+    const { token } = await issueUninstallPlan();
+
+    const response = await post(applyUninstall, 'uninstall', { planToken: token });
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.operation).toMatchObject({
+      state: 'SUCCEEDED',
+      result: 'succeeded',
+      committed: true,
+      reconcilePending: false,
+      replayed: false,
+      nextActionKey: 'skills.uninstall.nextAction.succeeded',
+    });
+    expect(payload.uninstall).toMatchObject({
+      skillId: SKILL_ID,
+      version: VERSION,
+      installRoot: `.agents/skills/${SKILL_ID}`,
+      receiptRemoved: true,
+      fullyRemoved: true,
+      retained: [],
+    });
+    expect(existsSync(installRootAbs())).toBe(false);
+  });
+
+  it('clears the index row and appends an uninstall audit row', async () => {
+    const { token } = await issueUninstallPlan();
+
+    await post(applyUninstall, 'uninstall', { planToken: token });
+
+    expect(getSkillInstallation(db, WORKTREE_ID, SKILL_ID)).toBeNull();
+
+    const audit = listSkillOperationAudit(db, { worktreeId: WORKTREE_ID });
+    expect(audit[0]).toMatchObject({
+      operation: 'uninstall',
+      result: 'succeeded',
+      state: 'SUCCEEDED',
+      actorType: 'user',
+      skillVersion: VERSION,
+      sourceRepository: 'Kewton/commandmate-skills',
+      sourceCommit: COMMIT,
+      artifactSha256: artifactSha,
+    });
+  });
+
+  it('tells each agent how to stop offering the Skill', async () => {
+    const { token } = await issueUninstallPlan();
+
+    const payload = await (await post(applyUninstall, 'uninstall', { planToken: token })).json();
+
+    expect(payload.reload.agents).toEqual([
+      { agent: 'claude', support: 'native', messageKey: 'skills.uninstall.reload.native' },
+    ]);
+  });
+
+  it('leaves an unrelated directory the user created, and names it', async () => {
+    mkdirSync(path.join(installRootAbs(), 'scratch'));
+    const { token } = await issueUninstallPlan();
+
+    const payload = await (await post(applyUninstall, 'uninstall', { planToken: token })).json();
+
+    expect(payload.uninstall.fullyRemoved).toBe(false);
+    expect(payload.uninstall.retained).toContainEqual(
+      expect.objectContaining({ path: `.agents/skills/${SKILL_ID}/scratch` })
+    );
+    expect(existsSync(path.join(installRootAbs(), 'scratch'))).toBe(true);
+  });
+});
+
+// =============================================================================
+// Apply — zero-delete
+// =============================================================================
+
+describe('POST …/uninstall — nothing is deleted when anything is ambiguous', () => {
+  it('refuses a plan that was already blocked, without spending the token', async () => {
+    writeFileSync(path.join(installRootAbs(), 'my-notes.md'), 'keep me\n');
+    const { token } = await issueUninstallPlan();
+
+    const response = await post(applyUninstall, 'uninstall', { planToken: token });
+
+    expect(response.status).toBe(409);
+    const payload = await response.json();
+    expect(payload.code).toBe('SKILL_UNINSTALL_BLOCKED');
+    expect(payload.nextActionKey).toBe('skills.uninstall.nextAction.blocked');
+    expect(payload.blockers.map((entry: { code: string }) => entry.code)).toContain(
+      'SKILL_UNINSTALL_UNMANAGED_FILE'
+    );
+    expect(readFileSync(path.join(installRootAbs(), 'my-notes.md'), 'utf-8')).toBe('keep me\n');
+    expect(existsSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME))).toBe(true);
+  });
+
+  it('refuses when a file changed after the plan was built', async () => {
+    const { token } = await issueUninstallPlan();
+    overwrite('reference/notes.md', '# Notes\n\nedited after planning\n');
+
+    const response = await post(applyUninstall, 'uninstall', { planToken: token });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_STALE');
+    expect(existsSync(path.join(installRootAbs(), 'assets/logo.svg'))).toBe(true);
+    expect(existsSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME))).toBe(true);
+    expect(getSkillInstallation(db, WORKTREE_ID, SKILL_ID)).not.toBeNull();
+  });
+
+  it('refuses when a different version was installed between plan and apply', async () => {
+    const { token } = await issueUninstallPlan();
+    rmSync(installRootAbs(), { recursive: true });
+    resetSkillInstallPlanCacheForTesting();
+    useArtifact([{ path: 'reference/notes.md', content: '# Different package\n' }]);
+    await installSkill('install-key-00000002');
+
+    const response = await post(applyUninstall, 'uninstall', { planToken: token });
+
+    // The token was issued against a receipt that is no longer the one on disk,
+    // so spending it would delete an install the user never previewed.
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_STALE');
+    expect(existsSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME))).toBe(true);
+    expect(existsSync(path.join(installRootAbs(), 'reference/notes.md'))).toBe(true);
+  });
+
+  it('refuses a body that tries to force the delete', async () => {
+    const { token } = await issueUninstallPlan();
+
+    const response = await post(applyUninstall, 'uninstall', { planToken: token, force: true });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).code).toBe('SKILL_PLAN_INPUT_REJECTED');
+    expect(existsSync(installRootAbs())).toBe(true);
+  });
+});
+
+// =============================================================================
+// Token contract
+// =============================================================================
+
+describe('POST …/uninstall — the token contract', () => {
+  it('refuses a second apply of the same token', async () => {
+    const { token } = await issueUninstallPlan();
+    expect((await post(applyUninstall, 'uninstall', { planToken: token })).status).toBe(200);
+
+    const replay = await post(applyUninstall, 'uninstall', { planToken: token });
+
+    expect(replay.status).toBe(409);
+    expect((await replay.json()).code).toBe('SKILL_PLAN_CONSUMED');
+  });
+
+  it('refuses a browser token presented by the CLI', async () => {
+    const { token } = await issueUninstallPlan();
+
+    const response = await post(
+      applyUninstall,
+      'uninstall',
+      { planToken: token },
+      { authorization: 'Bearer local-token' }
+    );
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe('SKILL_PLAN_BINDING_MISMATCH');
+    expect(existsSync(installRootAbs())).toBe(true);
+  });
+
+  it('refuses a token that is not a token at all', async () => {
+    const response = await post(applyUninstall, 'uninstall', { planToken: 'nope' });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).code).toBe('SKILL_UNINSTALL_INVALID_BODY');
+  });
+
+  it('replays a retried request instead of running it twice', async () => {
+    const { token } = await issueUninstallPlan();
+    const key = 'uninstall-retry-key-0001';
+    expect(
+      (await post(applyUninstall, 'uninstall', { planToken: token, idempotencyKey: key })).status
+    ).toBe(200);
+
+    const replay = await post(applyUninstall, 'uninstall', {
+      planToken: token,
+      idempotencyKey: key,
+    });
+
+    expect(replay.status).toBe(200);
+    const payload = await replay.json();
+    expect(payload.operation).toMatchObject({ replayed: true, state: 'SUCCEEDED' });
+    const uninstalls = listSkillOperationAudit(db, { worktreeId: WORKTREE_ID }).filter(
+      (row) => row.operation === 'uninstall'
+    );
+    expect(uninstalls).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// Partial failure
+// =============================================================================
+
+describe('POST …/uninstall — a failure part-way through', () => {
+  const asRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+  it.skipIf(asRoot)('keeps the receipt and audits the failure without leaking paths', async () => {
+    const { token } = await issueUninstallPlan();
+    // Deletion needs write permission on the parent directory. Read permission
+    // is untouched, so nothing about the plan's view of the tree changes.
+    chmodSync(path.join(installRootAbs(), 'reference'), 0o500);
+
+    try {
+      const response = await post(applyUninstall, 'uninstall', { planToken: token });
+
+      expect(response.status).toBe(500);
+      expect((await response.json()).code).toBe('SKILL_UNINSTALL_DELETE_FAILED');
+      expect(existsSync(path.join(installRootAbs(), 'reference/notes.md'))).toBe(true);
+      expect(existsSync(path.join(installRootAbs(), SKILL_RECEIPT_FILENAME))).toBe(true);
+
+      const audit = listSkillOperationAudit(db, { worktreeId: WORKTREE_ID });
+      const failure = audit.find((row) => row.result === 'failed');
+      expect(failure).toMatchObject({
+        operation: 'uninstall',
+        state: 'FAILED_RECONCILABLE',
+        errorCode: 'SKILL_UNINSTALL_DELETE_FAILED',
+      });
+      expect(failure?.errorMessage ?? '').not.toContain(worktreeDir);
+    } finally {
+      chmodSync(path.join(installRootAbs(), 'reference'), 0o700);
+    }
+  });
+});

--- a/tests/unit/components/skills/skills-i18n-keys.test.ts
+++ b/tests/unit/components/skills/skills-i18n-keys.test.ts
@@ -28,6 +28,11 @@ import {
   SKILL_INSTALL_NEXT_ACTION_KEYS,
   SKILL_INSTALL_RELOAD_MESSAGE_KEYS,
 } from '@/lib/skills/install-apply';
+import {
+  SKILL_UNINSTALL_NEXT_ACTION_KEYS,
+  SKILL_UNINSTALL_REASON_MESSAGE_KEYS,
+  SKILL_UNINSTALL_RELOAD_MESSAGE_KEYS,
+} from '@/lib/skills/uninstall-plan';
 
 const ROOT = path.resolve(__dirname, '../../../..');
 const LOCALES_DIR = path.join(ROOT, 'locales');
@@ -95,6 +100,11 @@ function contractKeys(): string[] {
     // instruction per agent and the next action per outcome.
     ...Object.values(SKILL_INSTALL_RELOAD_MESSAGE_KEYS),
     ...Object.values(SKILL_INSTALL_NEXT_ACTION_KEYS),
+    // Emitted by the uninstall plan/apply API (#1236): the plan names why each
+    // retained path could not be removed, and the response what to do next.
+    ...Object.values(SKILL_UNINSTALL_REASON_MESSAGE_KEYS),
+    ...Object.values(SKILL_UNINSTALL_NEXT_ACTION_KEYS),
+    ...Object.values(SKILL_UNINSTALL_RELOAD_MESSAGE_KEYS),
   ]
     .map(resolveSkillMessageKey)
     .concat(Object.values(RECOMMENDATION_LABEL_KEY))
@@ -133,6 +143,10 @@ const PLACEHOLDERS: Record<string, string[]> = {
   'catalog.fetchedAt': ['{timestamp}'],
   'catalog.revalidatedAt': ['{timestamp}'],
   'catalog.sourceLabel': ['{repository}', '{ref}'],
+  'uninstall.reload.native': ['{agent}', '{skillId}'],
+  'uninstall.reload.commandmateRuntime': ['{agent}', '{skillId}'],
+  'uninstall.reload.unsupported': ['{agent}', '{skillId}'],
+  'uninstall.reload.unknown': ['{agent}', '{skillId}'],
 };
 
 /**

--- a/tests/unit/lib/skills/uninstall-apply.test.ts
+++ b/tests/unit/lib/skills/uninstall-apply.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Issue #1236: deleting exactly the files CommandMate wrote.
+ *
+ * Two things are being proved here, and they pull in opposite directions.
+ *
+ * The first is that a clean install disappears completely — files, the
+ * directories they lived in, and the receipt last of all. The second is that
+ * almost nothing else does: a locally edited file, a file the user added, a
+ * directory swapped for a link, a path that walked out of the install root. For
+ * every one of those the assertion is not "it reported an error" but "the bytes
+ * are still on disk", because an error message is no consolation for a deleted
+ * file.
+ *
+ * The low-level guards are exercised directly as well as through
+ * `applySkillUninstall`. That is deliberate: the whole-operation path is
+ * defended several times over, so a test that only went through the front door
+ * could not tell which guard was actually load-bearing.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import { applySkillInstall } from '@/lib/skills/install-apply';
+import {
+  SKILL_RECEIPT_FILENAME,
+  buildSkillInstallReceipt,
+  serializeSkillInstallReceipt,
+} from '@/lib/skills/install-plan';
+import { computeSkillTreeHash, readExistingSkillTree } from '@/lib/skills/preview-diff';
+import { inspectSkillPackage } from '@/lib/skills/package-validator';
+import type { SkillPackageSnapshot } from '@/lib/skills/package-validator';
+import {
+  SkillUninstallErrorCode,
+  applySkillUninstall,
+  hasRemovedSkillPayload,
+  isSkillUninstallError,
+  removeReceiptOwnedFile,
+  resolveSkillUninstallTarget,
+  assertSkillUninstallAncestors,
+} from '@/lib/skills/uninstall-apply';
+import { assessSkillUninstall, readSkillReceiptDigest } from '@/lib/skills/uninstall-plan';
+import { buildPackage } from '../../../fixtures/skills/malicious-packages/package';
+import type { PackageFileSpec } from '../../../fixtures/skills/malicious-packages/package';
+import { makeCatalogVersion } from './fixtures';
+
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const OPERATION_ID = '9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f';
+
+let worktree: string;
+
+function installRoot(): string {
+  return path.join(worktree, '.agents', 'skills', SKILL_ID);
+}
+
+function sha256(content: string | Uint8Array): string {
+  return createHash('sha256')
+    .update(typeof content === 'string' ? Buffer.from(content, 'utf-8') : content)
+    .digest('hex');
+}
+
+/** Install a real package the way #1235 does, so the receipt is genuine. */
+function install(files?: PackageFileSpec[]): SkillPackageSnapshot {
+  const built = buildPackage(files ? { files } : {});
+  const snapshot = inspectSkillPackage(built.bytes, { skillId: SKILL_ID, version: VERSION });
+  const receipt = buildSkillInstallReceipt({ snapshot, version: makeCatalogVersion() });
+  const receiptBytes = serializeSkillInstallReceipt(receipt);
+
+  applySkillInstall({
+    worktreePath: worktree,
+    worktreeRealPath: realpathSync(worktree),
+    skillId: SKILL_ID,
+    operationId: OPERATION_ID,
+    snapshot,
+    receiptBytes,
+    plannedTreeHash: computeSkillTreeHash([
+      ...snapshot.files.map((file) => ({
+        path: file.path,
+        sha256: file.sha256,
+        executable: file.executable,
+      })),
+      { path: SKILL_RECEIPT_FILENAME, sha256: sha256(receiptBytes), executable: false },
+    ]),
+  });
+  return snapshot;
+}
+
+/** The apply inputs a freshly built plan would produce. */
+function currentInput(overrides: Record<string, unknown> = {}) {
+  const existing = readExistingSkillTree(installRoot());
+  return {
+    worktreePath: worktree,
+    worktreeRealPath: realpathSync(worktree),
+    skillId: SKILL_ID,
+    expectedReceiptDigest: readSkillReceiptDigest(existing) ?? '',
+    expectedTreeHash: computeSkillTreeHash(existing.files),
+    ...overrides,
+  };
+}
+
+/** Payload files are written 0600, so an edit needs the bit put back first. */
+function overwrite(relative: string, content: string): void {
+  const target = path.join(installRoot(), relative);
+  chmodSync(target, 0o600);
+  writeFileSync(target, content);
+}
+
+/** Assert a rejection carries the expected code. */
+function expectRejection(run: () => unknown, code: string): void {
+  let thrown: unknown;
+  try {
+    run();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(isSkillUninstallError(thrown)).toBe(true);
+  expect((thrown as { code: string }).code).toBe(code);
+}
+
+beforeEach(() => {
+  worktree = mkdtempSync(path.join(tmpdir(), 'cm-skill-uninstall-'));
+});
+
+afterEach(() => {
+  rmSync(worktree, { recursive: true, force: true });
+});
+
+// =============================================================================
+// The clean case
+// =============================================================================
+
+describe('applySkillUninstall — a clean managed install', () => {
+  it('removes every file, the directories they lived in, and the root', () => {
+    install();
+
+    const result = applySkillUninstall(currentInput());
+
+    expect(result.fullyRemoved).toBe(true);
+    expect(result.receiptRemoved).toBe(true);
+    expect(result.retained).toEqual([]);
+    expect(existsSync(installRoot())).toBe(false);
+    expect(result.removedFiles.map((file) => file.path)).toContain(
+      `.agents/skills/${SKILL_ID}/${SKILL_RECEIPT_FILENAME}`
+    );
+    expect(result.removedDirectories.sort()).toEqual([
+      `.agents/skills/${SKILL_ID}/assets`,
+      `.agents/skills/${SKILL_ID}/reference`,
+    ]);
+  });
+
+  it('leaves the rest of the worktree, and other Skills, alone', () => {
+    install();
+    const sibling = path.join(worktree, '.agents', 'skills', 'other-skill');
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(path.join(sibling, 'SKILL.md'), '# other\n');
+    writeFileSync(path.join(worktree, 'README.md'), '# repo\n');
+
+    applySkillUninstall(currentInput());
+
+    expect(existsSync(path.join(sibling, 'SKILL.md'))).toBe(true);
+    expect(existsSync(path.join(worktree, 'README.md'))).toBe(true);
+    expect(readdirSync(path.join(worktree, '.agents', 'skills'))).toEqual(['other-skill']);
+  });
+
+  it('reports its commit point once, before anything is deleted', () => {
+    install();
+    const observed: boolean[] = [];
+
+    applySkillUninstall(
+      currentInput({
+        onCommitPoint: () => observed.push(existsSync(path.join(installRoot(), 'SKILL.md'))),
+      })
+    );
+
+    expect(observed).toEqual([true]);
+  });
+
+  it('does not report a commit point when the plan is refused', () => {
+    install();
+    writeFileSync(path.join(installRoot(), 'my-notes.md'), 'keep me\n');
+    let committed = false;
+
+    expectRejection(
+      () => applySkillUninstall(currentInput({ onCommitPoint: () => (committed = true) })),
+      SkillUninstallErrorCode.BLOCKED
+    );
+
+    expect(committed).toBe(false);
+  });
+
+  it('answers the reconciler once the payload is gone', () => {
+    install();
+    const digest = readSkillReceiptDigest(readExistingSkillTree(installRoot()));
+
+    expect(hasRemovedSkillPayload(worktree, SKILL_ID, digest)).toBe(false);
+    applySkillUninstall(currentInput());
+    expect(hasRemovedSkillPayload(worktree, SKILL_ID, digest)).toBe(true);
+  });
+});
+
+// =============================================================================
+// Zero-delete
+// =============================================================================
+
+describe('applySkillUninstall — nothing is deleted when anything is ambiguous', () => {
+  it('keeps every file when one of them was edited locally', () => {
+    install();
+    const input = currentInput();
+    overwrite('reference/notes.md', '# Notes\n\nmine now\n');
+
+    expectRejection(() => applySkillUninstall(input), SkillUninstallErrorCode.BLOCKED);
+
+    expect(existsSync(path.join(installRoot(), 'reference/notes.md'))).toBe(true);
+    expect(existsSync(path.join(installRoot(), 'assets/logo.svg'))).toBe(true);
+    expect(existsSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME))).toBe(true);
+  });
+
+  it('keeps every file when the user added one of their own', () => {
+    install();
+    const input = currentInput();
+    writeFileSync(path.join(installRoot(), 'my-notes.md'), 'keep me\n');
+
+    expectRejection(() => applySkillUninstall(input), SkillUninstallErrorCode.BLOCKED);
+
+    expect(readFileSync(path.join(installRoot(), 'my-notes.md'), 'utf-8')).toBe('keep me\n');
+    expect(existsSync(path.join(installRoot(), 'assets/logo.svg'))).toBe(true);
+  });
+
+  it('keeps every file when a recorded one has already gone', () => {
+    install();
+    const input = currentInput();
+    rmSync(path.join(installRoot(), 'assets/logo.svg'));
+
+    expectRejection(() => applySkillUninstall(input), SkillUninstallErrorCode.BLOCKED);
+
+    expect(existsSync(path.join(installRoot(), 'reference/notes.md'))).toBe(true);
+    expect(existsSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME))).toBe(true);
+  });
+
+  it('keeps every file when a payload path was swapped for a symlink after planning', () => {
+    install();
+    const input = currentInput();
+    const outside = path.join(worktree, 'outside.txt');
+    writeFileSync(outside, 'victim\n');
+    rmSync(path.join(installRoot(), 'reference/notes.md'));
+    symlinkSync(outside, path.join(installRoot(), 'reference/notes.md'));
+
+    expectRejection(() => applySkillUninstall(input), SkillUninstallErrorCode.BLOCKED);
+
+    expect(readFileSync(outside, 'utf-8')).toBe('victim\n');
+    expect(existsSync(path.join(installRoot(), 'assets/logo.svg'))).toBe(true);
+  });
+
+  it('keeps every file when the tree the plan fixed no longer matches', () => {
+    install();
+
+    expectRejection(
+      () => applySkillUninstall(currentInput({ expectedTreeHash: '0'.repeat(64) })),
+      SkillUninstallErrorCode.DRIFT
+    );
+
+    expect(existsSync(path.join(installRoot(), 'assets/logo.svg'))).toBe(true);
+    expect(existsSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME))).toBe(true);
+  });
+
+  it('keeps every file when the receipt is no longer the one that was planned', () => {
+    install();
+
+    expectRejection(
+      () => applySkillUninstall(currentInput({ expectedReceiptDigest: 'a'.repeat(64) })),
+      SkillUninstallErrorCode.DRIFT
+    );
+
+    expect(existsSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME))).toBe(true);
+  });
+
+  it('reports nothing installed rather than succeeding vacuously', () => {
+    expectRejection(
+      () =>
+        applySkillUninstall({
+          worktreePath: worktree,
+          worktreeRealPath: realpathSync(worktree),
+          skillId: SKILL_ID,
+          expectedReceiptDigest: 'b'.repeat(64),
+          expectedTreeHash: computeSkillTreeHash([]),
+        }),
+      SkillUninstallErrorCode.NOT_INSTALLED
+    );
+  });
+});
+
+// =============================================================================
+// Directories
+// =============================================================================
+
+describe('applySkillUninstall — directories', () => {
+  it('leaves a directory the install did not create, and says what stayed', () => {
+    install();
+    const input = currentInput();
+    // Empty directories are invisible to the file scan, so this one cannot make
+    // the plan non-removable — it must survive the delete instead.
+    mkdirSync(path.join(installRoot(), 'scratch'));
+
+    const result = applySkillUninstall(input);
+
+    expect(existsSync(path.join(installRoot(), 'scratch'))).toBe(true);
+    expect(result.fullyRemoved).toBe(false);
+    expect(result.retained).toEqual([
+      expect.objectContaining({
+        path: `.agents/skills/${SKILL_ID}/scratch`,
+        messageKey: 'skills.uninstall.reason.unmanagedFile',
+      }),
+    ]);
+  });
+
+  it('leaves a payload directory that gained an unrelated file mid-delete', () => {
+    install();
+    const input = currentInput({
+      onCommitPoint: () => writeFileSync(path.join(installRoot(), 'assets', 'late.txt'), 'late\n'),
+    });
+
+    const result = applySkillUninstall(input);
+
+    expect(existsSync(path.join(installRoot(), 'assets', 'late.txt'))).toBe(true);
+    expect(result.removedDirectories).toEqual([`.agents/skills/${SKILL_ID}/reference`]);
+    expect(result.fullyRemoved).toBe(false);
+  });
+});
+
+// =============================================================================
+// Partial failure
+// =============================================================================
+
+describe('applySkillUninstall — a failure part-way through', () => {
+  it('leaves the receipt and the undeleted files in place for diagnosis', () => {
+    install();
+    const input = currentInput();
+    // Deletion needs write permission on the *parent* directory, so this makes
+    // `reference/notes.md` undeletable while leaving it perfectly readable.
+    chmodSync(path.join(installRoot(), 'reference'), 0o500);
+
+    try {
+      expectRejection(() => applySkillUninstall(input), SkillUninstallErrorCode.DELETE_FAILED);
+
+      // The earlier file went; the receipt that explains the directory did not.
+      expect(existsSync(path.join(installRoot(), 'assets/logo.svg'))).toBe(false);
+      expect(existsSync(path.join(installRoot(), 'reference/notes.md'))).toBe(true);
+      expect(existsSync(path.join(installRoot(), SKILL_RECEIPT_FILENAME))).toBe(true);
+      expect(assessSkillUninstall(installRoot(), SKILL_ID).receipt?.version).toBe(VERSION);
+    } finally {
+      chmodSync(path.join(installRoot(), 'reference'), 0o700);
+    }
+  });
+});
+
+// =============================================================================
+// Guards, exercised directly
+// =============================================================================
+
+describe('removeReceiptOwnedFile — the per-file guards', () => {
+  it('refuses a file whose bytes no longer match the receipt', () => {
+    install();
+    const original = readFileSync(path.join(installRoot(), 'reference/notes.md'));
+    overwrite('reference/notes.md', 'edited\n');
+
+    expectRejection(
+      () =>
+        removeReceiptOwnedFile(installRoot(), 'reference/notes.md', {
+          sha256: sha256(original),
+          executable: false,
+        }),
+      SkillUninstallErrorCode.FILE_CHANGED
+    );
+
+    expect(existsSync(path.join(installRoot(), 'reference/notes.md'))).toBe(true);
+  });
+
+  it('refuses a file whose mode no longer matches the receipt', () => {
+    install();
+    const bytes = readFileSync(path.join(installRoot(), 'reference/notes.md'));
+    chmodSync(path.join(installRoot(), 'reference/notes.md'), 0o700);
+
+    expectRejection(
+      () =>
+        removeReceiptOwnedFile(installRoot(), 'reference/notes.md', {
+          sha256: sha256(bytes),
+          executable: false,
+        }),
+      SkillUninstallErrorCode.FILE_CHANGED
+    );
+
+    expect(existsSync(path.join(installRoot(), 'reference/notes.md'))).toBe(true);
+  });
+
+  it('refuses to delete through a directory that became a symlink', () => {
+    install();
+    const outside = mkdtempSync(path.join(tmpdir(), 'cm-uninstall-outside-'));
+    const victim = path.join(outside, 'notes.md');
+    writeFileSync(victim, 'not yours\n');
+    rmSync(path.join(installRoot(), 'reference'), { recursive: true });
+    symlinkSync(outside, path.join(installRoot(), 'reference'));
+
+    try {
+      // The digest is the *victim's*, so only the link guard can stop this.
+      expectRejection(
+        () =>
+          removeReceiptOwnedFile(installRoot(), 'reference/notes.md', {
+            sha256: sha256('not yours\n'),
+            executable: false,
+          }),
+        SkillUninstallErrorCode.PATH_UNSAFE
+      );
+
+      expect(existsSync(victim)).toBe(true);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to delete a symlink standing where a payload file should be', () => {
+    install();
+    const outside = path.join(worktree, 'outside.txt');
+    writeFileSync(outside, 'victim\n');
+    rmSync(path.join(installRoot(), 'reference/notes.md'));
+    symlinkSync(outside, path.join(installRoot(), 'reference/notes.md'));
+
+    expectRejection(
+      () =>
+        removeReceiptOwnedFile(installRoot(), 'reference/notes.md', {
+          sha256: sha256('victim\n'),
+          executable: false,
+        }),
+      SkillUninstallErrorCode.PATH_UNSAFE
+    );
+
+    expect(existsSync(outside)).toBe(true);
+  });
+
+  it('refuses a path that walks out of the install root', () => {
+    install();
+    writeFileSync(path.join(worktree, 'outside.txt'), 'victim\n');
+
+    for (const relative of ['../outside.txt', '../../outside.txt', '/etc/hosts', '']) {
+      expectRejection(
+        () =>
+          removeReceiptOwnedFile(installRoot(), relative, {
+            sha256: sha256('victim\n'),
+            executable: false,
+          }),
+        SkillUninstallErrorCode.PATH_UNSAFE
+      );
+    }
+
+    expect(existsSync(path.join(worktree, 'outside.txt'))).toBe(true);
+  });
+
+  it('refuses a file that is hard-linked from outside the install root', () => {
+    install();
+    const bytes = readFileSync(path.join(installRoot(), 'reference/notes.md'));
+    linkSync(path.join(installRoot(), 'reference/notes.md'), path.join(worktree, 'alias.md'));
+
+    expectRejection(
+      () =>
+        removeReceiptOwnedFile(installRoot(), 'reference/notes.md', {
+          sha256: sha256(bytes),
+          executable: false,
+        }),
+      SkillUninstallErrorCode.PATH_UNSAFE
+    );
+
+    expect(existsSync(path.join(installRoot(), 'reference/notes.md'))).toBe(true);
+  });
+});
+
+describe('path derivation', () => {
+  it('rejects a Skill ID that is not a plain slug', () => {
+    for (const skillId of ['../escape', '.hidden', 'UPPER', 'a'.repeat(65)]) {
+      expectRejection(
+        () => resolveSkillUninstallTarget(worktree, skillId),
+        SkillUninstallErrorCode.TARGET_UNSAFE
+      );
+    }
+  });
+
+  it('derives the same root the install wrote to', () => {
+    install();
+
+    expect(resolveSkillUninstallTarget(worktree, SKILL_ID)).toBe(installRoot());
+  });
+
+  it('refuses when an ancestor of the install root is a symlink', () => {
+    const elsewhere = path.join(worktree, 'elsewhere');
+    mkdirSync(path.join(elsewhere, 'skills'), { recursive: true });
+    symlinkSync(elsewhere, path.join(worktree, '.agents'));
+
+    expectRejection(
+      () => assertSkillUninstallAncestors(realpathSync(worktree), worktree),
+      SkillUninstallErrorCode.ANCESTOR_UNSAFE
+    );
+  });
+
+  it('refuses when the worktree is no longer the directory that was resolved', () => {
+    expectRejection(
+      () => assertSkillUninstallAncestors(path.join(worktree, 'moved'), worktree),
+      SkillUninstallErrorCode.ANCESTOR_UNSAFE
+    );
+  });
+});

--- a/tests/unit/lib/skills/uninstall-plan.test.ts
+++ b/tests/unit/lib/skills/uninstall-plan.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Issue #1236: assessing whether a Skill directory is safe to remove.
+ *
+ * Every case here is about the *refusal*. A clean uninstall is one line of
+ * behaviour; the value of this module is that it can tell a file CommandMate
+ * wrote from one it did not, and stops on the difference. So each case plants
+ * exactly one anomaly in an otherwise perfect install and asserts that the
+ * whole plan goes non-removable — never that "most of it" is still deletable.
+ *
+ * The installs under test are produced by #1235's real apply, not hand-built,
+ * so a drift between what install writes and what uninstall recognises surfaces
+ * here rather than in a user's worktree.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import { applySkillInstall } from '@/lib/skills/install-apply';
+import {
+  SKILL_RECEIPT_FILENAME,
+  buildSkillInstallReceipt,
+  isSkillPlanError,
+  serializeSkillInstallReceipt,
+} from '@/lib/skills/install-plan';
+import { computeSkillTreeHash, readExistingSkillTree } from '@/lib/skills/preview-diff';
+import { inspectSkillPackage } from '@/lib/skills/package-validator';
+import type { SkillPackageSnapshot } from '@/lib/skills/package-validator';
+import {
+  SkillUninstallReason,
+  assessSkillUninstall,
+  consumeSkillUninstallPlan,
+  createSkillUninstallPlan,
+  getSkillUninstallPlan,
+  readSkillReceiptDigest,
+  resetSkillUninstallPlanCacheForTesting,
+} from '@/lib/skills/uninstall-plan';
+import { buildPackage } from '../../../fixtures/skills/malicious-packages/package';
+import type { PackageFileSpec } from '../../../fixtures/skills/malicious-packages/package';
+import { makeCatalogVersion } from './fixtures';
+import type { SkillGitTargetState } from '@/lib/skills/preview-diff';
+import type { SkillPlanActor } from '@/lib/skills/install-plan';
+
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const WORKTREE_ID = 'wt-1';
+const OPERATION_ID = '9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f';
+const ACTOR: SkillPlanActor = { type: 'user', id: null };
+
+const GIT: SkillGitTargetState = {
+  headState: 'attached',
+  branch: 'feature/demo',
+  headCommit: 'f'.repeat(40),
+  dirty: false,
+};
+
+let worktree: string;
+
+function installRoot(): string {
+  return path.join(worktree, '.agents', 'skills', SKILL_ID);
+}
+
+/** Install a real package the way #1235 does, so the receipt is genuine. */
+function install(files?: PackageFileSpec[]): SkillPackageSnapshot {
+  const built = buildPackage(files ? { files } : {});
+  const snapshot = inspectSkillPackage(built.bytes, { skillId: SKILL_ID, version: VERSION });
+  const receipt = buildSkillInstallReceipt({ snapshot, version: makeCatalogVersion() });
+  const receiptBytes = serializeSkillInstallReceipt(receipt);
+
+  applySkillInstall({
+    worktreePath: worktree,
+    worktreeRealPath: realpathSync(worktree),
+    skillId: SKILL_ID,
+    operationId: OPERATION_ID,
+    snapshot,
+    receiptBytes,
+    plannedTreeHash: computeSkillTreeHash([
+      ...snapshot.files.map((file) => ({
+        path: file.path,
+        sha256: file.sha256,
+        executable: file.executable,
+      })),
+      {
+        path: SKILL_RECEIPT_FILENAME,
+        sha256: createHash('sha256').update(receiptBytes).digest('hex'),
+        executable: false,
+      },
+    ]),
+  });
+  return snapshot;
+}
+
+function plan() {
+  return createSkillUninstallPlan({
+    actor: ACTOR,
+    worktree: {
+      id: WORKTREE_ID,
+      name: 'demo-worktree',
+      path: worktree,
+      repositoryName: 'CommandMate',
+    },
+    skillId: SKILL_ID,
+    installRootAbs: installRoot(),
+    git: GIT,
+  });
+}
+
+function observationFromDisk() {
+  const existing = readExistingSkillTree(installRoot());
+  return {
+    branch: GIT.branch,
+    headCommit: GIT.headCommit,
+    currentTreeHash: computeSkillTreeHash(existing.files),
+    receiptDigest: readSkillReceiptDigest(existing),
+  };
+}
+
+/** Payload files are written 0600, so an edit needs the bit put back first. */
+function overwrite(relative: string, content: string): void {
+  const target = path.join(installRoot(), relative);
+  chmodSync(target, 0o600);
+  writeFileSync(target, content);
+}
+
+beforeEach(() => {
+  worktree = mkdtempSync(path.join(tmpdir(), 'cm-skill-uninstall-plan-'));
+  resetSkillUninstallPlanCacheForTesting();
+});
+
+afterEach(() => {
+  rmSync(worktree, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Assessment
+// =============================================================================
+
+describe('assessSkillUninstall — a clean managed install', () => {
+  it('marks every payload file and the receipt removable', () => {
+    const snapshot = install();
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(true);
+    expect(assessment.blockers).toEqual([]);
+    expect(assessment.stats).toMatchObject({
+      removable: snapshot.files.length + 1,
+      modified: 0,
+      missing: 0,
+      unknown: 0,
+      irregular: 0,
+    });
+    // The receipt does not list itself, so it must be folded in explicitly or
+    // it would read as an unmanaged file and block its own removal.
+    const receiptEntry = assessment.entries.find((entry) => entry.generated);
+    expect(receiptEntry).toMatchObject({
+      relativePath: SKILL_RECEIPT_FILENAME,
+      disposition: 'remove',
+    });
+  });
+
+  it('reports the receipt digest, which identifies this install specifically', () => {
+    install();
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.receiptDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(assessment.receipt?.version).toBe(VERSION);
+  });
+});
+
+describe('assessSkillUninstall — one anomaly blocks the whole directory', () => {
+  it('refuses when a payload file was edited locally', () => {
+    install();
+    overwrite('reference/notes.md', '# Notes\n\nMy own additions.\n');
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers).toContainEqual(
+      expect.objectContaining({
+        code: SkillUninstallReason.LOCAL_MODIFICATION,
+        path: `.agents/skills/${SKILL_ID}/reference/notes.md`,
+      })
+    );
+    // The untouched siblings are still classified as removable — the refusal is
+    // a property of the plan, not of every individual file.
+    expect(assessment.stats.removable).toBeGreaterThan(0);
+  });
+
+  it('refuses when a payload file only changed its mode', () => {
+    install();
+    chmodSync(path.join(installRoot(), 'reference/notes.md'), 0o700);
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.LOCAL_MODIFICATION
+    );
+  });
+
+  it('refuses when the user left a file of their own in the directory', () => {
+    install();
+    writeFileSync(path.join(installRoot(), 'my-notes.md'), 'do not delete this\n');
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers).toContainEqual(
+      expect.objectContaining({
+        code: SkillUninstallReason.UNMANAGED_FILE,
+        path: `.agents/skills/${SKILL_ID}/my-notes.md`,
+      })
+    );
+  });
+
+  it('refuses when a recorded file has gone missing', () => {
+    install();
+    rmSync(path.join(installRoot(), 'assets/logo.svg'));
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.RECEIPT_ORPHAN
+    );
+  });
+
+  it('refuses when a payload path became a symlink', () => {
+    install();
+    const outside = path.join(worktree, 'outside.txt');
+    writeFileSync(outside, 'victim\n');
+    rmSync(path.join(installRoot(), 'reference/notes.md'));
+    symlinkSync(outside, path.join(installRoot(), 'reference/notes.md'));
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.NOT_A_REGULAR_FILE
+    );
+  });
+
+  it('refuses a directory with no receipt at all', () => {
+    mkdirSync(path.join(worktree, '.agents', 'skills', SKILL_ID), { recursive: true });
+    writeFileSync(path.join(installRoot(), 'SKILL.md'), '# hand-made\n');
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.receipt).toBeNull();
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.RECEIPT_MISSING
+    );
+  });
+
+  it('refuses an unreadable receipt rather than guessing at ownership', () => {
+    install();
+    overwrite(SKILL_RECEIPT_FILENAME, 'not json at all');
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.RECEIPT_UNREADABLE
+    );
+  });
+
+  it('refuses a receipt that describes a different Skill', () => {
+    install();
+    overwrite(SKILL_RECEIPT_FILENAME, JSON.stringify({ skill_id: 'other-skill', files: [] }));
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.RECEIPT_FOREIGN
+    );
+  });
+
+  it('reports nothing installed when the directory does not exist', () => {
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID);
+
+    expect(assessment.present).toBe(false);
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toEqual([
+      SkillUninstallReason.NOT_INSTALLED,
+    ]);
+  });
+
+  it('refuses when the directory walk could not complete', () => {
+    install();
+
+    const assessment = assessSkillUninstall(installRoot(), SKILL_ID, {
+      existing: { ...readExistingSkillTree(installRoot()), truncated: true },
+    });
+
+    expect(assessment.removable).toBe(false);
+    expect(assessment.blockers.map((entry) => entry.code)).toContain(
+      SkillUninstallReason.TREE_SCAN_TRUNCATED
+    );
+  });
+});
+
+// =============================================================================
+// Plan and token contract
+// =============================================================================
+
+describe('createSkillUninstallPlan', () => {
+  it('splits the directory into what goes and what stays, with reasons', () => {
+    install();
+    writeFileSync(path.join(installRoot(), 'my-notes.md'), 'keep me\n');
+
+    const record = plan();
+
+    expect(record.dto.removable).toBe(false);
+    expect(record.dto.nextActionKey).toBe('skills.uninstall.nextAction.blocked');
+    expect(record.dto.retained.map((entry) => entry.path)).toContain(
+      `.agents/skills/${SKILL_ID}/my-notes.md`
+    );
+    expect(record.dto.blockers[0].messageKey).toMatch(/^skills\.uninstall\.reason\./);
+  });
+
+  it('describes the install from its receipt, not from the Catalog', () => {
+    install();
+
+    const record = plan();
+
+    expect(record.dto.removable).toBe(true);
+    expect(record.dto.skill).toMatchObject({
+      id: SKILL_ID,
+      version: VERSION,
+      source: { repository: 'Kewton/commandmate-skills' },
+    });
+    expect(record.dto.target.installRoot).toBe(`.agents/skills/${SKILL_ID}`);
+  });
+
+  it('refuses to plan when nothing is installed', () => {
+    let thrown: unknown;
+    try {
+      plan();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(isSkillPlanError(thrown)).toBe(true);
+    expect((thrown as { code: string }).code).toBe('SKILL_PLAN_NOT_FOUND');
+  });
+});
+
+describe('consumeSkillUninstallPlan — the token contract', () => {
+  it('spends a token exactly once', () => {
+    install();
+    const record = plan();
+
+    consumeSkillUninstallPlan(
+      record.token,
+      { actor: ACTOR, worktreeId: WORKTREE_ID, skillId: SKILL_ID },
+      observationFromDisk()
+    );
+
+    expect(() =>
+      consumeSkillUninstallPlan(
+        record.token,
+        { actor: ACTOR, worktreeId: WORKTREE_ID, skillId: SKILL_ID },
+        observationFromDisk()
+      )
+    ).toThrowError(/SKILL_PLAN_CONSUMED/);
+  });
+
+  it('refuses a token presented by a different channel', () => {
+    install();
+    const record = plan();
+
+    expect(() =>
+      consumeSkillUninstallPlan(
+        record.token,
+        { actor: { type: 'cli', id: null }, worktreeId: WORKTREE_ID, skillId: SKILL_ID },
+        observationFromDisk()
+      )
+    ).toThrowError(/SKILL_PLAN_BINDING_MISMATCH/);
+  });
+
+  it('refuses a token bound to another worktree', () => {
+    install();
+    const record = plan();
+
+    expect(() =>
+      consumeSkillUninstallPlan(
+        record.token,
+        { actor: ACTOR, worktreeId: 'wt-other', skillId: SKILL_ID },
+        observationFromDisk()
+      )
+    ).toThrowError(/SKILL_PLAN_BINDING_MISMATCH/);
+  });
+
+  it('expires a token rather than letting a stale preview be applied', () => {
+    install();
+    const record = plan();
+
+    expect(() =>
+      getSkillUninstallPlan(record.token, { now: record.expiresAt + 1 })
+    ).toThrowError(/SKILL_PLAN_EXPIRED/);
+  });
+
+  it('refuses once a file under the install root has changed', () => {
+    install();
+    const record = plan();
+    overwrite('reference/notes.md', '# Notes\n\nedited after planning\n');
+
+    expect(() =>
+      consumeSkillUninstallPlan(
+        record.token,
+        { actor: ACTOR, worktreeId: WORKTREE_ID, skillId: SKILL_ID },
+        observationFromDisk()
+      )
+    ).toThrowError(/SKILL_PLAN_STALE/);
+  });
+
+  it('refuses once the branch has moved', () => {
+    install();
+    const record = plan();
+
+    expect(() =>
+      consumeSkillUninstallPlan(
+        record.token,
+        { actor: ACTOR, worktreeId: WORKTREE_ID, skillId: SKILL_ID },
+        { ...observationFromDisk(), branch: 'main' }
+      )
+    ).toThrowError(/SKILL_PLAN_STALE/);
+  });
+
+  it('refuses a plan that was never removable in the first place', () => {
+    install();
+    writeFileSync(path.join(installRoot(), 'my-notes.md'), 'keep me\n');
+    const record = plan();
+
+    expect(() =>
+      consumeSkillUninstallPlan(
+        record.token,
+        { actor: ACTOR, worktreeId: WORKTREE_ID, skillId: SKILL_ID },
+        observationFromDisk()
+      )
+    ).toThrowError(/SKILL_PLAN_NOT_INSTALLABLE/);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1236（Epic #1227 Phase 1）。#1235 の install の逆操作。receipt ownership と全 file digest を照合し、**modified / unknown / missing / unmanaged / irregular が 1 つでもあれば何も削除せずに停止する**（zero-delete fail closed）。「一部だけ消す」は実装しない。

## 追加

### `uninstall-plan.ts`

- `assessSkillUninstall()` — install root 配下の全 path を receipt と照合し remove / modified / missing / unknown / irregular に分類。**receipt は自分自身を `files` に載せない**ため on-disk digest で明示的に畳み込む（無いと receipt 自身が unmanaged 判定になり正当な uninstall が全て詰まる）
- plan token は #1233 の契約をそのまま再利用（TTL / 1 回性 / LRU / 定数時間比較）。drift は install と同じ `SKILL_PLAN_STALE` 409
- **drift 観測に receipt digest を含む** — plan 発行後に別 version が入り直された場合、これが「同じ install か」を判定する唯一の証拠

### `uninstall-apply.ts`

- install root の導出は `resolveSkillInstallRoot` + `SKILL_ID_PATTERN` 再検証（install 側と同一。`path.join` が `..` を正規化する罠への対策を削除側でも維持）
- `removeReceiptOwnedFile()` — unlink 直前に、install root からの directory 全 component を `lstat`、対象を `lstat`（symlink / 非 regular / `nlink !== 1` を拒否）、mode 照合、bytes 再読込 + digest 照合、を経てから unlink。**scan は「過ぎた瞬間の証拠」でしかないため syscall 直前に取り直す**
- directory は **`rmdir(2)` のみ**使用（recursive remove を使わない）。削除対象は receipt の file 一覧から導出した directory だけなので、**ユーザーが作った空 directory は回収しない**
- **receipt は最後に削除** — それまで directory は自分が何かを説明できるので、途中失敗時に journal / 人間の両方から reconcile 可能

### route

手順は #1235 の install route と同一順序（journal → lock → 再読込 & token 消費 → filesystem → index & audit）。atomic rename が無いため `onCommitPoint` callback で**「最初の unlink 直前」を FS_COMMITTED として記録**する。`force` / `recursive` は無視ではなく**明示的に拒否**。

## Mutation run（ガードを意図的に壊して該当 test が落ちることを確認）

| # | 壊したガード | 結果 |
|---|---|---|
| 1 | `removeReceiptOwnedFile` の digest 再照合 | FAIL（変更済み file が unlink される） |
| 2 | assessment の digest 照合 | FAIL（`SKILL_UNINSTALL_DRIFT` に縮退。tree hash が最後の砦） |
| 2c | 上記 + apply の tree-hash drift 検出 | FAIL（例外が出ず、**変更済み file が実際に削除される**） |
| 3 | assessment の unknown 検出 | FAIL（`SKILL_UNINSTALL_DRIFT` に縮退） |
| 3b | 上記 + tree-hash drift 検出 | FAIL（例外が出ず、**ユーザー作成 file が巻き込まれる**） |
| 4 | `assertDirectoryChainIsReal`（symlink 追従ガード） | FAIL（例外が出ず、**install root 外の victim が削除される**） |

**2 と 3 は単独では tree-hash drift 検出に受け止められる。** digest 照合と drift 検出が独立した 2 重のガードになっていることを示す結果で、実削除まで到達させるには両方を外す必要があった（2c / 3b）。

## Issue 記載からの訂正

- Issue の変更対象候補は `uninstall.ts` 単体だったが、#1233/#1234/#1235 が plan/apply を別 module に分けている既存 architecture に合わせ 2 分割した
- `SkillOperationTarget.version` は #1234 の doc comment で「uninstall では null」とされていたが、**receipt から取れる version を入れている**。idempotency key と audit 行を「どの install を消したか」まで束縛できるほうが強く、型も string を許している
- **UI（`SkillUninstallDialog.tsx`）は本 PR に含まない。** route の DTO が removals / retained / blockers / nextActionKey / reload を返すところまでで、画面は #1237 の担当
- barrel には追加していない（両 module とも `fs` を引くため、contract surface 限定という既存規約に従う）

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run test:unit` | worker 側 exit 0 / 628 files / 10987 tests |
| skills 系 integration | worker 側 exit 0 / 99 tests |
| `npm run build` | worker 側 exit 0 |

Refs #1236, #1227