### PR TITLE
feat(cli): commandmate skill管理コマンド (#1237)

### DIFF
--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -63,6 +63,7 @@ CM_PORT=3000 node bin/commandmate.js send abc123 "msg"
 | [`commandmate auto-yes`](#commandmate-auto-yes) | Auto-Yesの制御 |
 | [`commandmate instances`](#commandmate-instances) | エージェントインスタンス（roster）の一覧・追加・削除・alias変更 |
 | [`commandmate report`](#commandmate-report) | 日次レポートの生成・表示・一覧 |
+| [`commandmate skill`](#commandmate-skill) | 公式Skillのカタログ参照・Install Plan・install・uninstall・status |
 | [`commandmate update`](#commandmate-update) | CommandMate本体の更新（停止 → 更新 → 再起動） |
 
 ---
@@ -457,6 +458,84 @@ commandmate report list --json                     # JSON出力
 2026-06-20  [no report]  messages=3
 2026-06-19  [report] tool=codex  messages=8
 ```
+
+---
+
+## commandmate skill
+
+公式 Agent Skill を CLI から管理します。ブラウザ UI と**同一の API / domain service** を利用する thin client であり、
+CLI 側で download / extract / write / delete は一切行いません。
+
+filesystem path・artifact URL・file list・checksum は API 側で明示的に拒否されるため、CLI はそれらを再構成しません。
+plan で server が発行した plan token を、そのまま install / uninstall へ渡します。
+
+### 使用方法
+
+```bash
+# カタログ参照
+commandmate skill list                                    # 一覧（表形式）
+commandmate skill list --json                             # JSON（API レスポンスそのまま）
+commandmate skill list --prerelease                       # prerelease を含める
+commandmate skill info <skill-id>                         # 能力・提供元・version・互換性
+commandmate skill info <skill-id> --version 1.2.0
+
+# Install Plan（書き込みなし）
+commandmate skill plan <skill-id> --worktree <worktree-id>
+commandmate skill plan <skill-id> --worktree <worktree-id> --version 1.2.0 --json
+
+# install（plan → 確認 → apply）
+commandmate skill install <skill-id> --worktree <worktree-id> --version 1.2.0
+commandmate skill install <skill-id> --worktree <worktree-id> --version 1.2.0 --dry-run
+commandmate skill install <skill-id> --worktree <worktree-id> --version 1.2.0 --yes
+commandmate skill install <skill-id> --worktree <worktree-id> --version 1.2.0 \
+  --yes --ack-risk <skill-id>@1.2.0                       # high-risk Skill
+
+# uninstall / status
+commandmate skill uninstall <skill-id> --worktree <worktree-id> --dry-run
+commandmate skill uninstall <skill-id> --worktree <worktree-id> --yes
+commandmate skill status <skill-id> --worktree <worktree-id> --json
+```
+
+### 確認規約（install / uninstall）
+
+| 状況 | 挙動 |
+|------|------|
+| 常に | 先に plan を構築して内容を表示する |
+| `--dry-run` | plan までで停止し、書き込み・削除を行わない |
+| TTY かつ `--yes` なし | plan summary を表示してから確認プロンプト（stderr）を出す |
+| **非TTY かつ `--yes` なし** | **書き込まず exit 12**。プロンプトを出せない環境で暗黙実行しない |
+| **high-risk Skill** | `--yes` に加えて `--ack-risk <skill-id>@<version>` の**完全一致**が必要。`--yes` だけでは通らない（TTY で承諾しても同じ） |
+
+### オプション
+
+| オプション | 対象サブコマンド | 説明 |
+|-----------|-----------------|------|
+| `--worktree <id>` | plan / install / uninstall / status | 対象worktree ID（`commandmate ls` で確認） |
+| `--version <version>` | info / plan / install | install では**必須**（exact version） |
+| `--dry-run` | install / uninstall | plan までで停止 |
+| `-y, --yes` | install / uninstall | 確認プロンプトをスキップ（非対話環境では必須） |
+| `--ack-risk <id>@<version>` | install | high-risk Skill の明示的な承認 |
+| `--prerelease` | list / info / plan / install | prerelease version を対象に含める |
+| `--json` | 全サブコマンド | JSON出力（API レスポンスをそのまま出力） |
+| `--token <token>` | 全サブコマンド | 認証トークン（`CM_AUTH_TOKEN` 環境変数を推奨） |
+
+### 終了コード
+
+| コード | 意味 | 対処 |
+|-------|------|------|
+| 0 | 成功 | - |
+| 1 | サーバー／Catalog へ到達できない | リトライ可 |
+| 2 | 引数不正・Skill / version が存在しない | argv を修正 |
+| 11 | worktree 側が拒否（local変更・衝突・lock・plan drift） | 該当pathを解消して再 plan |
+| 12 | 書き込みが確認されなかった（`--yes` なし・拒否・`--ack-risk` 不一致） | 明示的に承認して再実行 |
+| 13 | ファイルは変更されたが reconciliation が必要 | 状態を確認（自動収束する） |
+
+> **stdout / stderr の分離**: `--json` 成功時の stdout は parse 可能な JSON のみになります。
+> plan summary・確認プロンプト・警告・エラー（typed code と blocker path を含む）はすべて stderr に出るため、
+> `--json` 実行が失敗した場合の stdout は空です。
+
+> **`skill status` について**: 1 worktree × 1 Skill の導入状態を、install receipt（ディスク上の実体）から報告します。
+> worktree 単位で導入済み Skill を一覧する API は未提供のため、`<skill-id>` は必須です。
 
 ---
 

--- a/src/cli/commands/skill-format.ts
+++ b/src/cli/commands/skill-format.ts
@@ -1,0 +1,183 @@
+/**
+ * skill command output formatting
+ * Issue #1237: renders Catalog entries and plans in the same vocabulary the UI
+ * uses (capability, effect, provenance, risk, target, diff, next action) so a
+ * user reading `--help` and one reading the browser see the same thing.
+ *
+ * Nothing here prints an absolute path, a token or an artifact URL: the API does
+ * not serve them, and these functions must not reconstruct them either.
+ */
+
+import type {
+  SkillCatalogMeta,
+  SkillCatalogSummary,
+  SkillInstallPlan,
+  SkillUninstallPlan,
+} from '../types/api-responses';
+
+/** [DR1-08 consistency] Mirrors ls.ts / instances.ts table rendering. */
+function formatTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => row[i].length))
+  );
+  const line = (cells: string[]): string =>
+    cells.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+  return [
+    line(headers),
+    widths.map((w) => '-'.repeat(w)).join('  '),
+    ...rows.map(line),
+  ].join('\n');
+}
+
+/**
+ * Freshness notice for a Catalog response, or null when it was confirmed current.
+ * Belongs on stderr: it qualifies the listing rather than being part of it.
+ */
+export function formatCatalogFreshness(catalog: SkillCatalogMeta): string | null {
+  if (!catalog.stale) return null;
+  const reason = catalog.staleReason ?? catalog.state;
+  return `Warning: showing the last known good Catalog (${reason}); it could not be confirmed current.`;
+}
+
+export function formatSkillTable(skills: SkillCatalogSummary[]): string {
+  if (skills.length === 0) return 'No Skills are published in the official Catalog.';
+
+  return formatTable(
+    ['SKILL_ID', 'NAME', 'LATEST', 'RECOMMENDED', 'COMPATIBILITY'],
+    skills.map((skill) => [
+      skill.id,
+      skill.name,
+      skill.latest,
+      skill.recommendedVersion ?? '-',
+      skill.compatibility?.status ?? 'unknown',
+    ])
+  );
+}
+
+export function formatSkillDetail(skill: SkillCatalogSummary, version?: string): string {
+  const lines: string[] = [
+    `${skill.name} (${skill.id})`,
+    skill.summary,
+    '',
+    `Provider:     ${skill.provider.name}`,
+    `License:      ${skill.license}`,
+    `Latest:       ${skill.latest}`,
+    `Recommended:  ${skill.recommendedVersion ?? '-'} (${skill.recommendedReason})`,
+  ];
+  if (skill.homepage) lines.push(`Homepage:     ${skill.homepage}`);
+  if (skill.compatibility) {
+    lines.push(`Compatibility: ${skill.compatibility.status} — ${skill.compatibility.message}`);
+  }
+
+  const versions = version
+    ? skill.versions.filter((entry) => entry.version === version)
+    : skill.versions;
+  lines.push('', 'Versions:');
+  if (versions.length === 0) {
+    lines.push(
+      version
+        ? `  (no published version ${version}; pass --prerelease if it is a prerelease)`
+        : '  (none listed; pass --prerelease to include prereleases)'
+    );
+  } else {
+    lines.push(
+      formatTable(
+        ['VERSION', 'RISK', 'PRERELEASE', 'COMPATIBILITY', 'PUBLISHED'],
+        versions.map((entry) => [
+          entry.version,
+          entry.declaredRisk,
+          entry.prerelease ? 'yes' : 'no',
+          entry.compatibility.commandmate.status,
+          entry.publishedAt,
+        ])
+      )
+        .split('\n')
+        .map((row) => `  ${row}`)
+        .join('\n')
+    );
+  }
+  return lines.join('\n');
+}
+
+function formatList(label: string, values: readonly string[]): string {
+  return `${label}${values.length > 0 ? values.join(', ') : '(none)'}`;
+}
+
+/** The install preview: what lands, where, at what risk, and what stands in the way. */
+export function formatInstallPlan(plan: SkillInstallPlan): string {
+  const { skill, target, stats } = plan;
+  const lines: string[] = [
+    `Install plan: ${skill.name} ${skill.version} (${skill.id})`,
+    skill.summary,
+    '',
+    `Target:       ${target.repositoryName} / ${target.worktreeName} (${target.worktreeId})`,
+    `Branch:       ${target.branch ?? `(${target.headState})`}${target.workingTreeDirty ? ' [working tree dirty]' : ''}`,
+    `Install root: ${target.installRoot}`,
+    `Risk:         ${skill.effectiveRisk} — ${skill.riskRationale}`,
+    `Compatibility: ${skill.compatibility.commandmate.status} — ${skill.compatibility.commandmate.message}`,
+    formatList('Permissions:  ', skill.declaredPermissions),
+    formatList('Scripts:      ', skill.scriptPaths),
+    formatList(
+      'Requires:     ',
+      skill.requirements.commands.map((command) =>
+        command.versionRange ? `${command.name} ${command.versionRange}` : command.name
+      )
+    ),
+    formatList('Network:      ', skill.requirements.networkHosts),
+    `Changes:      +${stats.added} added, ~${stats.modified} modified, =${stats.unchanged} unchanged, !${stats.conflicted} conflicting, ?${stats.unmanaged} unmanaged`,
+  ];
+
+  if (target.existingInstall) {
+    lines.push(`Already installed: ${target.existingInstall.version}`);
+  }
+  if (plan.warnings.length > 0) {
+    lines.push(`Warnings:     ${plan.warnings.join(', ')}`);
+  }
+  if (plan.blockers.length > 0) {
+    lines.push('Blockers:');
+    for (const blocker of plan.blockers) {
+      lines.push(`  - ${blocker.code}${blocker.path ? `: ${blocker.path}` : ''}`);
+    }
+  }
+  lines.push(
+    plan.installable
+      ? 'Installable:  yes'
+      : 'Installable:  no — nothing would be written'
+  );
+  if (plan.requiresRiskAcknowledgement) {
+    lines.push(
+      `High risk:    installing requires --ack-risk ${skill.id}@${skill.version} in addition to --yes`
+    );
+  }
+  return lines.join('\n');
+}
+
+/** The uninstall preview: what would be deleted, what would stay, and why. */
+export function formatUninstallPlan(plan: SkillUninstallPlan): string {
+  const { skill, target, stats } = plan;
+  const lines: string[] = [
+    `Uninstall plan: ${skill.id} ${skill.version}`,
+    '',
+    `Target:       ${target.repositoryName} / ${target.worktreeName} (${target.worktreeId})`,
+    `Branch:       ${target.branch ?? '(detached)'}${target.workingTreeDirty ? ' [working tree dirty]' : ''}`,
+    `Install root: ${target.installRoot}`,
+    `Risk:         ${skill.effectiveRisk}`,
+    `Files:        ${stats.removable} removable, ${stats.modified} locally modified, ${stats.missing} missing, ${stats.unknown} unmanaged, ${stats.irregular} irregular`,
+    `Removable:    ${plan.removable ? 'yes' : 'no — nothing would be deleted'}`,
+  ];
+
+  if (plan.retained.length > 0) {
+    lines.push('Retained:');
+    for (const entry of plan.retained) {
+      lines.push(`  - ${entry.path} (${entry.reason})`);
+    }
+  }
+  if (plan.blockers.length > 0) {
+    lines.push('Blockers:');
+    for (const blocker of plan.blockers) {
+      lines.push(`  - ${blocker.code}${blocker.path ? `: ${blocker.path}` : ''}`);
+    }
+  }
+  lines.push(`Next action:  ${plan.nextActionKey}`);
+  return lines.join('\n');
+}

--- a/src/cli/commands/skill-guards.ts
+++ b/src/cli/commands/skill-guards.ts
@@ -1,0 +1,166 @@
+/**
+ * skill command guards — confirmation contract and typed error mapping
+ * Issue #1237: `commandmate skill` is a thin client over the Skill APIs, so the
+ * only safety logic that belongs here is the part the server cannot enforce:
+ * whether *this invocation* is allowed to ask for a write at all.
+ */
+
+import * as readline from 'readline';
+import { ExitCode, SkillExitCode } from '../types';
+import { ApiError } from '../utils/api-client';
+import { isInteractive } from '../utils/prompt';
+
+/** Mirrors: src/lib/skills/constants.ts SKILL_ID_PATTERN / SKILL_ID_MAX_LENGTH. */
+const SKILL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SKILL_ID_MAX_LENGTH = 64;
+
+/**
+ * Validate a Skill ID before it is interpolated into a request path.
+ * The server validates it again; this only turns a typo into exit 2 instead of
+ * a request carrying an arbitrary path segment.
+ */
+export function isValidSkillId(id: string): boolean {
+  return id.length > 0 && id.length <= SKILL_ID_MAX_LENGTH && SKILL_ID_PATTERN.test(id);
+}
+
+/**
+ * Print a refusal on stderr and set the process exit code.
+ *
+ * Callers must `return` immediately afterwards: process.exit is stubbed in
+ * tests, so anything written after this line would still run — and, for a write
+ * command, would still reach the API.
+ */
+export function refuse(message: string, exitCode: number): void {
+  console.error(`Error: ${message}`);
+  process.exit(exitCode);
+}
+
+/**
+ * Exit code for each typed Skill API error.
+ *
+ * The point of the table is the split the Issue asks for: a bad request or a
+ * missing Skill (fix the argv) must not look like a worktree that refused the
+ * write (fix the files, then re-plan), and neither may look like the Catalog
+ * being unreachable (retry later).
+ */
+const SKILL_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
+  // The request was wrong. Nothing about the worktree needs to change.
+  SKILL_PLAN_INPUT_REJECTED: ExitCode.CONFIG_ERROR,
+  SKILL_PLAN_INVALID_BODY: ExitCode.CONFIG_ERROR,
+  SKILL_INSTALL_INVALID_BODY: ExitCode.CONFIG_ERROR,
+  SKILL_UNINSTALL_INVALID_BODY: ExitCode.CONFIG_ERROR,
+  SKILL_PLAN_TARGET_UNSAFE: ExitCode.CONFIG_ERROR,
+  SKILL_NOT_FOUND: ExitCode.CONFIG_ERROR,
+  SKILL_VERSION_NOT_FOUND: ExitCode.CONFIG_ERROR,
+  SKILL_UNINSTALL_NOT_INSTALLED: ExitCode.CONFIG_ERROR,
+
+  // The target refused. Resolve the named path, or re-plan, then retry.
+  SKILL_PLAN_STALE: SkillExitCode.BLOCKED,
+  SKILL_PLAN_EXPIRED: SkillExitCode.BLOCKED,
+  SKILL_PLAN_CONSUMED: SkillExitCode.BLOCKED,
+  SKILL_PLAN_BINDING_MISMATCH: SkillExitCode.BLOCKED,
+  SKILL_PLAN_NOT_INSTALLABLE: SkillExitCode.BLOCKED,
+  SKILL_INSTALL_DESTINATION_EXISTS: SkillExitCode.BLOCKED,
+  SKILL_INSTALL_DESTINATION_UNMANAGED: SkillExitCode.BLOCKED,
+  SKILL_INSTALL_TARGET_UNSAFE: SkillExitCode.BLOCKED,
+  SKILL_INSTALL_LOCKED: SkillExitCode.BLOCKED,
+  SKILL_INSTALL_IDEMPOTENCY_CONFLICT: SkillExitCode.BLOCKED,
+  SKILL_INSTALL_IN_PROGRESS: SkillExitCode.BLOCKED,
+  SKILL_UNINSTALL_BLOCKED: SkillExitCode.BLOCKED,
+  SKILL_UNINSTALL_TARGET_UNSAFE: SkillExitCode.BLOCKED,
+  SKILL_UNINSTALL_LOCKED: SkillExitCode.BLOCKED,
+  SKILL_UNINSTALL_IDEMPOTENCY_CONFLICT: SkillExitCode.BLOCKED,
+  SKILL_UNINSTALL_IN_PROGRESS: SkillExitCode.BLOCKED,
+
+  // An acknowledgement was missing, not a file.
+  SKILL_PLAN_RISK_NOT_ACKNOWLEDGED: SkillExitCode.CONFIRMATION_REQUIRED,
+};
+
+/** Statuses that mean "the dependency is unavailable", not "your request was wrong". */
+const AVAILABILITY_STATUSES: readonly number[] = [502, 503, 504];
+
+/** Exit code for a failed Skill API call. */
+export function skillExitCode(error: ApiError): number {
+  const mapped = error.apiCode ? SKILL_ERROR_EXIT_CODES[error.apiCode] : undefined;
+  if (mapped !== undefined) return mapped;
+  if (error.statusCode !== undefined && AVAILABILITY_STATUSES.includes(error.statusCode)) {
+    return ExitCode.DEPENDENCY_ERROR;
+  }
+  return error.exitCode;
+}
+
+/**
+ * Report a failed skill subcommand.
+ *
+ * Everything goes to stderr, including the typed code and any blocker paths, so
+ * a `--json` run that fails emits nothing at all on stdout rather than a
+ * half-written or error-shaped document.
+ */
+export function handleSkillCommandError(error: unknown): void {
+  if (error instanceof ApiError) {
+    const detail = error.payload?.error ?? error.message;
+    console.error(error.apiCode ? `Error: ${detail} [${error.apiCode}]` : `Error: ${detail}`);
+    for (const blocker of error.payload?.blockers ?? []) {
+      console.error(`  - ${blocker.code}${blocker.path ? `: ${blocker.path}` : ''}`);
+    }
+    process.exit(skillExitCode(error));
+    return;
+  }
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(ExitCode.UNEXPECTED_ERROR);
+}
+
+/**
+ * Ask a yes/no question on stderr.
+ *
+ * The shared confirm() in utils/prompt.ts writes to stdout, which would land
+ * inside the document a `--json` run is expected to emit. Skill writes own their
+ * prompt so stdout carries the result and nothing else, in every mode.
+ */
+async function confirmOnStderr(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolvePromise) => {
+      rl.question(`${question} (y/N): `, resolvePromise);
+    });
+    const normalized = answer.trim().toLowerCase();
+    return normalized === 'y' || normalized === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+/** How the confirmation requirement was settled. Only `confirmed` may write. */
+export type ConfirmationOutcome = 'confirmed' | 'declined' | 'non_interactive';
+
+/**
+ * Decide whether this invocation may proceed to a write.
+ *
+ * A non-TTY without `--yes` is refused rather than assumed: an environment that
+ * cannot show a prompt is exactly the one where an implicit yes would install
+ * something nobody watched.
+ */
+export async function resolveWriteConfirmation(
+  question: string,
+  options: { yes?: boolean }
+): Promise<ConfirmationOutcome> {
+  if (options.yes) return 'confirmed';
+  if (!isInteractive()) return 'non_interactive';
+  return (await confirmOnStderr(question)) ? 'confirmed' : 'declined';
+}
+
+/**
+ * Whether `--ack-risk` names exactly this Skill and version.
+ *
+ * Deliberately an exact value rather than a flag: `--yes` is a blanket "don't
+ * prompt me" that a wrapper script sets once and forgets, so it must not be
+ * able to carry a high-risk install with it. Typing the id and version is the
+ * acknowledgement.
+ */
+export function riskAcknowledgementMatches(
+  ackRisk: string | undefined,
+  skillId: string,
+  version: string
+): boolean {
+  return ackRisk !== undefined && ackRisk.trim() === `${skillId}@${version}`;
+}

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1,0 +1,502 @@
+/**
+ * skill Command - manage official Agent Skills from the CLI
+ * Issue #1237: a thin client over the Skill APIs (#1231/#1233/#1235/#1236)
+ *
+ *   commandmate skill list [--json]
+ *   commandmate skill info <skill-id> [--version <v>] [--json]
+ *   commandmate skill plan <skill-id> --worktree <id> [--version <v>] [--json]
+ *   commandmate skill install <skill-id> --worktree <id> --version <exact> [--dry-run] [--yes] [--ack-risk <id>@<version>]
+ *   commandmate skill uninstall <skill-id> --worktree <id> [--dry-run] [--yes] [--json]
+ *   commandmate skill status <skill-id> --worktree <id> [--json]
+ *
+ * The CLI never downloads, extracts, writes or deletes anything: it asks the
+ * server for a plan, shows it, and presents the token the server issued back to
+ * the server unchanged. It reconstructs no file list, no checksum and no path —
+ * those inputs are rejected by the API by design (#1233), and reproducing them
+ * here would create exactly the UI/CLI security drift the design forbids.
+ *
+ * `--json` prints the API response body verbatim, so the JSON contract is the
+ * API's. Every diagnostic, prompt and error goes to stderr, so a failed `--json`
+ * run leaves stdout empty rather than half-written.
+ */
+
+import { Command } from 'commander';
+import type {
+  SkillInfoOptions,
+  SkillInstallOptions,
+  SkillListOptions,
+  SkillPlanOptions,
+  SkillStatusOptions,
+  SkillUninstallOptions,
+} from '../types';
+import { ExitCode, SkillExitCode } from '../types';
+import type {
+  SkillDetailResponse,
+  SkillInstallPlan,
+  SkillInstallPlanResponse,
+  SkillInstallResponse,
+  SkillListResponse,
+  SkillUninstallPlan,
+  SkillUninstallPlanResponse,
+  SkillUninstallResponse,
+} from '../types/api-responses';
+import { ApiClient, ApiError, assertResponseShape, isValidWorktreeId } from '../utils/api-client';
+import { TOKEN_WARNING } from '../utils/command-helpers';
+import {
+  formatCatalogFreshness,
+  formatInstallPlan,
+  formatSkillDetail,
+  formatSkillTable,
+  formatUninstallPlan,
+} from './skill-format';
+import {
+  handleSkillCommandError,
+  isValidSkillId,
+  refuse,
+  resolveWriteConfirmation,
+  riskAcknowledgementMatches,
+} from './skill-guards';
+
+/** Validated `<skill-id>` plus `--worktree`, or null when either was rejected. */
+function resolveTarget(
+  skillId: string,
+  worktree: string | undefined
+): { skillId: string; worktreeId: string } | null {
+  if (!isValidSkillId(skillId)) {
+    refuse('Invalid Skill ID. Expected lowercase alphanumeric segments joined by hyphens.', ExitCode.CONFIG_ERROR);
+    return null;
+  }
+  if (!worktree) {
+    refuse('--worktree <id> is required. List candidates with: commandmate ls', ExitCode.CONFIG_ERROR);
+    return null;
+  }
+  if (!isValidWorktreeId(worktree)) {
+    refuse('Invalid worktree ID format.', ExitCode.CONFIG_ERROR);
+    return null;
+  }
+  return { skillId, worktreeId: worktree };
+}
+
+function catalogQuery(options: { prerelease?: boolean }): string {
+  return options.prerelease ? '?prerelease=true' : '';
+}
+
+// =============================================================================
+// Read commands
+// =============================================================================
+
+async function listSkills(options: SkillListOptions): Promise<void> {
+  const client = new ApiClient({ token: options.token });
+  const response = await client.get<SkillListResponse>(`/api/skills${catalogQuery(options)}`);
+  const body = assertResponseShape<SkillListResponse>(response, ['catalog', 'skills'], 'GET /api/skills');
+
+  const freshness = formatCatalogFreshness(body.catalog);
+  if (freshness) console.error(freshness);
+
+  console.log(options.json ? JSON.stringify(body, null, 2) : formatSkillTable(body.skills));
+}
+
+async function showSkill(skillId: string, options: SkillInfoOptions): Promise<void> {
+  if (!isValidSkillId(skillId)) {
+    refuse('Invalid Skill ID. Expected lowercase alphanumeric segments joined by hyphens.', ExitCode.CONFIG_ERROR);
+    return;
+  }
+
+  const client = new ApiClient({ token: options.token });
+  const response = await client.get<SkillDetailResponse>(
+    `/api/skills/${encodeURIComponent(skillId)}${catalogQuery(options)}`
+  );
+  const body = assertResponseShape<SkillDetailResponse>(
+    response,
+    ['catalog', 'skill'],
+    `GET /api/skills/${skillId}`
+  );
+
+  const freshness = formatCatalogFreshness(body.catalog);
+  if (freshness) console.error(freshness);
+
+  console.log(
+    options.json ? JSON.stringify(body, null, 2) : formatSkillDetail(body.skill, options.version)
+  );
+}
+
+/** Ask the server to build an Install Plan. The only inputs are what to install. */
+async function requestInstallPlan(
+  client: ApiClient,
+  target: { skillId: string; worktreeId: string },
+  options: { version?: string; prerelease?: boolean }
+): Promise<SkillInstallPlan> {
+  const body: Record<string, unknown> = {};
+  if (options.version) body.version = options.version;
+  if (options.prerelease) body.includePrerelease = true;
+
+  const response = await client.post<SkillInstallPlanResponse>(
+    `/api/worktrees/${encodeURIComponent(target.worktreeId)}/skills/${encodeURIComponent(target.skillId)}/plan`,
+    body
+  );
+  return assertResponseShape<SkillInstallPlanResponse>(response, ['plan'], 'POST .../skills/plan').plan;
+}
+
+/** Ask the server to build an Uninstall Plan. It takes no parameters at all. */
+async function requestUninstallPlan(
+  client: ApiClient,
+  target: { skillId: string; worktreeId: string }
+): Promise<SkillUninstallPlan> {
+  const response = await client.post<SkillUninstallPlanResponse>(
+    `/api/worktrees/${encodeURIComponent(target.worktreeId)}/skills/${encodeURIComponent(target.skillId)}/uninstall-plan`
+  );
+  return assertResponseShape<SkillUninstallPlanResponse>(
+    response,
+    ['plan'],
+    'POST .../skills/uninstall-plan'
+  ).plan;
+}
+
+async function planInstall(skillId: string, options: SkillPlanOptions): Promise<void> {
+  const target = resolveTarget(skillId, options.worktree);
+  if (!target) return;
+
+  const client = new ApiClient({ token: options.token });
+  const plan = await requestInstallPlan(client, target, options);
+
+  console.log(options.json ? JSON.stringify({ plan }, null, 2) : formatInstallPlan(plan));
+  if (!plan.installable) process.exit(SkillExitCode.BLOCKED);
+}
+
+/**
+ * Report whether one Skill is installed in one worktree.
+ *
+ * Derived from the uninstall preview, which is the only endpoint that reports
+ * installed state: it reads the on-disk receipt rather than the index, so what
+ * it reports is evidence rather than a claim. It writes nothing. There is no
+ * per-worktree listing endpoint yet, so `<skill-id>` is required.
+ */
+async function showStatus(skillId: string, options: SkillStatusOptions): Promise<void> {
+  const target = resolveTarget(skillId, options.worktree);
+  if (!target) return;
+
+  const client = new ApiClient({ token: options.token });
+  let plan: SkillUninstallPlan;
+  try {
+    plan = await requestUninstallPlan(client, target);
+  } catch (error) {
+    // Not installed is an answer, not a failure: `status` must be usable as a
+    // precondition check without a script having to swallow an exit code.
+    if (error instanceof ApiError && error.apiCode === 'SKILL_UNINSTALL_NOT_INSTALLED') {
+      const notInstalled = { skillId: target.skillId, worktreeId: target.worktreeId, installed: false };
+      console.log(
+        options.json
+          ? JSON.stringify(notInstalled, null, 2)
+          : `${target.skillId} is not installed in ${target.worktreeId}.`
+      );
+      return;
+    }
+    throw error;
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({ installed: true, plan }, null, 2));
+    return;
+  }
+  console.log(
+    [
+      `${plan.skill.id} ${plan.skill.version} is installed in ${plan.target.worktreeId}.`,
+      `Install root: ${plan.target.installRoot}`,
+      `Risk:         ${plan.skill.effectiveRisk}`,
+      `Removable:    ${plan.removable ? 'yes' : 'no'}`,
+    ].join('\n')
+  );
+}
+
+// =============================================================================
+// Write commands
+// =============================================================================
+
+async function installSkill(skillId: string, options: SkillInstallOptions): Promise<void> {
+  const target = resolveTarget(skillId, options.worktree);
+  if (!target) return;
+  if (!options.version) {
+    refuse(
+      '--version <exact> is required for install. Inspect published versions with: commandmate skill info ' + skillId,
+      ExitCode.CONFIG_ERROR
+    );
+    return;
+  }
+
+  const client = new ApiClient({ token: options.token });
+  const plan = await requestInstallPlan(client, target, options);
+
+  // --dry-run stops here by construction: the plan is the whole output and no
+  // token is ever presented back to the server.
+  if (options.dryRun) {
+    console.log(options.json ? JSON.stringify({ plan }, null, 2) : formatInstallPlan(plan));
+    if (!plan.installable) process.exit(SkillExitCode.BLOCKED);
+    return;
+  }
+
+  console.error(formatInstallPlan(plan));
+
+  if (!plan.installable) {
+    refuse('The Skill cannot be installed into this worktree; nothing was written.', SkillExitCode.BLOCKED);
+    return;
+  }
+
+  // Checked before the generic confirmation so `--yes` alone can never carry a
+  // high-risk install, in a TTY or out of one.
+  if (
+    plan.requiresRiskAcknowledgement &&
+    !riskAcknowledgementMatches(options.ackRisk, plan.skill.id, plan.skill.version)
+  ) {
+    refuse(
+      `${plan.skill.id} ${plan.skill.version} is high risk. Re-run with --ack-risk ${plan.skill.id}@${plan.skill.version} to acknowledge it explicitly.`,
+      SkillExitCode.CONFIRMATION_REQUIRED
+    );
+    return;
+  }
+
+  const outcome = await resolveWriteConfirmation(
+    `Install ${plan.skill.id} ${plan.skill.version} into ${plan.target.worktreeId} (${plan.target.installRoot})?`,
+    options
+  );
+  if (outcome === 'non_interactive') {
+    refuse(
+      'Refusing to install without a confirmation. Pass --yes to install from a non-interactive environment.',
+      SkillExitCode.CONFIRMATION_REQUIRED
+    );
+    return;
+  }
+  if (outcome === 'declined') {
+    refuse('Install declined; nothing was written.', SkillExitCode.CONFIRMATION_REQUIRED);
+    return;
+  }
+
+  const response = await client.post<SkillInstallResponse>(
+    `/api/worktrees/${encodeURIComponent(target.worktreeId)}/skills/${encodeURIComponent(target.skillId)}/install`,
+    {
+      planToken: plan.token,
+      version: plan.skill.version,
+      acknowledgeRisk: plan.requiresRiskAcknowledgement,
+    }
+  );
+  const body = assertResponseShape<SkillInstallResponse>(
+    response,
+    ['operation', 'install'],
+    'POST .../skills/install'
+  );
+
+  if (options.json) {
+    console.log(JSON.stringify(body, null, 2));
+  } else {
+    console.log(
+      `Installed ${body.install?.skillId ?? target.skillId} ${body.install?.version ?? plan.skill.version} into ${body.install?.installRoot ?? plan.target.installRoot}`
+    );
+  }
+
+  if (body.operation.result === 'committed_reconciling') {
+    // The payload is on disk; saying "install failed" would contradict what the
+    // user can see. Report it as needing attention instead.
+    console.error(
+      `Warning: the files landed but the operation did not finish cleanly (${body.operation.nextActionKey}). Reconciliation will converge it.`
+    );
+    process.exit(SkillExitCode.COMMITTED_RECONCILING);
+  }
+}
+
+async function uninstallSkill(skillId: string, options: SkillUninstallOptions): Promise<void> {
+  const target = resolveTarget(skillId, options.worktree);
+  if (!target) return;
+
+  const client = new ApiClient({ token: options.token });
+  const plan = await requestUninstallPlan(client, target);
+
+  if (options.dryRun) {
+    console.log(options.json ? JSON.stringify({ plan }, null, 2) : formatUninstallPlan(plan));
+    if (!plan.removable) process.exit(SkillExitCode.BLOCKED);
+    return;
+  }
+
+  console.error(formatUninstallPlan(plan));
+
+  if (!plan.removable) {
+    refuse('The uninstall is blocked by the paths listed above; nothing was deleted.', SkillExitCode.BLOCKED);
+    return;
+  }
+
+  const outcome = await resolveWriteConfirmation(
+    `Remove ${plan.skill.id} ${plan.skill.version} from ${plan.target.worktreeId} (${plan.target.installRoot})?`,
+    options
+  );
+  if (outcome === 'non_interactive') {
+    refuse(
+      'Refusing to uninstall without a confirmation. Pass --yes to uninstall from a non-interactive environment.',
+      SkillExitCode.CONFIRMATION_REQUIRED
+    );
+    return;
+  }
+  if (outcome === 'declined') {
+    refuse('Uninstall declined; nothing was deleted.', SkillExitCode.CONFIRMATION_REQUIRED);
+    return;
+  }
+
+  const response = await client.post<SkillUninstallResponse>(
+    `/api/worktrees/${encodeURIComponent(target.worktreeId)}/skills/${encodeURIComponent(target.skillId)}/uninstall`,
+    { planToken: plan.token }
+  );
+  const body = assertResponseShape<SkillUninstallResponse>(
+    response,
+    ['operation', 'uninstall'],
+    'POST .../skills/uninstall'
+  );
+
+  if (options.json) {
+    console.log(JSON.stringify(body, null, 2));
+  } else {
+    console.log(
+      `Removed ${body.uninstall?.skillId ?? target.skillId} ${body.uninstall?.version ?? plan.skill.version} from ${plan.target.installRoot}`
+    );
+  }
+
+  for (const entry of body.uninstall?.retained ?? []) {
+    console.error(`Retained: ${entry.path} (${entry.reason})`);
+  }
+
+  if (body.operation.result === 'committed_reconciling') {
+    console.error(
+      `Warning: deletion had already begun when the operation ended (${body.operation.nextActionKey}). Reconciliation will converge it.`
+    );
+    process.exit(SkillExitCode.COMMITTED_RECONCILING);
+  }
+}
+
+// =============================================================================
+// Wiring
+// =============================================================================
+
+export function createSkillCommand(): Command {
+  const skill = new Command('skill');
+  skill.description('Manage official Agent Skills (catalog, install plan, install, uninstall)');
+
+  skill
+    .command('list')
+    .description('List Skills published in the official Catalog')
+    .option('--json', 'JSON output (the API response body, verbatim)')
+    .option('--prerelease', 'Include prerelease versions')
+    .option('--token <token>', TOKEN_WARNING)
+    .action(async (options: SkillListOptions) => {
+      try {
+        await listSkills(options);
+      } catch (error) {
+        handleSkillCommandError(error);
+      }
+    });
+
+  skill
+    .command('info')
+    .description('Show one Skill: capabilities, provider, versions and compatibility')
+    .argument('<skill-id>', 'Skill ID from the Catalog')
+    .option('--version <version>', 'Show only this published version')
+    .option('--json', 'JSON output (the API response body, verbatim)')
+    .option('--prerelease', 'Include prerelease versions')
+    .option('--token <token>', TOKEN_WARNING)
+    .action(async (skillId: string, options: SkillInfoOptions) => {
+      try {
+        await showSkill(skillId, options);
+      } catch (error) {
+        handleSkillCommandError(error);
+      }
+    });
+
+  skill
+    .command('plan')
+    .description('Preview installing a Skill into a worktree. Never writes.')
+    .argument('<skill-id>', 'Skill ID from the Catalog')
+    .option('--worktree <id>', 'Target worktree ID (see: commandmate ls)')
+    .option('--version <version>', 'Exact version to plan (default: the recommended version)')
+    .option('--json', 'JSON output (the API response body, verbatim)')
+    .option('--prerelease', 'Include prerelease versions when resolving --version')
+    .option('--token <token>', TOKEN_WARNING)
+    .action(async (skillId: string, options: SkillPlanOptions) => {
+      try {
+        await planInstall(skillId, options);
+      } catch (error) {
+        handleSkillCommandError(error);
+      }
+    });
+
+  skill
+    .command('install')
+    .description('Install a Skill into a worktree, after showing the plan and confirming')
+    .argument('<skill-id>', 'Skill ID from the Catalog')
+    .option('--worktree <id>', 'Target worktree ID (see: commandmate ls)')
+    .option('--version <version>', 'Exact version to install')
+    .option('--dry-run', 'Build and print the plan, then stop without writing')
+    .option('-y, --yes', 'Skip the confirmation prompt (required for non-interactive use)')
+    .option(
+      '--ack-risk <skill-id@version>',
+      'Explicitly acknowledge a high-risk Skill. Required in addition to --yes.'
+    )
+    .option('--json', 'JSON output (the API response body, verbatim)')
+    .option('--prerelease', 'Allow a prerelease --version')
+    .option('--token <token>', TOKEN_WARNING)
+    .action(async (skillId: string, options: SkillInstallOptions) => {
+      try {
+        await installSkill(skillId, options);
+      } catch (error) {
+        handleSkillCommandError(error);
+      }
+    });
+
+  skill
+    .command('uninstall')
+    .description('Remove an installed Skill from a worktree, after showing the plan and confirming')
+    .argument('<skill-id>', 'Installed Skill ID')
+    .option('--worktree <id>', 'Target worktree ID (see: commandmate ls)')
+    .option('--dry-run', 'Build and print the plan, then stop without deleting')
+    .option('-y, --yes', 'Skip the confirmation prompt (required for non-interactive use)')
+    .option('--json', 'JSON output (the API response body, verbatim)')
+    .option('--token <token>', TOKEN_WARNING)
+    .action(async (skillId: string, options: SkillUninstallOptions) => {
+      try {
+        await uninstallSkill(skillId, options);
+      } catch (error) {
+        handleSkillCommandError(error);
+      }
+    });
+
+  skill
+    .command('status')
+    .description('Report whether a Skill is installed in a worktree, and whether it is removable')
+    .argument('<skill-id>', 'Skill ID to look for')
+    .option('--worktree <id>', 'Target worktree ID (see: commandmate ls)')
+    .option('--json', 'JSON output')
+    .option('--token <token>', TOKEN_WARNING)
+    .action(async (skillId: string, options: SkillStatusOptions) => {
+      try {
+        await showStatus(skillId, options);
+      } catch (error) {
+        handleSkillCommandError(error);
+      }
+    });
+
+  skill.addHelpText(
+    'after',
+    `
+Confirmation contract:
+  - Writes (install, uninstall) always build a plan first and print it.
+  - Without a TTY, a write requires --yes; a missing --yes is refused, never assumed.
+  - A high-risk Skill additionally requires --ack-risk <skill-id>@<version>.
+    --yes alone never carries a high-risk install.
+  - --dry-run stops at the plan and writes nothing.
+
+Exit codes:
+  0   success
+  1   the server or the Catalog could not be reached
+  2   invalid arguments, unknown Skill or unknown version
+  11  the worktree refused the operation (local change, conflict, lock, plan drift)
+  12  the write was never confirmed (no --yes, declined, or missing --ack-risk)
+  13  the files changed but the operation needs reconciliation
+`
+  );
+
+  return skill;
+}

--- a/src/cli/docs/agent-operations.ts
+++ b/src/cli/docs/agent-operations.ts
@@ -116,6 +116,42 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
 
   See "Multi-Session" below for the ID convention and roster semantics.
 
+### commandmate skill <subcommand>
+  Manage official Agent Skills. Every subcommand is a thin client over the same
+  APIs the browser UI uses: the CLI never downloads, extracts, writes or deletes
+  anything itself, and never sends a filesystem path, artifact URL, file list or
+  checksum (the API rejects those outright).
+
+  commandmate skill list [--json] [--prerelease]
+  commandmate skill info <skill-id> [--version <v>] [--json]
+  commandmate skill plan <skill-id> --worktree <id> [--version <v>] [--json]
+  commandmate skill install <skill-id> --worktree <id> --version <exact> [--dry-run] [--yes] [--ack-risk <id>@<version>] [--json]
+  commandmate skill uninstall <skill-id> --worktree <id> [--dry-run] [--yes] [--json]
+  commandmate skill status <skill-id> --worktree <id> [--json]
+
+  Confirmation contract (writes = install / uninstall):
+    - A plan is always built and shown first. --dry-run stops there.
+    - Without a TTY, a write REQUIRES --yes. A missing --yes is refused, never
+      assumed: an environment that cannot prompt must not install silently.
+    - A high-risk Skill additionally requires --ack-risk <skill-id>@<version>
+      with the exact id and version. --yes alone never carries a high-risk
+      install, in a TTY or out of one.
+
+  Exit codes:
+    0   success
+    1   the server or the Catalog could not be reached (retryable)
+    2   invalid arguments, unknown Skill or unknown version
+    11  the worktree refused it (local change, conflict, lock, plan drift)
+    12  the write was never confirmed (no --yes, declined, or missing --ack-risk)
+    13  files changed but the operation needs reconciliation
+
+  --json prints the API response body verbatim on stdout; diagnostics, prompts
+  and errors always go to stderr, so a failed --json run leaves stdout empty.
+
+  'skill status' reports one Skill in one worktree, read from the install
+  receipt on disk. There is no per-worktree listing endpoint yet, so <skill-id>
+  is required.
+
 ## Multi-Session (1 agent, multiple sessions)
 
   A worktree can run several sessions of the same CLI tool concurrently. Each

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -24,6 +24,8 @@ import { createAutoYesCommand } from './commands/auto-yes';
 import { createReportCommand } from './commands/report';
 // Issue #1000: Agent-instance roster management (discover/add/remove/alias/kill)
 import { createInstancesCommand } from './commands/instances';
+// Issue #1237: Skill management as a thin client over the Skill APIs
+import { createSkillCommand } from './commands/skill';
 // Issue #1195: Guided quickstart for bare `npx commandmate`
 import { quickstartCommand } from './commands/quickstart';
 import { isInteractive } from './utils/prompt';
@@ -221,6 +223,9 @@ export function buildProgram(): Command {
 
   // Issue #1000: Agent-instance roster management
   program.addCommand(createInstancesCommand());
+
+  // Issue #1237: Skill management (catalog / plan / install / uninstall / status)
+  program.addCommand(createSkillCommand());
 
   // Issue #264: AI Tool Integration help section
   program.addHelpText('after', `

--- a/src/cli/types/api-responses.ts
+++ b/src/cli/types/api-responses.ts
@@ -167,3 +167,208 @@ export interface ChatMessage {
   cliToolId?: string;
   createdAt?: string;
 }
+
+// =============================================================================
+// Skill management [Issue #1237]
+//
+// Mirrors: src/lib/api/skills-api.ts (Catalog), src/lib/skills/install-plan.ts,
+// src/lib/skills/uninstall-plan.ts and the four skill route modules.
+//
+// Only the fields the CLI reads are declared. `--json` prints the server body
+// verbatim rather than a re-serialization of these types, so the JSON contract
+// is the API's and cannot drift from what these declarations happen to cover.
+// =============================================================================
+
+/** Mirrors: src/lib/skills/compatibility.ts SkillCompatibilityStatus. */
+export type SkillCompatibilityStatus = 'compatible' | 'incompatible' | 'unknown';
+
+/** Mirrors: src/lib/skills/compatibility.ts SkillCommandMateCompatibility (subset). */
+export interface SkillCompatibilityView {
+  status: SkillCompatibilityStatus;
+  /** English fallback message built server-side from code, range and host version. */
+  message: string;
+  requiredRange: string;
+}
+
+/** Mirrors: src/lib/api/skills-api.ts SkillCatalogMetaDto (subset). */
+export interface SkillCatalogMeta {
+  stale: boolean;
+  offline: boolean;
+  state: string;
+  /** Why the served Catalog is stale, or null when it was confirmed current. */
+  staleReason: string | null;
+  fetchedAt: string;
+  revalidatedAt: string;
+  source: { repository: string; ref: string; revision: string | null };
+}
+
+/** Mirrors: src/lib/api/skills-api.ts SkillVersionDto (subset; artifact.url is never served). */
+export interface SkillCatalogVersionSummary {
+  version: string;
+  declaredRisk: string;
+  prerelease: boolean;
+  publishedAt: string;
+  compatibility: { commandmate: SkillCompatibilityView };
+}
+
+/** Mirrors: src/lib/api/skills-api.ts SkillDto (subset). */
+export interface SkillCatalogSummary {
+  id: string;
+  name: string;
+  summary: string;
+  provider: { name: string };
+  license: string;
+  homepage: string | null;
+  latest: string;
+  recommendedVersion: string | null;
+  recommendedReason: string;
+  compatibility: SkillCompatibilityView | null;
+  versions: SkillCatalogVersionSummary[];
+}
+
+/** Mirrors: src/app/api/skills/route.ts GET response. */
+export interface SkillListResponse {
+  catalog: SkillCatalogMeta;
+  skills: SkillCatalogSummary[];
+}
+
+/** Mirrors: src/app/api/skills/[id]/route.ts GET response. */
+export interface SkillDetailResponse {
+  catalog: SkillCatalogMeta;
+  skill: SkillCatalogSummary;
+}
+
+/** A typed reason an operation is refused, with the repository-relative path responsible. */
+export interface SkillPlanBlocker {
+  code: string;
+  path: string | null;
+}
+
+/** Mirrors: src/lib/skills/install-plan.ts SkillInstallPlanDto (subset). */
+export interface SkillInstallPlan {
+  /** Single-use token the apply step presents unchanged. The CLI never inspects it. */
+  token: string;
+  expiresAt: string;
+  installable: boolean;
+  requiresRiskAcknowledgement: boolean;
+  riskAcknowledged: boolean;
+  blockers: SkillPlanBlocker[];
+  warnings: string[];
+  target: {
+    worktreeId: string;
+    worktreeName: string;
+    repositoryName: string;
+    branch: string | null;
+    headState: string;
+    workingTreeDirty: boolean;
+    /** Repository-relative; the server never serves a machine-absolute path. */
+    installRoot: string;
+    existingInstall: { version: string; receiptDigest: string } | null;
+  };
+  skill: {
+    id: string;
+    name: string;
+    version: string;
+    summary: string;
+    license: string;
+    declaredPermissions: string[];
+    effectiveRisk: string;
+    riskRationale: string;
+    scriptPaths: string[];
+    executablePaths: string[];
+    requirements: {
+      commands: Array<{ name: string; versionRange: string | null }>;
+      networkHosts: string[];
+    };
+    compatibility: {
+      commandmate: SkillCompatibilityView;
+      agents: Array<{ agent: string; support: string }>;
+    };
+  };
+  stats: {
+    added: number;
+    modified: number;
+    unchanged: number;
+    conflicted: number;
+    unmanaged: number;
+  };
+}
+
+/** Mirrors: src/app/api/worktrees/[id]/skills/[skillId]/plan/route.ts POST response. */
+export interface SkillInstallPlanResponse {
+  plan: SkillInstallPlan;
+}
+
+/**
+ * Mirrors: SkillInstallOperationDto / SkillUninstallOperationDto (subset).
+ * `committed_reconciling` means the worktree already changed — never reported as a failure.
+ */
+export interface SkillOperationResult {
+  operationId: string;
+  state: string;
+  result: 'succeeded' | 'committed_reconciling';
+  committed: boolean;
+  reconcilePending: boolean;
+  nextActionKey: string;
+  replayed: boolean;
+}
+
+/**
+ * Mirrors: src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts POST response.
+ * `files` is absent from the narrower replay body, and `install` is null when a
+ * replay finds no index row.
+ */
+export interface SkillInstallResponse {
+  operation: SkillOperationResult;
+  install: {
+    skillId: string;
+    version: string;
+    installRoot: string;
+    files?: Array<{ path: string }>;
+  } | null;
+}
+
+/** Mirrors: src/lib/skills/uninstall-plan.ts SkillUninstallPlanDto (subset). */
+export interface SkillUninstallPlan {
+  token: string;
+  expiresAt: string;
+  removable: boolean;
+  blockers: SkillPlanBlocker[];
+  nextActionKey: string;
+  target: {
+    worktreeId: string;
+    worktreeName: string;
+    repositoryName: string;
+    branch: string | null;
+    workingTreeDirty: boolean;
+    installRoot: string;
+  };
+  skill: { id: string; version: string; effectiveRisk: string };
+  removals: Array<{ path: string }>;
+  retained: Array<{ path: string; reason: string }>;
+  stats: {
+    removable: number;
+    modified: number;
+    missing: number;
+    unknown: number;
+    irregular: number;
+  };
+}
+
+/** Mirrors: src/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route.ts POST response. */
+export interface SkillUninstallPlanResponse {
+  plan: SkillUninstallPlan;
+}
+
+/** Mirrors: src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts POST response. */
+export interface SkillUninstallResponse {
+  operation: SkillOperationResult;
+  uninstall: {
+    skillId: string;
+    version: string | null;
+    installRoot?: string;
+    removedFiles?: Array<{ path: string }>;
+    retained?: Array<{ path: string; reason: string }>;
+    fullyRemoved?: boolean;
+  } | null;
+}

--- a/src/cli/types/index.ts
+++ b/src/cli/types/index.ts
@@ -264,6 +264,74 @@ export interface AutoYesOptions {
   token?: string;
 }
 
+/**
+ * skill command exit codes [Issue #1237]
+ *
+ * Follows the WaitExitCode precedent: infrastructure and input failures keep
+ * using {@link ExitCode}, while these name outcomes a caller must be able to
+ * distinguish without parsing stderr. Values start at 11 so they cannot collide
+ * with WaitExitCode.PROMPT_DETECTED.
+ */
+export const SkillExitCode = {
+  SUCCESS: 0,
+  /**
+   * The target worktree refused the operation: an unmanaged or locally modified
+   * file, an occupied destination, a concurrent operation, or a plan whose world
+   * moved. Distinct from a network/API failure (ExitCode.DEPENDENCY_ERROR) so an
+   * automation can retry the latter but must not retry the former blindly.
+   */
+  BLOCKED: 11,
+  /** The write was never confirmed: non-TTY without --yes, missing/mismatched --ack-risk, or a declined prompt. */
+  CONFIRMATION_REQUIRED: 12,
+  /** The payload reached the worktree but the operation did not finish cleanly (`committed_reconciling`). */
+  COMMITTED_RECONCILING: 13,
+} as const;
+export type SkillExitCode = typeof SkillExitCode[keyof typeof SkillExitCode];
+
+/** Shared by every skill subcommand [Issue #1237] */
+export interface SkillCommonOptions {
+  json?: boolean;
+  token?: string;
+}
+
+/** skill list options [Issue #1237] */
+export interface SkillListOptions extends SkillCommonOptions {
+  prerelease?: boolean;
+}
+
+/** skill info options [Issue #1237] */
+export interface SkillInfoOptions extends SkillListOptions {
+  version?: string;
+}
+
+/** skill plan options [Issue #1237] */
+export interface SkillPlanOptions extends SkillListOptions {
+  worktree?: string;
+  version?: string;
+}
+
+/** skill install options [Issue #1237] */
+export interface SkillInstallOptions extends SkillPlanOptions {
+  /** Build the plan and stop; never writes. */
+  dryRun?: boolean;
+  /** Skip the interactive confirmation. Required to write from a non-TTY. */
+  yes?: boolean;
+  /** Explicit `<skill-id>@<version>` acknowledgement, demanded on top of --yes for high risk. */
+  ackRisk?: string;
+}
+
+/** skill uninstall options [Issue #1237] */
+export interface SkillUninstallOptions extends SkillCommonOptions {
+  worktree?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/** skill status options [Issue #1237] */
+export interface SkillStatusOptions extends SkillCommonOptions {
+  worktree?: string;
+}
+
 /** instances command options [Issue #1000] */
 export interface InstancesOptions {
   json?: boolean;

--- a/src/cli/utils/api-client.ts
+++ b/src/cli/utils/api-client.ts
@@ -206,7 +206,8 @@ export class ApiClient {
 
       if (!response.ok) {
         const errResult = handleApiError(null, response.status);
-        throw new ApiError(errResult.message, errResult.exitCode, response.status);
+        const payload = await readErrorPayload(response);
+        throw new ApiError(errResult.message, errResult.exitCode, response.status, payload);
       }
 
       return (await response.json()) as T;
@@ -231,7 +232,8 @@ export class ApiClient {
 
       if (!response.ok) {
         const errResult = handleApiError(null, response.status);
-        throw new ApiError(errResult.message, errResult.exitCode, response.status);
+        const payload = await readErrorPayload(response);
+        throw new ApiError(errResult.message, errResult.exitCode, response.status, payload);
       }
 
       // Handle 204 No Content
@@ -260,7 +262,8 @@ export class ApiClient {
 
       if (!response.ok) {
         const errResult = handleApiError(null, response.status);
-        throw new ApiError(errResult.message, errResult.exitCode, response.status);
+        const payload = await readErrorPayload(response);
+        throw new ApiError(errResult.message, errResult.exitCode, response.status, payload);
       }
 
       const text = await response.text();
@@ -275,6 +278,40 @@ export class ApiClient {
 }
 
 /**
+ * Machine-readable part of a failed API response (Issue #1237).
+ * Every Skill route answers `{ error, code }`; the uninstall routes add `blockers`.
+ */
+export interface ApiErrorPayload {
+  code?: string;
+  error?: string;
+  blockers?: Array<{ code: string; path: string | null }>;
+}
+
+/**
+ * Read the typed error body of a failed response.
+ *
+ * The generic status-to-message mapping in {@link handleApiError} cannot tell
+ * "a local file is in the way" from "the version does not exist" — both are 409
+ * or 404 — so commands that need a stable exit code read the server's `code`
+ * from here. Never throws: a body that is absent, truncated or not JSON simply
+ * yields undefined and the status-based classification stands.
+ */
+async function readErrorPayload(response: Response): Promise<ApiErrorPayload | undefined> {
+  try {
+    const text = await response.text();
+    if (!text) return undefined;
+    const parsed: unknown = JSON.parse(text);
+    if (parsed === null || typeof parsed !== 'object') return undefined;
+    const record = parsed as ApiErrorPayload;
+    return typeof record.code === 'string' || typeof record.error === 'string'
+      ? record
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * API Error with exit code for CLI process.exit()
  */
 export class ApiError extends Error {
@@ -282,9 +319,16 @@ export class ApiError extends Error {
     message: string,
     public readonly exitCode: number,
     public readonly statusCode?: number,
+    /** Typed error body, when the server sent one (Issue #1237). */
+    public readonly payload?: ApiErrorPayload,
   ) {
     super(message);
     this.name = 'ApiError';
+  }
+
+  /** Stable machine code the server assigned to this failure, if any. */
+  get apiCode(): string | undefined {
+    return this.payload?.code;
   }
 }
 

--- a/tests/unit/cli/commands/skill.test.ts
+++ b/tests/unit/cli/commands/skill.test.ts
@@ -1,0 +1,648 @@
+/**
+ * skill Command Tests
+ * Issue #1237
+ *
+ * Every test drives the command through mocked fetch. Nothing here contacts a
+ * real server: the official Skill repository is private and the Catalog is not
+ * published, so a network-dependent test would be untrustworthy by construction.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { mockFetchResponse, mockFetchSequence, restoreFetch } from '../../../helpers/mock-api';
+
+/** Answer the next stderr confirmation prompt with this string. */
+let promptAnswer = 'n';
+
+vi.mock('readline', () => ({
+  createInterface: () => ({
+    question: (_query: string, callback: (answer: string) => void) => callback(promptAnswer),
+    close: () => {},
+  }),
+}));
+
+const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+const originalIsTTY = process.stdin.isTTY;
+
+beforeEach(() => {
+  promptAnswer = 'n';
+  process.stdin.isTTY = undefined as unknown as boolean;
+});
+
+afterEach(() => {
+  restoreFetch();
+  process.stdin.isTTY = originalIsTTY;
+  mockExit.mockClear();
+  mockConsoleLog.mockClear();
+  mockConsoleError.mockClear();
+});
+
+async function loadCommand() {
+  const { createSkillCommand } = await import('../../../../src/cli/commands/skill');
+  return createSkillCommand();
+}
+
+function run(argv: string[]): Promise<unknown> {
+  return loadCommand().then((cmd) => cmd.parseAsync(['node', 'skill', ...argv]));
+}
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const catalogMeta = {
+  stale: false,
+  offline: false,
+  state: 'fresh',
+  staleReason: null,
+  fetchedAt: '2026-07-20T00:00:00Z',
+  revalidatedAt: '2026-07-20T00:00:00Z',
+  source: { repository: 'Kewton/commandmate-skills', ref: 'main', revision: 'abc' },
+};
+
+const catalogSkill = {
+  id: 'cmate-repository-analysis',
+  name: 'Repository Analysis',
+  summary: 'Analyze a repository.',
+  provider: { name: 'CommandMate' },
+  license: 'MIT',
+  homepage: null,
+  latest: '1.2.0',
+  recommendedVersion: '1.2.0',
+  recommendedReason: 'SKILL_RECOMMENDATION_LATEST_COMPATIBLE',
+  compatibility: { status: 'compatible', message: 'ok', requiredRange: '>=1.0.0' },
+  versions: [
+    {
+      version: '1.2.0',
+      declaredRisk: 'low',
+      prerelease: false,
+      publishedAt: '2026-07-01T00:00:00Z',
+      compatibility: { commandmate: { status: 'compatible', message: 'ok', requiredRange: '>=1.0.0' } },
+    },
+  ],
+};
+
+function installPlan(overrides: Record<string, unknown> = {}) {
+  return {
+    plan: {
+      token: 'a'.repeat(48),
+      expiresAt: '2026-07-20T00:10:00Z',
+      installable: true,
+      requiresRiskAcknowledgement: false,
+      riskAcknowledged: false,
+      blockers: [],
+      warnings: [],
+      target: {
+        worktreeId: 'anvil-develop',
+        worktreeName: 'develop',
+        repositoryName: 'anvil',
+        branch: 'develop',
+        headState: 'attached',
+        workingTreeDirty: false,
+        installRoot: '.agents/skills/cmate-repository-analysis',
+        existingInstall: null,
+      },
+      skill: {
+        id: 'cmate-repository-analysis',
+        name: 'Repository Analysis',
+        version: '1.2.0',
+        summary: 'Analyze a repository.',
+        license: 'MIT',
+        declaredPermissions: ['filesystem_read'],
+        effectiveRisk: 'low',
+        riskRationale: 'read-only',
+        scriptPaths: [],
+        executablePaths: [],
+        requirements: { commands: [], networkHosts: [] },
+        compatibility: {
+          commandmate: { status: 'compatible', message: 'ok', requiredRange: '>=1.0.0' },
+          agents: [],
+        },
+      },
+      stats: { added: 3, modified: 0, unchanged: 0, conflicted: 0, unmanaged: 0 },
+      ...overrides,
+    },
+  };
+}
+
+function highRiskPlan() {
+  const base = installPlan();
+  base.plan.requiresRiskAcknowledgement = true;
+  base.plan.skill.effectiveRisk = 'high';
+  return base;
+}
+
+const installResult = {
+  operation: {
+    operationId: 'op-1',
+    state: 'SUCCEEDED',
+    result: 'succeeded',
+    committed: true,
+    reconcilePending: false,
+    nextActionKey: 'skills.install.succeeded',
+    replayed: false,
+  },
+  install: {
+    skillId: 'cmate-repository-analysis',
+    version: '1.2.0',
+    installRoot: '.agents/skills/cmate-repository-analysis',
+    files: [{ path: '.agents/skills/cmate-repository-analysis/SKILL.md' }],
+  },
+};
+
+function uninstallPlan(overrides: Record<string, unknown> = {}) {
+  return {
+    plan: {
+      token: 'b'.repeat(48),
+      expiresAt: '2026-07-20T00:10:00Z',
+      removable: true,
+      blockers: [],
+      nextActionKey: 'skills.uninstall.removable',
+      target: {
+        worktreeId: 'anvil-develop',
+        worktreeName: 'develop',
+        repositoryName: 'anvil',
+        branch: 'develop',
+        workingTreeDirty: false,
+        installRoot: '.agents/skills/cmate-repository-analysis',
+      },
+      skill: { id: 'cmate-repository-analysis', version: '1.2.0', effectiveRisk: 'low' },
+      removals: [{ path: '.agents/skills/cmate-repository-analysis/SKILL.md' }],
+      retained: [],
+      stats: { removable: 2, modified: 0, missing: 0, unknown: 0, irregular: 0 },
+      ...overrides,
+    },
+  };
+}
+
+const uninstallResult = {
+  operation: {
+    operationId: 'op-2',
+    state: 'SUCCEEDED',
+    result: 'succeeded',
+    committed: true,
+    reconcilePending: false,
+    nextActionKey: 'skills.uninstall.succeeded',
+    replayed: false,
+  },
+  uninstall: {
+    skillId: 'cmate-repository-analysis',
+    version: '1.2.0',
+    installRoot: '.agents/skills/cmate-repository-analysis',
+    removedFiles: [],
+    retained: [],
+    fullyRemoved: true,
+  },
+};
+
+/** Body of the nth fetch call, parsed. */
+function requestBody(index: number): Record<string, unknown> {
+  const call = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls[index];
+  const init = call[1] as { body?: string };
+  return init.body ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+}
+
+// =============================================================================
+// Wiring
+// =============================================================================
+
+describe('createSkillCommand', () => {
+  it('creates a Command named "skill" with every documented subcommand', async () => {
+    const cmd = await loadCommand();
+    expect(cmd.name()).toBe('skill');
+    expect(cmd.commands.map((c) => c.name()).sort()).toEqual([
+      'info',
+      'install',
+      'list',
+      'plan',
+      'status',
+      'uninstall',
+    ]);
+  });
+
+  it('spells out the confirmation contract and exit codes in `skill --help`', async () => {
+    const cmd = await loadCommand();
+    let out = '';
+    cmd.configureOutput({ writeOut: (chunk) => { out += chunk; } });
+    cmd.outputHelp();
+
+    expect(out).toContain('--dry-run stops at the plan and writes nothing');
+    expect(out).toContain('12  the write was never confirmed');
+  });
+
+  it('documents --ack-risk, --dry-run and --yes in `install --help`', async () => {
+    const cmd = await loadCommand();
+    const install = cmd.commands.find((c) => c.name() === 'install');
+    const help = install?.helpInformation() ?? '';
+
+    expect(help).toContain('--ack-risk');
+    expect(help).toContain('--dry-run');
+    expect(help).toContain('--yes');
+  });
+});
+
+// =============================================================================
+// list / info
+// =============================================================================
+
+describe('skill list', () => {
+  it('renders the Catalog as a table', async () => {
+    mockFetchResponse({ catalog: catalogMeta, skills: [catalogSkill] });
+    await run(['list']);
+
+    const output = mockConsoleLog.mock.calls[0][0] as string;
+    expect(output).toContain('SKILL_ID');
+    expect(output).toContain('cmate-repository-analysis');
+    expect(output).toContain('compatible');
+  });
+
+  it('prints the API response verbatim with --json', async () => {
+    const body = { catalog: catalogMeta, skills: [catalogSkill] };
+    mockFetchResponse(body);
+    await run(['list', '--json']);
+
+    expect(JSON.parse(mockConsoleLog.mock.calls[0][0] as string)).toEqual(body);
+  });
+
+  it('warns on stderr when the served Catalog is stale, keeping stdout pure JSON', async () => {
+    const body = {
+      catalog: { ...catalogMeta, stale: true, staleReason: 'SKILL_CATALOG_FETCH_FAILED' },
+      skills: [catalogSkill],
+    };
+    mockFetchResponse(body);
+    await run(['list', '--json']);
+
+    expect(mockConsoleError.mock.calls[0][0]).toContain('SKILL_CATALOG_FETCH_FAILED');
+    expect(() => JSON.parse(mockConsoleLog.mock.calls[0][0] as string)).not.toThrow();
+  });
+
+  it('opts into prereleases only when --prerelease is passed', async () => {
+    mockFetchResponse({ catalog: catalogMeta, skills: [] });
+    await run(['list', '--prerelease']);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/skills?prerelease=true'),
+      expect.anything()
+    );
+  });
+
+  it('maps an unreachable Catalog to the dependency exit code', async () => {
+    mockFetchResponse({ error: 'offline', code: 'SKILL_CATALOG_FETCH_FAILED' }, 503);
+    await run(['list']);
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+});
+
+describe('skill info', () => {
+  it('shows provider, versions and compatibility', async () => {
+    mockFetchResponse({ catalog: catalogMeta, skill: catalogSkill });
+    await run(['info', 'cmate-repository-analysis']);
+
+    const output = mockConsoleLog.mock.calls[0][0] as string;
+    expect(output).toContain('Repository Analysis');
+    expect(output).toContain('1.2.0');
+    expect(output).toContain('VERSION');
+  });
+
+  it('rejects a malformed Skill ID without contacting the server', async () => {
+    mockFetchResponse({ catalog: catalogMeta, skill: catalogSkill });
+    await run(['info', '../etc/passwd']);
+
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// plan
+// =============================================================================
+
+describe('skill plan', () => {
+  it('asks the server for a plan and prints the summary', async () => {
+    mockFetchResponse(installPlan());
+    await run(['plan', 'cmate-repository-analysis', '--worktree', 'anvil-develop', '--version', '1.2.0']);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/api/worktrees/anvil-develop/skills/cmate-repository-analysis/plan'
+      ),
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(mockConsoleLog.mock.calls[0][0]).toContain('Install plan');
+  });
+
+  it('sends only what to install — never a path, URL, file list or checksum', async () => {
+    mockFetchResponse(installPlan());
+    await run(['plan', 'cmate-repository-analysis', '--worktree', 'anvil-develop', '--version', '1.2.0']);
+
+    expect(requestBody(0)).toEqual({ version: '1.2.0' });
+  });
+
+  it('exits blocked when the plan reports it is not installable', async () => {
+    mockFetchResponse(
+      installPlan({ installable: false, blockers: [{ code: 'SKILL_DIFF_UNMANAGED_SKILL', path: 'a/b' }] })
+    );
+    await run(['plan', 'cmate-repository-analysis', '--worktree', 'anvil-develop']);
+
+    expect(mockExit).toHaveBeenCalledWith(11);
+  });
+
+  it('requires --worktree', async () => {
+    mockFetchResponse(installPlan());
+    await run(['plan', 'cmate-repository-analysis']);
+
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// install: the confirmation contract
+// =============================================================================
+
+describe('skill install: confirmation contract', () => {
+  it('refuses to write from a non-TTY without --yes, after building the plan', async () => {
+    mockFetchResponse(installPlan());
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0',
+    ]);
+
+    expect(mockExit).toHaveBeenCalledWith(12);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect((global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0]).toContain('/plan');
+  });
+
+  it('installs from a non-TTY when --yes is given', async () => {
+    mockFetchSequence([{ data: installPlan() }, { data: installResult }]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect((global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls[1][0]).toContain('/install');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('presents the server-issued plan token unchanged and reconstructs nothing', async () => {
+    mockFetchSequence([{ data: installPlan() }, { data: installResult }]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+    ]);
+
+    expect(requestBody(1)).toEqual({
+      planToken: 'a'.repeat(48),
+      version: '1.2.0',
+      acknowledgeRisk: false,
+    });
+  });
+
+  it('prompts in a TTY and installs when the user accepts', async () => {
+    process.stdin.isTTY = true;
+    promptAnswer = 'y';
+    mockFetchSequence([{ data: installPlan() }, { data: installResult }]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0',
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes nothing when the TTY prompt is declined', async () => {
+    process.stdin.isTTY = true;
+    promptAnswer = 'n';
+    mockFetchResponse(installPlan());
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0',
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockExit).toHaveBeenCalledWith(12);
+  });
+
+  it('stops at the plan with --dry-run even when --yes is given', async () => {
+    mockFetchResponse(installPlan());
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes', '--dry-run',
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockExit).not.toHaveBeenCalled();
+    expect(mockConsoleLog.mock.calls[0][0]).toContain('Install plan');
+  });
+
+  it('requires an exact --version', async () => {
+    mockFetchResponse(installPlan());
+    await run(['install', 'cmate-repository-analysis', '--worktree', 'anvil-develop']);
+
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the plan is not installable, before any confirmation', async () => {
+    mockFetchResponse(
+      installPlan({ installable: false, blockers: [{ code: 'SKILL_DIFF_UNMANAGED_SKILL', path: 'x' }] })
+    );
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+    ]);
+
+    expect(mockExit).toHaveBeenCalledWith(11);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('skill install: high-risk acknowledgement', () => {
+  it('refuses a high-risk install carried by --yes alone', async () => {
+    mockFetchResponse(highRiskPlan());
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+    ]);
+
+    expect(mockExit).toHaveBeenCalledWith(12);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a high-risk install when --ack-risk names another version', async () => {
+    mockFetchResponse(highRiskPlan());
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+      '--ack-risk', 'cmate-repository-analysis@1.1.0',
+    ]);
+
+    expect(mockExit).toHaveBeenCalledWith(12);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a high-risk install in a TTY even when the prompt is accepted', async () => {
+    process.stdin.isTTY = true;
+    promptAnswer = 'y';
+    mockFetchResponse(highRiskPlan());
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0',
+    ]);
+
+    expect(mockExit).toHaveBeenCalledWith(12);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('installs a high-risk Skill when --ack-risk names it exactly', async () => {
+    mockFetchSequence([{ data: highRiskPlan() }, { data: installResult }]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+      '--ack-risk', 'cmate-repository-analysis@1.2.0',
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(requestBody(1)).toMatchObject({ acknowledgeRisk: true });
+  });
+});
+
+describe('skill install: outcomes', () => {
+  it('reports a committed-but-reconciling install without calling it a failure', async () => {
+    mockFetchSequence([
+      { data: installPlan() },
+      {
+        data: {
+          ...installResult,
+          operation: {
+            ...installResult.operation,
+            state: 'FAILED_RECONCILABLE',
+            result: 'committed_reconciling',
+            reconcilePending: true,
+            nextActionKey: 'skills.install.committedReconciling',
+          },
+        },
+      },
+    ]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+    ]);
+
+    expect(mockConsoleLog.mock.calls[0][0]).toContain('Installed');
+    expect(mockExit).toHaveBeenCalledWith(13);
+  });
+
+  it('maps a destination held by an unmanaged file to the blocked exit code', async () => {
+    mockFetchSequence([
+      { data: installPlan() },
+      {
+        data: { error: 'refused', code: 'SKILL_INSTALL_DESTINATION_UNMANAGED' },
+        status: 409,
+      },
+    ]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes',
+    ]);
+
+    expect(mockExit).toHaveBeenLastCalledWith(11);
+  });
+
+  it('leaves stdout empty when a --json install fails', async () => {
+    mockFetchSequence([
+      { data: installPlan() },
+      { data: { error: 'drifted', code: 'SKILL_PLAN_STALE' }, status: 409 },
+    ]);
+    await run([
+      'install', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--version', '1.2.0', '--yes', '--json',
+    ]);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+    expect(mockConsoleError.mock.calls.some((call) => String(call[0]).includes('SKILL_PLAN_STALE'))).toBe(true);
+    expect(mockExit).toHaveBeenLastCalledWith(11);
+  });
+});
+
+// =============================================================================
+// uninstall
+// =============================================================================
+
+describe('skill uninstall', () => {
+  it('refuses to delete from a non-TTY without --yes', async () => {
+    mockFetchResponse(uninstallPlan());
+    await run(['uninstall', 'cmate-repository-analysis', '--worktree', 'anvil-develop']);
+
+    expect(mockExit).toHaveBeenCalledWith(12);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends nothing but the plan token', async () => {
+    mockFetchSequence([{ data: uninstallPlan() }, { data: uninstallResult }]);
+    await run(['uninstall', 'cmate-repository-analysis', '--worktree', 'anvil-develop', '--yes']);
+
+    expect(requestBody(0)).toEqual({});
+    expect(requestBody(1)).toEqual({ planToken: 'b'.repeat(48) });
+  });
+
+  it('refuses a blocked uninstall and deletes nothing', async () => {
+    mockFetchResponse(
+      uninstallPlan({
+        removable: false,
+        blockers: [{ code: 'SKILL_UNINSTALL_LOCAL_MODIFICATION', path: 'a/SKILL.md' }],
+        nextActionKey: 'skills.uninstall.blocked',
+      })
+    );
+    await run(['uninstall', 'cmate-repository-analysis', '--worktree', 'anvil-develop', '--yes']);
+
+    expect(mockExit).toHaveBeenCalledWith(11);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops at the plan with --dry-run', async () => {
+    mockFetchResponse(uninstallPlan());
+    await run([
+      'uninstall', 'cmate-repository-analysis',
+      '--worktree', 'anvil-develop', '--yes', '--dry-run',
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockConsoleLog.mock.calls[0][0]).toContain('Uninstall plan');
+  });
+});
+
+// =============================================================================
+// status
+// =============================================================================
+
+describe('skill status', () => {
+  it('reports an installed Skill with its version and removability', async () => {
+    mockFetchResponse(uninstallPlan());
+    await run(['status', 'cmate-repository-analysis', '--worktree', 'anvil-develop']);
+
+    const output = mockConsoleLog.mock.calls[0][0] as string;
+    expect(output).toContain('1.2.0');
+    expect(output).toContain('Removable:    yes');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('treats "not installed" as an answer, not a failure', async () => {
+    mockFetchResponse(
+      { error: 'nothing installed', code: 'SKILL_UNINSTALL_NOT_INSTALLED' },
+      404
+    );
+    await run(['status', 'cmate-repository-analysis', '--worktree', 'anvil-develop', '--json']);
+
+    expect(JSON.parse(mockConsoleLog.mock.calls[0][0] as string)).toEqual({
+      skillId: 'cmate-repository-analysis',
+      worktreeId: 'anvil-develop',
+      installed: false,
+    });
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -104,6 +104,8 @@ describe('buildProgram', () => {
       'auto-yes',
       'report',
       'instances',
+      // Issue #1237: Skill management (list/info/plan/install/uninstall/status)
+      'skill',
     ];
 
     it.each(expectedCommands)('should register the %s command', (name) => {


### PR DESCRIPTION
## 概要

Issue #1237（Epic #1227 Phase 1）。既存 Skill API（#1231/#1233/#1235/#1236）の **thin client** として `commandmate skill list/info/plan/install/uninstall/status` を追加する。

**CLI 側では download / extract / write / delete を一切行わず**、server が発行した plan token をそのまま apply へ渡す。file list・checksum・path・artifact URL は再構成しない（API 側が明示的に拒否する入力のため）。

## 確認規約

- 書き込み系（install / uninstall）は必ず先に plan を構築して表示する
- `--dry-run` は plan までで停止し、書き込み・削除を行わない
- TTY では plan summary の後に確認プロンプト（**stderr**）を出す
- **非TTY では明示 `--yes` が無い限り write しない**（暗黙実行しない）
- **high-risk は `--yes` とは別に `--ack-risk <skill-id>@<version>` の完全一致を要求する。`--yes` だけでは通らず、TTY で承諾しても通らない**

## exit code

| code | 意味 |
|------|------|
| 0 | 成功 |
| 1 | server / Catalog 到達不可（retryable） |
| 2 | 引数不正・Skill / version 不在 |
| 11 | worktree 側の拒否（local 変更・衝突・lock・plan drift） |
| 12 | 書き込みが未確認（`--yes` なし・拒否・`--ack-risk` 不一致） |
| 13 | files は変更済みだが reconciliation 待ち（`committed_reconciling`） |

`--json` 成功時の stdout は API レスポンスをそのまま出力し、plan summary・確認プロンプト・警告・エラーはすべて **stderr**。**失敗時の stdout は空**になる。

## Issue 記載の前提に対する訂正

1. **`skill status [--worktree]`（worktree 単位の一覧）は現状実装不能。** 導入済み Skill を列挙する読み取り API が存在しない（`listSkillInstallations()` は `installed-state.ts` にあるが**どの route からも公開されていない**）。本 PR では `skill status <skill-id> --worktree <id>` として uninstall-plan preview（ディスク上の receipt を読む read-only 経路）から導出する形で実装した。worktree 単位の一覧は listing API を持つ **#1248 待ち**。なお status は uninstall plan token を 1 件生成する（TTL 10 分・LRU 32 枠）
2. Issue の「`src/cli/index.ts` への subcommand 登録」は実体と不一致。#1195 以降 program 構築は `program.ts` が担い `index.ts` は parse のみ
3. **shell completion は本リポジトリに存在しない**（script も生成経路も無し）。よって「completion 更新」は該当なしとし、help と埋め込み docs（`src/cli/docs/agent-operations.ts`）、`docs/user-guide/cli-operations-guide.md` を更新
4. 変更対象候補は `skill.ts` 単一だったが、責務ごとに `skill.ts`（wiring/flow）・`skill-guards.ts`（確認規約・typed error mapping）・`skill-format.ts`（表示）へ分割
5. **`ApiClient` は失敗レスポンスの body を捨てており typed code を取得できなかった。** 409 は「plan drift」と「destination unmanaged」の両方に使われ status だけでは区別できないため、`ApiError` に `{ code, error, blockers }` payload を持たせた（既存 command への影響なし。optional な第 4 引数と getter のみ）

## ガード破壊検証

| # | 破壊した内容 | 落ちたテスト |
|---|-------------|-------------|
| M1 | 非TTY を `confirmed` として扱う | install / uninstall の「非TTY で `--yes` 無しに write しない」2 件 |
| M2 | high-risk の `--ack-risk` 要求を無効化 | `--yes` 単独 / 別 version 指定 / TTY 承諾 の 3 件 |
| M3 | error を `console.error` → `console.log`（stdout 汚染） | 2 件 |
| M4 | `--dry-run` の早期 return を無効化 | 1 件 |
| M5 | `installable: false` の拒否を無効化 | 1 件 |
| M6 | plan request に `files` を追加（client 側で file list を再構成） | 「path・URL・file list・checksum を送らない」1 件 |
| M7 | typed code → exit code の mapping を無効化 | 2 件 |
| M8 | `removable: false` の拒否を無効化 | 1 件 |

テストは API を全面 mock（`Kewton/commandmate-skills` は private かつ Catalog 未公開のため実ネットワーク前提のテストは書いていない）。

## 品質ゲート（オーケストレーター側で exit code 実測）

| チェック | 結果 |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0（warning 4 件は既存ファイル由来） |
| `npm run build:cli` | exit 0 |
| `npm run test:unit` | worker 側 exit 0 / 629 files / 11023 tests |
| `npm run build` | worker 側 exit 0 |

Refs #1237, #1227