### PR TITLE
fix(db): worktree削除時にskill_installationsをCASCADEで削除 (#1430)

### DIFF
--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -28,6 +28,7 @@ import { v42_migrations } from './v42-push-subscription-locale';
 import { v43_migrations } from './v43-remove-cm-root-dir-ghost-repository';
 import { v44_migrations } from './v44-skill-operations';
 import { v45_migrations } from './v45-skill-installations';
+import { v46_migrations } from './v46-skill-installations-cascade';
 
 /**
  * Complete ordered list of all migrations.
@@ -61,4 +62,5 @@ export const migrations: Migration[] = [
   ...v43_migrations,
   ...v44_migrations,
   ...v45_migrations,
+  ...v46_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 45;
+export const CURRENT_SCHEMA_VERSION = 46;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v46-skill-installations-cascade.ts
+++ b/src/lib/db/migrations/v46-skill-installations-cascade.ts
@@ -1,0 +1,118 @@
+/**
+ * Migration v46: `skill_installations` follows the worktree it belongs to (Issue #1430).
+ *
+ * v45 created the table with `worktree_id TEXT NOT NULL` and no foreign key, so
+ * deleting a worktree left its install rows behind forever (`UNIQUE(worktree_id,
+ * skill_id)` keeps them). Recreating a worktree at the same path mints a new
+ * UUID, so the UI reports "not installed" while the payload and receipt are
+ * still on disk: re-install fails with SKILL_INSTALL_DESTINATION_EXISTS and
+ * uninstall has no record to act on.
+ *
+ * The fix follows the convention every other worktree-scoped table already uses
+ * — `ON DELETE CASCADE` — rather than an explicit DELETE at one call site. Two
+ * reasons beyond consistency: `deleteWorktreesByIds` is not the only path that
+ * removes a worktree row, and `migrateWorktreeIdPreservingChildren` (#1151)
+ * discovers child tables through `PRAGMA foreign_key_list`, so the constraint is
+ * also what makes a same-directory branch switch *carry* installs forward
+ * instead of orphaning them.
+ *
+ * SQLite cannot add a constraint in place, so the table is rebuilt (same pattern
+ * as v33). Rows whose worktree is already gone are dropped by the copy filter,
+ * which is what clears the dangling rows existing databases have accumulated —
+ * `PRAGMA foreign_keys` cannot be toggled inside the migration transaction, so
+ * the filter must be in the SELECT rather than deferred to the constraint.
+ */
+
+import type Database from 'better-sqlite3';
+import type { Migration } from './runner';
+
+const COLUMNS = `
+  id, worktree_id, skill_id, version, install_root, receipt_sha256,
+  source_repository, source_ref, source_commit, artifact_sha256,
+  effective_risk, operation_id, installed_at, updated_at
+`;
+
+const COLUMN_DEFINITIONS = `
+  id TEXT PRIMARY KEY,
+  worktree_id TEXT NOT NULL,
+  skill_id TEXT NOT NULL,
+  version TEXT NOT NULL,
+  install_root TEXT NOT NULL,
+  receipt_sha256 TEXT NOT NULL,
+  source_repository TEXT NOT NULL,
+  source_ref TEXT NOT NULL,
+  source_commit TEXT NOT NULL,
+  artifact_sha256 TEXT NOT NULL,
+  effective_risk TEXT NOT NULL,
+  operation_id TEXT NOT NULL,
+  installed_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (worktree_id, skill_id)
+`;
+
+function createIndexes(db: Database.Database): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_skill_installations_worktree
+      ON skill_installations(worktree_id);
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_skill_installations_skill
+      ON skill_installations(skill_id, version);
+  `);
+}
+
+export const v46_migrations: Migration[] = [
+  {
+    version: 46,
+    name: 'skill-installations-worktree-cascade',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE skill_installations_new (
+          ${COLUMN_DEFINITIONS},
+          FOREIGN KEY (worktree_id) REFERENCES worktrees(id) ON DELETE CASCADE
+        );
+      `);
+
+      // The WHERE clause is the dangling-row sweep: rows pointing at a worktree
+      // that no longer exists are not carried over.
+      db.exec(`
+        INSERT INTO skill_installations_new (${COLUMNS})
+        SELECT ${COLUMNS} FROM skill_installations
+        WHERE worktree_id IN (SELECT id FROM worktrees);
+      `);
+
+      const dangling = db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM skill_installations
+           WHERE worktree_id NOT IN (SELECT id FROM worktrees)`
+        )
+        .get() as { n: number };
+
+      // Dropping the table drops its indexes too; recreate them on the new one.
+      db.exec('DROP TABLE skill_installations;');
+      db.exec('ALTER TABLE skill_installations_new RENAME TO skill_installations;');
+      createIndexes(db);
+
+      if (dangling.n > 0) {
+        console.log(`Removed ${dangling.n} skill_installations row(s) with no worktree`);
+      }
+      console.log('skill_installations now cascades with its worktree');
+    },
+    down: (db) => {
+      db.exec(`
+        CREATE TABLE skill_installations_old (
+          ${COLUMN_DEFINITIONS}
+        );
+      `);
+      db.exec(`
+        INSERT INTO skill_installations_old (${COLUMNS})
+        SELECT ${COLUMNS} FROM skill_installations;
+      `);
+      db.exec('DROP TABLE skill_installations;');
+      db.exec('ALTER TABLE skill_installations_old RENAME TO skill_installations;');
+      createIndexes(db);
+
+      console.log('Rolled back skill_installations cascade (v46)');
+    },
+  },
+];

--- a/src/lib/db/worktree-db.ts
+++ b/src/lib/db/worktree-db.ts
@@ -720,8 +720,11 @@ export function getWorktreesByRepository(
 
 /**
  * Delete all worktrees for a given repository path
- * Related data (chat_messages, session_states, worktree_memos, worktree_todos)
- * will be automatically deleted via CASCADE foreign key constraints.
+ * Related data is automatically deleted via ON DELETE CASCADE in every table
+ * holding a foreign key to worktrees(id) — chat_messages, session_states,
+ * worktree_memos, worktree_todos, agent_instances, scheduled_executions,
+ * execution_logs, timer_messages and skill_installations (#1430). The live list
+ * is whatever `PRAGMA foreign_key_list` reports; see getWorktreeChildTables.
  *
  * @param db - Database instance
  * @param repositoryPath - Path of the repository to delete
@@ -741,8 +744,10 @@ export function deleteRepositoryWorktrees(
 
 /**
  * Delete worktrees by their IDs
- * Related data (chat_messages, session_states, worktree_memos, worktree_todos)
- * will be automatically deleted via CASCADE foreign key constraints.
+ * Related data is automatically deleted via ON DELETE CASCADE in every table
+ * holding a foreign key to worktrees(id) — including skill_installations, whose
+ * rows used to survive the worktree and make a re-created worktree at the same
+ * path un-installable (#1430). See getWorktreeChildTables for the live list.
  *
  * @param db - Database instance
  * @param worktreeIds - Array of worktree IDs to delete

--- a/tests/integration/api/skills-install.test.ts
+++ b/tests/integration/api/skills-install.test.ts
@@ -224,6 +224,17 @@ function setHead(commit: string | null): void {
   });
 }
 
+/**
+ * The route resolves the worktree through the DB; since #1430 the install index
+ * has a foreign key to it, so the row has to be in the test database too.
+ */
+function seedWorktreeRow(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, 'demo-worktree', ?, ?, 'commandmate')`
+  ).run(WORKTREE_ID, worktreeDir, path.dirname(worktreeDir));
+}
+
 function makeWorktree(): Worktree {
   return {
     id: WORKTREE_ID,
@@ -276,6 +287,7 @@ beforeEach(() => {
 
   db = new Database(':memory:');
   runMigrations(db);
+  seedWorktreeRow(db);
   getDbInstanceMock.mockReturnValue(db);
   getWorktreeByIdMock.mockReturnValue(makeWorktree());
 

--- a/tests/integration/api/skills-uninstall.test.ts
+++ b/tests/integration/api/skills-uninstall.test.ts
@@ -205,6 +205,17 @@ function wireMocks(): void {
   readSkillSnapshotBytesMock.mockImplementation(() => artifact);
 }
 
+/**
+ * The route resolves the worktree through the DB; since #1430 the install index
+ * has a foreign key to it, so the row has to be in the test database too.
+ */
+function seedWorktreeRow(db: Database.Database): void {
+  db.prepare(
+    `INSERT INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, 'demo-worktree', ?, ?, 'commandmate')`
+  ).run(WORKTREE_ID, worktreeDir, path.dirname(worktreeDir));
+}
+
 function makeWorktree(): Worktree {
   return {
     id: WORKTREE_ID,
@@ -290,6 +301,7 @@ beforeEach(async () => {
 
   db = new Database(':memory:');
   runMigrations(db);
+  seedWorktreeRow(db);
   getDbInstanceMock.mockReturnValue(db);
   getWorktreeByIdMock.mockReturnValue(makeWorktree());
 

--- a/tests/integration/skills-mvp-install-flow.test.ts
+++ b/tests/integration/skills-mvp-install-flow.test.ts
@@ -85,6 +85,7 @@ import {
   initGitRepo,
   installRootOf,
   removeTestRoot,
+  seedWorktreeRow,
   listDirEntries,
   residueReport,
   snapshotTree,
@@ -221,6 +222,7 @@ beforeEach(() => {
 
   db = new Database(':memory:');
   runMigrations(db);
+  seedWorktreeRow(db, worktreeDir);
   getDbInstanceMock.mockReturnValue(db);
   getWorktreeByIdMock.mockReturnValue(makeWorktree());
 

--- a/tests/integration/skills-mvp-security-regression.test.ts
+++ b/tests/integration/skills-mvp-security-regression.test.ts
@@ -79,6 +79,7 @@ import {
   initGitRepo,
   installRootOf,
   removeTestRoot,
+  seedWorktreeRow,
   residueReport,
   snapshotTree,
   treeDelta,
@@ -213,6 +214,7 @@ beforeEach(() => {
 
   db = new Database(':memory:');
   runMigrations(db);
+  seedWorktreeRow(db, worktreeDir);
   getDbInstanceMock.mockReturnValue(db);
   getWorktreeByIdMock.mockReturnValue(makeWorktree());
 

--- a/tests/integration/skills/mvp-harness.ts
+++ b/tests/integration/skills/mvp-harness.ts
@@ -32,6 +32,7 @@ import {
 } from 'fs';
 import { homedir } from 'os';
 import path from 'path';
+import type Database from 'better-sqlite3';
 import { SKILL_INSTALL_ROOT_PREFIX, SKILL_STAGING_DIRNAME } from '@/lib/skills/constants';
 import type { SkillCatalog, SkillCatalogVersion } from '@/types/skills';
 import { buildPackage, type PackageOptions } from '../../fixtures/skills/malicious-packages/package';
@@ -54,6 +55,24 @@ export const MVP_SKILLS = [
 
 export const WORKTREE_ID = 'wt-00000000-0000-4000-8000-000000000001';
 export const CATALOG_REPOSITORY = 'Kewton/commandmate-skills';
+
+/**
+ * Insert the worktree row the mocked `getWorktreeById` pretends to read.
+ *
+ * Since #1430 `skill_installations.worktree_id` is a foreign key, so the row the
+ * routes resolve must also exist in the test database — in production both come
+ * from the same connection.
+ */
+export function seedWorktreeRow(
+  db: Database.Database,
+  worktreePath: string,
+  id: string = WORKTREE_ID
+): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, 'demo-worktree', ?, ?, 'commandmate')`
+  ).run(id, worktreePath, path.dirname(worktreePath));
+}
 
 /** Deterministic 40-hex commit per Skill, so receipts are reproducible. */
 export function commitFor(skillId: string): string {

--- a/tests/unit/db/migration-v45-skill-installations.test.ts
+++ b/tests/unit/db/migration-v45-skill-installations.test.ts
@@ -24,6 +24,14 @@ function tableNames(db: Database.Database): string[] {
   ).map((r) => r.name);
 }
 
+/** v46 made worktree_id a real foreign key, so the parent row must exist. */
+function insertWorktree(db: Database.Database, id: string): void {
+  db.prepare(
+    `INSERT INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, ?, ?, '/tmp/cm-1235/repo', 'repo')`
+  ).run(id, id, `/tmp/cm-1235/repo/${id}`);
+}
+
 function insertRow(
   db: Database.Database,
   id: string,
@@ -104,6 +112,8 @@ describe('migration v45: one row per (worktree, skill)', () => {
   beforeEach(() => {
     db = new Database(':memory:');
     runMigrations(db);
+    insertWorktree(db, 'wt-1');
+    insertWorktree(db, 'wt-2');
     insertRow(db, 'install-1');
   });
 

--- a/tests/unit/db/migration-v46-skill-installations-cascade.test.ts
+++ b/tests/unit/db/migration-v46-skill-installations-cascade.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for migration v46 (skill_installations cascade, Issue #1430).
+ *
+ * The bug this pins is not "a stale row": a surviving row is invisible (the
+ * re-created worktree has a new UUID) yet the payload it describes is still on
+ * disk, so the worktree becomes un-installable *and* un-uninstallable from the
+ * UI. Both halves are covered here — the constraint that keeps new rows honest,
+ * and the sweep that clears what v45 already let accumulate.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  runMigrations,
+  rollbackMigrations,
+  getCurrentVersion,
+  CURRENT_SCHEMA_VERSION,
+} from '@/lib/db/db-migrations';
+import {
+  deleteWorktreesByIds,
+  migrateWorktreeIdPreservingChildren,
+} from '@/lib/db/worktree-db';
+
+function insertWorktree(db: Database.Database, id: string): void {
+  db.prepare(
+    `INSERT INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, ?, ?, '/tmp/cm-1430/repo', 'repo')`
+  ).run(id, id, `/tmp/cm-1430/repo/${id}`);
+}
+
+function insertInstallation(
+  db: Database.Database,
+  id: string,
+  worktreeId: string,
+  skillId = 'demo-skill'
+): void {
+  db.prepare(
+    `INSERT INTO skill_installations (
+      id, worktree_id, skill_id, version, install_root, receipt_sha256,
+      source_repository, source_ref, source_commit, artifact_sha256,
+      effective_risk, operation_id, installed_at, updated_at
+    ) VALUES (?, ?, ?, '1.2.3', ?, ?,
+      'Kewton/commandmate-skills', 'demo-skill-v1.2.3', ?, ?,
+      'low', 'op-1', 1800000000000, 1800000000001)`
+  ).run(
+    id,
+    worktreeId,
+    skillId,
+    `.agents/skills/${skillId}`,
+    'd'.repeat(64),
+    'b'.repeat(40),
+    'c'.repeat(64)
+  );
+}
+
+function installationIds(db: Database.Database): string[] {
+  return (
+    db
+      .prepare('SELECT id FROM skill_installations ORDER BY id')
+      .all() as Array<{ id: string }>
+  ).map((r) => r.id);
+}
+
+function worktreeForeignKeys(db: Database.Database): Array<{ table: string; on_delete: string }> {
+  return db.pragma('foreign_key_list(skill_installations)') as Array<{
+    table: string;
+    on_delete: string;
+  }>;
+}
+
+/** Bring a database up to v45 only — the state an existing install is in. */
+function migrateToV45(db: Database.Database): void {
+  runMigrations(db);
+  rollbackMigrations(db, 45);
+}
+
+describe('migration v46: fresh DB end state', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('ties skill_installations to worktrees with ON DELETE CASCADE', () => {
+    expect(worktreeForeignKeys(db)).toEqual([
+      expect.objectContaining({ table: 'worktrees', on_delete: 'CASCADE' }),
+    ]);
+  });
+
+  it('keeps the v45 columns', () => {
+    const cols = (db.pragma('table_info(skill_installations)') as Array<{ name: string }>).map(
+      (c) => c.name
+    );
+    expect(cols).toEqual([
+      'id',
+      'worktree_id',
+      'skill_id',
+      'version',
+      'install_root',
+      'receipt_sha256',
+      'source_repository',
+      'source_ref',
+      'source_commit',
+      'artifact_sha256',
+      'effective_risk',
+      'operation_id',
+      'installed_at',
+      'updated_at',
+    ]);
+  });
+
+  it('keeps the lookup indexes the rebuild dropped along with the old table', () => {
+    const indexes = (
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='skill_installations'"
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        'idx_skill_installations_worktree',
+        'idx_skill_installations_skill',
+      ])
+    );
+  });
+
+  it('keeps one row per (worktree, skill)', () => {
+    insertWorktree(db, 'wt-1');
+    insertInstallation(db, 'install-1', 'wt-1');
+    expect(() => insertInstallation(db, 'install-2', 'wt-1')).toThrow(/UNIQUE/);
+  });
+
+  it('refuses a row for a worktree that does not exist', () => {
+    expect(() => insertInstallation(db, 'install-1', 'ghost-wt')).toThrow(/FOREIGN KEY/);
+  });
+
+  it('reports the schema version the migration chain ends at', () => {
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(46);
+  });
+});
+
+describe('migration v46: upgrading a v45 database', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    migrateToV45(db);
+    insertWorktree(db, 'wt-live');
+    insertInstallation(db, 'install-live', 'wt-live');
+    // v45 has no foreign key, which is exactly how these accumulated.
+    insertInstallation(db, 'install-dangling', 'wt-deleted-long-ago');
+    insertInstallation(db, 'install-dangling-2', 'wt-deleted-long-ago', 'other-skill');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('sweeps rows whose worktree is gone', () => {
+    runMigrations(db);
+    expect(installationIds(db)).toEqual(['install-live']);
+  });
+
+  it('carries a live row over with every column value intact', () => {
+    const before = db
+      .prepare('SELECT * FROM skill_installations WHERE id = ?')
+      .get('install-live');
+
+    runMigrations(db);
+
+    const after = db.prepare('SELECT * FROM skill_installations WHERE id = ?').get('install-live');
+    expect(after).toEqual(before);
+  });
+
+  it('frees the (worktree, skill) pair a swept row was holding', () => {
+    runMigrations(db);
+    insertWorktree(db, 'wt-deleted-long-ago');
+    expect(() => insertInstallation(db, 'install-new', 'wt-deleted-long-ago')).not.toThrow();
+  });
+});
+
+describe('migration v46: worktree deletion', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    insertWorktree(db, 'wt-1');
+    insertWorktree(db, 'wt-2');
+    insertInstallation(db, 'install-1', 'wt-1');
+    insertInstallation(db, 'install-2', 'wt-2');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('removes the installations of the deleted worktree only', () => {
+    deleteWorktreesByIds(db, ['wt-1']);
+    expect(installationIds(db)).toEqual(['install-2']);
+  });
+
+  it('keeps installations across a same-directory branch switch (#1151)', () => {
+    db.transaction(() => {
+      migrateWorktreeIdPreservingChildren(db, 'wt-1', 'wt-1-renamed');
+    })();
+
+    const row = db
+      .prepare('SELECT worktree_id FROM skill_installations WHERE id = ?')
+      .get('install-1') as { worktree_id: string } | undefined;
+    expect(row?.worktree_id).toBe('wt-1-renamed');
+  });
+});
+
+describe('migration v46: rollback and idempotency', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    insertWorktree(db, 'wt-1');
+    insertInstallation(db, 'install-1', 'wt-1');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('down() drops the constraint without dropping the rows', () => {
+    rollbackMigrations(db, 45);
+
+    expect(getCurrentVersion(db)).toBe(45);
+    expect(worktreeForeignKeys(db)).toEqual([]);
+    expect(installationIds(db)).toEqual(['install-1']);
+  });
+
+  it('re-running runMigrations changes nothing', () => {
+    expect(() => runMigrations(db)).not.toThrow();
+    expect(installationIds(db)).toEqual(['install-1']);
+    expect(worktreeForeignKeys(db)).toEqual([
+      expect.objectContaining({ table: 'worktrees', on_delete: 'CASCADE' }),
+    ]);
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 45 after Migration #45 (skill_installations index)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(45);
+    it('should be 46 after Migration #46 (skill_installations cascade)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(46);
     });
   });
 

--- a/tests/unit/lib/skills/installed-state.test.ts
+++ b/tests/unit/lib/skills/installed-state.test.ts
@@ -62,9 +62,19 @@ function makeReceipt(overrides: Partial<SkillInstallReceipt> = {}): SkillInstall
   };
 }
 
+/** Since #1430 a row is tied to a live worktree, so the parents must exist. */
+function insertWorktree(db: Database.Database, id: string): void {
+  db.prepare(
+    `INSERT INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, ?, ?, '/tmp/cm-1235/repo', 'repo')`
+  ).run(id, id, `/tmp/cm-1235/repo/${id}`);
+}
+
 beforeEach(() => {
   db = new Database(':memory:');
   runMigrations(db);
+  insertWorktree(db, 'wt-1');
+  insertWorktree(db, 'wt-2');
   dir = mkdtempSync(path.join(tmpdir(), 'cm-installed-state-'));
 });
 


### PR DESCRIPTION
## 概要
Issue #1430 の対応。`skill_installations` に `FOREIGN KEY (worktree_id) REFERENCES worktrees(id) ON DELETE CASCADE` を付与する migration v46 を追加し、worktree 削除時に install 行が残留する問題を解消する。

## 実装
- migration v46 で table rebuild（v33 と同じ方式）。`CURRENT_SCHEMA_VERSION` 45 → 46
- rebuild の `INSERT … SELECT` に `WHERE worktree_id IN (SELECT id FROM worktrees)` を置き、既存 dangling 行も同時に一掃（`PRAGMA foreign_keys` は migration transaction 内で切替できないため、制約任せにせず SELECT で濾す）
- v45 の CREATE 文は不変

## Issue 記載からの変更（実装者の判断、Issue 本文は未変更）
- **明示 DELETE ではなく FK を採用**。決め手は `migrateWorktreeIdPreservingChildren`（#1151）が `PRAGMA foreign_key_list` で子テーブルを動的に発見する点 — FK にして初めて同一 path の branch 切替で install が引き継がれる。明示 DELETE では切替のたび孤児化していた
- `worktree-db.ts` の docstring の CASCADE 一覧は実際には 4 ではなく 8 テーブルで v33 以降ずっと古かった。実体に合わせて更新し、正は `getWorktreeChildTables` である旨を明記
- `docs/user-guide/skills.md` の追記は orchestrator 側で実施（worker 契約によりドキュメント共有ファイルは編集しない）

## 検証
- unit 11036 / integration 926 全 pass、tsc・lint・build green（worktree 内で実行）
- 実 cm.db のコピーを隔離パスで v46 まで migrate し `integrity_check` / `foreign_key_check` とも ok（本番 DB・稼働サーバーには未接触）
- better-sqlite3 は `foreign_keys = ON`（db-instance.ts:50）のため、worktrees 行を作らず書いていた既存テスト 5 ファイルに seed を追加。production 経路は `resolveWorktreeOr404` 経由で必ず実在 ID を渡すため変更不要

Refs #1430