### PR TITLE
fix(skills): 失効plan tokenのsnapshot解放をTTLで自動化 (#1429)

### DIFF
--- a/src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts
@@ -84,6 +84,7 @@ import {
   getSkillInstallation,
   upsertSkillInstallation,
 } from '@/lib/skills/installed-state';
+import { ensureSkillPlanSweeper } from '@/lib/skills/plan-sweeper';
 import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
 import type { SkillInstalledFile } from '@/types/skills';
 
@@ -292,6 +293,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; skillId: string }> }
 ): Promise<NextResponse> {
+  ensureSkillPlanSweeper();
+
   let snapshotId: string | null = null;
   let lock: ReturnType<typeof acquireSkillOperationLock> | null = null;
 

--- a/src/app/api/worktrees/[id]/skills/[skillId]/plan/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/plan/route.ts
@@ -43,6 +43,7 @@ import {
   type SkillInstallPlanDto,
   type SkillPlanActor,
 } from '@/lib/skills/install-plan';
+import { ensureSkillPlanSweeper } from '@/lib/skills/plan-sweeper';
 import { getServerVersion } from '@/lib/version-checker';
 import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
 
@@ -156,6 +157,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; skillId: string }> }
 ): Promise<NextResponse> {
+  ensureSkillPlanSweeper();
+
   let snapshotId: string | null = null;
   try {
     const { id, skillId } = await params;

--- a/src/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route.ts
@@ -30,6 +30,7 @@ import {
   isSkillUninstallError,
   resolveSkillUninstallTarget,
 } from '@/lib/skills/uninstall-apply';
+import { ensureSkillPlanSweeper } from '@/lib/skills/plan-sweeper';
 import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
 
 export const dynamic = 'force-dynamic';
@@ -99,6 +100,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; skillId: string }> }
 ): Promise<NextResponse> {
+  ensureSkillPlanSweeper();
+
   try {
     const { id, skillId } = await params;
 

--- a/src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts
@@ -74,6 +74,7 @@ import {
   type SkillUninstallRetainedPath,
 } from '@/lib/skills/uninstall-apply';
 import { deleteSkillInstallation } from '@/lib/skills/installed-state';
+import { ensureSkillPlanSweeper } from '@/lib/skills/plan-sweeper';
 import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
 import type { SkillAgentSupport } from '@/types/skills';
 
@@ -292,6 +293,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; skillId: string }> }
 ): Promise<NextResponse> {
+  ensureSkillPlanSweeper();
+
   let lock: ReturnType<typeof acquireSkillOperationLock> | null = null;
 
   try {

--- a/src/config/skill-security-config.ts
+++ b/src/config/skill-security-config.ts
@@ -169,6 +169,14 @@ export const SKILL_SNAPSHOT_ID_BYTES = 16;
 /** Opaque snapshot ID grammar: lowercase hex of {@link SKILL_SNAPSHOT_ID_BYTES}. */
 export const SKILL_SNAPSHOT_ID_PATTERN = /^[0-9a-f]{32}$/;
 
+/**
+ * How often the background sweeper reclaims expired plans and snapshots.
+ *
+ * Short relative to both TTLs so an abandoned plan releases its snapshot within
+ * a minute of expiring, rather than waiting for the next plan to be created.
+ */
+export const SKILL_PLAN_SWEEP_INTERVAL_MS = 60 * 1000;
+
 // =============================================================================
 // URL construction
 // =============================================================================

--- a/src/lib/skills/install-plan.ts
+++ b/src/lib/skills/install-plan.ts
@@ -379,15 +379,44 @@ function dropRecord(record: SkillInstallPlanRecord): void {
   if (record.consumedAt === null) releaseSkillSnapshot(record.binding.snapshotId);
 }
 
-function sweep(now: number): void {
+/**
+ * Drop every expired plan, releasing the snapshot each one pinned.
+ *
+ * @param keep Token to leave in place so its own lookup can still answer
+ *   `EXPIRED` rather than the ambiguous `NOT_FOUND`
+ * @returns Number of plans dropped
+ */
+function sweepExpired(now: number, keep?: string): number {
+  let dropped = 0;
   for (const record of [...cache.records.values()]) {
-    if (now >= record.expiresAt) dropRecord(record);
+    if (record.token !== keep && now >= record.expiresAt) {
+      dropRecord(record);
+      dropped += 1;
+    }
   }
+  return dropped;
+}
+
+function sweep(now: number): void {
+  sweepExpired(now);
   while (cache.records.size >= SKILL_PLAN_MAX_ENTRIES) {
     const oldest = [...cache.records.values()].sort((a, b) => a.createdAt - b.createdAt)[0];
     if (!oldest) break;
     dropRecord(oldest);
   }
+}
+
+/**
+ * Reclaim expired plans without creating one.
+ *
+ * Creating a plan is not the only thing that should free a snapshot: a plan
+ * left unapplied would otherwise pin its artifact bytes for the life of the
+ * process. Called from every token access and from the background sweeper.
+ *
+ * @returns Number of plans dropped
+ */
+export function sweepSkillInstallPlans(options: { now?: number } = {}): number {
+  return sweepExpired(options.now ?? Date.now());
 }
 
 /**
@@ -402,6 +431,9 @@ function requireRecord(token: string, now: number): SkillInstallPlanRecord {
     throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
   }
   const record = cache.records.get(token);
+  // Every token access reclaims the siblings that expired meanwhile, so a plan
+  // nobody applies is not held until the next plan is created.
+  sweepExpired(now, token);
   if (!record) throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
 
   const presented = Buffer.from(token, 'utf-8');

--- a/src/lib/skills/plan-sweeper.ts
+++ b/src/lib/skills/plan-sweeper.ts
@@ -1,0 +1,97 @@
+/**
+ * Background reclamation of expired Skill plans and snapshots (Issue #1429)
+ *
+ * A plan pins its verified artifact snapshot with a reference the snapshot store
+ * will never evict, no matter how much quota pressure there is. That is correct
+ * while the plan is live and wrong once it has expired, and until this module
+ * existed the only thing that noticed the difference was the creation of the
+ * *next* plan. A user who built a plan and never applied it therefore pinned up
+ * to one artifact per abandoned plan for the life of the process.
+ *
+ * So expiry is made to happen on the clock rather than on traffic. The sweeper
+ * drops expired plans first and expired snapshots second: the plan is what holds
+ * the reference, so sweeping the other way round would always be one round late.
+ *
+ * Started lazily by the Skill routes rather than at boot, because a deployment
+ * that never touches Skills should not carry a timer for them. The interval is
+ * `unref`'d, so it never keeps the process alive.
+ *
+ * @module lib/skills/plan-sweeper
+ */
+
+import { SKILL_PLAN_SWEEP_INTERVAL_MS } from '@/config/skill-security-config';
+import { createLogger } from '@/lib/logger';
+import { sweepSkillInstallPlans } from '@/lib/skills/install-plan';
+import { sweepSkillUninstallPlans } from '@/lib/skills/uninstall-plan';
+import { isSkillSnapshotStoreInitialized, sweepSkillSnapshots } from '@/lib/skills/snapshot-store';
+
+const logger = createLogger('lib/skills/plan-sweeper');
+
+/** What one sweep reclaimed. */
+export interface SkillPlanSweepResult {
+  installPlans: number;
+  uninstallPlans: number;
+  snapshots: number;
+}
+
+interface SweeperState {
+  timer: ReturnType<typeof setInterval> | null;
+}
+
+declare global {
+  // eslint-disable-next-line no-var -- globalThis cache pattern for hot-reload persistence (snapshot-store.ts precedent)
+  var __skillPlanSweeper: SweeperState | undefined;
+}
+
+const state: SweeperState =
+  globalThis.__skillPlanSweeper ?? (globalThis.__skillPlanSweeper = { timer: null });
+
+/**
+ * Reclaim everything whose TTL has passed, once.
+ *
+ * Plans before snapshots: a snapshot is only a candidate once the plan holding
+ * its reference is gone.
+ *
+ * @param options.now Epoch milliseconds to judge expiry against, for tests
+ */
+export function runSkillPlanSweep(options: { now?: number } = {}): SkillPlanSweepResult {
+  const now = options.now ?? Date.now();
+  const installPlans = sweepSkillInstallPlans({ now });
+  const uninstallPlans = sweepSkillUninstallPlans({ now });
+  const snapshots = isSkillSnapshotStoreInitialized() ? sweepSkillSnapshots({ now }) : 0;
+  return { installPlans, uninstallPlans, snapshots };
+}
+
+/**
+ * Start the sweeper if it is not already running. Safe to call on every request.
+ */
+export function ensureSkillPlanSweeper(): void {
+  if (state.timer) return;
+
+  const timer = setInterval(() => {
+    try {
+      const result = runSkillPlanSweep();
+      if (result.installPlans || result.uninstallPlans || result.snapshots) {
+        logger.debug('skill-plan-sweep', { ...result });
+      }
+    } catch (error) {
+      logger.warn('skill-plan-sweep-failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, SKILL_PLAN_SWEEP_INTERVAL_MS);
+
+  timer.unref();
+  state.timer = timer;
+}
+
+/** @internal */
+export function stopSkillPlanSweeperForTesting(): void {
+  if (state.timer) clearInterval(state.timer);
+  state.timer = null;
+}
+
+/** @internal Handle of the running interval, for `unref` assertions. */
+export function getSkillPlanSweeperTimerForTesting(): ReturnType<typeof setInterval> | null {
+  return state.timer;
+}

--- a/src/lib/skills/snapshot-store.ts
+++ b/src/lib/skills/snapshot-store.ts
@@ -147,6 +147,17 @@ function requireRoot(): string {
   return state.rootDir;
 }
 
+/**
+ * Whether a data root has been resolved.
+ *
+ * For callers that may run before the first artifact download — the background
+ * sweeper starts with the process, the store only on first use — and must skip
+ * rather than treat an untouched store as an error.
+ */
+export function isSkillSnapshotStoreInitialized(): boolean {
+  return state.rootDir !== null;
+}
+
 /** Remove every snapshot file the in-memory index does not account for. */
 function purgeOrphanFiles(): void {
   const rootDir = requireRoot();
@@ -371,9 +382,9 @@ export function resolveSkillSnapshotPath(snapshotId: string): string {
  *
  * @returns Number of snapshots removed
  */
-export function sweepSkillSnapshots(): number {
+export function sweepSkillSnapshots(options: { now?: number } = {}): number {
   requireRoot();
-  const now = Date.now();
+  const now = options.now ?? Date.now();
   let removed = 0;
   for (const record of [...state.records.values()]) {
     if (record.refCount === 0 && now >= record.expiresAt) {

--- a/src/lib/skills/uninstall-plan.ts
+++ b/src/lib/skills/uninstall-plan.ts
@@ -459,10 +459,26 @@ export const SKILL_UNINSTALL_PLAN_TOKEN_PATTERN = /^[0-9a-f]{48}$/;
 
 const SKILL_UNINSTALL_PLAN_TOKEN_BYTES = 24;
 
-function sweep(now: number): void {
+/**
+ * Drop every expired plan.
+ *
+ * @param keep Token to leave in place so its own lookup can still answer
+ *   `EXPIRED` rather than the ambiguous `NOT_FOUND`
+ * @returns Number of plans dropped
+ */
+function sweepExpired(now: number, keep?: string): number {
+  let dropped = 0;
   for (const record of [...cache.records.values()]) {
-    if (now >= record.expiresAt) cache.records.delete(record.token);
+    if (record.token !== keep && now >= record.expiresAt) {
+      cache.records.delete(record.token);
+      dropped += 1;
+    }
   }
+  return dropped;
+}
+
+function sweep(now: number): void {
+  sweepExpired(now);
   while (cache.records.size >= SKILL_PLAN_MAX_ENTRIES) {
     const oldest = [...cache.records.values()].sort((a, b) => a.createdAt - b.createdAt)[0];
     if (!oldest) break;
@@ -470,11 +486,27 @@ function sweep(now: number): void {
   }
 }
 
+/**
+ * Reclaim expired plans without creating one.
+ *
+ * The install cache's counterpart ({@link module:lib/skills/install-plan}).
+ * An uninstall plan pins no snapshot, but it does hold the assessed tree, and
+ * the two caches must not diverge in when they let go of it.
+ *
+ * @returns Number of plans dropped
+ */
+export function sweepSkillUninstallPlans(options: { now?: number } = {}): number {
+  return sweepExpired(options.now ?? Date.now());
+}
+
 function requireRecord(token: string, now: number): SkillUninstallPlanRecord {
   if (!SKILL_UNINSTALL_PLAN_TOKEN_PATTERN.test(token)) {
     throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
   }
   const record = cache.records.get(token);
+  // Every token access reclaims the siblings that expired meanwhile, so a plan
+  // nobody applies is not held until the next plan is created.
+  sweepExpired(now, token);
   if (!record) throw new SkillPlanError(SkillPlanErrorCode.NOT_FOUND);
 
   const presented = Buffer.from(token, 'utf-8');

--- a/tests/unit/lib/skills/install-plan.test.ts
+++ b/tests/unit/lib/skills/install-plan.test.ts
@@ -39,6 +39,7 @@ import {
   parseInstalledReceipt,
   resetSkillInstallPlanCacheForTesting,
   serializeSkillInstallReceipt,
+  sweepSkillInstallPlans,
   type CreateSkillInstallPlanInput,
   type SkillPlanActor,
 } from '@/lib/skills/install-plan';
@@ -595,6 +596,26 @@ describe('plan token lifecycle', () => {
     const record = await createSkillInstallPlan(makeInput());
     consumeSkillInstallPlan(record.token, expected, observed(record));
     discardSkillInstallPlan(record.token);
+    expect(releaseSkillSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('releases the artifact reference on the sweeper alone (Issue #1429)', async () => {
+    const record = await createSkillInstallPlan(makeInput());
+
+    expect(sweepSkillInstallPlans({ now: record.expiresAt - 1 })).toBe(0);
+    expect(releaseSkillSnapshotMock).not.toHaveBeenCalled();
+
+    expect(sweepSkillInstallPlans({ now: record.expiresAt })).toBe(1);
+    expect(releaseSkillSnapshotMock).toHaveBeenCalledWith(SNAPSHOT_ID);
+    expect(sweepSkillInstallPlans({ now: record.expiresAt })).toBe(0);
+    expect(releaseSkillSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the artifact reference when the sweeper meets a consumed plan', async () => {
+    const record = await createSkillInstallPlan(makeInput());
+    consumeSkillInstallPlan(record.token, expected, observed(record));
+
+    expect(sweepSkillInstallPlans({ now: record.expiresAt })).toBe(1);
     expect(releaseSkillSnapshotMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/lib/skills/plan-sweeper.test.ts
+++ b/tests/unit/lib/skills/plan-sweeper.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Background plan/snapshot sweeper (Issue #1429)
+ *
+ * The property under test is the one the plan cache could not previously
+ * offer: a plan that is built and never applied must stop pinning its artifact
+ * snapshot on its own schedule, without a second plan ever being created. These
+ * tests therefore run the real snapshot store against the real plan cache —
+ * mocking the store would prove only that a mock was called.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+
+vi.mock('@/lib/git/git-exec', () => ({
+  execGitCommand: vi.fn(),
+  execFileAsync: vi.fn(),
+}));
+
+import {
+  SKILL_PLAN_SWEEP_INTERVAL_MS,
+  SKILL_SNAPSHOT_TTL_MS,
+} from '@/config/skill-security-config';
+import {
+  SKILL_PLAN_TTL_MS,
+  createSkillInstallPlan,
+  getSkillInstallPlan,
+  getSkillInstallPlanCount,
+  resetSkillInstallPlanCacheForTesting,
+} from '@/lib/skills/install-plan';
+import {
+  createSkillSnapshot,
+  getSkillSnapshotUsage,
+  initSkillSnapshotStore,
+  resetSkillSnapshotStoreForTesting,
+  sweepSkillSnapshots,
+} from '@/lib/skills/snapshot-store';
+import {
+  ensureSkillPlanSweeper,
+  getSkillPlanSweeperTimerForTesting,
+  runSkillPlanSweep,
+  stopSkillPlanSweeperForTesting,
+} from '@/lib/skills/plan-sweeper';
+import { execFileAsync, execGitCommand } from '@/lib/git/git-exec';
+import type { SkillPackageSnapshot } from '@/lib/skills/package-validator';
+import type { SkillCommandMateCompatibility } from '@/lib/skills/compatibility';
+import type { SkillManifest } from '@/types/skills';
+import { makeCatalogVersion } from './fixtures';
+
+const execGitCommandMock = vi.mocked(execGitCommand);
+const execFileAsyncMock = vi.mocked(execFileAsync) as unknown as ReturnType<typeof vi.fn>;
+
+/** The store refuses system directories, and os.tmpdir() is under /var on macOS. */
+const TEST_ROOT_PARENT = path.join(process.cwd(), 'temp');
+
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const HEAD = 'f'.repeat(40);
+const T0 = Date.parse('2026-07-20T00:00:00Z');
+const ARTIFACT = Buffer.from('demo-skill artifact payload bytes for the sweeper test');
+
+const COMPATIBLE: SkillCommandMateCompatibility = {
+  status: 'compatible',
+  requiredRange: '>=0.11.0',
+  currentVersion: '0.11.4',
+  reasonCode: 'SKILL_COMPAT_SATISFIED',
+  messageKey: 'skills.compatibility.reason.satisfied',
+  message: 'CommandMate 0.11.4 satisfies >=0.11.0.',
+};
+
+let rootDir: string;
+let worktreeDir: string;
+
+function makePackageSnapshot(): SkillPackageSnapshot {
+  const bytes = Buffer.from('# demo\n', 'utf-8');
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const manifest: SkillManifest = {
+    schema_version: 1,
+    id: SKILL_ID,
+    name: SKILL_ID,
+    version: VERSION,
+    summary: 'Draft release notes.',
+    description: 'A demo Skill used by the sweeper tests.',
+    capabilities: ['Draft release notes from merged pull requests.'],
+    expected_outcomes: ['A reviewable draft in under a minute.'],
+    provider: { name: 'CommandMate', url: 'https://example.invalid' },
+    license: 'MIT',
+    compatibility: { commandmate: '>=0.11.0', agents: [] },
+    requirements: { commands: [], network_hosts: [] },
+    declared_permissions: ['filesystem_read'],
+    declared_risk: 'low',
+    risk_rationale: 'Reads the repository only.',
+    files: [
+      {
+        path: 'SKILL.md',
+        sha256,
+        size: bytes.byteLength,
+        kind: 'skill_md',
+        executable: false,
+        script: false,
+      },
+    ],
+  };
+
+  return {
+    skillId: SKILL_ID,
+    version: VERSION,
+    manifest,
+    files: [{ path: 'SKILL.md', sha256, size: bytes.byteLength, executable: false }],
+    directories: [],
+    inspection: {
+      executable_paths: [],
+      script_paths: [],
+      network_hosts: [],
+      declared_permissions: ['filesystem_read'],
+    },
+    declaredRisk: 'low',
+    computedRisk: 'low',
+    effectiveRisk: 'low',
+    readFile: () => new Uint8Array(bytes),
+  };
+}
+
+/** Snapshot the artifact, then pin it with an install plan. Mirrors the plan route. */
+async function pinSnapshotWithPlan(): Promise<{ snapshotId: string; token: string }> {
+  const handle = createSkillSnapshot({
+    skillId: SKILL_ID,
+    version: VERSION,
+    commit: 'a'.repeat(40),
+    sha256: createHash('sha256').update(ARTIFACT).digest('hex'),
+    bytes: ARTIFACT,
+  });
+
+  const record = await createSkillInstallPlan({
+    actor: { type: 'user', id: null },
+    worktree: {
+      id: 'demo-wt',
+      name: 'feature/demo',
+      path: worktreeDir,
+      repositoryName: 'CommandMate',
+      syncedBranch: 'feature/demo',
+    },
+    snapshot: makePackageSnapshot(),
+    version: makeCatalogVersion({ version: VERSION }),
+    snapshotId: handle.snapshotId,
+    compatibility: COMPATIBLE,
+    now: T0,
+  });
+
+  return { snapshotId: handle.snapshotId, token: record.token };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(T0);
+
+  fs.mkdirSync(TEST_ROOT_PARENT, { recursive: true });
+  rootDir = fs.mkdtempSync(path.join(TEST_ROOT_PARENT, 'skill-sweeper-'));
+  worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cm-sweeper-wt-'));
+  initSkillSnapshotStore({ rootDir });
+  resetSkillInstallPlanCacheForTesting();
+
+  execGitCommandMock.mockReset();
+  execFileAsyncMock.mockReset();
+  execGitCommandMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'symbolic-ref') return 'feature/demo';
+    if (args[0] === 'rev-parse') return HEAD;
+    if (args[0] === 'status') return '';
+    return null;
+  });
+  execFileAsyncMock.mockRejectedValue(Object.assign(new Error('exit 1'), { stdout: '' }));
+});
+
+afterEach(() => {
+  stopSkillPlanSweeperForTesting();
+  resetSkillInstallPlanCacheForTesting();
+  resetSkillSnapshotStoreForTesting();
+  fs.rmSync(rootDir, { recursive: true, force: true });
+  fs.rmSync(worktreeDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+describe('an abandoned plan', () => {
+  it('pins its snapshot past both TTLs while nothing sweeps the plan cache', async () => {
+    await pinSnapshotWithPlan();
+
+    // Long past the snapshot TTL, but the plan still holds the reference.
+    expect(sweepSkillSnapshots({ now: T0 + SKILL_SNAPSHOT_TTL_MS + 1 })).toBe(0);
+    expect(getSkillSnapshotUsage().count).toBe(1);
+  });
+
+  it('releases its snapshot on the sweeper without a second plan being created', async () => {
+    await pinSnapshotWithPlan();
+    expect(getSkillInstallPlanCount()).toBe(1);
+
+    const planExpired = runSkillPlanSweep({ now: T0 + SKILL_PLAN_TTL_MS + 1 });
+    expect(planExpired.installPlans).toBe(1);
+    expect(getSkillInstallPlanCount()).toBe(0);
+    // Reference dropped, but the bytes stay until their own TTL elapses.
+    expect(planExpired.snapshots).toBe(0);
+    expect(getSkillSnapshotUsage().count).toBe(1);
+
+    const snapshotExpired = runSkillPlanSweep({ now: T0 + SKILL_SNAPSHOT_TTL_MS + 1 });
+    expect(snapshotExpired.snapshots).toBe(1);
+    expect(getSkillSnapshotUsage()).toEqual({ totalBytes: 0, count: 0 });
+  });
+
+  it('is reclaimed by an unrelated token lookup, not only by the timer', async () => {
+    const { token } = await pinSnapshotWithPlan();
+
+    expect(() =>
+      getSkillInstallPlan('0'.repeat(48), { now: T0 + SKILL_PLAN_TTL_MS + 1 })
+    ).toThrowError(/SKILL_PLAN_NOT_FOUND/);
+
+    expect(getSkillInstallPlanCount()).toBe(0);
+    expect(sweepSkillSnapshots({ now: T0 + SKILL_SNAPSHOT_TTL_MS + 1 })).toBe(1);
+    // The plan is gone, so its own token now reads as absent rather than expired.
+    expect(() => getSkillInstallPlan(token, { now: T0 })).toThrowError(/SKILL_PLAN_NOT_FOUND/);
+  });
+
+  it('still answers EXPIRED for its own token rather than NOT_FOUND', async () => {
+    const { token } = await pinSnapshotWithPlan();
+
+    expect(() =>
+      getSkillInstallPlan(token, { now: T0 + SKILL_PLAN_TTL_MS + 1 })
+    ).toThrowError(/SKILL_PLAN_EXPIRED/);
+  });
+});
+
+describe('runSkillPlanSweep', () => {
+  it('skips snapshots when no artifact has been downloaded yet', () => {
+    resetSkillSnapshotStoreForTesting();
+
+    expect(runSkillPlanSweep({ now: T0 })).toEqual({
+      installPlans: 0,
+      uninstallPlans: 0,
+      snapshots: 0,
+    });
+  });
+});
+
+describe('ensureSkillPlanSweeper', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs one timer no matter how many requests start it', () => {
+    ensureSkillPlanSweeper();
+    const first = getSkillPlanSweeperTimerForTesting();
+    ensureSkillPlanSweeper();
+
+    expect(first).not.toBeNull();
+    expect(getSkillPlanSweeperTimerForTesting()).toBe(first);
+  });
+
+  it('does not hold the event loop open', () => {
+    ensureSkillPlanSweeper();
+
+    expect(getSkillPlanSweeperTimerForTesting()?.hasRef()).toBe(false);
+  });
+
+  it('sweeps on the configured interval', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    ensureSkillPlanSweeper();
+
+    vi.advanceTimersByTime(SKILL_PLAN_SWEEP_INTERVAL_MS * 2);
+
+    // Nothing to reclaim, but the interval must have fired without throwing.
+    expect(getSkillInstallPlanCount()).toBe(0);
+  });
+});

--- a/tests/unit/lib/skills/uninstall-plan.test.ts
+++ b/tests/unit/lib/skills/uninstall-plan.test.ts
@@ -43,8 +43,10 @@ import {
   consumeSkillUninstallPlan,
   createSkillUninstallPlan,
   getSkillUninstallPlan,
+  getSkillUninstallPlanCount,
   readSkillReceiptDigest,
   resetSkillUninstallPlanCacheForTesting,
+  sweepSkillUninstallPlans,
 } from '@/lib/skills/uninstall-plan';
 import { buildPackage } from '../../../fixtures/skills/malicious-packages/package';
 import type { PackageFileSpec } from '../../../fixtures/skills/malicious-packages/package';
@@ -356,6 +358,29 @@ describe('createSkillUninstallPlan', () => {
     }
     expect(isSkillPlanError(thrown)).toBe(true);
     expect((thrown as { code: string }).code).toBe('SKILL_PLAN_NOT_FOUND');
+  });
+});
+
+describe('the uninstall cache lets go on its own schedule (Issue #1429)', () => {
+  it('drops an expired plan without a second plan being created', () => {
+    install();
+    const record = plan();
+    expect(getSkillUninstallPlanCount()).toBe(1);
+
+    expect(sweepSkillUninstallPlans({ now: record.expiresAt - 1 })).toBe(0);
+    expect(sweepSkillUninstallPlans({ now: record.expiresAt })).toBe(1);
+    expect(getSkillUninstallPlanCount()).toBe(0);
+  });
+
+  it('reclaims an expired plan on an unrelated token lookup', () => {
+    install();
+    const record = plan();
+
+    expect(() =>
+      getSkillUninstallPlan('0'.repeat(48), { now: record.expiresAt + 1 })
+    ).toThrowError(/SKILL_PLAN_NOT_FOUND/);
+
+    expect(getSkillUninstallPlanCount()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## 概要
Issue #1429 の対応。plan が pin した検証済み snapshot が、token 失効後も解放されずプロセス存続中残り続ける問題を解消する。

## 原因
plan は snapshot を `refCount=1` で pin するが、解放する `dropRecord` へ到達する経路が実質 `sweep()` のみで、その `sweep()` は `createSkillInstallPlan` からしか呼ばれていなかった。plan を作って適用せず放置すると、以後 plan が作られない限り最大 16MB/件 がプロセス終了まで残る。snapshot 側の TTL sweep も quota eviction も `refCount === 0` のみ対象のため無効。

## 実装
- 新規 `src/lib/skills/plan-sweeper.ts` — 60 秒ごとに両 plan cache と snapshot store を sweep。**plan → snapshot の順**（plan が参照を手放して初めて snapshot が候補になる）
- 4 つの Skill route handler から lazy 起動。**`server.ts` は未変更**（#1428 が所有）。timer は `unref()` 済み
- `sweep()` を expired-reclaim と LRU eviction に分割し、expired-reclaim は token アクセス時にも走るようにした。提示された token 自身は当該 pass から除外し、`EXPIRED`(410) が `NOT_FOUND`(404) に化けないようにしている
- 未配線だった `sweepSkillSnapshots` を配線

## 補足
- uninstall plan は snapshotId を持たないため、リークは plan record のみで snapshot bytes は元から漏れていない
- Issue 前提はすべて実コードで確認済み、訂正なし
- `docs/user-guide/skills.md` §3-7 の記述更新は orchestrator 側で実施（worker 契約）

## 検証
- **ガードを意図的に壊す変異テスト**: token アクセス時 sweep 除去 → 2 失敗 / sweep 本体を no-op → 3 失敗 / `unref()` 除去 → 1 失敗。いずれも対応するテストのみが赤
- lint 0 / tsc 0 / test:unit 11035 pass（`CI=true` でも同一）/ skills integration 92 pass（`CM_DB_PATH` を homedir へ隔離）/ build green（worktree 内）

Refs #1429