### PR TITLE
feat(skills): install/uninstall UI導線接続（SkillTargetSelectorマウント・書き込みclient） (#1431)

### DIFF
--- a/locales/en/skills.json
+++ b/locales/en/skills.json
@@ -106,7 +106,6 @@
     },
     "install": {
       "action": "Choose an install target",
-      "unavailableYet": "Choosing an install target is not available yet. This screen covers browsing the Catalog only.",
       "blockedIncompatible": "Install is unavailable: {reason}",
       "blockedNoVersion": "Install is unavailable because no published version applies to the CommandMate you are running."
     }
@@ -131,7 +130,87 @@
     "branchFreshnessNotice": "The branch shown here comes from the last worktree scan. CommandMate resolves the live branch and commit when it builds the install plan, and reports any difference there."
   },
   "plan": {
-    "highRiskAcknowledgement": "CommandMate rated this package high risk after inspecting its contents. Review the files, scripts and declared permissions below, then confirm explicitly that you want to install it into this worktree."
+    "highRiskAcknowledgement": "CommandMate rated this package high risk after inspecting its contents. Review the files, scripts and declared permissions below, then confirm explicitly that you want to install it into this worktree.",
+    "build": "Build install plan",
+    "building": "Building the install plan…",
+    "chooseTarget": "Choose the worktree this Skill would be installed into.",
+    "ready": "Building a plan writes nothing. It downloads the package, inspects it and reports exactly what installing would change.",
+    "heading": "Install plan",
+    "expiresAt": "This plan is valid until {timestamp}. After that, build a new one.",
+    "targetHeading": "Where this would be installed",
+    "headStateLabel": "Git HEAD",
+    "headState": {
+      "attached": "On a branch",
+      "detached": "Detached HEAD",
+      "unborn": "No commit yet",
+      "unknown": "Could not be resolved"
+    },
+    "installRoot": "Install directory",
+    "existingInstall": "Already installed here",
+    "existingInstallNone": "Nothing installed here yet",
+    "existingInstallVersion": "Version {version}",
+    "riskHeading": "Risk",
+    "riskDeclared": "Declared",
+    "riskComputed": "Computed",
+    "riskEffective": "Effective",
+    "riskNotice": "The computed level comes from inspecting the downloaded package. Where it disagrees with the publisher's claim, the higher of the two is the effective level.",
+    "permission": {
+      "filesystemRead": "Reads files",
+      "filesystemWrite": "Writes files",
+      "networkAccess": "Accesses the network",
+      "processExecution": "Runs other programs",
+      "environmentRead": "Reads environment variables",
+      "credentialAccess": "Accesses credentials"
+    },
+    "permissionsNone": "The manifest declares no permissions.",
+    "requirementsNone": "The manifest requires no commands and no network access.",
+    "requirementsCommands": "Commands",
+    "requirementsHosts": "Network hosts",
+    "commandAnyVersion": "(any version)",
+    "scriptsHeading": "Scripts and executables in the package",
+    "scriptsNone": "The package contains no scripts and no executable files.",
+    "warningsHeading": "Caveats",
+    "warning": {
+      "detachedHead": "This worktree is not on a branch, so the install would not belong to any branch history.",
+      "unbornHead": "This worktree has no commit yet.",
+      "headUnresolved": "The current commit could not be resolved.",
+      "workingTreeDirty": "This worktree has uncommitted changes, so the install would mix with work in progress.",
+      "pathGitIgnored": "Some destination paths are ignored by git, so the installed files would not show up in git status.",
+      "diffTruncated": "Some diffs were too large to show in full.",
+      "binaryContent": "Some files are binary, so no diff can be shown for them.",
+      "lineEndingCrlf": "Some files use CRLF line endings.",
+      "treeScanTruncated": "The destination directory was too large to inspect completely."
+    },
+    "filesHeading": "What this install would write",
+    "stats": "{added} added, {modified} modified, {unchanged} unchanged, {conflicted} conflicting, {unmanaged} unmanaged",
+    "filesEmpty": "This plan writes no files.",
+    "fileGenerated": "Install record",
+    "gitIgnored": "This path is ignored by git.",
+    "diffToggle": "Show the diff (+{additions} / -{deletions})",
+    "diffTruncated": "This diff was truncated.",
+    "diffBinary": "Binary file, so no diff is shown.",
+    "change": {
+      "add": "Add",
+      "modify": "Modify",
+      "unchanged": "Unchanged",
+      "conflict": "Conflict",
+      "unmanaged": "Unmanaged"
+    },
+    "diffReason": {
+      "newFile": "Nothing is at this path, so the file would simply be created.",
+      "contentIdentical": "What is already there is byte-identical to what would be written.",
+      "managedUpdate": "CommandMate installed this file and it is unchanged, so it would be replaced.",
+      "localModification": "This file has been edited since it was installed. CommandMate will not overwrite your changes.",
+      "unmanagedSkill": "A Skill directory is already here that CommandMate did not install, so it is not CommandMate's to replace.",
+      "receiptOrphan": "The install record lists this file but it is no longer on disk, so the recorded installation no longer matches the worktree.",
+      "notARegularFile": "This path is a symbolic link or another non-regular entry. CommandMate will not follow it."
+    },
+    "blockersHeading": "What stops this install",
+    "blockedNotice": "Nothing has been written. Resolve the paths above, then build a new plan.",
+    "acknowledgeLabel": "I have reviewed the files, scripts and declared permissions above, and I want to install this high-risk Skill into this worktree.",
+    "confirm": "Install into this worktree",
+    "confirming": "Installing…",
+    "discard": "Discard this plan"
   },
   "install": {
     "reload": {
@@ -171,6 +250,27 @@
       "commandmateRuntime": "{agent} ran this Skill through the CommandMate runtime. Restart the {agent} session in this worktree so the runtime drops {skillId}.",
       "unsupported": "{agent} did not support this Skill, so removing {skillId} changes nothing for {agent} sessions.",
       "unknown": "Support for {agent} was never verified. The files are removed; restart the {agent} session if {skillId} is still offered."
+    },
+    "build": "Build uninstall plan",
+    "building": "Building the uninstall plan…",
+    "heading": "Uninstall plan",
+    "expiresAt": "This plan is valid until {timestamp}. After that, build a new one.",
+    "installedVersion": "Installed version",
+    "versionUnknown": "Not recorded",
+    "stats": "{removable} removable, {modified} modified, {missing} missing, {unknown} unknown, {irregular} not a regular file",
+    "removalsHeading": "What would be deleted",
+    "removalsEmpty": "This plan deletes nothing.",
+    "retainedHeading": "What would stay",
+    "retainedEmpty": "Nothing would be left behind.",
+    "blockersHeading": "What stops this uninstall",
+    "confirm": "Remove from this worktree",
+    "confirming": "Removing…",
+    "disposition": {
+      "remove": "Delete",
+      "modified": "Keep (edited)",
+      "missing": "Already gone",
+      "unknown": "Keep (not recorded)",
+      "irregular": "Keep (not a regular file)"
     }
   },
   "card": {
@@ -204,6 +304,41 @@
       "malformed": "The Catalog response was not valid JSON.",
       "invalidSchema": "The Catalog response failed contract validation.",
       "unknown": "The reason was not reported."
+    }
+  },
+  "operation": {
+    "errorHeading": "The operation was refused",
+    "reloadHeading": "Restart these agent sessions",
+    "installedHeading": "Installed",
+    "uninstalledHeading": "Removed",
+    "replayNotice": "This answers a request CommandMate had already carried out, so the per-file list is not repeated.",
+    "filesWritten": "{count} files written",
+    "filesRemoved": "{count} files removed",
+    "startOver": "Choose another target",
+    "error": {
+      "planStale": "The worktree changed after this plan was built, so the plan no longer describes what would happen. Nothing was written. Build a new plan.",
+      "planExpired": "This plan is too old to spend. Nothing was written. Build a new plan.",
+      "planConsumed": "This plan has already been used. Nothing was written a second time.",
+      "planNotFound": "CommandMate no longer holds this plan. Nothing was written. Build a new plan.",
+      "planBindingMismatch": "This plan was built for a different request and cannot be spent here. Build a new plan from this screen.",
+      "planNotInstallable": "This plan reports blockers, so it cannot be applied. Nothing was written.",
+      "planRiskNotAcknowledged": "This package is high risk and the install was not explicitly acknowledged. Nothing was written.",
+      "installLocked": "Another Skill operation is running in this worktree. Nothing was written. Try again once it finishes.",
+      "installInProgress": "An earlier attempt at this exact install is still running. Wait for it rather than starting a second one.",
+      "installDestinationExists": "Something is already at the install path. Nothing was written; CommandMate does not overwrite what it did not install.",
+      "installDestinationUnmanaged": "A Skill directory that CommandMate did not install is already at this path. Nothing was written.",
+      "installIdempotencyConflict": "This retry does not match the request it repeats. Nothing was written. Build a new plan.",
+      "installFailed": "An earlier attempt at this install failed and nothing was written. Build a new plan.",
+      "uninstallLocked": "Another Skill operation is running in this worktree. Nothing was deleted. Try again once it finishes.",
+      "uninstallInProgress": "An earlier attempt at this exact uninstall is still running. Wait for it rather than starting a second one.",
+      "uninstallIdempotencyConflict": "This retry does not match the request it repeats. Nothing was deleted. Build a new plan.",
+      "uninstallNotInstalled": "CommandMate has no record of this Skill in this worktree, so there is nothing for it to remove.",
+      "uninstallBlocked": "Nothing was deleted. Some paths are not CommandMate's to remove.",
+      "uninstallDrift": "The worktree no longer matches the install record, so CommandMate cannot tell which files it owns. Nothing was deleted.",
+      "uninstallFileChanged": "A file changed after the plan was built. Nothing was deleted. Build a new plan.",
+      "uninstallFailed": "An earlier attempt at this uninstall failed and nothing was deleted. Build a new plan.",
+      "requestFailed": "The request did not reach CommandMate, or it answered without naming a reason. Nothing is known to have changed.",
+      "unexpected": "CommandMate reported a failure it has no explanation for. Treat the worktree as unchanged only after checking it."
     }
   }
 }

--- a/locales/ja/skills.json
+++ b/locales/ja/skills.json
@@ -106,7 +106,6 @@
     },
     "install": {
       "action": "導入先を選択",
-      "unavailableYet": "導入先の選択はまだ利用できません。この画面はCatalogの閲覧のみを扱います。",
       "blockedIncompatible": "導入できません: {reason}",
       "blockedNoVersion": "稼働中のCommandMateに適用できる公開versionがないため導入できません。"
     }
@@ -131,7 +130,87 @@
     "branchFreshnessNotice": "ここに表示しているブランチは直近のworktree同期時点の値です。CommandMateはinstall plan生成時に現在のブランチとコミットを解決し、差異があればそこで報告します。"
   },
   "plan": {
-    "highRiskAcknowledgement": "CommandMateはpackageの内容を検査した結果、このSkillをhigh riskと判定しました。以下のファイル・スクリプト・宣言された権限を確認したうえで、このworktreeへ導入することを明示的に承認してください。"
+    "highRiskAcknowledgement": "CommandMateはpackageの内容を検査した結果、このSkillをhigh riskと判定しました。以下のファイル・スクリプト・宣言された権限を確認したうえで、このworktreeへ導入することを明示的に承認してください。",
+    "build": "install planを作成",
+    "building": "install planを作成しています…",
+    "chooseTarget": "このSkillを導入するworktreeを選択してください。",
+    "ready": "planの作成では何も書き込みません。packageを取得して内容を検査し、導入した場合に何が変わるかだけを報告します。",
+    "heading": "install planの内容",
+    "expiresAt": "このplanは{timestamp}まで有効です。それ以降は作り直してください。",
+    "targetHeading": "導入先",
+    "headStateLabel": "Git HEADの状態",
+    "headState": {
+      "attached": "ブランチ上",
+      "detached": "detached HEAD",
+      "unborn": "コミットがまだありません",
+      "unknown": "解決できませんでした"
+    },
+    "installRoot": "導入先ディレクトリ",
+    "existingInstall": "既存の導入",
+    "existingInstallNone": "まだ導入されていません",
+    "existingInstallVersion": "version {version}",
+    "riskHeading": "リスク",
+    "riskDeclared": "publisher申告",
+    "riskComputed": "CommandMate判定",
+    "riskEffective": "実効",
+    "riskNotice": "判定値は取得したpackageの内容を検査した結果です。publisherの申告と食い違う場合は、高いほうを実効値として扱います。",
+    "permission": {
+      "filesystemRead": "ファイルを読み取る",
+      "filesystemWrite": "ファイルを書き込む",
+      "networkAccess": "ネットワークへ接続する",
+      "processExecution": "他のプログラムを実行する",
+      "environmentRead": "環境変数を読み取る",
+      "credentialAccess": "認証情報へアクセスする"
+    },
+    "permissionsNone": "manifestは権限を宣言していません。",
+    "requirementsNone": "manifestは必要なコマンドもネットワーク接続も宣言していません。",
+    "requirementsCommands": "コマンド",
+    "requirementsHosts": "ネットワークホスト",
+    "commandAnyVersion": "（version不問）",
+    "scriptsHeading": "package内のスクリプト・実行ファイル",
+    "scriptsNone": "packageにスクリプトも実行ファイルも含まれていません。",
+    "warningsHeading": "留意点",
+    "warning": {
+      "detachedHead": "このworktreeはブランチ上にないため、導入内容はどのブランチ履歴にも属しません。",
+      "unbornHead": "このworktreeにはまだコミットがありません。",
+      "headUnresolved": "現在のコミットを解決できませんでした。",
+      "workingTreeDirty": "このworktreeには未コミットの変更があるため、導入内容が作業中の変更と混ざります。",
+      "pathGitIgnored": "一部の書き込み先はgitのignore対象です。導入したファイルはgit statusに現れません。",
+      "diffTruncated": "一部の差分は大きすぎるため省略されています。",
+      "binaryContent": "一部のファイルはバイナリのため差分を表示できません。",
+      "lineEndingCrlf": "一部のファイルの改行コードはCRLFです。",
+      "treeScanTruncated": "書き込み先ディレクトリが大きすぎるため、完全には検査できませんでした。"
+    },
+    "filesHeading": "導入によって書き込まれる内容",
+    "stats": "追加{added}件 / 変更{modified}件 / 変更なし{unchanged}件 / 衝突{conflicted}件 / 管理外{unmanaged}件",
+    "filesEmpty": "このplanはファイルを書き込みません。",
+    "fileGenerated": "導入記録",
+    "gitIgnored": "このパスはgitのignore対象です。",
+    "diffToggle": "差分を表示（+{additions} / -{deletions}）",
+    "diffTruncated": "この差分は途中で打ち切られています。",
+    "diffBinary": "バイナリファイルのため差分は表示できません。",
+    "change": {
+      "add": "追加",
+      "modify": "変更",
+      "unchanged": "変更なし",
+      "conflict": "衝突",
+      "unmanaged": "管理外"
+    },
+    "diffReason": {
+      "newFile": "このパスには何もないため、ファイルは新規作成されます。",
+      "contentIdentical": "既にあるファイルは書き込む内容とバイト単位で同一です。",
+      "managedUpdate": "CommandMateが導入したファイルで変更もないため、置き換えます。",
+      "localModification": "導入後に編集されたファイルです。CommandMateはあなたの変更を上書きしません。",
+      "unmanagedSkill": "CommandMateが導入していないSkillディレクトリが既にあります。CommandMateが置き換えてよいものではありません。",
+      "receiptOrphan": "導入記録にはあるファイルですが、ディスク上には存在しません。記録された導入内容とworktreeが一致していません。",
+      "notARegularFile": "このパスはシンボリックリンク等の通常ファイル以外です。CommandMateはこれをたどりません。"
+    },
+    "blockersHeading": "導入できない理由",
+    "blockedNotice": "何も書き込んでいません。上記のパスを解消してからplanを作り直してください。",
+    "acknowledgeLabel": "上記のファイル・スクリプト・宣言された権限を確認したうえで、このhigh riskのSkillをこのworktreeへ導入します。",
+    "confirm": "このworktreeへ導入する",
+    "confirming": "導入しています…",
+    "discard": "このplanを破棄"
   },
   "install": {
     "reload": {
@@ -171,6 +250,27 @@
       "commandmateRuntime": "{agent} はCommandMate runtime経由でこのSkillを実行していました。runtimeが {skillId} を解放するよう、このworktreeの {agent} セッションを再起動してください。",
       "unsupported": "{agent} はこのSkillに対応していなかったため、{skillId} の削除による {agent} セッションへの影響はありません。",
       "unknown": "{agent} での対応状況は未検証でした。ファイルは削除済みです。{skillId} がまだ提示される場合は {agent} セッションを再起動してください。"
+    },
+    "build": "uninstall planを作成",
+    "building": "uninstall planを作成しています…",
+    "heading": "uninstall planの内容",
+    "expiresAt": "このplanは{timestamp}まで有効です。それ以降は作り直してください。",
+    "installedVersion": "導入済みversion",
+    "versionUnknown": "記録されていません",
+    "stats": "削除可能{removable}件 / 変更済み{modified}件 / 消失{missing}件 / 未記録{unknown}件 / 通常ファイル以外{irregular}件",
+    "removalsHeading": "削除される対象",
+    "removalsEmpty": "このplanは何も削除しません。",
+    "retainedHeading": "残す対象",
+    "retainedEmpty": "残るものはありません。",
+    "blockersHeading": "削除できない理由",
+    "confirm": "このworktreeから削除する",
+    "confirming": "削除しています…",
+    "disposition": {
+      "remove": "削除",
+      "modified": "残す（編集済み）",
+      "missing": "既に存在しません",
+      "unknown": "残す（未記録）",
+      "irregular": "残す（通常ファイル以外）"
     }
   },
   "card": {
@@ -204,6 +304,41 @@
       "malformed": "Catalogの応答が正しいJSONではありませんでした。",
       "invalidSchema": "Catalogの応答が契約検証に失敗しました。",
       "unknown": "理由は報告されていません。"
+    }
+  },
+  "operation": {
+    "errorHeading": "操作は実行されませんでした",
+    "reloadHeading": "以下のagentセッションを再起動してください",
+    "installedHeading": "導入しました",
+    "uninstalledHeading": "削除しました",
+    "replayNotice": "既に実行済みの要求に対する応答のため、ファイル単位の一覧は再掲されません。",
+    "filesWritten": "{count}件のファイルを書き込みました",
+    "filesRemoved": "{count}件のファイルを削除しました",
+    "startOver": "別の導入先を選ぶ",
+    "error": {
+      "planStale": "plan作成後にworktreeが変化したため、planは現状を説明していません。何も書き込んでいません。planを作り直してください。",
+      "planExpired": "このplanは有効期限切れです。何も書き込んでいません。planを作り直してください。",
+      "planConsumed": "このplanは既に使用済みです。二重には書き込んでいません。",
+      "planNotFound": "CommandMateはこのplanを保持していません。何も書き込んでいません。planを作り直してください。",
+      "planBindingMismatch": "このplanは別の要求向けに作成されたもので、ここでは使用できません。この画面からplanを作り直してください。",
+      "planNotInstallable": "このplanには阻害要因があるため適用できません。何も書き込んでいません。",
+      "planRiskNotAcknowledged": "high riskのpackageですが導入の明示的な承認がありません。何も書き込んでいません。",
+      "installLocked": "このworktreeでは別のSkill操作が実行中です。何も書き込んでいません。完了後に再試行してください。",
+      "installInProgress": "同一内容の導入が既に実行中です。二重に開始せず完了を待ってください。",
+      "installDestinationExists": "導入先には既に何かが存在します。CommandMateは自身が導入していないものを上書きしないため、何も書き込んでいません。",
+      "installDestinationUnmanaged": "CommandMateが導入していないSkillディレクトリが導入先にあります。何も書き込んでいません。",
+      "installIdempotencyConflict": "この再試行は元の要求と内容が一致しません。何も書き込んでいません。planを作り直してください。",
+      "installFailed": "先行する導入が失敗しており、何も書き込まれていません。planを作り直してください。",
+      "uninstallLocked": "このworktreeでは別のSkill操作が実行中です。何も削除していません。完了後に再試行してください。",
+      "uninstallInProgress": "同一内容の削除が既に実行中です。二重に開始せず完了を待ってください。",
+      "uninstallIdempotencyConflict": "この再試行は元の要求と内容が一致しません。何も削除していません。planを作り直してください。",
+      "uninstallNotInstalled": "このworktreeにこのSkillの導入記録がないため、削除する対象がありません。",
+      "uninstallBlocked": "何も削除していません。CommandMateが削除してよくないパスが含まれています。",
+      "uninstallDrift": "worktreeが導入記録と一致しなくなっており、どのファイルがCommandMate管理下か判別できません。何も削除していません。",
+      "uninstallFileChanged": "plan作成後にファイルが変更されました。何も削除していません。planを作り直してください。",
+      "uninstallFailed": "先行する削除が失敗しており、何も削除されていません。planを作り直してください。",
+      "requestFailed": "要求がCommandMateに届かなかったか、理由を伴わない応答が返りました。変更が起きたとは確認できていません。",
+      "unexpected": "CommandMateが説明を持たない失敗を報告しました。worktreeを確認したうえで、変更なしと判断してください。"
     }
   }
 }

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -61,7 +61,13 @@ import { Kbd } from '@/components/ui/Kbd';
 import { useToast } from '@/components/common/Toast';
 import type { Worktree } from '@/types/models';
 
-/** Navigation targets shown in the palette (mirrors Header / GlobalMobileNav). */
+/**
+ * Navigation targets shown in the palette.
+ *
+ * Mirrors Header / GlobalMobileNav except for Skills, which is reachable from
+ * More and this palette only: #1232 kept it out of the primary nav rather than
+ * spend one of the few top-level slots on it.
+ */
 const NAV_ITEMS = [
   { key: 'home', href: '/' },
   { key: 'chat', href: '/chat' },

--- a/src/components/skills/SkillDetailView.tsx
+++ b/src/components/skills/SkillDetailView.tsx
@@ -34,6 +34,7 @@ import type { SkillCommandMateCompatibility } from '@/lib/skills/compatibility';
 import { AgentSupportBadge, SkillCompatibilityBadge, SkillRiskBadge } from './SkillBadges';
 import { CatalogStatusBanner } from './CatalogStatusBanner';
 import { SkillChangelog } from './SkillChangelog';
+import { SkillInstallPanel } from './SkillInstallPanel';
 import { SkillNotice } from './SkillNotice';
 import { fetchSkillDetail, type SkillFetchFailure } from './skills-client';
 import { RECOMMENDATION_LABEL_KEY, resolveSkillMessageKey } from './skill-vocabulary';
@@ -255,7 +256,7 @@ export function SkillDetailView({ skillId }: SkillDetailViewProps) {
             currentVersion: compatibility.currentVersion ?? '',
           }),
         })
-      : t('detail.install.unavailableYet');
+      : null;
 
   return (
     <div className="space-y-4">
@@ -272,17 +273,11 @@ export function SkillDetailView({ skillId }: SkillDetailViewProps) {
       </div>
 
       <SectionCard title={t('detail.install.action')} testId="skill-install-section">
-        <Button
-          variant="primary"
-          disabled
-          data-testid="skill-install-action"
-          aria-describedby="skill-install-reason"
-        >
-          {t('detail.install.action')}
-        </Button>
-        <p id="skill-install-reason" className="text-sm text-muted-foreground" data-testid="skill-install-reason">
-          {installBlockedReason}
-        </p>
+        <SkillInstallPanel
+          skillId={skill.id}
+          version={skill.recommendedVersion}
+          blockedReason={installBlockedReason}
+        />
       </SectionCard>
 
       <SectionCard title={t('capabilities.heading')} testId="skill-capabilities-section">

--- a/src/components/skills/SkillInstallPanel.tsx
+++ b/src/components/skills/SkillInstallPanel.tsx
@@ -1,0 +1,443 @@
+/**
+ * Install and uninstall flow for one Skill (Issue #1431)
+ *
+ * Connects the pieces #1232/#1233 built but never wired together: pick a
+ * worktree, build a plan, read what the plan says would happen, and only then
+ * apply it. Nothing is written before the user has seen the preview, and the
+ * apply request spends the plan token the preview was built from, so what is
+ * approved and what is executed are the same plan.
+ *
+ * Two rules the flow does not bend:
+ * - A high-risk package gets its own acknowledgement, separate from the ordinary
+ *   confirm. The apply request is never sent without it, so the API's
+ *   `SKILL_PLAN_RISK_NOT_ACKNOWLEDGED` refusal stays a backstop rather than the
+ *   thing the user meets.
+ * - Every refusal is reported with what the server said. A blocked plan is
+ *   rendered, not swallowed: "nothing was written and here is what is in the
+ *   way" is a different message from "install failed".
+ *
+ * @module components/skills/SkillInstallPanel
+ */
+
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button, Card, Checkbox } from '@/components/ui';
+import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
+import { SkillNotice } from './SkillNotice';
+import { SkillTargetSelector } from './SkillTargetSelector';
+import { SkillInstallPlanPreview, SkillUninstallPlanPreview } from './SkillPlanPreview';
+import { operationErrorLabelKey, resolveSkillMessageKey } from './skill-vocabulary';
+import {
+  applySkillInstall,
+  applySkillUninstall,
+  createSkillInstallPlan,
+  createSkillUninstallPlan,
+  type SkillFetchFailure,
+} from './skills-client';
+import type {
+  SkillInstallApplyResponse,
+  SkillInstallPlanDto,
+  SkillUninstallApplyResponse,
+  SkillUninstallPlanDto,
+} from './types';
+
+type Busy = 'install-plan' | 'install-apply' | 'uninstall-plan' | 'uninstall-apply' | null;
+
+interface PanelState {
+  worktreeId: string | null;
+  busy: Busy;
+  installPlan: SkillInstallPlanDto | null;
+  uninstallPlan: SkillUninstallPlanDto | null;
+  installResult: SkillInstallApplyResponse | null;
+  uninstallResult: SkillUninstallApplyResponse | null;
+  /** The user's explicit consent to a high-risk install, reset with the plan. */
+  riskAcknowledged: boolean;
+  failure: SkillFetchFailure | null;
+}
+
+const INITIAL_STATE: PanelState = {
+  worktreeId: null,
+  busy: null,
+  installPlan: null,
+  uninstallPlan: null,
+  installResult: null,
+  uninstallResult: null,
+  riskAcknowledged: false,
+  failure: null,
+};
+
+/** Everything a plan produced, cleared whenever a new operation starts. */
+function clearOutcome(state: PanelState): PanelState {
+  return {
+    ...state,
+    installPlan: null,
+    uninstallPlan: null,
+    installResult: null,
+    uninstallResult: null,
+    riskAcknowledged: false,
+    failure: null,
+  };
+}
+
+/**
+ * Retry key for an apply.
+ *
+ * Derived from the plan token so retrying the same approved plan replays the
+ * original operation instead of starting a second one. A fresh plan means a
+ * fresh key, which is what makes a genuinely new install genuinely new.
+ */
+function idempotencyKey(prefix: string, token: string): string {
+  return `${prefix}-${token}`;
+}
+
+function FailureNotice({ failure }: { failure: SkillFetchFailure }) {
+  const t = useTranslations('skills');
+  return (
+    <div className="space-y-2" data-testid="skill-operation-error">
+      <SkillNotice tone="danger">
+        <p className="font-medium">{t('operation.errorHeading')}</p>
+        <p className="mt-1">{t(operationErrorLabelKey(failure.code))}</p>
+        <p className="mt-1 break-words">{t('state.errorCode', { code: failure.code })}</p>
+      </SkillNotice>
+      {failure.nextActionKey && (
+        <SkillNotice tone="warning">{t(resolveSkillMessageKey(failure.nextActionKey))}</SkillNotice>
+      )}
+      {failure.blockers && failure.blockers.length > 0 && (
+        <ul className="space-y-1" data-testid="skill-operation-error-blockers">
+          {failure.blockers.map((blocker) => (
+            <li
+              key={`${blocker.code}:${blocker.path ?? ''}`}
+              className="text-xs text-danger-foreground"
+            >
+              {blocker.path && <span className="mr-1 break-all font-mono">{blocker.path}</span>}
+              {t(resolveSkillMessageKey(blocker.messageKey))}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ReloadGuidance({
+  agents,
+  skillId,
+  version,
+}: {
+  agents: Array<{ agent: string; messageKey: string }>;
+  skillId: string;
+  version: string;
+}) {
+  const t = useTranslations('skills');
+  if (agents.length === 0) return null;
+  return (
+    <div className="space-y-1" data-testid="skill-operation-reload">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {t('operation.reloadHeading')}
+      </h4>
+      <ul className="space-y-1">
+        {agents.map((agent) => (
+          <li key={agent.agent} className="text-xs text-muted-foreground">
+            {t(resolveSkillMessageKey(agent.messageKey), {
+              agent: getCliToolDisplayNameSafe(agent.agent),
+              skillId,
+              version,
+            })}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export interface SkillInstallPanelProps {
+  skillId: string;
+  /** Version to plan, or null when the Catalog offers none that applies here. */
+  version: string | null;
+  /**
+   * Why the Catalog rules out installing, or null when it does not. Uninstall
+   * stays available either way: a Skill that no longer runs here is exactly the
+   * one a user needs to be able to remove.
+   */
+  blockedReason: string | null;
+}
+
+export function SkillInstallPanel({ skillId, version, blockedReason }: SkillInstallPanelProps) {
+  const t = useTranslations('skills');
+  const [state, setState] = useState<PanelState>(INITIAL_STATE);
+
+  const selectTarget = useCallback((worktreeId: string) => {
+    setState((current) =>
+      current.worktreeId === worktreeId
+        ? current
+        : clearOutcome({ ...current, worktreeId, busy: null })
+    );
+  }, []);
+
+  const buildInstallPlan = useCallback(async () => {
+    const worktreeId = state.worktreeId;
+    if (!worktreeId) return;
+    setState((current) => ({ ...clearOutcome(current), busy: 'install-plan' }));
+
+    const result = await createSkillInstallPlan(worktreeId, skillId, {
+      version: version ?? undefined,
+    });
+    setState((current) => ({
+      ...current,
+      busy: null,
+      installPlan: result.ok ? result.data.plan : null,
+      failure: result.ok ? null : result.failure,
+    }));
+  }, [skillId, state.worktreeId, version]);
+
+  const confirmInstall = useCallback(async () => {
+    const worktreeId = state.worktreeId;
+    const plan = state.installPlan;
+    if (!worktreeId || !plan) return;
+    // The API refuses an unacknowledged high-risk apply, but the request must
+    // not leave the browser in the first place.
+    if (plan.requiresRiskAcknowledgement && !state.riskAcknowledged) return;
+
+    setState((current) => ({ ...current, busy: 'install-apply', failure: null }));
+
+    const result = await applySkillInstall(worktreeId, skillId, {
+      planToken: plan.token,
+      version: plan.skill.version,
+      acknowledgeRisk: plan.requiresRiskAcknowledgement ? true : undefined,
+      idempotencyKey: idempotencyKey('skill-install', plan.token),
+    });
+    setState((current) => ({
+      ...current,
+      busy: null,
+      installPlan: result.ok ? null : current.installPlan,
+      installResult: result.ok ? result.data : null,
+      failure: result.ok ? null : result.failure,
+    }));
+  }, [skillId, state.installPlan, state.riskAcknowledged, state.worktreeId]);
+
+  const buildUninstallPlan = useCallback(async () => {
+    const worktreeId = state.worktreeId;
+    if (!worktreeId) return;
+    setState((current) => ({ ...clearOutcome(current), busy: 'uninstall-plan' }));
+
+    const result = await createSkillUninstallPlan(worktreeId, skillId);
+    setState((current) => ({
+      ...current,
+      busy: null,
+      uninstallPlan: result.ok ? result.data.plan : null,
+      failure: result.ok ? null : result.failure,
+    }));
+  }, [skillId, state.worktreeId]);
+
+  const confirmUninstall = useCallback(async () => {
+    const worktreeId = state.worktreeId;
+    const plan = state.uninstallPlan;
+    if (!worktreeId || !plan) return;
+
+    setState((current) => ({ ...current, busy: 'uninstall-apply', failure: null }));
+
+    const result = await applySkillUninstall(worktreeId, skillId, {
+      planToken: plan.token,
+      idempotencyKey: idempotencyKey('skill-uninstall', plan.token),
+    });
+    setState((current) => ({
+      ...current,
+      busy: null,
+      uninstallPlan: result.ok ? null : current.uninstallPlan,
+      uninstallResult: result.ok ? result.data : null,
+      failure: result.ok ? null : result.failure,
+    }));
+  }, [skillId, state.uninstallPlan, state.worktreeId]);
+
+  const discardPlan = useCallback(() => {
+    setState((current) => clearOutcome(current));
+  }, []);
+
+  const busy = state.busy !== null;
+  const installPlan = state.installPlan;
+  const uninstallPlan = state.uninstallPlan;
+
+  const planReason = blockedReason ?? (state.worktreeId ? t('plan.ready') : t('plan.chooseTarget'));
+  const awaitingAcknowledgement =
+    installPlan !== null && installPlan.requiresRiskAcknowledgement && !state.riskAcknowledged;
+
+  return (
+    <div className="space-y-3" data-testid="skill-install-panel">
+      <SkillTargetSelector
+        selectedWorktreeId={state.worktreeId}
+        onSelect={selectTarget}
+        disabled={busy}
+      />
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="primary"
+          disabled={busy || blockedReason !== null || !state.worktreeId}
+          onClick={buildInstallPlan}
+          data-testid="skill-install-action"
+          aria-describedby="skill-install-reason"
+        >
+          {state.busy === 'install-plan' ? t('plan.building') : t('plan.build')}
+        </Button>
+        <Button
+          variant="secondary"
+          disabled={busy || !state.worktreeId}
+          onClick={buildUninstallPlan}
+          data-testid="skill-uninstall-action"
+        >
+          {state.busy === 'uninstall-plan' ? t('uninstall.building') : t('uninstall.build')}
+        </Button>
+      </div>
+      <p
+        id="skill-install-reason"
+        className="text-sm text-muted-foreground"
+        data-testid="skill-install-reason"
+      >
+        {planReason}
+      </p>
+
+      {state.failure && <FailureNotice failure={state.failure} />}
+
+      {installPlan && (
+        <div className="space-y-3">
+          <SkillInstallPlanPreview plan={installPlan} />
+
+          {installPlan.requiresRiskAcknowledgement && (
+            <Card className="space-y-3" data-testid="skill-install-risk-acknowledgement">
+              <SkillNotice tone="danger">
+                {t(
+                  resolveSkillMessageKey(
+                    installPlan.riskAcknowledgementMessageKey ?? 'skills.plan.highRiskAcknowledgement'
+                  )
+                )}
+              </SkillNotice>
+              <label className="flex items-start gap-2 text-sm text-foreground">
+                <Checkbox
+                  checked={state.riskAcknowledged}
+                  onCheckedChange={(checked) =>
+                    setState((current) => ({ ...current, riskAcknowledged: checked === true }))
+                  }
+                  disabled={busy}
+                  data-testid="skill-install-risk-checkbox"
+                  className="mt-0.5"
+                />
+                <span>{t('plan.acknowledgeLabel')}</span>
+              </label>
+            </Card>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant={installPlan.requiresRiskAcknowledgement ? 'danger' : 'primary'}
+              disabled={busy || !installPlan.installable || awaitingAcknowledgement}
+              onClick={confirmInstall}
+              data-testid="skill-install-confirm"
+            >
+              {state.busy === 'install-apply' ? t('plan.confirming') : t('plan.confirm')}
+            </Button>
+            <Button
+              variant="ghost"
+              disabled={busy}
+              onClick={discardPlan}
+              data-testid="skill-install-discard"
+            >
+              {t('plan.discard')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {uninstallPlan && (
+        <div className="space-y-3">
+          <SkillUninstallPlanPreview plan={uninstallPlan} />
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="danger"
+              disabled={busy || !uninstallPlan.removable}
+              onClick={confirmUninstall}
+              data-testid="skill-uninstall-confirm"
+            >
+              {state.busy === 'uninstall-apply'
+                ? t('uninstall.confirming')
+                : t('uninstall.confirm')}
+            </Button>
+            <Button
+              variant="ghost"
+              disabled={busy}
+              onClick={discardPlan}
+              data-testid="skill-uninstall-discard"
+            >
+              {t('plan.discard')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {state.installResult && (
+        <Card className="space-y-3" data-testid="skill-install-result">
+          <h3 className="text-sm font-semibold text-foreground">{t('operation.installedHeading')}</h3>
+          <SkillNotice tone="info">
+            {t(resolveSkillMessageKey(state.installResult.operation.nextActionKey))}
+          </SkillNotice>
+          {state.installResult.operation.replayed && (
+            <SkillNotice tone="neutral" data-testid="skill-operation-replayed">
+              {t('operation.replayNotice')}
+            </SkillNotice>
+          )}
+          {state.installResult.install && 'files' in state.installResult.install && (
+            <p className="text-xs text-muted-foreground">
+              {t('operation.filesWritten', { count: state.installResult.install.files.length })}
+            </p>
+          )}
+          {'reload' in state.installResult && (
+            <ReloadGuidance
+              agents={state.installResult.reload.agents}
+              skillId={state.installResult.reload.skillId}
+              version={state.installResult.reload.version}
+            />
+          )}
+          <Button variant="secondary" size="sm" onClick={discardPlan} data-testid="skill-operation-reset">
+            {t('operation.startOver')}
+          </Button>
+        </Card>
+      )}
+
+      {state.uninstallResult && (
+        <Card className="space-y-3" data-testid="skill-uninstall-result">
+          <h3 className="text-sm font-semibold text-foreground">
+            {t('operation.uninstalledHeading')}
+          </h3>
+          <SkillNotice tone="info">
+            {t(resolveSkillMessageKey(state.uninstallResult.operation.nextActionKey))}
+          </SkillNotice>
+          {state.uninstallResult.operation.replayed && (
+            <SkillNotice tone="neutral" data-testid="skill-operation-replayed">
+              {t('operation.replayNotice')}
+            </SkillNotice>
+          )}
+          {state.uninstallResult.uninstall && 'removedFiles' in state.uninstallResult.uninstall && (
+            <p className="text-xs text-muted-foreground">
+              {t('operation.filesRemoved', {
+                count: state.uninstallResult.uninstall.removedFiles.length,
+              })}
+            </p>
+          )}
+          {'reload' in state.uninstallResult && (
+            <ReloadGuidance
+              agents={state.uninstallResult.reload.agents}
+              skillId={state.uninstallResult.reload.skillId}
+              version={state.uninstallResult.reload.version}
+            />
+          )}
+          <Button variant="secondary" size="sm" onClick={discardPlan} data-testid="skill-operation-reset">
+            {t('operation.startOver')}
+          </Button>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default SkillInstallPanel;

--- a/src/components/skills/SkillPlanPreview.tsx
+++ b/src/components/skills/SkillPlanPreview.tsx
@@ -1,0 +1,440 @@
+/**
+ * Install and uninstall plan previews (Issue #1431)
+ *
+ * What the user approves is this preview, so it renders the plan and nothing
+ * else. Every fact shown — the branch, the risk CommandMate computed, which
+ * paths would be written, which ones stop the operation — comes from the plan
+ * response. The browser holds no filesystem path and makes no security
+ * judgement of its own, so there is nothing here for it to get wrong or for a
+ * tampered client to talk itself past.
+ *
+ * A plan that refuses is still rendered in full: "why can I not install this"
+ * is the question a bare error code leaves unanswered.
+ *
+ * @module components/skills/SkillPlanPreview
+ */
+
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge, Card } from '@/components/ui';
+import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
+import type { SkillRiskLevel } from '@/types/skills';
+import { SkillNotice } from './SkillNotice';
+import {
+  DIFF_CHANGE_BADGE_VARIANT,
+  DIFF_CHANGE_LABEL_KEY,
+  DIFF_REASON_LABEL_KEY,
+  HEAD_STATE_LABEL_KEY,
+  PERMISSION_LABEL_KEY,
+  PREVIEW_WARNING_LABEL_KEY,
+  RISK_BADGE_VARIANT,
+  RISK_LABEL_KEY,
+  UNINSTALL_DISPOSITION_LABEL_KEY,
+  UNINSTALL_REASON_LABEL_KEY,
+  resolveSkillMessageKey,
+} from './skill-vocabulary';
+import type {
+  SkillDiffEntry,
+  SkillInstallPlanDto,
+  SkillUninstallFileEntry,
+  SkillUninstallPlanDto,
+} from './types';
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5 break-words text-sm text-foreground">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * A risk level with the assessment it came from named in the label.
+ *
+ * The publisher's claim and CommandMate's own computation are different
+ * statements about the same package; a bare "high" badge would let one be read
+ * as the other.
+ */
+function PlanRiskBadge({
+  level,
+  kind,
+  label,
+}: {
+  level: SkillRiskLevel;
+  kind: string;
+  label: string;
+}) {
+  const t = useTranslations('skills');
+  return (
+    <Badge variant={RISK_BADGE_VARIANT[level]} data-testid={`skill-plan-risk-${kind}-${level}`}>
+      {label}: {t(RISK_LABEL_KEY[level])}
+    </Badge>
+  );
+}
+
+function PlanFile({ entry }: { entry: SkillDiffEntry }) {
+  const t = useTranslations('skills');
+  const reasonKey = DIFF_REASON_LABEL_KEY[entry.reason];
+
+  return (
+    <li className="space-y-1.5 rounded-md border border-border px-3 py-2" data-testid={`skill-plan-file-${entry.path}`}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={DIFF_CHANGE_BADGE_VARIANT[entry.change]}>
+          {t(DIFF_CHANGE_LABEL_KEY[entry.change])}
+        </Badge>
+        <span className="break-all font-mono text-xs text-foreground">{entry.path}</span>
+        {entry.generated && <Badge variant="gray">{t('plan.fileGenerated')}</Badge>}
+      </div>
+      {reasonKey && <p className="text-xs text-muted-foreground">{t(reasonKey)}</p>}
+      {entry.gitIgnored && <p className="text-xs text-warning-foreground">{t('plan.gitIgnored')}</p>}
+      {entry.binary ? (
+        <p className="text-xs text-muted-foreground">{t('plan.diffBinary')}</p>
+      ) : entry.diff ? (
+        <details>
+          <summary className="cursor-pointer text-xs text-accent-600 dark:text-accent-400">
+            {t('plan.diffToggle', { additions: entry.additions, deletions: entry.deletions })}
+          </summary>
+          <pre className="mt-1 overflow-x-auto rounded bg-muted p-2 font-mono text-[11px] leading-snug text-foreground">
+            {entry.diff}
+          </pre>
+          {entry.diffTruncated && (
+            <p className="mt-1 text-xs text-muted-foreground">{t('plan.diffTruncated')}</p>
+          )}
+        </details>
+      ) : null}
+    </li>
+  );
+}
+
+export interface SkillInstallPlanPreviewProps {
+  plan: SkillInstallPlanDto;
+}
+
+export function SkillInstallPlanPreview({ plan }: SkillInstallPlanPreviewProps) {
+  const t = useTranslations('skills');
+  const { target, skill } = plan;
+  const compatibility = skill.compatibility.commandmate;
+
+  return (
+    <Card className="space-y-4" data-testid="skill-install-plan">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">{t('plan.heading')}</h3>
+        <p className="text-xs text-muted-foreground">
+          {t('plan.expiresAt', { timestamp: plan.expiresAt })}
+        </p>
+      </div>
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('plan.targetHeading')}
+        </h4>
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label={t('target.repository')}>{target.repositoryName}</Field>
+          <Field label={t('target.heading')}>{target.worktreeName}</Field>
+          <Field label={t('target.branch')}>{target.branch ?? t('target.branchUnknown')}</Field>
+          <Field label={t('plan.headStateLabel')}>
+            {t(HEAD_STATE_LABEL_KEY[target.headState] ?? 'plan.headState.unknown')}
+          </Field>
+          <Field label={t('target.workingTree')}>
+            {target.workingTreeDirty ? t('target.workingTreeDirty') : t('target.workingTreeClean')}
+          </Field>
+          <Field label={t('plan.installRoot')}>
+            <span className="break-all font-mono text-xs">{target.installRoot}</span>
+          </Field>
+          <Field label={t('plan.existingInstall')}>
+            {target.existingInstall
+              ? t('plan.existingInstallVersion', { version: target.existingInstall.version })
+              : t('plan.existingInstallNone')}
+          </Field>
+          <Field label={t('detail.recommendedVersion')}>
+            <span className="font-mono text-xs">{skill.version}</span>
+          </Field>
+        </dl>
+      </section>
+
+      <section className="space-y-2" data-testid="skill-plan-risk-section">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('plan.riskHeading')}
+        </h4>
+        <div className="flex flex-wrap gap-1.5">
+          <PlanRiskBadge level={skill.declaredRisk} kind="declared" label={t('plan.riskDeclared')} />
+          <PlanRiskBadge level={skill.computedRisk} kind="computed" label={t('plan.riskComputed')} />
+          <PlanRiskBadge
+            level={skill.effectiveRisk}
+            kind="effective"
+            label={t('plan.riskEffective')}
+          />
+        </div>
+        <p className="break-words text-sm text-foreground">{skill.riskRationale}</p>
+        <SkillNotice tone="neutral">{t('plan.riskNotice')}</SkillNotice>
+      </section>
+
+      <section className="space-y-2" data-testid="skill-plan-permissions">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('permissions.heading')}
+        </h4>
+        {skill.declaredPermissions.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {skill.declaredPermissions.map((permission) => (
+              <Badge key={permission} variant="warning">
+                {PERMISSION_LABEL_KEY[permission] ? t(PERMISSION_LABEL_KEY[permission]) : permission}
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">{t('plan.permissionsNone')}</p>
+        )}
+        <SkillNotice tone="warning">{t('permissions.declarationOnlyNotice')}</SkillNotice>
+      </section>
+
+      <section className="space-y-2" data-testid="skill-plan-requirements">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('requirements.heading')}
+        </h4>
+        {skill.requirements.commands.length === 0 && skill.requirements.networkHosts.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('plan.requirementsNone')}</p>
+        ) : (
+          <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {skill.requirements.commands.length > 0 && (
+              <Field label={t('plan.requirementsCommands')}>
+                {skill.requirements.commands
+                  .map((command) => `${command.name} ${command.versionRange ?? t('plan.commandAnyVersion')}`)
+                  .join(', ')}
+              </Field>
+            )}
+            {skill.requirements.networkHosts.length > 0 && (
+              <Field label={t('plan.requirementsHosts')}>
+                {skill.requirements.networkHosts.join(', ')}
+              </Field>
+            )}
+          </dl>
+        )}
+      </section>
+
+      <section className="space-y-2" data-testid="skill-plan-scripts">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('plan.scriptsHeading')}
+        </h4>
+        {skill.executablePaths.length === 0 && skill.scriptPaths.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('plan.scriptsNone')}</p>
+        ) : (
+          <ul className="space-y-1">
+            {[...new Set([...skill.scriptPaths, ...skill.executablePaths])].map((path) => (
+              <li key={path} className="break-all font-mono text-xs text-foreground">
+                {path}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {compatibility.status !== 'compatible' && (
+        <SkillNotice tone="warning" data-testid="skill-plan-compatibility-notice">
+          {t(resolveSkillMessageKey(compatibility.messageKey), {
+            range: compatibility.requiredRange,
+            currentVersion: compatibility.currentVersion ?? '',
+          })}
+        </SkillNotice>
+      )}
+
+      {plan.warnings.length > 0 && (
+        <section className="space-y-2" data-testid="skill-plan-warnings">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('plan.warningsHeading')}
+          </h4>
+          <ul className="space-y-1">
+            {plan.warnings.map((warning) => (
+              <li key={warning} className="text-xs text-warning-foreground">
+                {PREVIEW_WARNING_LABEL_KEY[warning] ? t(PREVIEW_WARNING_LABEL_KEY[warning]) : warning}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="space-y-2" data-testid="skill-plan-files">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('plan.filesHeading')}
+        </h4>
+        <p className="text-xs text-muted-foreground" data-testid="skill-plan-stats">
+          {t('plan.stats', {
+            added: plan.stats.added,
+            modified: plan.stats.modified,
+            unchanged: plan.stats.unchanged,
+            conflicted: plan.stats.conflicted,
+            unmanaged: plan.stats.unmanaged,
+          })}
+        </p>
+        {plan.files.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('plan.filesEmpty')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {plan.files.map((entry) => (
+              <PlanFile key={entry.path} entry={entry} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {plan.blockers.length > 0 && (
+        <section className="space-y-2" data-testid="skill-install-blockers">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-danger-foreground">
+            {t('plan.blockersHeading')}
+          </h4>
+          <ul className="space-y-1">
+            {plan.blockers.map((blocker) => (
+              <li
+                key={`${blocker.code}:${blocker.path ?? ''}`}
+                className="text-xs text-danger-foreground"
+              >
+                {blocker.path && (
+                  <span className="mr-1 break-all font-mono">{blocker.path}</span>
+                )}
+                {blocker.code.startsWith('skills.')
+                  ? t(resolveSkillMessageKey(blocker.code), {
+                      range: compatibility.requiredRange,
+                      currentVersion: compatibility.currentVersion ?? '',
+                    })
+                  : DIFF_REASON_LABEL_KEY[blocker.code]
+                    ? t(DIFF_REASON_LABEL_KEY[blocker.code])
+                    : blocker.code}
+              </li>
+            ))}
+          </ul>
+          <SkillNotice tone="danger">{t('plan.blockedNotice')}</SkillNotice>
+        </section>
+      )}
+    </Card>
+  );
+}
+
+function UninstallFile({ entry }: { entry: SkillUninstallFileEntry }) {
+  const t = useTranslations('skills');
+  const dispositionKey = UNINSTALL_DISPOSITION_LABEL_KEY[entry.disposition];
+  const reasonKey = UNINSTALL_REASON_LABEL_KEY[entry.reason];
+
+  return (
+    <li
+      className="flex flex-wrap items-center gap-2"
+      data-testid={`skill-uninstall-file-${entry.path}`}
+    >
+      <Badge variant={entry.disposition === 'remove' ? 'info' : 'warning'}>
+        {dispositionKey ? t(dispositionKey) : entry.disposition}
+      </Badge>
+      <span className="break-all font-mono text-xs text-foreground">{entry.path}</span>
+      {reasonKey && <span className="text-xs text-muted-foreground">{t(reasonKey)}</span>}
+    </li>
+  );
+}
+
+export interface SkillUninstallPlanPreviewProps {
+  plan: SkillUninstallPlanDto;
+}
+
+export function SkillUninstallPlanPreview({ plan }: SkillUninstallPlanPreviewProps) {
+  const t = useTranslations('skills');
+  const { target, skill } = plan;
+
+  return (
+    <Card className="space-y-4" data-testid="skill-uninstall-plan">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">{t('uninstall.heading')}</h3>
+        <p className="text-xs text-muted-foreground">
+          {t('uninstall.expiresAt', { timestamp: plan.expiresAt })}
+        </p>
+      </div>
+
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label={t('target.repository')}>{target.repositoryName}</Field>
+        <Field label={t('target.heading')}>{target.worktreeName}</Field>
+        <Field label={t('target.branch')}>{target.branch ?? t('target.branchUnknown')}</Field>
+        <Field label={t('uninstall.installedVersion')}>
+          <span className="font-mono text-xs">{skill.version || t('uninstall.versionUnknown')}</span>
+        </Field>
+        <Field label={t('plan.installRoot')}>
+          <span className="break-all font-mono text-xs">{target.installRoot}</span>
+        </Field>
+        <Field label={t('target.workingTree')}>
+          {target.workingTreeDirty ? t('target.workingTreeDirty') : t('target.workingTreeClean')}
+        </Field>
+      </dl>
+
+      <p className="text-xs text-muted-foreground" data-testid="skill-uninstall-stats">
+        {t('uninstall.stats', {
+          removable: plan.stats.removable,
+          modified: plan.stats.modified,
+          missing: plan.stats.missing,
+          unknown: plan.stats.unknown,
+          irregular: plan.stats.irregular,
+        })}
+      </p>
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('uninstall.removalsHeading')}
+        </h4>
+        {plan.removals.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('uninstall.removalsEmpty')}</p>
+        ) : (
+          <ul className="space-y-1.5">
+            {plan.removals.map((entry) => (
+              <UninstallFile key={entry.path} entry={entry} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('uninstall.retainedHeading')}
+        </h4>
+        {plan.retained.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('uninstall.retainedEmpty')}</p>
+        ) : (
+          <ul className="space-y-1.5">
+            {plan.retained.map((entry) => (
+              <UninstallFile key={entry.path} entry={entry} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="space-y-2">
+        {plan.skill.agents.length > 0 && (
+          <div className="flex flex-wrap gap-1.5" data-testid="skill-uninstall-agents">
+            {plan.skill.agents.map((agent) => (
+              <Badge key={agent.agent} variant="gray">
+                {getCliToolDisplayNameSafe(agent.agent)}
+              </Badge>
+            ))}
+          </div>
+        )}
+        <SkillNotice tone="neutral">
+          {t(resolveSkillMessageKey(plan.nextActionKey))}
+        </SkillNotice>
+      </div>
+
+      {plan.blockers.length > 0 && (
+        <section className="space-y-2" data-testid="skill-uninstall-blockers">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-danger-foreground">
+            {t('uninstall.blockersHeading')}
+          </h4>
+          <ul className="space-y-1">
+            {plan.blockers.map((blocker) => (
+              <li
+                key={`${blocker.code}:${blocker.path ?? ''}`}
+                className="text-xs text-danger-foreground"
+              >
+                {blocker.path && <span className="mr-1 break-all font-mono">{blocker.path}</span>}
+                {t(resolveSkillMessageKey(blocker.messageKey))}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </Card>
+  );
+}

--- a/src/components/skills/skill-vocabulary.ts
+++ b/src/components/skills/skill-vocabulary.ts
@@ -14,7 +14,7 @@ import type {
   SkillRecommendationReasonCode,
 } from '@/lib/skills/compatibility';
 import type { SkillAgentSupport, SkillRiskLevel } from '@/types/skills';
-import type { SkillDto } from './types';
+import type { SkillDiffChange, SkillDto } from './types';
 
 /**
  * `unknown` is warning, never success.
@@ -63,6 +63,143 @@ export const RECOMMENDATION_LABEL_KEY: Record<SkillRecommendationReasonCode, str
   SKILL_RECOMMEND_NONE_COMPATIBLE: 'detail.recommendation.noneCompatible',
   SKILL_RECOMMEND_NO_VERSIONS: 'detail.recommendation.noVersions',
 };
+
+/**
+ * How a planned file change reads (Issue #1431).
+ *
+ * `conflict` and `unmanaged` are errors, not warnings: each one is a path the
+ * install refuses to touch, and colouring them like a caution would suggest the
+ * install could proceed anyway.
+ */
+export const DIFF_CHANGE_BADGE_VARIANT: Record<SkillDiffChange, BadgeVariant> = {
+  add: 'info',
+  modify: 'warning',
+  unchanged: 'gray',
+  conflict: 'error',
+  unmanaged: 'error',
+};
+
+export const DIFF_CHANGE_LABEL_KEY: Record<SkillDiffChange, string> = {
+  add: 'plan.change.add',
+  modify: 'plan.change.modify',
+  unchanged: 'plan.change.unchanged',
+  conflict: 'plan.change.conflict',
+  unmanaged: 'plan.change.unmanaged',
+};
+
+/** Why the planner classified a path the way it did. Keyed by `SkillDiffReasonCode`. */
+export const DIFF_REASON_LABEL_KEY: Record<string, string> = {
+  SKILL_DIFF_NEW_FILE: 'plan.diffReason.newFile',
+  SKILL_DIFF_CONTENT_IDENTICAL: 'plan.diffReason.contentIdentical',
+  SKILL_DIFF_MANAGED_UPDATE: 'plan.diffReason.managedUpdate',
+  SKILL_DIFF_LOCAL_MODIFICATION: 'plan.diffReason.localModification',
+  SKILL_DIFF_UNMANAGED_SKILL: 'plan.diffReason.unmanagedSkill',
+  SKILL_DIFF_RECEIPT_ORPHAN: 'plan.diffReason.receiptOrphan',
+  SKILL_DIFF_NOT_A_REGULAR_FILE: 'plan.diffReason.notARegularFile',
+};
+
+/**
+ * Manifest-declared permissions, keyed by `SkillDeclaredPermission`.
+ *
+ * Localized rather than shown as raw identifiers: the user is being asked to
+ * approve what the Skill says it will do, and `credential_access` is not a
+ * sentence anyone should have to decode under a confirmation prompt.
+ */
+export const PERMISSION_LABEL_KEY: Record<string, string> = {
+  filesystem_read: 'plan.permission.filesystemRead',
+  filesystem_write: 'plan.permission.filesystemWrite',
+  network_access: 'plan.permission.networkAccess',
+  process_execution: 'plan.permission.processExecution',
+  environment_read: 'plan.permission.environmentRead',
+  credential_access: 'plan.permission.credentialAccess',
+};
+
+/** State of the target's git HEAD, keyed by `SkillHeadState`. */
+export const HEAD_STATE_LABEL_KEY: Record<string, string> = {
+  attached: 'plan.headState.attached',
+  detached: 'plan.headState.detached',
+  unborn: 'plan.headState.unborn',
+  unknown: 'plan.headState.unknown',
+};
+
+/** What an uninstall would do with a path, keyed by `SkillUninstallDisposition`. */
+export const UNINSTALL_DISPOSITION_LABEL_KEY: Record<string, string> = {
+  remove: 'uninstall.disposition.remove',
+  modified: 'uninstall.disposition.modified',
+  missing: 'uninstall.disposition.missing',
+  unknown: 'uninstall.disposition.unknown',
+  irregular: 'uninstall.disposition.irregular',
+};
+
+/**
+ * Why an uninstall would keep or drop a path, keyed by `SkillUninstallReasonCode`.
+ *
+ * Mirrors `SKILL_UNINSTALL_REASON_MESSAGE_KEYS`, which lives in a module that
+ * reads the filesystem and so cannot be imported here. The i18n guard asserts
+ * the two agree, so a new reason code cannot land with no label.
+ */
+export const UNINSTALL_REASON_LABEL_KEY: Record<string, string> = {
+  SKILL_UNINSTALL_MANAGED_UNCHANGED: 'uninstall.reason.managedUnchanged',
+  SKILL_UNINSTALL_LOCAL_MODIFICATION: 'uninstall.reason.localModification',
+  SKILL_UNINSTALL_RECEIPT_ORPHAN: 'uninstall.reason.receiptOrphan',
+  SKILL_UNINSTALL_UNMANAGED_FILE: 'uninstall.reason.unmanagedFile',
+  SKILL_UNINSTALL_NOT_A_REGULAR_FILE: 'uninstall.reason.notARegularFile',
+  SKILL_UNINSTALL_NOT_INSTALLED: 'uninstall.reason.notInstalled',
+  SKILL_UNINSTALL_RECEIPT_MISSING: 'uninstall.reason.receiptMissing',
+  SKILL_UNINSTALL_RECEIPT_UNREADABLE: 'uninstall.reason.receiptUnreadable',
+  SKILL_UNINSTALL_RECEIPT_FOREIGN: 'uninstall.reason.receiptForeign',
+  SKILL_UNINSTALL_TREE_SCAN_TRUNCATED: 'uninstall.reason.treeScanTruncated',
+};
+
+/** Caveats the preview attaches to an otherwise installable plan. */
+export const PREVIEW_WARNING_LABEL_KEY: Record<string, string> = {
+  SKILL_PREVIEW_DETACHED_HEAD: 'plan.warning.detachedHead',
+  SKILL_PREVIEW_UNBORN_HEAD: 'plan.warning.unbornHead',
+  SKILL_PREVIEW_HEAD_UNRESOLVED: 'plan.warning.headUnresolved',
+  SKILL_PREVIEW_WORKING_TREE_DIRTY: 'plan.warning.workingTreeDirty',
+  SKILL_PREVIEW_PATH_GIT_IGNORED: 'plan.warning.pathGitIgnored',
+  SKILL_PREVIEW_DIFF_TRUNCATED: 'plan.warning.diffTruncated',
+  SKILL_PREVIEW_BINARY_CONTENT: 'plan.warning.binaryContent',
+  SKILL_PREVIEW_LINE_ENDING_CRLF: 'plan.warning.lineEndingCrlf',
+  SKILL_PREVIEW_TREE_SCAN_TRUNCATED: 'plan.warning.treeScanTruncated',
+};
+
+/**
+ * Typed refusals from the plan and apply routes, in the user's words.
+ *
+ * Each entry says what state the worktree is in and what to do about it,
+ * because "SKILL_PLAN_STALE" tells a user nothing about whether their files
+ * were touched. Anything unmapped falls back to a message that shows the raw
+ * code rather than inventing a diagnosis.
+ */
+export const OPERATION_ERROR_LABEL_KEY: Record<string, string> = {
+  SKILL_PLAN_STALE: 'operation.error.planStale',
+  SKILL_PLAN_EXPIRED: 'operation.error.planExpired',
+  SKILL_PLAN_CONSUMED: 'operation.error.planConsumed',
+  SKILL_PLAN_NOT_FOUND: 'operation.error.planNotFound',
+  SKILL_PLAN_BINDING_MISMATCH: 'operation.error.planBindingMismatch',
+  SKILL_PLAN_NOT_INSTALLABLE: 'operation.error.planNotInstallable',
+  SKILL_PLAN_RISK_NOT_ACKNOWLEDGED: 'operation.error.planRiskNotAcknowledged',
+  SKILL_INSTALL_LOCKED: 'operation.error.installLocked',
+  SKILL_INSTALL_IN_PROGRESS: 'operation.error.installInProgress',
+  SKILL_INSTALL_DESTINATION_EXISTS: 'operation.error.installDestinationExists',
+  SKILL_INSTALL_DESTINATION_UNMANAGED: 'operation.error.installDestinationUnmanaged',
+  SKILL_INSTALL_IDEMPOTENCY_CONFLICT: 'operation.error.installIdempotencyConflict',
+  SKILL_INSTALL_FAILED: 'operation.error.installFailed',
+  SKILL_UNINSTALL_LOCKED: 'operation.error.uninstallLocked',
+  SKILL_UNINSTALL_IN_PROGRESS: 'operation.error.uninstallInProgress',
+  SKILL_UNINSTALL_IDEMPOTENCY_CONFLICT: 'operation.error.uninstallIdempotencyConflict',
+  SKILL_UNINSTALL_NOT_INSTALLED: 'operation.error.uninstallNotInstalled',
+  SKILL_UNINSTALL_BLOCKED: 'operation.error.uninstallBlocked',
+  SKILL_UNINSTALL_DRIFT: 'operation.error.uninstallDrift',
+  SKILL_UNINSTALL_FILE_CHANGED: 'operation.error.uninstallFileChanged',
+  SKILL_UNINSTALL_FAILED: 'operation.error.uninstallFailed',
+  SKILL_REQUEST_FAILED: 'operation.error.requestFailed',
+};
+
+export function operationErrorLabelKey(code: string): string {
+  return OPERATION_ERROR_LABEL_KEY[code] ?? 'operation.error.unexpected';
+}
 
 const CATALOG_REASON_LABEL_KEY: Record<string, string> = {
   SKILL_CATALOG_FETCH_FAILED: 'catalog.reason.fetchFailed',

--- a/src/components/skills/skills-client.ts
+++ b/src/components/skills/skills-client.ts
@@ -13,16 +13,41 @@
  * @module components/skills/skills-client
  */
 
-import type { SkillApiErrorResponse, SkillDetailResponse, SkillListResponse } from './types';
+import type {
+  SkillApiErrorResponse,
+  SkillDetailResponse,
+  SkillInstallApplyResponse,
+  SkillInstallPlanResponse,
+  SkillListResponse,
+  SkillUninstallApplyResponse,
+  SkillUninstallBlocker,
+  SkillUninstallPlanResponse,
+} from './types';
 
 /** Code used when the request never produced a JSON error body. */
 export const SKILL_CATALOG_UNREACHABLE = 'SKILL_CATALOG_UNREACHABLE';
+
+/**
+ * Fallback code for a write request that failed without a typed code.
+ *
+ * The shared worktree guard answers `{ error }` with no `code`, so a write can
+ * legitimately fail without naming a Skill error. Reporting it as a Catalog
+ * problem would send the user looking in the wrong place.
+ */
+export const SKILL_REQUEST_FAILED = 'SKILL_REQUEST_FAILED';
 
 export interface SkillFetchFailure {
   code: string;
   message: string;
   /** HTTP status, or null when the request never completed. */
   status: number | null;
+  /**
+   * Paths a refused uninstall named as responsible. Present only when the API
+   * supplied them; the UI must not invent a reason the server did not give.
+   */
+  blockers?: SkillUninstallBlocker[];
+  /** i18n key naming what to do next, when the refusal carried one. */
+  nextActionKey?: string;
 }
 
 export type SkillFetchResult<T> = { ok: true; data: T } | { ok: false; failure: SkillFetchFailure };
@@ -33,19 +58,53 @@ function isApiError(value: unknown): value is SkillApiErrorResponse {
   return typeof error === 'string' && typeof code === 'string';
 }
 
+/**
+ * Turn an error body into a failure, keeping whatever the server actually said.
+ *
+ * `blockers` and `nextActionKey` only survive when the response carried them,
+ * so a screen rendering them is always rendering a server fact.
+ */
+function toFailure(body: unknown, status: number, fallbackCode: string): SkillFetchFailure {
+  const record = (body && typeof body === 'object' ? body : {}) as Record<string, unknown>;
+  const failure: SkillFetchFailure = {
+    code: isApiError(body) ? body.code : fallbackCode,
+    message: typeof record.error === 'string' ? record.error : '',
+    status,
+  };
+  if (Array.isArray(record.blockers)) {
+    failure.blockers = record.blockers as SkillUninstallBlocker[];
+  }
+  if (typeof record.nextActionKey === 'string') {
+    failure.nextActionKey = record.nextActionKey;
+  }
+  return failure;
+}
+
 async function getJson<T>(url: string, signal?: AbortSignal): Promise<SkillFetchResult<T>> {
   const response = await fetch(url, { signal, headers: { Accept: 'application/json' } });
   const body: unknown = await response.json().catch(() => null);
 
   if (!response.ok) {
-    return {
-      ok: false,
-      failure: {
-        code: isApiError(body) ? body.code : SKILL_CATALOG_UNREACHABLE,
-        message: isApiError(body) ? body.error : '',
-        status: response.status,
-      },
-    };
+    return { ok: false, failure: toFailure(body, response.status, SKILL_CATALOG_UNREACHABLE) };
+  }
+  return { ok: true, data: body as T };
+}
+
+async function postJson<T>(
+  url: string,
+  payload: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<T>> {
+  const response = await fetch(url, {
+    method: 'POST',
+    signal,
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const body: unknown = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    return { ok: false, failure: toFailure(body, response.status, SKILL_REQUEST_FAILED) };
   }
   return { ok: true, data: body as T };
 }
@@ -57,15 +116,19 @@ async function getJson<T>(url: string, signal?: AbortSignal): Promise<SkillFetch
  * outcome to show, and rendering it as an error would flash a false failure
  * whenever the user navigates away mid-fetch.
  */
-async function request<T>(url: string, signal?: AbortSignal): Promise<SkillFetchResult<T>> {
+async function request<T>(
+  perform: () => Promise<SkillFetchResult<T>>,
+  fallbackCode: string,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<T>> {
   try {
-    return await getJson<T>(url, signal);
+    return await perform();
   } catch (error) {
     if (signal?.aborted) throw error;
     return {
       ok: false,
       failure: {
-        code: SKILL_CATALOG_UNREACHABLE,
+        code: fallbackCode,
         message: error instanceof Error ? error.message : '',
         status: null,
       },
@@ -74,12 +137,144 @@ async function request<T>(url: string, signal?: AbortSignal): Promise<SkillFetch
 }
 
 export function fetchSkillList(signal?: AbortSignal): Promise<SkillFetchResult<SkillListResponse>> {
-  return request<SkillListResponse>('/api/skills', signal);
+  return request(
+    () => getJson<SkillListResponse>('/api/skills', signal),
+    SKILL_CATALOG_UNREACHABLE,
+    signal
+  );
 }
 
 export function fetchSkillDetail(
   skillId: string,
   signal?: AbortSignal
 ): Promise<SkillFetchResult<SkillDetailResponse>> {
-  return request<SkillDetailResponse>(`/api/skills/${encodeURIComponent(skillId)}`, signal);
+  return request(
+    () => getJson<SkillDetailResponse>(`/api/skills/${encodeURIComponent(skillId)}`, signal),
+    SKILL_CATALOG_UNREACHABLE,
+    signal
+  );
+}
+
+/**
+ * Route for an operation on one Skill in one worktree.
+ *
+ * The worktree ID is the only location input any of these routes accept: the
+ * server resolves it to a trusted path. Nothing the browser holds — no
+ * filesystem path, no artifact URL — is ever part of the request.
+ */
+function operationUrl(worktreeId: string, skillId: string, operation: string): string {
+  return `/api/worktrees/${encodeURIComponent(worktreeId)}/skills/${encodeURIComponent(skillId)}/${operation}`;
+}
+
+export interface SkillInstallPlanRequest {
+  /** Omitted to plan the recommended version. */
+  version?: string;
+  acknowledgeRisk?: boolean;
+}
+
+/**
+ * Build an Install Plan.
+ *
+ * Optional fields are omitted rather than sent as `null`: the route rejects a
+ * body key it does not expect, and `undefined` would be dropped by
+ * `JSON.stringify` anyway, so building the object explicitly keeps the wire
+ * body and the accepted key list in step.
+ */
+export function createSkillInstallPlan(
+  worktreeId: string,
+  skillId: string,
+  options: SkillInstallPlanRequest = {},
+  signal?: AbortSignal
+): Promise<SkillFetchResult<SkillInstallPlanResponse>> {
+  const payload: Record<string, unknown> = {};
+  if (options.version) payload.version = options.version;
+  if (options.acknowledgeRisk) payload.acknowledgeRisk = true;
+
+  return request(
+    () =>
+      postJson<SkillInstallPlanResponse>(
+        operationUrl(worktreeId, skillId, 'plan'),
+        payload,
+        signal
+      ),
+    SKILL_REQUEST_FAILED,
+    signal
+  );
+}
+
+export interface SkillInstallApplyRequest {
+  planToken: string;
+  /** Must equal the version the plan was built for, or the token is refused. */
+  version: string;
+  acknowledgeRisk?: boolean;
+  idempotencyKey?: string;
+}
+
+export function applySkillInstall(
+  worktreeId: string,
+  skillId: string,
+  apply: SkillInstallApplyRequest,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<SkillInstallApplyResponse>> {
+  const payload: Record<string, unknown> = {
+    planToken: apply.planToken,
+    version: apply.version,
+  };
+  if (apply.acknowledgeRisk) payload.acknowledgeRisk = true;
+  if (apply.idempotencyKey) payload.idempotencyKey = apply.idempotencyKey;
+
+  return request(
+    () =>
+      postJson<SkillInstallApplyResponse>(
+        operationUrl(worktreeId, skillId, 'install'),
+        payload,
+        signal
+      ),
+    SKILL_REQUEST_FAILED,
+    signal
+  );
+}
+
+/** Build an Uninstall Plan. The route accepts no body parameters at all. */
+export function createSkillUninstallPlan(
+  worktreeId: string,
+  skillId: string,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<SkillUninstallPlanResponse>> {
+  return request(
+    () =>
+      postJson<SkillUninstallPlanResponse>(
+        operationUrl(worktreeId, skillId, 'uninstall-plan'),
+        {},
+        signal
+      ),
+    SKILL_REQUEST_FAILED,
+    signal
+  );
+}
+
+export interface SkillUninstallApplyRequest {
+  planToken: string;
+  idempotencyKey?: string;
+}
+
+export function applySkillUninstall(
+  worktreeId: string,
+  skillId: string,
+  apply: SkillUninstallApplyRequest,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<SkillUninstallApplyResponse>> {
+  const payload: Record<string, unknown> = { planToken: apply.planToken };
+  if (apply.idempotencyKey) payload.idempotencyKey = apply.idempotencyKey;
+
+  return request(
+    () =>
+      postJson<SkillUninstallApplyResponse>(
+        operationUrl(worktreeId, skillId, 'uninstall'),
+        payload,
+        signal
+      ),
+    SKILL_REQUEST_FAILED,
+    signal
+  );
 }

--- a/src/components/skills/types.ts
+++ b/src/components/skills/types.ts
@@ -1,9 +1,13 @@
 /**
- * Wire types the Skill Catalog UI consumes (Issue #1232)
+ * Wire types the Skill Catalog UI consumes (Issue #1232, #1431)
  *
  * Type-only re-export of the #1231 serialization contract. `export type` is
  * erased at compile time, so nothing from `lib/api/skills-api` (which imports
  * `next/server`) reaches the client bundle.
+ *
+ * The write-path shapes (#1431) are re-exported from the route modules that
+ * define them rather than copied, so a change to what the API returns fails
+ * type-check here instead of silently drifting into a hand-written mirror.
  *
  * @module components/skills/types
  */
@@ -17,3 +21,53 @@ export type {
   SkillListResponse,
   SkillVersionDto,
 } from '@/lib/api/skills-api';
+
+export type {
+  SkillDiffChange,
+  SkillDiffEntry,
+  SkillDiffStats,
+  SkillPreviewWarningCode,
+} from '@/lib/skills/preview-diff';
+
+export type {
+  SkillInstallPlanDto,
+  SkillPlanSkillDto,
+  SkillPlanTargetDto,
+} from '@/lib/skills/install-plan';
+
+export type {
+  SkillUninstallBlocker,
+  SkillUninstallFileEntry,
+  SkillUninstallPlanDto,
+} from '@/lib/skills/uninstall-plan';
+
+export type { SkillInstallPlanResponse } from '@/app/api/worktrees/[id]/skills/[skillId]/plan/route';
+export type {
+  SkillInstallReplayResponse,
+  SkillInstallResponse,
+} from '@/app/api/worktrees/[id]/skills/[skillId]/install/route';
+export type { SkillUninstallPlanResponse } from '@/app/api/worktrees/[id]/skills/[skillId]/uninstall-plan/route';
+export type {
+  SkillUninstallReplayResponse,
+  SkillUninstallResponse,
+} from '@/app/api/worktrees/[id]/skills/[skillId]/uninstall/route';
+
+import type {
+  SkillInstallReplayResponse,
+  SkillInstallResponse,
+} from '@/app/api/worktrees/[id]/skills/[skillId]/install/route';
+import type {
+  SkillUninstallReplayResponse,
+  SkillUninstallResponse,
+} from '@/app/api/worktrees/[id]/skills/[skillId]/uninstall/route';
+
+/**
+ * What an apply request can answer with.
+ *
+ * A retried request is served from the operation index, which records that the
+ * install happened but not the per-file inventory, so the replay body is
+ * strictly narrower. Keeping both in one union forces the screen to check
+ * before reading a field a replay does not carry.
+ */
+export type SkillInstallApplyResponse = SkillInstallResponse | SkillInstallReplayResponse;
+export type SkillUninstallApplyResponse = SkillUninstallResponse | SkillUninstallReplayResponse;

--- a/tests/unit/components/skills/SkillDetailView.test.tsx
+++ b/tests/unit/components/skills/SkillDetailView.test.tsx
@@ -211,14 +211,25 @@ describe('SkillDetailView install gating', () => {
     expect(reason).toHaveTextContent('skills.compatibility.reason.rangeUnsupported');
   });
 
-  it('keeps install disabled even when the Skill is compatible, since this screen only browses', async () => {
+  it('mounts the install flow when the Skill is compatible (Issue #1431)', async () => {
     fetchMock.mockResolvedValue(mockDetail(makeSkill()));
     render(<SkillDetailView skillId="release-helper" />);
 
-    expect(await screen.findByTestId('skill-install-action')).toBeDisabled();
+    expect(await screen.findByTestId('skill-install-panel')).toBeInTheDocument();
+    // Still nothing to install into until a target has been chosen, and the
+    // reason says so rather than claiming the feature does not exist.
+    expect(screen.getByTestId('skill-install-action')).toBeDisabled();
     expect(screen.getByTestId('skill-install-reason')).toHaveTextContent(
-      'skills.detail.install.unavailableYet'
+      'skills.plan.chooseTarget'
     );
+  });
+
+  it('offers uninstall even for a Skill the Catalog rules out installing', async () => {
+    fetchMock.mockResolvedValue(mockDetail(makeIncompatibleSkill()));
+    render(<SkillDetailView skillId="future-skill" />);
+
+    await screen.findByTestId('skill-install-panel');
+    expect(screen.getByTestId('skill-uninstall-action')).toBeInTheDocument();
   });
 });
 

--- a/tests/unit/components/skills/SkillInstallPanel.test.tsx
+++ b/tests/unit/components/skills/SkillInstallPanel.test.tsx
@@ -1,0 +1,477 @@
+/**
+ * SkillInstallPanel (Issue #1431)
+ *
+ * These tests pin the promises the flow makes about writing to a worktree:
+ * that nothing is applied before a plan has been shown, that a plan reporting
+ * blockers cannot be applied at all, that a high-risk package is never applied
+ * without an explicit acknowledgement leaving the browser, and that a typed
+ * refusal is reported as the specific thing that happened rather than as a
+ * generic failure.
+ *
+ * The fetch mock answers per URL with the real request/response shapes, so a
+ * change to what the routes accept breaks these tests rather than sliding past
+ * them.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace?: string) =>
+    (key: string, params?: Record<string, string | number>) => {
+      const full = namespace ? `${namespace}.${key}` : key;
+      if (!params) return full;
+      const rendered = Object.entries(params)
+        .map(([name, value]) => `${name}=${value}`)
+        .join(',');
+      return `${full}(${rendered})`;
+    },
+  useLocale: () => 'en',
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { SkillInstallPanel } from '@/components/skills/SkillInstallPanel';
+import {
+  makeInstallPlan,
+  makeInstallResponse,
+  makeUninstallFile,
+  makeUninstallPlan,
+  makeUninstallResponse,
+  makeWorktree,
+} from './fixtures';
+
+interface Route {
+  status?: number;
+  body: unknown;
+}
+
+const fetchMock = vi.fn();
+
+/** Routes by URL suffix, so a request to an unexpected route fails loudly. */
+function routeFetch(routes: Record<string, Route>) {
+  fetchMock.mockImplementation(async (url: string) => {
+    const match = Object.keys(routes).find((suffix) => url.endsWith(suffix));
+    if (!match) throw new Error(`unexpected request: ${url}`);
+    const route = routes[match];
+    const status = route.status ?? 200;
+    return { ok: status < 400, status, json: async () => route.body } as unknown as Response;
+  });
+}
+
+const WORKTREES = { body: { worktrees: [makeWorktree()] } };
+
+function bodyOf(suffix: string): Record<string, unknown> {
+  const call = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).endsWith(suffix));
+  if (!call) throw new Error(`no request to ${suffix}`);
+  return JSON.parse(call[1].body as string);
+}
+
+function requestsTo(suffix: string): number {
+  return fetchMock.mock.calls.filter((call: unknown[]) => (call[0] as string).endsWith(suffix)).length;
+}
+
+async function selectTarget() {
+  fireEvent.click(await screen.findByTestId('skill-target-option-demo-wt'));
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SkillInstallPanel happy path', () => {
+  it('walks target → plan → preview → install and reports what landed', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { body: { plan: makeInstallPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+
+    // Nothing can be planned until a target is chosen.
+    expect(await screen.findByTestId('skill-install-action')).toBeDisabled();
+    await selectTarget();
+    expect(screen.getByTestId('skill-install-action')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+
+    const preview = await screen.findByTestId('skill-install-plan');
+    expect(preview).toHaveTextContent('.agents/skills/release-helper');
+    expect(screen.getByTestId('skill-plan-stats')).toHaveTextContent('added=1');
+    expect(
+      screen.getByTestId('skill-plan-file-.agents/skills/release-helper/SKILL.md')
+    ).toBeInTheDocument();
+
+    // Building a plan writes nothing.
+    expect(requestsTo('/install')).toBe(0);
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+
+    const result = await screen.findByTestId('skill-install-result');
+    expect(result).toHaveTextContent('skills.install.nextAction.succeeded');
+    expect(screen.getByTestId('skill-operation-reload')).toHaveTextContent(
+      'skills.install.reload.native'
+    );
+    expect(screen.queryByTestId('skill-install-plan')).not.toBeInTheDocument();
+  });
+
+  it('spends the plan token on the version the plan was built for', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { body: { plan: makeInstallPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    fireEvent.click(await screen.findByTestId('skill-install-confirm'));
+    await screen.findByTestId('skill-install-result');
+
+    expect(bodyOf('/plan')).toEqual({ version: '1.2.0' });
+    const install = bodyOf('/install');
+    expect(install.planToken).toBe(makeInstallPlan().token);
+    expect(install.version).toBe('1.2.0');
+    // The routes reject a body naming a location or an artifact outright.
+    for (const forbidden of ['path', 'worktreePath', 'installRoot', 'url', 'artifactUrl', 'files']) {
+      expect(install).not.toHaveProperty(forbidden);
+    }
+  });
+
+  it('never asks the API where to install, only which worktree', async () => {
+    routeFetch({ '/api/worktrees': WORKTREES, '/plan': { body: { plan: makeInstallPlan() } } });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    await screen.findByTestId('skill-install-plan');
+
+    const planCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).endsWith('/plan'));
+    expect(planCall?.[0]).toBe('/api/worktrees/demo-wt/skills/release-helper/plan');
+  });
+});
+
+describe('SkillInstallPanel blockers', () => {
+  it('refuses to apply a plan that reports blockers, and says what is in the way', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': {
+        body: {
+          plan: makeInstallPlan({
+            installable: false,
+            blockers: [
+              {
+                code: 'SKILL_DIFF_LOCAL_MODIFICATION',
+                path: '.agents/skills/release-helper/SKILL.md',
+              },
+            ],
+          }),
+        },
+      },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+
+    const blockers = await screen.findByTestId('skill-install-blockers');
+    expect(blockers).toHaveTextContent('skills.plan.diffReason.localModification');
+    expect(blockers).toHaveTextContent('.agents/skills/release-helper/SKILL.md');
+    expect(screen.getByTestId('skill-install-confirm')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+    expect(requestsTo('/install')).toBe(0);
+  });
+
+  it('keeps the Catalog-level reason on the button when no version applies here', async () => {
+    routeFetch({ '/api/worktrees': WORKTREES });
+
+    render(
+      <SkillInstallPanel
+        skillId="future-skill"
+        version={null}
+        blockedReason="skills.detail.install.blockedNoVersion"
+      />
+    );
+    await selectTarget();
+
+    expect(screen.getByTestId('skill-install-action')).toBeDisabled();
+    expect(screen.getByTestId('skill-install-reason')).toHaveTextContent(
+      'skills.detail.install.blockedNoVersion'
+    );
+    // Uninstall stays reachable: a Skill that no longer runs here is exactly
+    // the one a user needs to be able to remove.
+    expect(screen.getByTestId('skill-uninstall-action')).toBeEnabled();
+  });
+});
+
+describe('SkillInstallPanel high-risk acknowledgement', () => {
+  const highRiskPlan = () =>
+    makeInstallPlan({
+      requiresRiskAcknowledgement: true,
+      riskAcknowledgementMessageKey: 'skills.plan.highRiskAcknowledgement',
+      skill: { ...makeInstallPlan().skill, computedRisk: 'high', effectiveRisk: 'high' },
+    });
+
+  it('gates a high-risk install behind a confirmation the ordinary path does not have', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { body: { plan: highRiskPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+
+    const acknowledgement = await screen.findByTestId('skill-install-risk-acknowledgement');
+    expect(acknowledgement).toHaveTextContent('skills.plan.highRiskAcknowledgement');
+    expect(screen.getByTestId('skill-plan-risk-effective-high')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-install-confirm')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('skill-install-risk-checkbox'));
+    await waitFor(() => expect(screen.getByTestId('skill-install-confirm')).toBeEnabled());
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+    await screen.findByTestId('skill-install-result');
+
+    expect(bodyOf('/install').acknowledgeRisk).toBe(true);
+  });
+
+  it('sends no install request at all while the acknowledgement is unchecked', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { body: { plan: highRiskPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    await screen.findByTestId('skill-install-risk-acknowledgement');
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+    await waitFor(() => expect(requestsTo('/plan')).toBe(1));
+    expect(requestsTo('/install')).toBe(0);
+  });
+
+  it('omits acknowledgeRisk entirely when the plan does not require it', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { body: { plan: makeInstallPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    expect(await screen.findByTestId('skill-install-plan')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-install-risk-acknowledgement')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+    await screen.findByTestId('skill-install-result');
+    expect(bodyOf('/install')).not.toHaveProperty('acknowledgeRisk');
+  });
+});
+
+describe('SkillInstallPanel typed refusals', () => {
+  it.each([
+    ['SKILL_PLAN_STALE', 409, 'skills.operation.error.planStale'],
+    ['SKILL_INSTALL_LOCKED', 409, 'skills.operation.error.installLocked'],
+    ['SKILL_INSTALL_DESTINATION_EXISTS', 409, 'skills.operation.error.installDestinationExists'],
+  ])('explains %s rather than reporting a generic failure', async (code, status, expected) => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { body: { plan: makeInstallPlan() } },
+      '/install': { status, body: { error: 'refused', code } },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    fireEvent.click(await screen.findByTestId('skill-install-confirm'));
+
+    const error = await screen.findByTestId('skill-operation-error');
+    expect(error).toHaveTextContent(expected);
+    expect(error).toHaveTextContent(code);
+    // The plan stays on screen, so the user can see what they had approved.
+    expect(screen.getByTestId('skill-install-plan')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-install-result')).not.toBeInTheDocument();
+  });
+
+  it('names an unmapped code without inventing a diagnosis for it', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { status: 500, body: { error: 'boom', code: 'SKILL_PLAN_INTERNAL_ERROR' } },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+
+    const error = await screen.findByTestId('skill-operation-error');
+    expect(error).toHaveTextContent('skills.operation.error.unexpected');
+    expect(error).toHaveTextContent('SKILL_PLAN_INTERNAL_ERROR');
+  });
+
+  it('reports a failure with no typed code as a request failure, not a Catalog failure', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { status: 404, body: { error: 'Worktree not found' } },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+
+    expect(await screen.findByTestId('skill-operation-error')).toHaveTextContent(
+      'skills.operation.error.requestFailed'
+    );
+  });
+});
+
+describe('SkillInstallPanel uninstall', () => {
+  it('walks plan → preview → remove and reports what was removed', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/uninstall-plan': { body: { plan: makeUninstallPlan() } },
+      '/uninstall': { body: makeUninstallResponse() },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-uninstall-action'));
+
+    const preview = await screen.findByTestId('skill-uninstall-plan');
+    expect(preview).toHaveTextContent('skills.uninstall.disposition.remove');
+    expect(preview).toHaveTextContent('skills.uninstall.nextAction.removable');
+    // Building the uninstall plan deletes nothing.
+    expect(requestsTo('/skills/release-helper/uninstall')).toBe(0);
+
+    fireEvent.click(screen.getByTestId('skill-uninstall-confirm'));
+
+    expect(await screen.findByTestId('skill-uninstall-result')).toHaveTextContent(
+      'skills.uninstall.nextAction.succeeded'
+    );
+    expect(bodyOf('/skills/release-helper/uninstall').planToken).toBe(makeUninstallPlan().token);
+  });
+
+  it('will not remove anything when the plan says paths are not CommandMate’s to delete', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/uninstall-plan': {
+        body: {
+          plan: makeUninstallPlan({
+            removable: false,
+            nextActionKey: 'skills.uninstall.nextAction.blocked',
+            blockers: [
+              {
+                code: 'SKILL_UNINSTALL_LOCAL_MODIFICATION',
+                path: '.agents/skills/release-helper/SKILL.md',
+                messageKey: 'skills.uninstall.reason.localModification',
+              },
+            ],
+            removals: [],
+            retained: [
+              makeUninstallFile({
+                disposition: 'modified',
+                reason: 'SKILL_UNINSTALL_LOCAL_MODIFICATION',
+              }),
+            ],
+            stats: { removable: 0, modified: 1, missing: 0, unknown: 0, irregular: 0 },
+          }),
+        },
+      },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-uninstall-action'));
+
+    expect(await screen.findByTestId('skill-uninstall-blockers')).toHaveTextContent(
+      'skills.uninstall.reason.localModification'
+    );
+    expect(screen.getByTestId('skill-uninstall-confirm')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('skill-uninstall-confirm'));
+    expect(bodyOf('/uninstall-plan')).toEqual({});
+    expect(requestsTo('/skills/release-helper/uninstall')).toBe(0);
+  });
+
+  it('renders the blockers a refused uninstall names in its error body', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/uninstall-plan': { body: { plan: makeUninstallPlan() } },
+      '/skills/release-helper/uninstall': {
+        status: 409,
+        body: {
+          error: 'refused',
+          code: 'SKILL_UNINSTALL_FILE_CHANGED',
+          nextActionKey: 'skills.uninstall.nextAction.blocked',
+          blockers: [
+            {
+              code: 'SKILL_UNINSTALL_LOCAL_MODIFICATION',
+              path: '.agents/skills/release-helper/SKILL.md',
+              messageKey: 'skills.uninstall.reason.localModification',
+            },
+          ],
+        },
+      },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-uninstall-action'));
+    fireEvent.click(await screen.findByTestId('skill-uninstall-confirm'));
+
+    const error = await screen.findByTestId('skill-operation-error');
+    expect(error).toHaveTextContent('skills.operation.error.uninstallFileChanged');
+    expect(error).toHaveTextContent('skills.uninstall.nextAction.blocked');
+    expect(screen.getByTestId('skill-operation-error-blockers')).toHaveTextContent(
+      '.agents/skills/release-helper/SKILL.md'
+    );
+  });
+});
+
+describe('SkillInstallPanel state hygiene', () => {
+  it('drops a plan built for one worktree when another is chosen', async () => {
+    routeFetch({
+      '/api/worktrees': { body: { worktrees: [makeWorktree(), makeWorktree({ id: 'other-wt', name: 'main' })] } },
+      '/plan': { body: { plan: makeInstallPlan() } },
+    });
+
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    await screen.findByTestId('skill-install-plan');
+
+    fireEvent.click(screen.getByTestId('skill-target-option-other-wt'));
+    await waitFor(() => expect(screen.queryByTestId('skill-install-plan')).not.toBeInTheDocument());
+  });
+
+  it('clears an earlier refusal when a new plan is built', async () => {
+    routeFetch({
+      '/api/worktrees': WORKTREES,
+      '/plan': { status: 409, body: { error: 'refused', code: 'SKILL_INSTALL_LOCKED' } },
+    });
+    render(<SkillInstallPanel skillId="release-helper" version="1.2.0" blockedReason={null} />);
+    await selectTarget();
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    await screen.findByTestId('skill-operation-error');
+
+    routeFetch({ '/api/worktrees': WORKTREES, '/plan': { body: { plan: makeInstallPlan() } } });
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+
+    await screen.findByTestId('skill-install-plan');
+    expect(screen.queryByTestId('skill-operation-error')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/skills/fixtures.ts
+++ b/tests/unit/components/skills/fixtures.ts
@@ -7,9 +7,16 @@
 
 import type {
   SkillCatalogMetaDto,
+  SkillDiffEntry,
   SkillDto,
+  SkillInstallPlanDto,
+  SkillInstallResponse,
+  SkillUninstallFileEntry,
+  SkillUninstallPlanDto,
+  SkillUninstallResponse,
   SkillVersionDto,
 } from '@/components/skills/types';
+import type { Worktree } from '@/types/models';
 
 export function makeCatalogMeta(overrides: Partial<SkillCatalogMetaDto> = {}): SkillCatalogMetaDto {
   return {
@@ -148,4 +155,233 @@ export function makeUnknownSkill(): SkillDto {
     compatibility: version.compatibility.commandmate,
     versions: [version],
   });
+}
+
+// =============================================================================
+// Install / uninstall wire fixtures (Issue #1431)
+// =============================================================================
+
+export function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'demo-wt',
+    name: 'feature/demo',
+    path: '/srv/worktrees/demo',
+    repositoryPath: '/srv/repos/CommandMate',
+    repositoryName: 'CommandMate',
+    branch: 'feature/demo',
+    ...overrides,
+  };
+}
+
+export function makeDiffEntry(overrides: Partial<SkillDiffEntry> = {}): SkillDiffEntry {
+  return {
+    path: '.agents/skills/release-helper/SKILL.md',
+    change: 'add',
+    reason: 'SKILL_DIFF_NEW_FILE',
+    generated: false,
+    sha256: 'c'.repeat(64),
+    size: 128,
+    executable: false,
+    currentSha256: null,
+    currentSize: null,
+    binary: false,
+    lineEnding: 'lf',
+    gitIgnored: false,
+    diff: '+# Release Helper',
+    diffTruncated: false,
+    additions: 1,
+    deletions: 0,
+    ...overrides,
+  };
+}
+
+export function makeInstallPlan(overrides: Partial<SkillInstallPlanDto> = {}): SkillInstallPlanDto {
+  return {
+    token: 'a1b2c3d4'.repeat(6),
+    expiresAt: '2026-07-21T00:10:00Z',
+    installable: true,
+    requiresRiskAcknowledgement: false,
+    riskAcknowledged: false,
+    riskAcknowledgementMessageKey: null,
+    blockers: [],
+    warnings: [],
+    target: {
+      worktreeId: 'demo-wt',
+      worktreeName: 'feature/demo',
+      repositoryName: 'CommandMate',
+      syncedBranch: 'feature/demo',
+      branch: 'feature/demo',
+      headState: 'attached',
+      headCommit: 'd'.repeat(40),
+      workingTreeDirty: false,
+      installRoot: '.agents/skills/release-helper',
+      currentTreeHash: 'e'.repeat(64),
+      plannedTreeHash: 'f'.repeat(64),
+      existingInstall: null,
+    },
+    skill: {
+      id: 'release-helper',
+      name: 'Release Helper',
+      version: '1.2.0',
+      summary: 'Walks an agent through the release checklist.',
+      description: 'Longer description.',
+      capabilities: ['Release checklist'],
+      expectedOutcomes: ['A tagged release'],
+      provider: { name: 'CommandMate' },
+      license: 'MIT',
+      homepage: null,
+      declaredPermissions: ['filesystem_read'],
+      requirements: { commands: [{ name: 'git', versionRange: '>=2.0.0' }], networkHosts: [] },
+      declaredRisk: 'low',
+      computedRisk: 'low',
+      effectiveRisk: 'low',
+      riskRationale: 'The package contains no scripts.',
+      executablePaths: [],
+      scriptPaths: [],
+      compatibility: {
+        commandmate: {
+          status: 'compatible',
+          reasonCode: 'SKILL_COMPAT_SATISFIED',
+          messageKey: 'skills.compatibility.reason.satisfied',
+          message: 'ok',
+          requiredRange: '>=0.11.0',
+          currentVersion: '0.11.4',
+        },
+        agents: [{ agent: 'claude', support: 'native', evidence: 'Spec verified.' }],
+      },
+      source: { repository: 'Kewton/commandmate-skills', ref: 'v1.2.0', commit: 'a'.repeat(40) },
+      artifact: {
+        assetName: 'release-helper-1.2.0.tar.gz',
+        sha256: 'b'.repeat(64),
+        size: 20480,
+        format: 'tar.gz',
+      },
+    },
+    receipt: { path: '.agents/skills/release-helper/.commandmate-receipt.json', sha256: 'c'.repeat(64), size: 512 },
+    files: [makeDiffEntry()],
+    stats: {
+      added: 1,
+      modified: 0,
+      unchanged: 0,
+      conflicted: 0,
+      unmanaged: 0,
+      binaryFiles: 0,
+      truncatedFiles: 0,
+      diffBytes: 32,
+    },
+    ...overrides,
+  };
+}
+
+export function makeInstallResponse(): SkillInstallResponse {
+  return {
+    operation: {
+      operationId: 'op-1',
+      idempotencyKey: 'skill-install-token',
+      state: 'SUCCEEDED',
+      result: 'succeeded',
+      committed: true,
+      reconcilePending: false,
+      nextActionKey: 'skills.install.nextAction.succeeded',
+      replayed: false,
+    },
+    install: {
+      skillId: 'release-helper',
+      version: '1.2.0',
+      installRoot: '.agents/skills/release-helper',
+      receipt: { path: '.agents/skills/release-helper/.commandmate-receipt.json', sha256: 'c'.repeat(64), size: 512 },
+      files: [{ path: 'SKILL.md', sha256: 'c'.repeat(64), size: 128, executable: false }],
+      treeHash: 'f'.repeat(64),
+    },
+    reload: {
+      skillId: 'release-helper',
+      version: '1.2.0',
+      installRoot: '.agents/skills/release-helper',
+      agents: [{ agent: 'claude', support: 'native', messageKey: 'skills.install.reload.native' }],
+    },
+  };
+}
+
+export function makeUninstallFile(
+  overrides: Partial<SkillUninstallFileEntry> = {}
+): SkillUninstallFileEntry {
+  return {
+    path: '.agents/skills/release-helper/SKILL.md',
+    relativePath: 'SKILL.md',
+    disposition: 'remove',
+    reason: 'SKILL_UNINSTALL_MANAGED_UNCHANGED',
+    generated: false,
+    recordedSha256: 'c'.repeat(64),
+    currentSha256: 'c'.repeat(64),
+    size: 128,
+    executable: false,
+    ...overrides,
+  };
+}
+
+export function makeUninstallPlan(
+  overrides: Partial<SkillUninstallPlanDto> = {}
+): SkillUninstallPlanDto {
+  return {
+    token: 'f1e2d3c4'.repeat(6),
+    expiresAt: '2026-07-21T00:10:00Z',
+    removable: true,
+    blockers: [],
+    nextActionKey: 'skills.uninstall.nextAction.removable',
+    target: {
+      worktreeId: 'demo-wt',
+      worktreeName: 'feature/demo',
+      repositoryName: 'CommandMate',
+      branch: 'feature/demo',
+      headState: 'attached',
+      headCommit: 'd'.repeat(40),
+      workingTreeDirty: false,
+      installRoot: '.agents/skills/release-helper',
+      currentTreeHash: 'e'.repeat(64),
+    },
+    skill: {
+      id: 'release-helper',
+      version: '1.2.0',
+      source: { repository: 'Kewton/commandmate-skills', ref: 'v1.2.0', commit: 'a'.repeat(40) },
+      artifact: { assetName: 'release-helper-1.2.0.tar.gz', sha256: 'b'.repeat(64) },
+      effectiveRisk: 'low',
+      agents: [{ agent: 'claude', support: 'native', messageKey: 'skills.uninstall.reload.native' }],
+    },
+    receipt: { path: '.agents/skills/release-helper/.commandmate-receipt.json', sha256: 'c'.repeat(64), size: 512 },
+    removals: [makeUninstallFile()],
+    retained: [],
+    stats: { removable: 1, modified: 0, missing: 0, unknown: 0, irregular: 0 },
+    ...overrides,
+  };
+}
+
+export function makeUninstallResponse(): SkillUninstallResponse {
+  return {
+    operation: {
+      operationId: 'op-2',
+      idempotencyKey: 'skill-uninstall-token',
+      state: 'SUCCEEDED',
+      result: 'succeeded',
+      committed: true,
+      reconcilePending: false,
+      nextActionKey: 'skills.uninstall.nextAction.succeeded',
+      replayed: false,
+    },
+    uninstall: {
+      skillId: 'release-helper',
+      version: '1.2.0',
+      installRoot: '.agents/skills/release-helper',
+      removedFiles: [{ path: 'SKILL.md', sha256: 'c'.repeat(64), size: 128 }],
+      removedDirectories: [],
+      retained: [],
+      receiptRemoved: true,
+      fullyRemoved: true,
+    },
+    reload: {
+      skillId: 'release-helper',
+      version: '1.2.0',
+      installRoot: '.agents/skills/release-helper',
+      agents: [{ agent: 'claude', support: 'native', messageKey: 'skills.uninstall.reload.native' }],
+    },
+  };
 }

--- a/tests/unit/components/skills/skills-i18n-keys.test.ts
+++ b/tests/unit/components/skills/skills-i18n-keys.test.ts
@@ -16,11 +16,22 @@ import fs from 'fs';
 import path from 'path';
 import {
   COMPATIBILITY_LABEL_KEY,
+  DIFF_CHANGE_LABEL_KEY,
+  DIFF_REASON_LABEL_KEY,
+  HEAD_STATE_LABEL_KEY,
+  OPERATION_ERROR_LABEL_KEY,
+  PERMISSION_LABEL_KEY,
+  PREVIEW_WARNING_LABEL_KEY,
   RECOMMENDATION_LABEL_KEY,
   RISK_LABEL_KEY,
+  UNINSTALL_DISPOSITION_LABEL_KEY,
+  UNINSTALL_REASON_LABEL_KEY,
   catalogReasonLabelKey,
+  operationErrorLabelKey,
   resolveSkillMessageKey,
 } from '@/components/skills/skill-vocabulary';
+import { SkillDiffReason, SkillPreviewWarning } from '@/lib/skills/preview-diff';
+import { SkillUninstallReason } from '@/lib/skills/uninstall-plan';
 import { AGENT_SUPPORT_LABEL_KEYS, PERMISSION_DECLARATION_NOTICE_KEY } from '@/lib/skills/constants';
 import { SKILL_COMPATIBILITY_MESSAGE_KEYS } from '@/lib/skills/compatibility';
 import { SKILL_PLAN_HIGH_RISK_MESSAGE_KEY } from '@/lib/skills/install-plan';
@@ -110,6 +121,18 @@ function contractKeys(): string[] {
     .concat(Object.values(RECOMMENDATION_LABEL_KEY))
     .concat(Object.values(COMPATIBILITY_LABEL_KEY))
     .concat(Object.values(RISK_LABEL_KEY))
+    // Wire values the install/uninstall flow (#1431) maps to prose: the plan
+    // and the apply responses name a change, a reason, a warning or a refusal
+    // by code, and the screen looks the label up rather than writing it inline.
+    .concat(Object.values(DIFF_CHANGE_LABEL_KEY))
+    .concat(Object.values(DIFF_REASON_LABEL_KEY))
+    .concat(Object.values(PREVIEW_WARNING_LABEL_KEY))
+    .concat(Object.values(PERMISSION_LABEL_KEY))
+    .concat(Object.values(HEAD_STATE_LABEL_KEY))
+    .concat(Object.values(UNINSTALL_DISPOSITION_LABEL_KEY))
+    .concat(Object.values(UNINSTALL_REASON_LABEL_KEY))
+    .concat(Object.values(OPERATION_ERROR_LABEL_KEY))
+    .concat([operationErrorLabelKey('SKILL_SOMETHING_UNMAPPED')])
     .concat(
       [
         'SKILL_CATALOG_FETCH_FAILED',
@@ -147,6 +170,18 @@ const PLACEHOLDERS: Record<string, string[]> = {
   'uninstall.reload.commandmateRuntime': ['{agent}', '{skillId}'],
   'uninstall.reload.unsupported': ['{agent}', '{skillId}'],
   'uninstall.reload.unknown': ['{agent}', '{skillId}'],
+  'install.reload.native': ['{agent}', '{skillId}', '{version}'],
+  'install.reload.commandmateRuntime': ['{agent}', '{skillId}', '{version}'],
+  'install.reload.unsupported': ['{agent}', '{skillId}', '{version}'],
+  'install.reload.unknown': ['{agent}', '{skillId}', '{version}'],
+  'plan.expiresAt': ['{timestamp}'],
+  'plan.existingInstallVersion': ['{version}'],
+  'plan.stats': ['{added}', '{modified}', '{unchanged}', '{conflicted}', '{unmanaged}'],
+  'plan.diffToggle': ['{additions}', '{deletions}'],
+  'uninstall.expiresAt': ['{timestamp}'],
+  'uninstall.stats': ['{removable}', '{modified}', '{missing}', '{unknown}', '{irregular}'],
+  'operation.filesWritten': ['{count}'],
+  'operation.filesRemoved': ['{count}'],
 };
 
 /**
@@ -226,6 +261,26 @@ describe('skills i18n keys (Issue #1232)', () => {
       );
       expect(new Set(labels).size, `${locale}: two risk levels share a label`).toBe(3);
     }
+  });
+
+  it('labels every diff reason, preview warning and uninstall reason the contract can emit', () => {
+    // The screens cannot import these enums as values (their modules read the
+    // filesystem), so the maps are written out by hand. This is what stops a
+    // new contract code from reaching the user as a raw identifier.
+    expect(Object.keys(DIFF_REASON_LABEL_KEY).sort()).toEqual(
+      Object.values(SkillDiffReason).slice().sort()
+    );
+    expect(Object.keys(PREVIEW_WARNING_LABEL_KEY).sort()).toEqual(
+      Object.values(SkillPreviewWarning).slice().sort()
+    );
+    expect(Object.keys(UNINSTALL_REASON_LABEL_KEY).sort()).toEqual(
+      Object.values(SkillUninstallReason).slice().sort()
+    );
+  });
+
+  it('falls back to an explicit message for an unmapped operation code', () => {
+    expect(operationErrorLabelKey('SKILL_PLAN_STALE')).toBe('operation.error.planStale');
+    expect(operationErrorLabelKey('SKILL_WHAT_IS_THIS')).toBe('operation.error.unexpected');
   });
 
   it('defines the shared Skills navigation label in both locales', () => {


### PR DESCRIPTION
## 概要
Issue #1431 の対応。Catalog 閲覧専用だった Skill UI を書き込み系 API へ接続し、ブラウザから Skill を install/uninstall できるようにする。#1233 で作られたまま未マウントだった `SkillTargetSelector`（grep で test-only を確認）を production へ配線する。

## 実装
- `skills-client.ts` — 書き込み系 4 client（plan/install/uninstall-plan/uninstall）。typed error code（`SKILL_PLAN_STALE` / `SKILL_INSTALL_LOCKED` / `SKILL_INSTALL_DESTINATION_EXISTS` 等）を人間可読テキストへ伝搬。uninstall 拒否の blockers/nextActionKey も保持
- `SkillInstallPanel.tsx`（新規）— target → plan → preview → confirm → apply。**high-risk 確認チェックボックス**が未チェックの間は request をブラウザから送出させない
- `SkillPlanPreview.tsx`（新規）— plan-response の facts のみ描画（files/diff/3段階 risk/permissions/scripts/warnings/blockers）。filesystem path や client 側 security 判定は一切出さない
- `types.ts` — 書き込み系の型は route モジュールからの type-only re-export。契約変更が type-check で落ちる（drift 防止）
- locales en+ja 同時更新。`CommandPalette.tsx:64` の古いコメントを実態（Skills = More + palette、#1232 の設計判断）へ修正。**ナビ構成は不変**
- `skills-i18n-keys.test.ts`（新規）で en/ja キー parity を CI で担保

## 検証
- lint / tsc / build / unit 11044 / skills-integration 71 全 green
- **両 install ゲートを変異テスト**（どちらを外しても対応テストが赤）
- plan token の cookie=user binding、acknowledgeRisk の install request 接続を維持

## 本Issueでやっていないこと（正直な申告）
- **ブラウザ実機での install→uninstall UAT は未実施**。detail ページが panel を mount するには `/api/skills/[id]` が実 GitHub Catalog に解決する必要があり、稼働システムに触れずサンドボックスで確実に再現できない。代わりに render/build 全経路と、実 route モジュールに対する request/response 型の固定で裏取りした
- これにより #1242 の人手検証 3-1（初見参加者 UX 調査）がアンブロックされる

Refs #1431