### PR TITLE
fix(skills): 同一プロセス並行リクエストでlock leaseが横取りされる問題を修正 (#1427)

### DIFF
--- a/src/lib/skills/operation-lock.ts
+++ b/src/lib/skills/operation-lock.ts
@@ -6,12 +6,14 @@
  *
  * - **Owner nonce.** Release and renew require the caller to present the nonce
  *   written at acquisition, so no process can drop a lock it does not hold.
- * - **Lease heartbeat.** A long install renews its lease, so "old" never means
- *   "abandoned". Age alone is not sufficient evidence to reclaim.
+ * - **Lease heartbeat.** {@link renewSkillOperationLease} can extend a lease so
+ *   a long operation is not reclaimed by age. It is not yet wired into the
+ *   routes, so owner liveness below — not the heartbeat — is what currently
+ *   keeps a live operation safe (Issue #1427).
  * - **Owner liveness.** A lock whose lease expired is reclaimed only when the
  *   owning PID is verifiably gone on this host. A live owner that missed a
- *   heartbeat keeps its lock: reclaiming it would let two processes write the
- *   same payload.
+ *   heartbeat keeps its lock, including a same-process concurrent operation:
+ *   reclaiming it would let two processes write the same payload.
  *
  * The lock key is a digest of the *resolved* worktree path and the validated
  * Skill ID, so no untrusted name ever reaches a filename.
@@ -187,7 +189,30 @@ export function describeSkillLockHolder(record: SkillOperationLockRecord): Skill
  * Decide how an observed record may be treated, given the clock and liveness.
  *
  * Ordering matters: a valid lease short-circuits every other consideration, so
- * a live holder is never reclaimed regardless of what its PID looks like.
+ * a live holder is never reclaimed regardless of what its PID looks like. Once
+ * the lease has lapsed on this host, PID liveness is the *only* remaining
+ * evidence — a lock is reclaimed only when its owning process is verifiably gone.
+ *
+ * Same-process locks are deliberately not shortcut to RECLAIMABLE (Issue #1427).
+ * Every Next.js route handler runs in one shared process and none renews its
+ * lease ({@link renewSkillOperationLease} has no production caller), so a lapsed
+ * lease is not evidence that a *concurrent* same-process operation abandoned its
+ * lock. Shortcutting it to reclaimable let a second request steal a live
+ * install's lock ~one lease window in and write the same payload underneath it.
+ * A same-process owner that is still alive now resolves to HELD_BY_LIVE_OWNER
+ * and is left alone.
+ *
+ * Tradeoff: this process can no longer instantly reclaim a lock it truly leaked
+ * (acquired but never released). While the process stays alive such a lock reads
+ * as HELD_BY_LIVE_OWNER; it clears only on an explicit release or after the
+ * process exits — a later process then sees the dead PID and reclaims it. Note
+ * this is stronger than "next acquire waits at most one lease window": with no
+ * heartbeat there is no time-based signal, so within one live process the lock
+ * is held until release/exit, not merely until the lease lapses. In practice the
+ * acquire path always releases in a `finally`, so the only real remnant is a
+ * crash — and crash orphans are unaffected: a new process has a different
+ * generation and finds the old PID gone, so the liveness branch below reclaims
+ * them exactly as before.
  */
 export function evaluateSkillLock(
   record: SkillOperationLockRecord | null,
@@ -205,11 +230,6 @@ export function evaluateSkillLock(
     return expiredFor > SKILL_LOCK_FOREIGN_HOST_GRACE_MS
       ? 'RECLAIMABLE'
       : 'HELD_UNVERIFIABLE_OWNER';
-  }
-
-  // Our own abandoned lock: this process is demonstrably past that operation.
-  if (record.owner.processGeneration === PROCESS_GENERATION && record.owner.pid === process.pid) {
-    return 'RECLAIMABLE';
   }
 
   return isAlive(record.owner.pid) ? 'HELD_BY_LIVE_OWNER' : 'RECLAIMABLE';

--- a/tests/unit/lib/skills/operation-lock.test.ts
+++ b/tests/unit/lib/skills/operation-lock.test.ts
@@ -152,6 +152,23 @@ describe('a live owner is never reclaimed', () => {
     expect(readSkillOperationLock(KEY, { root })?.owner.nonce).toBe('foreign-nonce');
   });
 
+  it('does not reclaim a same-process lease-expired lock while this process is alive', () => {
+    // Issue #1427: the lock is written by THIS process (real generation + pid).
+    // Route handlers share one process and never renew, so a lapsed lease is not
+    // proof that a concurrent same-process operation abandoned it — it stays held.
+    const first = acquireSkillOperationLock({ key: KEY, operationId: 'op-1' }, { root, now: T0 });
+    expect(first.ok).toBe(true);
+    const contender = acquireSkillOperationLock(
+      { key: KEY, operationId: 'op-2' },
+      { root, now: T0 + SKILL_LOCK_LEASE_MS + 1, isProcessAlive: ALIVE }
+    );
+    expect(contender.ok).toBe(false);
+    if (contender.ok) return;
+    expect(contender.reason).toBe('HELD_BY_LIVE_OWNER');
+    // Nothing was stolen: op-1 still owns the lock.
+    expect(readSkillOperationLock(KEY, { root })?.operationId).toBe('op-1');
+  });
+
   it('a renewed lease keeps the lock out of reach', () => {
     const first = acquireSkillOperationLock({ key: KEY, operationId: 'op-1' }, { root, now: T0 });
     expect(first.ok).toBe(true);
@@ -212,16 +229,51 @@ describe('stale reclaim', () => {
     expect(later.ok).toBe(true);
   });
 
-  it('reclaims this process own abandoned lock without a liveness probe', () => {
+  it('reclaims a lease-expired lock this process wrote once its owning pid is gone', () => {
+    // Models a crash: the lock file this process wrote outlives its owner. Reclaim
+    // is now driven purely by liveness — the same-generation shortcut is gone
+    // (Issue #1427) — so a dead owner is still recovered.
     const first = acquireSkillOperationLock({ key: KEY, operationId: 'op-1' }, { root, now: T0 });
     expect(first.ok).toBe(true);
     const again = acquireSkillOperationLock(
       { key: KEY, operationId: 'op-2' },
-      { root, now: T0 + SKILL_LOCK_LEASE_MS + 1, isProcessAlive: ALIVE }
+      { root, now: T0 + SKILL_LOCK_LEASE_MS + 1, isProcessAlive: DEAD }
     );
     expect(again.ok).toBe(true);
     if (!again.ok) return;
     expect(again.reclaimed).toBe(true);
+    expect(readSkillOperationLock(KEY, { root })?.operationId).toBe('op-2');
+  });
+});
+
+describe('concurrent same-process requests never steal a live lock', () => {
+  // Issue #1427: two requests for the same (worktree, skill) hit one shared
+  // process. The install/uninstall route turns any denied acquire into
+  // SKILL_INSTALL_LOCKED (409); these pin that the *second* request is always
+  // denied rather than winning the lock, at both lease phases.
+  it('denies the second request while the first lease is still valid', () => {
+    const first = acquireSkillOperationLock({ key: KEY, operationId: 'op-1' }, { root, now: T0 });
+    expect(first.ok).toBe(true);
+    const second = acquireSkillOperationLock(
+      { key: KEY, operationId: 'op-2' },
+      { root, now: T0 + 5_000, isProcessAlive: ALIVE }
+    );
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.reason).toBe('HELD');
+  });
+
+  it('still denies the second request after the first lease lapses', () => {
+    const first = acquireSkillOperationLock({ key: KEY, operationId: 'op-1' }, { root, now: T0 });
+    expect(first.ok).toBe(true);
+    const second = acquireSkillOperationLock(
+      { key: KEY, operationId: 'op-2' },
+      { root, now: T0 + SKILL_LOCK_LEASE_MS + 5_000, isProcessAlive: ALIVE }
+    );
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.reason).toBe('HELD_BY_LIVE_OWNER');
+    expect(readSkillOperationLock(KEY, { root })?.operationId).toBe('op-1');
   });
 });
 
@@ -314,5 +366,22 @@ describe('orphan lock cleanup', () => {
 describe('evaluateSkillLock', () => {
   it('reports FREE for a missing record', () => {
     expect(evaluateSkillLock(null, { now: T0 })).toBe('FREE');
+  });
+
+  it('reclaims a crash orphan from another generation once its pid is gone', () => {
+    // A record left by a crashed prior process: same host, different generation,
+    // lease long expired. Liveness — not generation — is the deciding evidence,
+    // so crash recovery is preserved after the shortcut removal (Issue #1427).
+    const orphan = writeForeignLock();
+    expect(
+      evaluateSkillLock(orphan, { now: T0 + SKILL_LOCK_LEASE_MS + 1, isProcessAlive: DEAD })
+    ).toBe('RECLAIMABLE');
+  });
+
+  it('keeps a crash orphan whose pid was reused by a live process', () => {
+    const orphan = writeForeignLock();
+    expect(
+      evaluateSkillLock(orphan, { now: T0 + SKILL_LOCK_LEASE_MS + 1, isProcessAlive: ALIVE })
+    ).toBe('HELD_BY_LIVE_OWNER');
   });
 });


### PR DESCRIPTION
## 概要
Issue #1427 の対応。同一サーバプロセス内の並行リクエストが、lease 30 秒経過後に互いの Skill 操作 lock を横取りできてしまう問題を修正する。

## 原因
`evaluateSkillLock` の `same-pid && same-generation → RECLAIMABLE` ショートカットは「自プロセスの放棄 lock」を即時回収する意図だったが、Next.js の route handler は全て同一プロセスで並行実行されるため、**live な並行リクエストの lock もこの分岐に該当**していた。`renewSkillOperationLease` は実装済みだが production の呼び出し元が無く（grep -a で 0 件確認）、lease heartbeat 契約が成立していなかった。

## 実装（案A・simplicity 優先）
- `evaluateSkillLock` の same-pid/same-generation ショートカットを除去。lease 失効後の自プロセス lock は `isAlive(pid)`=true により `HELD_BY_LIVE_OWNER` となり、横取りされなくなる
- **route には一切触れていない**（#1428 と衝突しない）
- crash 後の orphan lock は generation 不一致経路で従来どおり回収可能

## Issue 記載からの訂正（commit message に記録、Issue 本文は未変更）
Issue の trade-off 記述「次回 acquire は最大 lease window 待ち」は不正確。heartbeat が無いため時間ベースのシグナルが存在せず、**真にリークした同一プロセス lock は release / プロセス終了まで `HELD_BY_LIVE_OWNER` のまま**（lease 経過では解けない）。doc comment はこの正確な挙動と、crash orphan は liveness 経路で回収されることを明記した。

## 検証
- 旧「自分の放棄 lock を回収する」テストを反転（生存中は回収しない）
- 追加: same-process-live-owner-not-reclaimed / concurrent-second-request-denied（409 パス・両 lease phase）/ crash-orphan の generation 不一致による回収・保持
- tsc / eslint / test:unit 11062 全 pass / build green（worktree 内）/ reconciler・integration・control-char guard・生NUL 0 も確認

Refs #1427