### PR TITLE
feat(skills): 起動時reconciliation配線とjournal retention (#1428)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -186,6 +186,34 @@ app.prepare().then(() => {
       const db = getDbInstance();
       runMigrations(db);
 
+      // Issue #1428: converge Skill install/uninstall operations that a crash
+      // left mid-flight, and garbage-collect expired journal entries. Runs after
+      // migrations (the audit table is migration-owned) and is fail-open in its
+      // own try/catch so a reconciliation error cannot stop the server — nor
+      // abort the worktree sync that follows in the outer try.
+      try {
+        // Loaded via dynamic import, NOT a top-level static import: pulling the
+        // skills module graph into server.ts's eval-time graph perturbs Next's
+        // AsyncLocalStorage bootstrap under `tsx server.ts` (dev/E2E), so the
+        // first request that compiles middleware crashes with
+        // "AsyncLocalStorage accessed in runtime where it is not available".
+        // Deferring the import to here (after app.prepare()) avoids it. Do not
+        // hoist this back to a static import.
+        const { runSkillStartupReconciliation } = await import(
+          './src/lib/skills/startup-reconcile'
+        );
+        const skillReport = runSkillStartupReconciliation(db);
+        if (skillReport.scanned > 0 || skillReport.pruned > 0) {
+          console.log(
+            `Skill operations reconciled: scanned=${skillReport.scanned} ` +
+              `converged=${skillReport.converged} failed=${skillReport.failed} ` +
+              `pruned=${skillReport.pruned} orphanLocks=${skillReport.orphanLocksReleased.length}`
+          );
+        }
+      } catch (error) {
+        console.error('Error reconciling Skill operations:', error);
+      }
+
       // Get repository paths from environment variables
       const repositoryPaths = getRepositoryPaths();
 

--- a/src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/install/route.ts
@@ -437,11 +437,11 @@ export async function POST(
       });
     } catch (error) {
       // Nothing was published: the staging directory is already gone and the
-      // destination was never touched.
-      entry = transitionSkillOperation(entry, 'FAILED_RECONCILABLE', {
-        error: { code: errorCodeOf(error), message: messageOf(error) },
-      });
-      recordAuditSafely(entry, 'failed');
+      // destination was never touched. Drop the journal entry so the key stays
+      // reusable, exactly as a failed plan consume above does (Issue #1428) —
+      // leaving a terminal FAILED entry here would pin the key to a 409 on
+      // replay until retention, for a failure that changed nothing on disk.
+      deleteSkillOperationJournal(entry.idempotencyKey);
       throw error;
     }
 
@@ -577,12 +577,6 @@ function answerReplay(
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function errorCodeOf(error: unknown): string {
-  if (isSkillInstallError(error) || isSkillPlanError(error)) return error.code;
-  if (isSkillPackageError(error) || isSkillFetchError(error)) return error.code;
-  return 'SKILL_INSTALL_INTERNAL_ERROR';
 }
 
 /** Audit failures must not mask the outcome they are describing. */

--- a/src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts
+++ b/src/app/api/worktrees/[id]/skills/[skillId]/uninstall/route.ts
@@ -428,14 +428,21 @@ export async function POST(
         },
       });
     } catch (error) {
+      if (!committed) {
+        // Deletion never started: the receipt and every file are intact, so
+        // nothing changed on disk. Drop the journal entry to keep the key
+        // reusable, exactly as a failed plan consume above does (Issue #1428),
+        // rather than pinning it to a 409 on replay until retention.
+        deleteSkillOperationJournal(entry.idempotencyKey);
+        throw error;
+      }
+
+      // Deletion had already begun, so the receipt and the surviving files are
+      // the diagnostic record; reconciliation converges from there.
       entry = transitionSkillOperation(entry, 'FAILED_RECONCILABLE', {
         error: { code: errorCodeOf(error), message: messageOf(error) },
       });
       recordAuditSafely(entry, 'failed');
-      if (!committed) throw error;
-
-      // Deletion had already begun, so the receipt and the surviving files are
-      // the diagnostic record; reconciliation converges from there.
       logger.error('skill-uninstall-partial', {
         operationId: entry.operationId,
         error: redactSkillOperationText(messageOf(error)),

--- a/src/lib/skills/operation-journal.ts
+++ b/src/lib/skills/operation-journal.ts
@@ -247,6 +247,52 @@ export function deleteSkillOperationJournal(
   }
 }
 
+/**
+ * How long a terminal journal entry is kept before it becomes collectable.
+ *
+ * The journal is the crash-recovery and idempotency record, not the audit trail
+ * (that lives in the append-only `skill_operations` table). A terminal entry is
+ * only still useful for the window during which a client might retry the same
+ * idempotency key; past it, the entry is pure growth. Seven days comfortably
+ * covers realistic retry and support windows while bounding the directory to the
+ * operations of one window rather than of all time (Issue #1428).
+ */
+export const SKILL_JOURNAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Collect terminal journal entries whose retention window has elapsed.
+ *
+ * Only {@link isSkillOperationTerminal} entries are eligible: SUCCEEDED, and a
+ * pre-commit FAILED_RECONCILABLE that rolled back cleanly. A FAILED_RECONCILABLE
+ * that *did* commit to the filesystem is non-terminal — it still owes the
+ * reconciler an index write — and is never pruned, so a genuine
+ * payload-on-disk/no-index inconsistency is not silently discarded. Retention is
+ * measured from `updatedAt`, which for a terminal entry is the moment it reached
+ * its terminal state and never moves again.
+ *
+ * Uniform retention across both terminal outcomes is deliberate (Issue #1428):
+ * a SUCCEEDED entry that were deleted immediately would let a delayed retry of
+ * the *same* idempotency key re-run the install and hit a spurious
+ * DESTINATION_EXISTS, so success and failure expire on the same clock and a key
+ * becomes reusable at a single, predictable time regardless of outcome.
+ *
+ * @returns the idempotency keys of the entries that were pruned.
+ */
+export function pruneExpiredSkillOperationJournal(
+  options: SkillJournalOptions & { retentionMs?: number } = {}
+): string[] {
+  const now = options.now ?? Date.now();
+  const retentionMs = options.retentionMs ?? SKILL_JOURNAL_RETENTION_MS;
+  const pruned: string[] = [];
+  for (const entry of listSkillOperationJournal(options)) {
+    if (!isSkillOperationTerminal(entry)) continue;
+    if (now - entry.updatedAt <= retentionMs) continue;
+    deleteSkillOperationJournal(entry.idempotencyKey, options);
+    pruned.push(entry.idempotencyKey);
+  }
+  return pruned;
+}
+
 export type SkillOperationBeginResult =
   | { ok: true; entry: SkillOperationJournalEntry; replayed: boolean }
   | { ok: false; reason: 'IDEMPOTENCY_KEY_CONFLICT'; entry: SkillOperationJournalEntry };

--- a/src/lib/skills/startup-reconcile.ts
+++ b/src/lib/skills/startup-reconcile.ts
@@ -1,0 +1,170 @@
+/**
+ * Startup wiring for Skill operation crash recovery (Issue #1428)
+ *
+ * #1234 built {@link reconcileSkillOperations} and left the concrete ports it
+ * needs — *is the payload on disk?* and *rebuild the index row* — to the layers
+ * that own the filesystem and the DB (#1235/#1236). This module is the assembly
+ * point those pieces were missing: it constructs the production ports and runs
+ * reconciliation, and it is the single function the server startup path calls so
+ * that a restart converges every interrupted install/uninstall on one answer.
+ *
+ * It is deliberately the *only* place the startup ports are assembled. The
+ * Phase 1 gap that shipped a never-invoked reconciler happened because the tests
+ * imported the library directly and never crossed the startup seam; this
+ * function is what both `server.ts` and its test now go through, so a future
+ * regression that unwires it fails a test rather than passing silently.
+ *
+ * Running here also garbage-collects the journal: terminal entries past their
+ * retention window are pruned, so the journal directory tracks the operations of
+ * one window rather than growing without bound.
+ *
+ * @module lib/skills/startup-reconcile
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type Database from 'better-sqlite3';
+import { getWorktreeById } from '@/lib/db';
+import { computeSha256Hex } from '@/lib/skills/integrity';
+import {
+  SKILL_RECEIPT_FILENAME,
+  parseInstalledReceipt,
+} from '@/lib/skills/install-plan';
+import {
+  hasCommittedSkillPayload,
+  resolveSkillInstallTarget,
+} from '@/lib/skills/install-apply';
+import { hasRemovedSkillPayload } from '@/lib/skills/uninstall-apply';
+import {
+  deleteSkillInstallation,
+  upsertSkillInstallation,
+} from '@/lib/skills/installed-state';
+import { recordSkillOperationAudit } from '@/lib/skills/operation-audit';
+import {
+  pruneExpiredSkillOperationJournal,
+  type SkillOperationJournalEntry,
+} from '@/lib/skills/operation-journal';
+import {
+  reconcileSkillOperations,
+  type SkillReconcileOptions,
+  type SkillReconcileReport,
+  type SkillReconcilerPorts,
+} from '@/lib/skills/operation-reconciler';
+
+/** Options for the startup assembly. Tests inject the clock, liveness and root. */
+export interface SkillStartupReconcileOptions extends SkillReconcileOptions {
+  /** Retention window for terminal journal entries; defaults to the module default. */
+  retentionMs?: number;
+  /**
+   * Resolve a worktree's absolute path from its id. Defaults to the DB lookup
+   * used in production; injectable so a test need not stand up a repository.
+   */
+  resolveWorktreePath?: (worktreeId: string) => string | null;
+}
+
+/** Reconciliation report plus what retention collected. */
+export interface SkillStartupReconcileReport extends SkillReconcileReport {
+  /** Idempotency keys whose expired terminal journal entries were pruned. */
+  prunedKeys: string[];
+  pruned: number;
+}
+
+/**
+ * Whether an operation's kind removes payload (uninstall) rather than adding it.
+ * `update` re-installs, so it shares the install-side probe and index write.
+ */
+function isRemovalOperation(entry: SkillOperationJournalEntry): boolean {
+  return entry.operation === 'uninstall';
+}
+
+/**
+ * Build the reconciler ports against the real filesystem and database.
+ *
+ * The reconciler asks one filesystem question and performs one index write per
+ * entry; both dispatch on the operation kind because "did it land?" and "rebuild
+ * the row" mean opposite things for an install and an uninstall.
+ */
+export function buildSkillReconcilerPorts(
+  db: Database.Database,
+  options: SkillStartupReconcileOptions = {}
+): SkillReconcilerPorts {
+  const resolveWorktreePath =
+    options.resolveWorktreePath ??
+    ((worktreeId: string): string | null => {
+      const worktree = getWorktreeById(db, worktreeId);
+      return worktree ? worktree.path : null;
+    });
+
+  return {
+    hasCommittedPayload: (entry: SkillOperationJournalEntry): boolean => {
+      const worktreePath = resolveWorktreePath(entry.target.worktreeId);
+      if (worktreePath === null) {
+        // The worktree is gone: an install could not have left payload behind,
+        // and an uninstall's payload is by definition no longer present.
+        return isRemovalOperation(entry);
+      }
+      return isRemovalOperation(entry)
+        ? hasRemovedSkillPayload(worktreePath, entry.target.skillId, entry.receiptDigest)
+        : hasCommittedSkillPayload(worktreePath, entry.target.skillId, entry.receiptDigest);
+    },
+
+    reindex: (entry: SkillOperationJournalEntry): void => {
+      if (isRemovalOperation(entry)) {
+        // The row is dropped by (worktree, skill); no path or receipt is needed,
+        // and the delete is idempotent so a replay after a partial pass is safe.
+        deleteSkillInstallation(db, entry.target.worktreeId, entry.target.skillId);
+        return;
+      }
+
+      const worktreePath = resolveWorktreePath(entry.target.worktreeId);
+      if (worktreePath === null) {
+        throw new Error('worktree path is unavailable for reindex');
+      }
+      // The index row is rebuilt from the receipt that actually landed rather
+      // than from the journal, which never carried the full receipt. The receipt
+      // on disk is the same artifact the user can see, so the row cannot drift
+      // from it.
+      const installRootAbs = resolveSkillInstallTarget(worktreePath, entry.target.skillId);
+      const bytes = readFileSync(join(installRootAbs, SKILL_RECEIPT_FILENAME));
+      const receipt = parseInstalledReceipt(bytes);
+      if (receipt === null) {
+        throw new Error('receipt on disk is unreadable during reindex');
+      }
+      upsertSkillInstallation(db, {
+        worktreeId: entry.target.worktreeId,
+        receipt,
+        receiptSha256: computeSha256Hex(bytes),
+        operationId: entry.operationId,
+        installedAt: entry.fsCommittedAt ?? options.now ?? Date.now(),
+      });
+    },
+
+    recordAudit: (input) => {
+      recordSkillOperationAudit(db, input);
+    },
+  };
+}
+
+/**
+ * Converge interrupted Skill operations and collect expired journal entries.
+ *
+ * Called once at server startup, after migrations (the audit table is
+ * migration-owned) and before the server begins accepting requests. Returns the
+ * reconciliation report augmented with what retention pruned.
+ */
+export function runSkillStartupReconciliation(
+  db: Database.Database,
+  options: SkillStartupReconcileOptions = {}
+): SkillStartupReconcileReport {
+  const ports = buildSkillReconcilerPorts(db, options);
+  const report = reconcileSkillOperations(ports, options);
+  // Pruning runs after convergence: an entry that just converged to SUCCEEDED
+  // has a fresh `updatedAt` and is well inside its window, so this pass only
+  // collects entries that were already terminal in an earlier one.
+  const prunedKeys = pruneExpiredSkillOperationJournal({
+    root: options.root,
+    now: options.now,
+    retentionMs: options.retentionMs,
+  });
+  return { ...report, prunedKeys, pruned: prunedKeys.length };
+}

--- a/tests/integration/skills-startup-reconcile.test.ts
+++ b/tests/integration/skills-startup-reconcile.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Issue #1428: the startup wiring that #1234 shipped without.
+ *
+ * These tests drive {@link runSkillStartupReconciliation} — the exact function
+ * `server.ts` calls after migrations — against a real database, a real journal
+ * on disk and a real receipt in a real worktree tree. Nothing here reaches into
+ * the reconciler with hand-built ports; the whole point is to cross the same
+ * assembly seam production crosses, because the Phase 1 gap (a reconciler that
+ * was never invoked) survived precisely because every test until now called the
+ * library directly.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { computeSha256Hex } from '@/lib/skills/integrity';
+import { SKILL_RECEIPT_FILENAME } from '@/lib/skills/install-plan';
+import {
+  beginSkillOperation,
+  readSkillOperationJournal,
+  transitionSkillOperation,
+  listSkillOperationJournal,
+  type SkillOperationBinding,
+  type SkillOperationSource,
+} from '@/lib/skills/operation-journal';
+import { buildSkillOperationLockKey } from '@/lib/skills/operation-lock';
+import {
+  getSkillInstallation,
+  upsertSkillInstallation,
+} from '@/lib/skills/installed-state';
+import { getSkillOperationAuditByOperationId } from '@/lib/skills/operation-audit';
+import { runSkillStartupReconciliation } from '@/lib/skills/startup-reconcile';
+import { seedWorktreeRow } from './skills/mvp-harness';
+import type { SkillInstallReceipt } from '@/types/skills';
+
+const T0 = 1_800_000_000_000;
+const WORKTREE_ID = 'wt-1';
+const SKILL_ID = 'demo-skill';
+const VERSION = '1.2.3';
+const INSTALL_ROOT_REL = `.agents/skills/${SKILL_ID}`;
+
+let db: Database.Database;
+let root: string;
+let worktreeDir: string;
+let receiptBytes: Buffer;
+let receiptDigest: string;
+
+const SOURCE: SkillOperationSource = {
+  origin: 'github-release',
+  repository: 'Kewton/commandmate-skills',
+  ref: 'demo-skill-v1.2.3',
+  commit: 'b'.repeat(40),
+  artifactSha256: 'c'.repeat(64),
+};
+
+function installBinding(planHash = 'a'.repeat(64)): SkillOperationBinding {
+  return {
+    actor: { type: 'user', id: 'user-1' },
+    operation: 'install',
+    target: { worktreeId: WORKTREE_ID, skillId: SKILL_ID, version: VERSION },
+    planHash,
+  };
+}
+
+function uninstallBinding(planHash = 'd'.repeat(64)): SkillOperationBinding {
+  return {
+    actor: { type: 'user', id: 'user-1' },
+    operation: 'uninstall',
+    target: { worktreeId: WORKTREE_ID, skillId: SKILL_ID, version: VERSION },
+    planHash,
+  };
+}
+
+/** A receipt with every field the reindex port reads, written to the worktree. */
+function buildReceipt(): SkillInstallReceipt {
+  return {
+    schema_version: 1,
+    skill_id: SKILL_ID,
+    version: VERSION,
+    install_root: INSTALL_ROOT_REL,
+    source: { repository: SOURCE.repository, ref: SOURCE.ref, commit: SOURCE.commit },
+    artifact: { asset_name: 'demo.tar.gz', sha256: SOURCE.artifactSha256, size: 10, format: 'tar.gz' },
+    files: [{ path: 'SKILL.md', sha256: 'e'.repeat(64), size: 4, executable: false }],
+    declared_risk: 'low',
+    computed_risk: 'low',
+    effective_risk: 'low',
+    declared_permissions: [],
+    agent_compatibility: [],
+  } as unknown as SkillInstallReceipt;
+}
+
+function writeReceiptOnDisk(): void {
+  const installRootAbs = join(worktreeDir, '.agents', 'skills', SKILL_ID);
+  mkdirSync(installRootAbs, { recursive: true });
+  receiptBytes = Buffer.from(JSON.stringify(buildReceipt()), 'utf-8');
+  receiptDigest = computeSha256Hex(receiptBytes);
+  writeFileSync(join(installRootAbs, SKILL_RECEIPT_FILENAME), receiptBytes);
+}
+
+function reconcile(now: number, retentionMs?: number) {
+  return runSkillStartupReconciliation(db, {
+    root,
+    now,
+    isProcessAlive: () => false,
+    retentionMs,
+    resolveWorktreePath: () => worktreeDir,
+  });
+}
+
+/** Create an operation left in `committed_reconciling`: rename landed, index write threw. */
+function seedCommittedReconciling(binding: SkillOperationBinding, key: string): string {
+  const begun = beginSkillOperation(
+    { idempotencyKey: key, binding, lockKey: buildSkillOperationLockKey(worktreeDir, SKILL_ID), source: SOURCE },
+    { root, now: T0 }
+  );
+  if (!begun.ok) throw new Error('failed to open journal entry');
+  let entry = transitionSkillOperation(begun.entry, 'FS_COMMITTED', { receiptDigest }, { root, now: T0 + 1 });
+  entry = transitionSkillOperation(
+    entry,
+    'FAILED_RECONCILABLE',
+    { error: { code: 'SKILL_INSTALL_INDEX_FAILED', message: 'database is locked' } },
+    { root, now: T0 + 2 }
+  );
+  return entry.operationId;
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  root = mkdtempSync(join(tmpdir(), 'cm-startup-reconcile-'));
+  worktreeDir = mkdtempSync(join(tmpdir(), 'cm-startup-wt-'));
+  // Since #1430 skill_installations.worktree_id is a foreign key, so the parent
+  // worktrees row the reindex port writes against must exist — in production the
+  // route and the reconciler resolve it from the same connection.
+  seedWorktreeRow(db, worktreeDir, WORKTREE_ID);
+  writeReceiptOnDisk();
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+  rmSync(worktreeDir, { recursive: true, force: true });
+});
+
+describe('startup reconciliation converges an interrupted install through the production ports', () => {
+  it('drives committed_reconciling to SUCCEEDED and rebuilds the index row from the receipt', () => {
+    const operationId = seedCommittedReconciling(installBinding(), 'inst-1');
+    // The index write never landed before the crash.
+    expect(getSkillInstallation(db, WORKTREE_ID, SKILL_ID)).toBeNull();
+
+    const report = reconcile(T0 + 100);
+
+    expect(report.converged).toBe(1);
+    expect(readSkillOperationJournal('inst-1', { root })?.state).toBe('SUCCEEDED');
+
+    // The real reindex port read the on-disk receipt and wrote the row — this is
+    // the wiring that was missing, proven end to end rather than mocked.
+    const row = getSkillInstallation(db, WORKTREE_ID, SKILL_ID);
+    expect(row).not.toBeNull();
+    expect(row?.version).toBe(VERSION);
+    expect(row?.receiptSha256).toBe(receiptDigest);
+
+    const trail = getSkillOperationAuditByOperationId(db, operationId);
+    expect(trail.map((r) => r.result)).toEqual(['reconciled']);
+    expect(trail[0].state).toBe('SUCCEEDED');
+  });
+
+  it('marks a genuinely rolled-back install as failed when no receipt is on disk', () => {
+    rmSync(join(worktreeDir, '.agents'), { recursive: true, force: true });
+    const begun = beginSkillOperation(
+      { idempotencyKey: 'inst-2', binding: installBinding(), lockKey: 'lk', source: SOURCE },
+      { root, now: T0 }
+    );
+    expect(begun.ok).toBe(true);
+
+    const report = reconcile(T0 + 100);
+
+    expect(report.failed).toBe(1);
+    expect(readSkillOperationJournal('inst-2', { root })?.state).toBe('FAILED_RECONCILABLE');
+    expect(getSkillInstallation(db, WORKTREE_ID, SKILL_ID)).toBeNull();
+  });
+});
+
+describe('startup reconciliation converges an interrupted uninstall through the production ports', () => {
+  it('drives committed_reconciling to SUCCEEDED and drops the index row', () => {
+    upsertSkillInstallation(db, {
+      worktreeId: WORKTREE_ID,
+      receipt: buildReceipt(),
+      receiptSha256: receiptDigest,
+      operationId: 'prior-install',
+      installedAt: T0 - 1000,
+    });
+    expect(getSkillInstallation(db, WORKTREE_ID, SKILL_ID)).not.toBeNull();
+
+    seedCommittedReconciling(uninstallBinding(), 'uninst-1');
+
+    const report = reconcile(T0 + 100);
+
+    expect(report.converged).toBe(1);
+    expect(readSkillOperationJournal('uninst-1', { root })?.state).toBe('SUCCEEDED');
+    // The uninstall reindex port dropped the row.
+    expect(getSkillInstallation(db, WORKTREE_ID, SKILL_ID)).toBeNull();
+  });
+});
+
+describe('retention keeps the journal directory from growing without bound', () => {
+  it('prunes terminal entries past the window and makes the key reusable', () => {
+    // A success recorded long ago.
+    const begun = beginSkillOperation(
+      { idempotencyKey: 'old-success', binding: installBinding(), lockKey: 'lk', source: SOURCE },
+      { root, now: T0 }
+    );
+    if (!begun.ok) throw new Error('seed failed');
+    let entry = transitionSkillOperation(begun.entry, 'FS_COMMITTED', { receiptDigest }, { root, now: T0 });
+    entry = transitionSkillOperation(entry, 'INDEXED', {}, { root, now: T0 });
+    transitionSkillOperation(entry, 'SUCCEEDED', { error: null }, { root, now: T0 });
+
+    const retentionMs = 1000;
+    const report = reconcile(T0 + retentionMs + 1, retentionMs);
+
+    expect(report.prunedKeys).toContain('old-success');
+    expect(readSkillOperationJournal('old-success', { root })).toBeNull();
+
+    // The idempotency key is free again: a new request opens a fresh entry
+    // rather than replaying the collected one.
+    const reopened = beginSkillOperation(
+      { idempotencyKey: 'old-success', binding: installBinding(), lockKey: 'lk', source: SOURCE },
+      { root, now: T0 + retentionMs + 2 }
+    );
+    expect(reopened.ok).toBe(true);
+    if (reopened.ok) expect(reopened.replayed).toBe(false);
+  });
+
+  it('keeps a fresh terminal entry and a still-reconcilable entry', () => {
+    // Fresh success: inside the window.
+    const fresh = beginSkillOperation(
+      { idempotencyKey: 'fresh', binding: installBinding('1'.repeat(64)), lockKey: 'lk', source: SOURCE },
+      { root, now: T0 + 100 }
+    );
+    if (!fresh.ok) throw new Error('seed failed');
+    let e = transitionSkillOperation(fresh.entry, 'FS_COMMITTED', { receiptDigest }, { root, now: T0 + 100 });
+    e = transitionSkillOperation(e, 'INDEXED', {}, { root, now: T0 + 100 });
+    transitionSkillOperation(e, 'SUCCEEDED', { error: null }, { root, now: T0 + 100 });
+
+    const report = reconcile(T0 + 200, 1000);
+
+    expect(report.prunedKeys).toEqual([]);
+    expect(readSkillOperationJournal('fresh', { root })?.state).toBe('SUCCEEDED');
+    expect(listSkillOperationJournal({ root })).toHaveLength(1);
+  });
+
+  it('does not let file count scale with total operations over time', () => {
+    for (let i = 0; i < 5; i += 1) {
+      const b = beginSkillOperation(
+        {
+          idempotencyKey: `op-${i}`,
+          binding: installBinding(String(i).repeat(64).slice(0, 64)),
+          lockKey: 'lk',
+          source: SOURCE,
+        },
+        { root, now: T0 }
+      );
+      if (!b.ok) throw new Error('seed failed');
+      let e = transitionSkillOperation(b.entry, 'FS_COMMITTED', { receiptDigest }, { root, now: T0 });
+      e = transitionSkillOperation(e, 'INDEXED', {}, { root, now: T0 });
+      transitionSkillOperation(e, 'SUCCEEDED', { error: null }, { root, now: T0 });
+    }
+    expect(listSkillOperationJournal({ root })).toHaveLength(5);
+
+    reconcile(T0 + 10_000, 1000);
+
+    expect(listSkillOperationJournal({ root })).toHaveLength(0);
+    expect(existsSync(root)).toBe(true);
+    expect(receiptBytes.length).toBeGreaterThan(0);
+    // The receipt on disk is untouched by journal retention.
+    expect(readFileSync(join(worktreeDir, '.agents', 'skills', SKILL_ID, SKILL_RECEIPT_FILENAME)).length).toBe(
+      receiptBytes.length
+    );
+  });
+});

--- a/tests/unit/lib/skills/operation-journal.test.ts
+++ b/tests/unit/lib/skills/operation-journal.test.ts
@@ -17,6 +17,7 @@ import {
   hasSkillFilesystemCommit,
   isSkillOperationTerminal,
   listSkillOperationJournal,
+  pruneExpiredSkillOperationJournal,
   readSkillOperationJournal,
   transitionSkillOperation,
   type SkillOperationBinding,
@@ -298,5 +299,64 @@ describe('journal content is safe to persist', () => {
     begin({ idempotencyKey: 'k1' });
     writeFileSync(join(root, SKILL_JOURNAL_DIRNAME, 'garbage.json'), 'not json');
     expect(listSkillOperationJournal({ root })).toHaveLength(1);
+  });
+});
+
+describe('retention', () => {
+  function succeed(key: string, at: number): void {
+    const started = begin({ idempotencyKey: key });
+    if (!started.ok) throw new Error('seed failed');
+    let entry = transitionSkillOperation(started.entry, 'FS_COMMITTED', {}, { root, now: at });
+    entry = transitionSkillOperation(entry, 'INDEXED', {}, { root, now: at });
+    transitionSkillOperation(entry, 'SUCCEEDED', {}, { root, now: at });
+  }
+
+  it('collects terminal entries past the window and returns their keys', () => {
+    succeed('old', T0);
+    const pruned = pruneExpiredSkillOperationJournal({ root, now: T0 + 1_001, retentionMs: 1_000 });
+    expect(pruned).toEqual(['old']);
+    expect(readSkillOperationJournal('old', { root })).toBeNull();
+  });
+
+  it('keeps a terminal entry that is still inside the window', () => {
+    succeed('recent', T0);
+    const pruned = pruneExpiredSkillOperationJournal({ root, now: T0 + 999, retentionMs: 1_000 });
+    expect(pruned).toEqual([]);
+    expect(readSkillOperationJournal('recent', { root })?.state).toBe('SUCCEEDED');
+  });
+
+  it('never collects a FAILED_RECONCILABLE that still owes an index write', () => {
+    // Committed to the filesystem, then the DB write failed: non-terminal, the
+    // reconciler must still converge it, so retention must not delete it however
+    // old it is.
+    const started = begin({ idempotencyKey: 'committed-failure' });
+    if (!started.ok) throw new Error('seed failed');
+    const committed = transitionSkillOperation(started.entry, 'FS_COMMITTED', {}, { root, now: T0 });
+    const stalled = transitionSkillOperation(
+      committed,
+      'FAILED_RECONCILABLE',
+      { error: { code: 'SKILL_INDEX_FAILED', message: 'locked' } },
+      { root, now: T0 }
+    );
+    expect(isSkillOperationTerminal(stalled)).toBe(false);
+
+    const pruned = pruneExpiredSkillOperationJournal({ root, now: T0 + 10_000_000, retentionMs: 1_000 });
+    expect(pruned).toEqual([]);
+    expect(readSkillOperationJournal('committed-failure', { root })?.state).toBe('FAILED_RECONCILABLE');
+  });
+
+  it('collects a pre-commit rollback once it is past the window', () => {
+    const started = begin({ idempotencyKey: 'rolled-back' });
+    if (!started.ok) throw new Error('seed failed');
+    const failed = transitionSkillOperation(
+      started.entry,
+      'FAILED_RECONCILABLE',
+      { error: { code: 'SKILL_DOWNLOAD_FAILED', message: 'reset' } },
+      { root, now: T0 }
+    );
+    expect(isSkillOperationTerminal(failed)).toBe(true);
+
+    const pruned = pruneExpiredSkillOperationJournal({ root, now: T0 + 2_000, retentionMs: 1_000 });
+    expect(pruned).toEqual(['rolled-back']);
   });
 });


### PR DESCRIPTION
## 概要
Issue #1428 の対応。#1234 が実装した crash recovery（`reconcileSkillOperations` / `releaseOrphanSkillLocks`）を production 起動経路へ配線し、operation journal の retention を実装する。docs/user-guide/skills.md §3-8 の正式解消。

## 実装
1. **起動時 reconciliation 配線** — `src/lib/skills/startup-reconcile.ts`（新規）に `runSkillStartupReconciliation(db)` を実装し、`server.ts:196`（migration 完了後・listen 前）から呼ぶ。releaseOrphanSkillLocks → reconcileSkillOperations を production の port（payload probe / reindex）を注入して実行
2. **journal retention** — `pruneExpiredSkillOperationJournal` + `SKILL_JOURNAL_RETENTION_MS`（7日）。terminal entry を保持期限超過で削除。成功・失敗を同一 window とする方式を採用（SUCCEEDED 即時削除は遅延 retry が install 再実行 → spurious DESTINATION_EXISTS を招くため）。fs-commit 済み FAILED_RECONCILABLE は非 terminal なので対象外。監査 DB は append-only のまま
3. **route journal 一貫性** — pre-commit apply 失敗を consume 失敗と同様に journal 削除へ統一し、恒久 409 の穴を塞ぐ。post-commit 失敗は従来どおり

## Issue 記載からの訂正（commit message に記録、Issue 本文は未変更）
Issue は「reindex port は #1235 が実装済み」としていたが、実コードに receipt から index 行を再構築する reindex 関数は**存在しなかった**（#1235 提供は payload probe と upsert/delete のみ）。reindex を assembly 内に実装（disk 上 receipt を parse → upsert）。

## 検証（テストは production と同じ組み立て関数を経由）
- 受入条件の最重要点に従い、テストは library 関数直呼びではなく `runSkillStartupReconciliation` を経由して起動配線を通す
- tsc / build:server / build（Next.js）/ lint 0 errors / `CI=true` test:unit 11027 pass / 関連 integration（新規 skills-startup-reconcile 含む）全 pass

## rebase での相互作用対応（orchestrator 検証済み）
develop 統合時、同 Wave の #1430（migration v46 で skill_installations に FK 追加、foreign_keys=ON）と相互作用し、新規テストが親 worktrees 行未 seed で FK 違反。#1430 提供の `seedWorktreeRow()` を用いて seed を追加（テスト1ファイルのみ、実装コードは不変）。orchestrator が隔離 DB で 6/6 pass を独立確認。

Refs #1428