### PR TITLE
feat(skills): worktree導入済みSkill一覧API（GET /api/worktrees/[id]/skills） (#1440)

### DIFF
--- a/src/app/api/worktrees/[id]/skills/route.ts
+++ b/src/app/api/worktrees/[id]/skills/route.ts
@@ -1,0 +1,112 @@
+/**
+ * GET /api/worktrees/[id]/skills — list installed Skills in one worktree (Issue #1440)
+ *
+ * Read-only projection of the installed-Skill index (#1235). The worktree ID is
+ * the only input; it is resolved against the database to a trusted worktree, and
+ * the response carries only receipt/index-derived facts — never a machine-absolute
+ * path or an artifact URL, matching the Catalog and install DTO policy (#1231).
+ *
+ * The index is a forward-converging cache of what the receipts say (#1234); this
+ * route reports the index as-is and does not walk the filesystem, so it is the
+ * cheap read the #1441/#1442 UIs consume to show "what is installed here".
+ *
+ * @module api/worktrees/[id]/skills
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createLogger } from '@/lib/logger';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { resolveWorktreeOr404 } from '@/lib/git/git-route-worktree';
+import { listSkillInstallations } from '@/lib/skills/installed-state';
+import type { SkillInstallationRecord } from '@/lib/skills/installed-state';
+import { SKILL_API_NO_STORE_HEADERS, skillApiError } from '@/lib/api/skills-api';
+import type { SkillRiskLevel } from '@/types/skills';
+
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/worktrees/[id]/skills');
+
+/**
+ * One installed Skill as served to clients.
+ *
+ * Provenance and receipt facts only. `installRoot` is repository-relative
+ * (`.agents/skills/<id>`); no machine-absolute path and no artifact URL is ever
+ * included, so the shape a client sees can never name where on disk the server
+ * lives or where the bytes came from.
+ */
+export interface InstalledSkillDto {
+  skillId: string;
+  version: string;
+  /** Repository-relative install root, always `.agents/skills/<skill-id>`. */
+  installRoot: string;
+  /** Digest of the exact receipt bytes on disk. */
+  receiptSha256: string;
+  /** Digest of the verified artifact the receipt was written from. */
+  artifactSha256: string;
+  source: {
+    repository: string;
+    ref: string;
+    /** Resolved 40-hex commit SHA — the trusted per-release coordinate. */
+    commit: string;
+  };
+  /** The higher of declared and computed risk, as recorded at install time. */
+  effectiveRisk: SkillRiskLevel;
+  /** Epoch millis the install first committed. */
+  installedAt: number;
+  /** Epoch millis the index row last converged. */
+  updatedAt: number;
+}
+
+export interface InstalledSkillListResponse {
+  worktreeId: string;
+  skills: InstalledSkillDto[];
+}
+
+function toInstalledSkillDto(record: SkillInstallationRecord): InstalledSkillDto {
+  return {
+    skillId: record.skillId,
+    version: record.version,
+    installRoot: record.installRoot,
+    receiptSha256: record.receiptSha256,
+    artifactSha256: record.artifactSha256,
+    source: {
+      repository: record.sourceRepository,
+      ref: record.sourceRef,
+      commit: record.sourceCommit,
+    },
+    effectiveRisk: record.effectiveRisk,
+    installedAt: record.installedAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+
+    const worktree = resolveWorktreeOr404(id);
+    if (worktree instanceof NextResponse) return worktree;
+
+    const db = getDbInstance();
+    const records = listSkillInstallations(db, worktree.id);
+
+    const response: InstalledSkillListResponse = {
+      worktreeId: worktree.id,
+      skills: records.map(toInstalledSkillDto),
+    };
+    return NextResponse.json(response, { headers: SKILL_API_NO_STORE_HEADERS });
+  } catch (error) {
+    logger.error('skill-installed-list-failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return skillApiError(
+      'SKILL_INSTALLED_LIST_INTERNAL_ERROR',
+      'Failed to list installed Skills.',
+      500
+    );
+  }
+}

--- a/src/components/skills/skills-client.ts
+++ b/src/components/skills/skills-client.ts
@@ -14,6 +14,7 @@
  */
 
 import type {
+  InstalledSkillListResponse,
   SkillApiErrorResponse,
   SkillDetailResponse,
   SkillInstallApplyResponse,
@@ -151,6 +152,31 @@ export function fetchSkillDetail(
   return request(
     () => getJson<SkillDetailResponse>(`/api/skills/${encodeURIComponent(skillId)}`, signal),
     SKILL_CATALOG_UNREACHABLE,
+    signal
+  );
+}
+
+/**
+ * List the Skills installed in one worktree.
+ *
+ * Reads the installed-Skill index (#1235) through `GET /api/worktrees/[id]/skills`.
+ * The worktree ID is the only input; the server resolves it to a trusted path and
+ * returns receipt/index facts only — the browser never supplies or receives a
+ * filesystem path or artifact URL. A transport failure is a distinct result from
+ * an empty install list, so the UI can say "could not load" rather than render a
+ * reassuring empty state.
+ */
+export function fetchWorktreeInstalledSkills(
+  worktreeId: string,
+  signal?: AbortSignal
+): Promise<SkillFetchResult<InstalledSkillListResponse>> {
+  return request(
+    () =>
+      getJson<InstalledSkillListResponse>(
+        `/api/worktrees/${encodeURIComponent(worktreeId)}/skills`,
+        signal
+      ),
+    SKILL_REQUEST_FAILED,
     signal
   );
 }

--- a/src/components/skills/types.ts
+++ b/src/components/skills/types.ts
@@ -51,6 +51,10 @@ export type {
   SkillUninstallReplayResponse,
   SkillUninstallResponse,
 } from '@/app/api/worktrees/[id]/skills/[skillId]/uninstall/route';
+export type {
+  InstalledSkillDto,
+  InstalledSkillListResponse,
+} from '@/app/api/worktrees/[id]/skills/route';
 
 import type {
   SkillInstallReplayResponse,

--- a/tests/integration/api/skills-installed-list.test.ts
+++ b/tests/integration/api/skills-installed-list.test.ts
@@ -1,0 +1,204 @@
+/**
+ * API integration tests — installed-Skill list route (Issue #1440)
+ *
+ * The route projects the installed-Skill index (#1235) for one worktree. What is
+ * under test: it resolves the worktree from the database (never from the request),
+ * returns only receipt/index facts — never a machine-absolute path or artifact
+ * URL — and scopes the list to the requested worktree alone.
+ *
+ * Nothing here touches the network or the production database: a fresh in-memory
+ * SQLite database backs `listSkillInstallations`, and worktree resolution is
+ * mocked, so the test exercises the real index read through the route.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import { upsertSkillInstallation } from '@/lib/skills/installed-state';
+import type { SkillInstallReceipt } from '@/types/skills';
+import type { Worktree } from '@/types/models';
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn(),
+  })),
+  generateRequestId: vi.fn(() => 'test-request-id'),
+}));
+
+vi.mock('@/lib/db/db-instance', () => ({ getDbInstance: vi.fn() }));
+vi.mock('@/lib/db', () => ({ getWorktreeById: vi.fn() }));
+
+import { GET } from '@/app/api/worktrees/[id]/skills/route';
+import { getDbInstance } from '@/lib/db/db-instance';
+import { getWorktreeById } from '@/lib/db';
+
+const getDbInstanceMock = vi.mocked(getDbInstance);
+const getWorktreeByIdMock = vi.mocked(getWorktreeById);
+
+const T0 = 1_800_000_000_000;
+const WORKTREE_ID = 'demo-wt';
+const WORKTREE_PATH = `/tmp/cm-1440/repo/${WORKTREE_ID}`;
+
+let db: Database.Database;
+
+function makeReceipt(overrides: Partial<SkillInstallReceipt> = {}): SkillInstallReceipt {
+  return {
+    schema_version: 1,
+    skill_id: 'demo-skill',
+    version: '1.2.3',
+    install_root: '.agents/skills/demo-skill',
+    source: {
+      repository: 'Kewton/commandmate-skills',
+      ref: 'demo-skill-v1.2.3',
+      commit: 'b'.repeat(40),
+    },
+    artifact: {
+      asset_name: 'demo-skill-1.2.3.tar.gz',
+      sha256: 'c'.repeat(64),
+      size: 2048,
+      format: 'tar.gz',
+    },
+    files: [],
+    declared_risk: 'low',
+    computed_risk: 'low',
+    effective_risk: 'low',
+    declared_permissions: [],
+    agent_compatibility: [],
+    ...overrides,
+  };
+}
+
+/** Since #1430 an index row is tied to a live worktree, so the parent must exist. */
+function insertWorktree(id: string): void {
+  db.prepare(
+    `INSERT INTO worktrees (id, name, path, repository_path, repository_name)
+     VALUES (?, ?, ?, '/tmp/cm-1440/repo', 'repo')`
+  ).run(id, id, `/tmp/cm-1440/repo/${id}`);
+}
+
+function install(worktreeId: string, receipt: SkillInstallReceipt, operationId: string): void {
+  upsertSkillInstallation(db, {
+    worktreeId,
+    receipt,
+    receiptSha256: 'd'.repeat(64),
+    operationId,
+    installedAt: T0,
+  });
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: WORKTREE_ID,
+    name: 'feature/demo',
+    path: WORKTREE_PATH,
+    repositoryPath: '/tmp/cm-1440/repo',
+    repositoryName: 'repo',
+    branch: 'feature/demo',
+  };
+}
+
+function call(id: string = WORKTREE_ID) {
+  const request = new NextRequest(`http://localhost:3000/api/worktrees/${id}/skills`);
+  return GET(request, { params: Promise.resolve({ id }) });
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  runMigrations(db);
+  insertWorktree(WORKTREE_ID);
+  insertWorktree('other-wt');
+  vi.clearAllMocks();
+  getDbInstanceMock.mockReturnValue(db);
+  getWorktreeByIdMock.mockReturnValue(makeWorktree());
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe('GET /api/worktrees/[id]/skills', () => {
+  it('lists the Skills installed in the resolved worktree', async () => {
+    install(WORKTREE_ID, makeReceipt(), 'op-1');
+
+    const response = await call();
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.worktreeId).toBe(WORKTREE_ID);
+    expect(body.skills).toHaveLength(1);
+    expect(body.skills[0]).toEqual({
+      skillId: 'demo-skill',
+      version: '1.2.3',
+      installRoot: '.agents/skills/demo-skill',
+      receiptSha256: 'd'.repeat(64),
+      artifactSha256: 'c'.repeat(64),
+      source: {
+        repository: 'Kewton/commandmate-skills',
+        ref: 'demo-skill-v1.2.3',
+        commit: 'b'.repeat(40),
+      },
+      effectiveRisk: 'low',
+      installedAt: T0,
+      updatedAt: T0,
+    });
+    expect(response.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  it('resolves the worktree from the database, never from the request', async () => {
+    await call();
+    expect(getWorktreeByIdMock).toHaveBeenCalledWith(expect.anything(), WORKTREE_ID);
+  });
+
+  it('returns an empty list — not an error — when nothing is installed', async () => {
+    const response = await call();
+    expect(response.status).toBe(200);
+    expect((await response.json()).skills).toEqual([]);
+  });
+
+  it('scopes the list to the requested worktree', async () => {
+    install(WORKTREE_ID, makeReceipt({ skill_id: 'skill-a' }), 'op-a');
+    install(WORKTREE_ID, makeReceipt({ skill_id: 'skill-b' }), 'op-b');
+    install('other-wt', makeReceipt({ skill_id: 'skill-c' }), 'op-c');
+
+    const body = await (await call()).json();
+    expect(body.skills.map((s: { skillId: string }) => s.skillId)).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('leaks no absolute path or artifact URL into the response', async () => {
+    install(
+      WORKTREE_ID,
+      makeReceipt({
+        artifact: {
+          asset_name: 'demo-skill-1.2.3.tar.gz',
+          sha256: 'c'.repeat(64),
+          size: 2048,
+          format: 'tar.gz',
+        },
+      }),
+      'op-1'
+    );
+
+    const text = await (await call()).text();
+    expect(text).not.toContain(WORKTREE_PATH);
+    expect(text).not.toContain('http://');
+    expect(text).not.toContain('https://');
+  });
+
+  it('rejects an invalid worktree ID with 400 before any DB read', async () => {
+    const response = await call('../etc');
+    expect(response.status).toBe(400);
+    expect(getWorktreeByIdMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for an unregistered worktree', async () => {
+    getWorktreeByIdMock.mockReturnValue(undefined as unknown as Worktree);
+    expect((await call()).status).toBe(404);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1440 の対応。worktree 単位で導入済み Skill を列挙する `GET /api/worktrees/[id]/skills` を新設し、実装済みだが production 呼び出し元ゼロだった `listSkillInstallations()` を配線する。後続の #1441(PC) / #1442(モバイル) が消費する読み取り面の先行実装。

## 実装（4 ファイル / 1 commit）
- `src/app/api/worktrees/[id]/skills/route.ts`（新規）— `resolveWorktreeOr404` で worktree 解決 → `listSkillInstallations` を呼び、receipt/index 由来の DTO へ射影。**installRoot は repository-relative のみ、絶対 path・artifact URL は不含**。no-store ヘッダ、400/404/500
- `skills-client.ts` — `fetchWorktreeInstalledSkills` を追加（フロント到達可能）
- `types.ts` — `InstalledSkillDto` / `InstalledSkillListResponse` を route から re-export
- `tests/integration/api/skills-installed-list.test.ts`（新規）— in-memory DB（本番 cm.db・ネットワーク不使用）で list/empty/scope/no-leak/400/404/no-store を検証（7 件緑）

## 配線の自己検証（grep -a）
- `listSkillInstallations`: **呼び出し元ゼロ → route.ts:95 で解消**（本 Issue の主眼を達成、§3-2 の穴を実際に塞ぐ）
- `fetchWorktreeInstalledSkills`: 現状は定義のみ。消費側 UI は #1441/#1442（本 Issue 範囲外・直列計画どおり）

## 検証
- tsc 0 / eslint（変更ファイル）0 / test:unit 11087 pass / 新規 integration 7 pass / build exit 0（自 worktree 内）

Refs #1440