### PR TITLE
feat(skills): worktree詳細アクティビティバーにSkills管理を追加（PC） (#1441)

### DIFF
--- a/locales/en/skills.json
+++ b/locales/en/skills.json
@@ -277,6 +277,15 @@
     "provider": "by {provider}",
     "noRecommendedVersion": "No installable version"
   },
+  "worktreePane": {
+    "installedHeading": "Installed in this worktree",
+    "installedError": "The installed Skills for this worktree could not be loaded.",
+    "installedEmpty": "No Skills are installed in this worktree yet.",
+    "catalogHeading": "Install from the Catalog",
+    "installedBadge": "Installed",
+    "version": "Version {version}",
+    "back": "Back to Skills"
+  },
   "state": {
     "loading": "Loading the Skill Catalog…",
     "empty": "The official Catalog publishes no Skills yet.",

--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -588,7 +588,8 @@
     "schedules": "Schedules",
     "agent": "Agent",
     "timer": "Timer",
-    "todo": "ToDo"
+    "todo": "ToDo",
+    "skills": "Skills"
   },
   "branchMismatch": {
     "changedFrom": "Branch changed from",

--- a/locales/ja/skills.json
+++ b/locales/ja/skills.json
@@ -277,6 +277,15 @@
     "provider": "提供元: {provider}",
     "noRecommendedVersion": "導入可能なversionなし"
   },
+  "worktreePane": {
+    "installedHeading": "このワークツリーに導入済み",
+    "installedError": "このワークツリーの導入済みSkillを読み込めませんでした。",
+    "installedEmpty": "このワークツリーにはまだSkillが導入されていません。",
+    "catalogHeading": "Catalogから導入",
+    "installedBadge": "導入済み",
+    "version": "バージョン {version}",
+    "back": "Skill一覧へ戻る"
+  },
   "state": {
     "loading": "Skill Catalogを読み込んでいます…",
     "empty": "公式Catalogにはまだ公開されているSkillがありません。",

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -588,7 +588,8 @@
     "schedules": "スケジュール",
     "agent": "エージェント",
     "timer": "タイマー",
-    "todo": "ToDo"
+    "todo": "ToDo",
+    "skills": "スキル"
   },
   "branchMismatch": {
     "changedFrom": "ブランチが",

--- a/src/components/skills/SkillInstallPanel.tsx
+++ b/src/components/skills/SkillInstallPanel.tsx
@@ -21,7 +21,7 @@
 
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button, Card, Checkbox } from '@/components/ui';
 import { getCliToolDisplayNameSafe } from '@/lib/cli-tools/types';
@@ -162,11 +162,25 @@ export interface SkillInstallPanelProps {
    * one a user needs to be able to remove.
    */
   blockedReason: string | null;
+  /**
+   * Issue #1441: when set, the panel installs into exactly this worktree and the
+   * target picker is not rendered — the caller (e.g. the worktree detail Skills
+   * pane) already knows which checkout it is acting on. When omitted the panel
+   * keeps its original behavior and asks the user to pick a target.
+   */
+  worktreeId?: string;
 }
 
-export function SkillInstallPanel({ skillId, version, blockedReason }: SkillInstallPanelProps) {
+export function SkillInstallPanel({
+  skillId,
+  version,
+  blockedReason,
+  worktreeId: fixedWorktreeId,
+}: SkillInstallPanelProps) {
   const t = useTranslations('skills');
-  const [state, setState] = useState<PanelState>(INITIAL_STATE);
+  const [state, setState] = useState<PanelState>(() =>
+    fixedWorktreeId ? { ...INITIAL_STATE, worktreeId: fixedWorktreeId } : INITIAL_STATE
+  );
 
   const selectTarget = useCallback((worktreeId: string) => {
     setState((current) =>
@@ -175,6 +189,14 @@ export function SkillInstallPanel({ skillId, version, blockedReason }: SkillInst
         : clearOutcome({ ...current, worktreeId, busy: null })
     );
   }, []);
+
+  // Keep the fixed target in step if the caller swaps worktrees without
+  // remounting. Guarded so it is a no-op once state already holds it (the
+  // initializer set it on mount), which keeps the ordinary picker path — where
+  // fixedWorktreeId is undefined — completely untouched.
+  useEffect(() => {
+    if (fixedWorktreeId) selectTarget(fixedWorktreeId);
+  }, [fixedWorktreeId, selectTarget]);
 
   const buildInstallPlan = useCallback(async () => {
     const worktreeId = state.worktreeId;
@@ -265,11 +287,16 @@ export function SkillInstallPanel({ skillId, version, blockedReason }: SkillInst
 
   return (
     <div className="space-y-3" data-testid="skill-install-panel">
-      <SkillTargetSelector
-        selectedWorktreeId={state.worktreeId}
-        onSelect={selectTarget}
-        disabled={busy}
-      />
+      {/* Issue #1441: with a fixed worktreeId the caller has already chosen the
+          target, so the picker is suppressed and the panel acts on that worktree
+          directly. Without it, the original target-selection flow is preserved. */}
+      {!fixedWorktreeId && (
+        <SkillTargetSelector
+          selectedWorktreeId={state.worktreeId}
+          onSelect={selectTarget}
+          disabled={busy}
+        />
+      )}
 
       <div className="flex flex-wrap gap-2">
         <Button

--- a/src/components/skills/WorktreeSkillsPane.tsx
+++ b/src/components/skills/WorktreeSkillsPane.tsx
@@ -1,0 +1,309 @@
+/**
+ * WorktreeSkillsPane (Issue #1441)
+ *
+ * The worktree-scoped Skills surface: browse the official Catalog, see what is
+ * installed in *this* worktree, and install or uninstall a Skill without ever
+ * choosing a target — the worktree is already fixed by the screen it lives on.
+ *
+ * It is deliberately placed under `components/skills/` rather than
+ * `components/worktree/` so the PC Activity Bar pane (#1441) and the mobile
+ * surface (#1442) mount the same component; the only input either supplies is a
+ * `worktreeId`.
+ *
+ * The installed list is read through `fetchWorktreeInstalledSkills` (#1440), the
+ * one client the API exposes for "what is installed here" — nothing here walks
+ * the filesystem or invents its own request. Selecting a Skill hands off to
+ * {@link SkillInstallPanel} with the worktree fixed, so plan → preview → apply
+ * runs against exactly this checkout.
+ *
+ * @module components/skills/WorktreeSkillsPane
+ */
+
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ArrowLeft } from 'lucide-react';
+import { Badge, Button, Card, Skeleton } from '@/components/ui';
+import { SkillCompatibilityBadge, SkillRiskBadge } from './SkillBadges';
+import { SkillInstallPanel } from './SkillInstallPanel';
+import { SkillNotice } from './SkillNotice';
+import {
+  fetchSkillList,
+  fetchWorktreeInstalledSkills,
+  type SkillFetchFailure,
+} from './skills-client';
+import { headlineDeclaredRisk, resolveSkillMessageKey } from './skill-vocabulary';
+import type { InstalledSkillDto, SkillDto } from './types';
+
+interface CatalogState {
+  status: 'loading' | 'loaded' | 'error';
+  skills: SkillDto[];
+  failure: SkillFetchFailure | null;
+}
+
+interface InstalledState {
+  status: 'loading' | 'loaded' | 'error';
+  skills: InstalledSkillDto[];
+  failure: SkillFetchFailure | null;
+}
+
+const CATALOG_INITIAL: CatalogState = { status: 'loading', skills: [], failure: null };
+const INSTALLED_INITIAL: InstalledState = { status: 'loading', skills: [], failure: null };
+
+export interface WorktreeSkillsPaneProps {
+  /** The worktree every install/uninstall in this pane acts on. */
+  worktreeId: string;
+  className?: string;
+}
+
+export function WorktreeSkillsPane({ worktreeId, className = '' }: WorktreeSkillsPaneProps) {
+  const t = useTranslations('skills');
+  const [catalog, setCatalog] = useState<CatalogState>(CATALOG_INITIAL);
+  const [installed, setInstalled] = useState<InstalledState>(INSTALLED_INITIAL);
+  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [catalogReloadToken, setCatalogReloadToken] = useState(0);
+  const [installedReloadToken, setInstalledReloadToken] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setCatalog(CATALOG_INITIAL);
+
+    fetchSkillList(controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setCatalog(
+          result.ok
+            ? { status: 'loaded', skills: result.data.skills, failure: null }
+            : { status: 'error', skills: [], failure: result.failure }
+        );
+      })
+      .catch(() => {
+        // Only an abort reaches here; the request has no outcome to render.
+      });
+
+    return () => controller.abort();
+  }, [catalogReloadToken]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setInstalled(INSTALLED_INITIAL);
+
+    fetchWorktreeInstalledSkills(worktreeId, controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setInstalled(
+          result.ok
+            ? { status: 'loaded', skills: result.data.skills, failure: null }
+            : { status: 'error', skills: [], failure: result.failure }
+        );
+      })
+      .catch(() => {
+        // Only an abort reaches here; the request has no outcome to render.
+      });
+
+    return () => controller.abort();
+  }, [worktreeId, installedReloadToken]);
+
+  const installedIds = useMemo(
+    () => new Set(installed.skills.map((skill) => skill.skillId)),
+    [installed.skills]
+  );
+  const selectedCatalogSkill = useMemo(
+    () => catalog.skills.find((skill) => skill.id === selectedSkillId) ?? null,
+    [catalog.skills, selectedSkillId]
+  );
+  const selectedInstalledSkill = useMemo(
+    () => installed.skills.find((skill) => skill.skillId === selectedSkillId) ?? null,
+    [installed.skills, selectedSkillId]
+  );
+
+  // Detail view: hand the selected Skill off to the shared install/uninstall
+  // panel with this worktree fixed. Returning to the list re-reads the installed
+  // index so an apply that just happened is reflected.
+  if (selectedSkillId) {
+    const skill = selectedCatalogSkill;
+    const compatibility = skill?.compatibility ?? null;
+    const version = skill ? skill.recommendedVersion : (selectedInstalledSkill?.version ?? null);
+    // Mirror SkillDetailView: install is offered only from a present, confirmed
+    // compatible version; uninstall stays available regardless.
+    const blockedReason = skill
+      ? !skill.recommendedVersion
+        ? t('detail.install.blockedNoVersion')
+        : compatibility && compatibility.status !== 'compatible'
+          ? t('detail.install.blockedIncompatible', {
+              reason: t(resolveSkillMessageKey(compatibility.messageKey), {
+                range: compatibility.requiredRange,
+                currentVersion: compatibility.currentVersion ?? '',
+              }),
+            })
+          : null
+      : null;
+
+    return (
+      <div
+        className={`flex flex-col min-h-0 ${className}`.trim()}
+        data-testid="worktree-skills-pane"
+      >
+        <div className="flex items-center gap-2 border-b border-border p-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setSelectedSkillId(null);
+              setInstalledReloadToken((token) => token + 1);
+            }}
+            data-testid="worktree-skills-back"
+          >
+            <ArrowLeft size={14} aria-hidden="true" className="mr-1" />
+            {t('worktreePane.back')}
+          </Button>
+          <h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
+            {skill?.name ?? selectedSkillId}
+          </h2>
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto p-3">
+          <SkillInstallPanel
+            skillId={selectedSkillId}
+            version={version}
+            blockedReason={blockedReason}
+            worktreeId={worktreeId}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col min-h-0 ${className}`.trim()} data-testid="worktree-skills-pane">
+      <div className="min-h-0 flex-1 space-y-4 overflow-auto p-3">
+        <section className="space-y-2" data-testid="worktree-skills-installed">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('worktreePane.installedHeading')}
+          </h2>
+          {installed.status === 'loading' ? (
+            <Skeleton
+              className="h-16 w-full rounded-lg"
+              data-testid="worktree-skills-installed-loading"
+            />
+          ) : installed.status === 'error' ? (
+            <Card className="space-y-2" data-testid="worktree-skills-installed-error">
+              <SkillNotice tone="danger">
+                <p>{t('worktreePane.installedError')}</p>
+                <p className="mt-1 break-words">
+                  {t('state.errorCode', { code: installed.failure?.code ?? '' })}
+                </p>
+              </SkillNotice>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setInstalledReloadToken((token) => token + 1)}
+                data-testid="worktree-skills-installed-retry"
+              >
+                {t('state.retry')}
+              </Button>
+            </Card>
+          ) : installed.skills.length === 0 ? (
+            <Card data-testid="worktree-skills-installed-empty">
+              <p className="text-sm text-muted-foreground">{t('worktreePane.installedEmpty')}</p>
+            </Card>
+          ) : (
+            <ul className="space-y-2">
+              {installed.skills.map((skill) => (
+                <li key={skill.skillId}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedSkillId(skill.skillId)}
+                    data-testid={`worktree-skills-installed-${skill.skillId}`}
+                    className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="break-all text-sm font-semibold text-foreground">
+                        {skill.skillId}
+                      </span>
+                      <SkillRiskBadge risk={skill.effectiveRisk} />
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {t('worktreePane.version', { version: skill.version })}
+                    </p>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="space-y-2" data-testid="worktree-skills-catalog">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('worktreePane.catalogHeading')}
+          </h2>
+          {catalog.status === 'loading' ? (
+            <Skeleton
+              className="h-24 w-full rounded-lg"
+              data-testid="worktree-skills-catalog-loading"
+            />
+          ) : catalog.status === 'error' ? (
+            <Card className="space-y-2" data-testid="worktree-skills-catalog-error">
+              <SkillNotice tone="danger">
+                <p>{t('state.errorNotice')}</p>
+                <p className="mt-1 break-words">
+                  {t('state.errorCode', { code: catalog.failure?.code ?? '' })}
+                </p>
+              </SkillNotice>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setCatalogReloadToken((token) => token + 1)}
+                data-testid="worktree-skills-catalog-retry"
+              >
+                {t('state.retry')}
+              </Button>
+            </Card>
+          ) : catalog.skills.length === 0 ? (
+            <Card data-testid="worktree-skills-catalog-empty">
+              <p className="text-sm text-muted-foreground">{t('state.empty')}</p>
+            </Card>
+          ) : (
+            <ul className="space-y-2">
+              {catalog.skills.map((skill) => {
+                const declaredRisk = headlineDeclaredRisk(skill);
+                return (
+                  <li key={skill.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedSkillId(skill.id)}
+                      data-testid={`worktree-skills-catalog-${skill.id}`}
+                      className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="min-w-0 break-all text-sm font-semibold text-foreground">
+                          {skill.name}
+                        </span>
+                        {installedIds.has(skill.id) && (
+                          <Badge variant="info" data-testid={`worktree-skills-installed-badge-${skill.id}`}>
+                            {t('worktreePane.installedBadge')}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {t('card.provider', { provider: skill.provider.name })}
+                      </p>
+                      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                        {skill.compatibility && (
+                          <SkillCompatibilityBadge status={skill.compatibility.status} />
+                        )}
+                        {declaredRisk && <SkillRiskBadge risk={declaredRisk} />}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default WorktreeSkillsPane;

--- a/src/components/worktree/ActivityPane.tsx
+++ b/src/components/worktree/ActivityPane.tsx
@@ -48,6 +48,7 @@ const ERROR_BOUNDARY_NAMES: Record<ActivityId, string> = {
   agent: 'AgentSettingsPane',
   timer: 'TimerPane',
   todo: 'TodoPane',
+  skills: 'WorktreeSkillsPane',
 };
 
 export const ActivityPane = memo(function ActivityPane({

--- a/src/components/worktree/WorktreeDetailDesktop.tsx
+++ b/src/components/worktree/WorktreeDetailDesktop.tsx
@@ -42,6 +42,7 @@ import { ExecutionLogPane } from '@/components/worktree/ExecutionLogPane';
 import { TimerPane } from '@/components/worktree/TimerPane';
 import { AgentInstancesPane } from '@/components/worktree/AgentInstancesPane';
 import { GitPane } from '@/components/worktree/GitPane';
+import { WorktreeSkillsPane } from '@/components/skills/WorktreeSkillsPane';
 import { Modal } from '@/components/ui/Modal';
 import { BranchMismatchAlert } from '@/components/worktree/BranchMismatchAlert';
 import { MoveDialog } from '@/components/worktree/MoveDialog';
@@ -636,6 +637,10 @@ export const WorktreeDetailDesktop = memo(function WorktreeDetailDesktop({
       // would NOT be a tsc error — it would silently render an empty pane. Keep
       // both this map entry and `worktreeId` in the deps array below.
       todo: <TodoPane worktreeId={worktreeId} className="h-full" />,
+      // Issue #1441: worktree-scoped Skill install/uninstall. The pane is fixed
+      // to the parent-owned worktreeId, so it plans/installs against this
+      // checkout without a target picker.
+      skills: <WorktreeSkillsPane worktreeId={worktreeId} className="h-full" />,
     }),
     [
       worktreeId,

--- a/src/config/activity-bar-config.ts
+++ b/src/config/activity-bar-config.ts
@@ -13,12 +13,20 @@
  */
 
 import type { ComponentType, SVGProps } from 'react';
-import { File, GitBranch, StickyNote, Calendar, Bot, Timer, ListTodo } from 'lucide-react';
+import { File, GitBranch, StickyNote, Calendar, Bot, Timer, ListTodo, Sparkles } from 'lucide-react';
 
 /**
  * Unique identifier for an activity in the Activity Bar.
  */
-export type ActivityId = 'files' | 'git' | 'notes' | 'schedules' | 'agent' | 'timer' | 'todo';
+export type ActivityId =
+  | 'files'
+  | 'git'
+  | 'notes'
+  | 'schedules'
+  | 'agent'
+  | 'timer'
+  | 'todo'
+  | 'skills';
 
 /**
  * Metadata for a single Activity Bar icon.
@@ -53,6 +61,8 @@ export const ACTIVITIES: readonly ActivityDefinition[] = [
   { id: 'timer', labelKey: 'activityBar.timer', icon: Timer },
   // Issue #1015: branch-scoped ToDo list.
   { id: 'todo', labelKey: 'activityBar.todo', icon: ListTodo },
+  // Issue #1441: worktree-scoped Skill install/uninstall management.
+  { id: 'skills', labelKey: 'activityBar.skills', icon: Sparkles },
 ] as const;
 
 /**

--- a/tests/unit/components/skills/SkillInstallPanel.test.tsx
+++ b/tests/unit/components/skills/SkillInstallPanel.test.tsx
@@ -475,3 +475,57 @@ describe('SkillInstallPanel state hygiene', () => {
     expect(screen.queryByTestId('skill-operation-error')).not.toBeInTheDocument();
   });
 });
+
+// Issue #1441: the worktree detail Skills pane mounts the panel with the target
+// already fixed, so no picker is shown and no worktree list is fetched.
+describe('SkillInstallPanel fixed worktreeId (Issue #1441)', () => {
+  it('hides the target picker and never fetches the worktree list', async () => {
+    // No '/api/worktrees' route is defined: routeFetch throws on any unexpected
+    // request, so a stray picker fetch would fail the test loudly.
+    routeFetch({ '/plan': { body: { plan: makeInstallPlan() } } });
+
+    render(
+      <SkillInstallPanel
+        skillId="release-helper"
+        version="1.2.0"
+        blockedReason={null}
+        worktreeId="demo-wt"
+      />
+    );
+
+    // The picker is gone, and the plan can be built without selecting a target.
+    expect(screen.queryByTestId('skill-target-selector')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('skill-target-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('skill-install-action')).toBeEnabled();
+    expect(requestsTo('/api/worktrees')).toBe(0);
+  });
+
+  it('plans against the fixed worktree without a target selection', async () => {
+    routeFetch({
+      '/plan': { body: { plan: makeInstallPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(
+      <SkillInstallPanel
+        skillId="release-helper"
+        version="1.2.0"
+        blockedReason={null}
+        worktreeId="demo-wt"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    await screen.findByTestId('skill-install-plan');
+
+    const planCall = fetchMock.mock.calls.find((call: unknown[]) =>
+      (call[0] as string).endsWith('/plan')
+    );
+    expect(planCall?.[0]).toBe('/api/worktrees/demo-wt/skills/release-helper/plan');
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+    expect(await screen.findByTestId('skill-install-result')).toHaveTextContent(
+      'skills.install.nextAction.succeeded'
+    );
+  });
+});

--- a/tests/unit/components/skills/WorktreeSkillsPane.test.tsx
+++ b/tests/unit/components/skills/WorktreeSkillsPane.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * WorktreeSkillsPane (Issue #1441)
+ *
+ * The worktree-scoped Skills surface reused by the PC Activity Bar (#1441) and
+ * the mobile screen (#1442). These tests pin the wiring the Issue calls out:
+ * the installed list is read through the #1440 client (`fetchWorktreeInstalledSkills`,
+ * i.e. `GET /api/worktrees/[id]/skills`) rather than a hand-rolled fetch, and
+ * selecting a Skill drives {@link SkillInstallPanel} with the worktree fixed —
+ * no target picker, so plan/install runs against exactly this checkout.
+ *
+ * The fetch mock answers per URL, so a request to an unexpected route fails
+ * loudly rather than sliding past.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+  useTranslations:
+    (namespace?: string) =>
+    (key: string, params?: Record<string, string | number>) => {
+      const full = namespace ? `${namespace}.${key}` : key;
+      if (!params) return full;
+      const rendered = Object.entries(params)
+        .map(([name, value]) => `${name}=${value}`)
+        .join(',');
+      return `${full}(${rendered})`;
+    },
+  useLocale: () => 'en',
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { WorktreeSkillsPane } from '@/components/skills/WorktreeSkillsPane';
+import { makeCatalogMeta, makeSkill, makeInstallPlan, makeInstallResponse } from './fixtures';
+import type { InstalledSkillDto } from '@/components/skills/types';
+
+interface Route {
+  status?: number;
+  body: unknown;
+}
+
+const fetchMock = vi.fn();
+
+function routeFetch(routes: Record<string, Route>) {
+  fetchMock.mockImplementation(async (url: string) => {
+    const match = Object.keys(routes).find((suffix) => url.endsWith(suffix));
+    if (!match) throw new Error(`unexpected request: ${url}`);
+    const route = routes[match];
+    const status = route.status ?? 200;
+    return { ok: status < 400, status, json: async () => route.body } as unknown as Response;
+  });
+}
+
+function requestsTo(suffix: string): number {
+  return fetchMock.mock.calls.filter((call: unknown[]) =>
+    (call[0] as string).endsWith(suffix)
+  ).length;
+}
+
+function makeInstalled(overrides: Partial<InstalledSkillDto> = {}): InstalledSkillDto {
+  return {
+    skillId: 'release-helper',
+    version: '1.2.0',
+    installRoot: '.agents/skills/release-helper',
+    receiptSha256: 'c'.repeat(64),
+    artifactSha256: 'b'.repeat(64),
+    source: { repository: 'Kewton/commandmate-skills', ref: 'v1.2.0', commit: 'a'.repeat(40) },
+    effectiveRisk: 'low',
+    installedAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+const CATALOG = { body: { catalog: makeCatalogMeta(), skills: [makeSkill()] } };
+const INSTALLED = { body: { worktreeId: 'wt-1', skills: [makeInstalled()] } };
+const INSTALLED_EMPTY = { body: { worktreeId: 'wt-1', skills: [] } };
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('WorktreeSkillsPane list', () => {
+  it('reads the installed list through the #1440 worktree endpoint', async () => {
+    routeFetch({ '/api/skills': CATALOG, '/api/worktrees/wt-1/skills': INSTALLED });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    // The installed section is populated from GET /api/worktrees/wt-1/skills,
+    // not a bespoke fetch — this is the wiring #1441 must not leave dangling.
+    await screen.findByTestId('worktree-skills-installed-release-helper');
+    expect(requestsTo('/api/worktrees/wt-1/skills')).toBe(1);
+    expect(
+      screen.getByTestId('worktree-skills-installed-release-helper')
+    ).toHaveTextContent('version=1.2.0');
+  });
+
+  it('renders the Catalog list from GET /api/skills', async () => {
+    routeFetch({ '/api/skills': CATALOG, '/api/worktrees/wt-1/skills': INSTALLED_EMPTY });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    expect(await screen.findByTestId('worktree-skills-catalog-release-helper')).toHaveTextContent(
+      'Release Helper'
+    );
+    expect(screen.getByTestId('worktree-skills-installed-empty')).toBeInTheDocument();
+  });
+
+  it('surfaces an installed-list failure without falling back to an empty list', async () => {
+    routeFetch({
+      '/api/skills': CATALOG,
+      '/api/worktrees/wt-1/skills': {
+        status: 500,
+        body: { error: 'boom', code: 'SKILL_INSTALLED_LIST_INTERNAL_ERROR' },
+      },
+    });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    const error = await screen.findByTestId('worktree-skills-installed-error');
+    expect(error).toHaveTextContent('SKILL_INSTALLED_LIST_INTERNAL_ERROR');
+    expect(screen.queryByTestId('worktree-skills-installed-empty')).not.toBeInTheDocument();
+  });
+});
+
+describe('WorktreeSkillsPane detail', () => {
+  it('installs into the fixed worktree with no target picker', async () => {
+    routeFetch({
+      '/api/skills': CATALOG,
+      '/api/worktrees/wt-1/skills': INSTALLED_EMPTY,
+      '/plan': { body: { plan: makeInstallPlan() } },
+      '/install': { body: makeInstallResponse() },
+    });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    fireEvent.click(await screen.findByTestId('worktree-skills-catalog-release-helper'));
+
+    // The shared install panel is mounted, but its target selector is not: the
+    // worktree is fixed by the pane, so plan/install runs against wt-1 directly.
+    const panel = await screen.findByTestId('skill-install-panel');
+    expect(panel).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-target-selector')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('skill-install-action'));
+    await screen.findByTestId('skill-install-plan');
+
+    const planCall = fetchMock.mock.calls.find((call: unknown[]) =>
+      (call[0] as string).endsWith('/plan')
+    );
+    expect(planCall?.[0]).toBe('/api/worktrees/wt-1/skills/release-helper/plan');
+
+    fireEvent.click(screen.getByTestId('skill-install-confirm'));
+    expect(await screen.findByTestId('skill-install-result')).toHaveTextContent(
+      'skills.install.nextAction.succeeded'
+    );
+  });
+
+  it('returns to the list and re-reads the installed index', async () => {
+    routeFetch({ '/api/skills': CATALOG, '/api/worktrees/wt-1/skills': INSTALLED });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    fireEvent.click(await screen.findByTestId('worktree-skills-catalog-release-helper'));
+    await screen.findByTestId('skill-install-panel');
+
+    fireEvent.click(screen.getByTestId('worktree-skills-back'));
+
+    // Back on the list, and the installed endpoint was polled again on return.
+    await screen.findByTestId('worktree-skills-catalog-release-helper');
+    await waitFor(() => expect(requestsTo('/api/worktrees/wt-1/skills')).toBe(2));
+  });
+});

--- a/tests/unit/components/worktree/ActivityBar.test.tsx
+++ b/tests/unit/components/worktree/ActivityBar.test.tsx
@@ -32,11 +32,11 @@ describe('ActivityBar', () => {
     sidebarMock.isOpen = true;
   });
 
-  it('renders all 7 activity tabs', () => {
+  it('renders all 8 activity tabs', () => {
     render(<ActivityBar active="files" onToggle={() => {}} />);
     const tabs = screen.getAllByRole('tab');
     expect(tabs).toHaveLength(ACTIVITIES.length);
-    expect(tabs).toHaveLength(7);
+    expect(tabs).toHaveLength(8);
   });
 
   it('renders with role="tablist" and aria-orientation="vertical"', () => {
@@ -170,14 +170,14 @@ describe('ActivityBar', () => {
       );
     });
 
-    it('is NOT a tab and lives outside the tablist (tab count stays 7)', () => {
+    it('is NOT a tab and lives outside the tablist (tab count stays 8)', () => {
       render(<ActivityBar active="files" onToggle={() => {}} />);
       const toggle = screen.getByTestId('activity-bar-toggle-sidebar');
       // Regression guard: keeping the toggle out of the tablist preserves the
       // roving-tabindex keyboard navigation and the WAI-ARIA tab count.
       expect(toggle).not.toHaveAttribute('role', 'tab');
       expect(screen.getByRole('tablist')).not.toContainElement(toggle);
-      expect(screen.getAllByRole('tab')).toHaveLength(7);
+      expect(screen.getAllByRole('tab')).toHaveLength(8);
     });
 
     it('does not trigger the activity onToggle when the sidebar toggle is clicked', () => {

--- a/tests/unit/i18n/worktree-git-panels-keys.test.ts
+++ b/tests/unit/i18n/worktree-git-panels-keys.test.ts
@@ -72,6 +72,7 @@ const DYNAMIC: Record<string, string[]> = {
     'activityBar.agent',
     'activityBar.timer',
     'activityBar.todo',
+    'activityBar.skills',
     // WorktreeInfoFields / DesktopHeader <- WORKTREE_STATUS_OPTIONS[].labelKey
     'worktreeStatus.notSet',
     'worktreeStatus.ready',


### PR DESCRIPTION
## 概要
Issue #1441 の対応。worktree 詳細画面の VS Code 風アクティビティバーに 8 個目「Skills」を追加し、その worktree に対する導入済み一覧・install・uninstall をペインで管理できるようにする（PC）。後続 #1442（モバイル）が再利用する共通コンポーネントもここで作る。

## 実装（13 ファイル / 1 commit）
- **共通コンポーネント**（#1442 が再利用）:
  - `src/components/skills/WorktreeSkillsPane.tsx`（新規）— Catalog 一覧 + 導入済み一覧 + install/uninstall。**`skills/` 配下に切り出し**てモバイルからも再利用可能に
  - `SkillInstallPanel.tsx` に `worktreeId?` 固定 prop を追加。指定時は SkillTargetSelector を出さず渡された worktree で動作、**未指定時は従来の picker 挙動を維持**（既存 /skills を壊さない）
- **アクティビティバー配線**: `activity-bar-config.ts`（ActivityId union + ACTIVITIES + Lucide アイコン）/ `ActivityPane.tsx`（ERROR_BOUNDARY_NAMES、tsc 強制）/ `WorktreeDetailDesktop.tsx`（activityContent.skills）/ `locales/{en,ja}/worktree.json`（activityBar.skills）
- 導入済み一覧は **#1440 の `fetchWorktreeInstalledSkills` を実際に呼ぶ**（`WorktreeSkillsPane.tsx:92`、自前 fetch なし）
- テスト: WorktreeSkillsPane / SkillInstallPanel（固定 prop）/ ActivityBar（7→8）

## 配線の自己検証（grep -a）
ライブチェーンを確認: `WorktreeDetailRefactored → WorktreeDetailDesktop → activityContent.skills → WorktreeSkillsPane → SkillInstallPanel(worktreeId) / fetchWorktreeInstalledSkills`

## E2E 破壊予防（前回 #1428 の教訓）
- ワーカーが `tsx server.ts`（隔離ポート/DB）で `/`・`/worktrees/[id]`（新ペインをコンパイル）・`/skills` が全て 200、ALS エラーなしを確認
- **orchestrator も dev モードで独立再確認**: `base=200` / `skills=200`、ALS クラッシュなし

## 検証
- tsc 0 / eslint 0（既存 warning 4 は無関係）/ test:unit 11094 pass（CI=true）/ build exit 0 / control-char guard pass（自 worktree 内）

Refs #1441