### PR TITLE
feat(skills): モバイルTools「Skills」サブタブ追加・横スライド化 (#1442)

### DIFF
--- a/locales/en/schedule.json
+++ b/locales/en/schedule.json
@@ -135,6 +135,7 @@
   },
   "timerTab": "Timer",
   "todoTab": "ToDo",
+  "skillsTab": "Skills",
   "timer": {
     "title": "Delayed Messages",
     "titleCreate": "New Timer",

--- a/locales/ja/schedule.json
+++ b/locales/ja/schedule.json
@@ -135,6 +135,7 @@
   },
   "timerTab": "Timer",
   "todoTab": "ToDo",
+  "skillsTab": "Skills",
   "timer": {
     "title": "遅延メッセージ",
     "titleCreate": "タイマー作成",

--- a/src/components/worktree/NotesAndLogsPane.tsx
+++ b/src/components/worktree/NotesAndLogsPane.tsx
@@ -19,14 +19,15 @@ import { ExecutionLogPane } from './ExecutionLogPane';
 import { AgentSettingsPane } from './AgentSettingsPane';
 import { MobileAgentInstancesPane } from './MobileAgentInstancesPane';
 import { TimerPane } from './TimerPane';
+import { WorktreeSkillsPane } from '@/components/skills/WorktreeSkillsPane';
 import type { AgentInstance, CLIToolType } from '@/lib/cli-tools/types';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-/** Issue #368: Extended with 'agent' sub-tab. Issue #534: Extended with 'timer' sub-tab. Issue #1015: 'todo' sub-tab */
-type SubTab = 'notes' | 'logs' | 'agent' | 'timer' | 'todo';
+/** Issue #368: Extended with 'agent' sub-tab. Issue #534: Extended with 'timer' sub-tab. Issue #1015: 'todo' sub-tab. Issue #1442: 'skills' sub-tab (mobile) */
+type SubTab = 'notes' | 'logs' | 'agent' | 'timer' | 'todo' | 'skills';
 
 /** Configuration for a sub-tab button */
 interface SubTabConfig {
@@ -89,6 +90,9 @@ const SUB_TABS: readonly SubTabConfig[] = [
   // Issue #1015: branch-scoped ToDo list. Label resolves from schedule.json
   // `todoTab` (added to BOTH en and ja, [S3-003]).
   { id: 'todo', labelKey: 'todoTab' },
+  // Issue #1442: worktree-scoped Skills surface (mobile). Reuses the PC pane
+  // (#1441). Label resolves from schedule.json `skillsTab` (BOTH en and ja).
+  { id: 'skills', labelKey: 'skillsTab' },
 ] as const;
 
 /** CSS class for the active sub-tab button */
@@ -129,14 +133,21 @@ export const NotesAndLogsPane = memo(function NotesAndLogsPane({
 
   return (
     <div className={`flex flex-col h-full ${className}`}>
-      {/* Sub-tab switcher */}
-      <div className="flex border-b border-border bg-surface dark:bg-surface-2 flex-shrink-0">
+      {/* Sub-tab switcher. Issue #1442: six tabs no longer fit a `flex-1`
+          equal-split on narrow (≈320px) mobile widths, so the row scrolls
+          horizontally (`overflow-x-auto scrollbar-hide`, mirroring the
+          agent-instance tabs in WorktreeDetailRefactored) and each button stays
+          at its natural width (`flex-shrink-0 whitespace-nowrap`) instead of
+          being squeezed/wrapped. `scrollbar-hide` is defined in globals.css.
+          Tabs use plain `onClick` with no hover-gated visibility, so every tab
+          stays tappable on touch devices. */}
+      <div className="flex overflow-x-auto scrollbar-hide border-b border-border bg-surface dark:bg-surface-2 flex-shrink-0">
         {SUB_TABS.map((tab) => (
           <button
             key={tab.id}
             type="button"
             onClick={() => handleSubTabChange(tab.id)}
-            className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+            className={`flex-shrink-0 whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors ${
               activeSubTab === tab.id ? ACTIVE_TAB_CLASS : INACTIVE_TAB_CLASS
             }`}
           >
@@ -197,6 +208,11 @@ export const NotesAndLogsPane = memo(function NotesAndLogsPane({
         )}
         {activeSubTab === 'todo' && (
           <TodoPane worktreeId={worktreeId} className="h-full" />
+        )}
+        {/* Issue #1442: same worktree-scoped Skills pane the PC Activity Bar
+            mounts (#1441); the worktree is fixed by this screen. */}
+        {activeSubTab === 'skills' && (
+          <WorktreeSkillsPane worktreeId={worktreeId} className="h-full" />
         )}
       </div>
     </div>

--- a/tests/unit/components/worktree/NotesAndLogsPane.test.tsx
+++ b/tests/unit/components/worktree/NotesAndLogsPane.test.tsx
@@ -2,6 +2,7 @@
  * Tests for NotesAndLogsPane extension
  * Issue #368: Adds 'agent' sub-tab for Agent settings
  * Issue #874: Adds instance-management mode (mobile) for the 'agent' sub-tab
+ * Issue #1442: Adds 'skills' sub-tab (mobile) + horizontal-scroll tab row
  * @vitest-environment jsdom
  */
 
@@ -29,6 +30,12 @@ vi.mock('@/components/worktree/ExecutionLogPane', () => ({
 vi.mock('@/components/worktree/AgentSettingsPane', () => ({
   AgentSettingsPane: ({ worktreeId }: { worktreeId: string }) => (
     <div data-testid="agent-settings-pane">AgentSettingsPane: {worktreeId}</div>
+  ),
+}));
+
+vi.mock('@/components/skills/WorktreeSkillsPane', () => ({
+  WorktreeSkillsPane: ({ worktreeId }: { worktreeId: string }) => (
+    <div data-testid="worktree-skills-pane">WorktreeSkillsPane: {worktreeId}</div>
   ),
 }));
 
@@ -80,6 +87,54 @@ describe('NotesAndLogsPane', () => {
       render(<NotesAndLogsPane {...defaultProps} />);
       expect(screen.getByText('schedule.agentTab')).toBeDefined();
     });
+
+    // Issue #1442
+    it('should render Skills tab', () => {
+      render(<NotesAndLogsPane {...defaultProps} />);
+      expect(screen.getByText('schedule.skillsTab')).toBeDefined();
+    });
+  });
+
+  // Issue #1442: six sub-tabs must remain fully reachable on ~320px mobile
+  // widths. The row scrolls horizontally instead of squeezing/wrapping tabs, so
+  // the container carries the scroll classes and every tab keeps its natural
+  // width (never `flex-1`, never wrapping).
+  describe('Narrow-width tab layout (Issue #1442)', () => {
+    const TAB_LABELS = [
+      'schedule.notes',
+      'schedule.logs',
+      'schedule.agentTab',
+      'schedule.timerTab',
+      'schedule.todoTab',
+      'schedule.skillsTab',
+    ];
+
+    it('renders all six sub-tabs', () => {
+      render(<NotesAndLogsPane {...defaultProps} />);
+      for (const label of TAB_LABELS) {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      }
+    });
+
+    it('lays the tab row out as a horizontal scroller (no equal-split squeeze)', () => {
+      render(<NotesAndLogsPane {...defaultProps} />);
+      // The row is the shared parent of every tab button.
+      const row = screen.getByText('schedule.notes').parentElement as HTMLElement;
+      expect(row.className).toContain('overflow-x-auto');
+      expect(row.className).toContain('scrollbar-hide');
+      expect(row.className).not.toContain('flex-1');
+    });
+
+    it('keeps every tab at its natural width so labels never wrap or truncate', () => {
+      render(<NotesAndLogsPane {...defaultProps} />);
+      for (const label of TAB_LABELS) {
+        const button = screen.getByText(label).closest('button') as HTMLElement;
+        expect(button.className).toContain('flex-shrink-0');
+        expect(button.className).toContain('whitespace-nowrap');
+        // The old equal-split layout would starve tabs on narrow screens.
+        expect(button.className).not.toContain('flex-1');
+      }
+    });
   });
 
   describe('Insert to message propagation (Issue #485)', () => {
@@ -114,6 +169,17 @@ describe('NotesAndLogsPane', () => {
       render(<NotesAndLogsPane {...defaultProps} />);
       fireEvent.click(screen.getByText('schedule.agentTab'));
       expect(screen.getByTestId('agent-settings-pane')).toBeDefined();
+    });
+
+    // Issue #1442: the skills tab mounts the shared worktree-scoped Skills pane
+    // (#1441) with this screen's worktree fixed.
+    it('should show WorktreeSkillsPane (with this worktreeId) when skills tab is clicked', () => {
+      render(<NotesAndLogsPane {...defaultProps} />);
+      expect(screen.queryByTestId('worktree-skills-pane')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('schedule.skillsTab'));
+      const pane = screen.getByTestId('worktree-skills-pane');
+      expect(pane).toBeInTheDocument();
+      expect(pane.textContent).toContain('test-worktree');
     });
   });
 

--- a/tests/unit/i18n/skills-tab-keys.test.ts
+++ b/tests/unit/i18n/skills-tab-keys.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the mobile Skills sub-tab i18n key (Issue #1442).
+ *
+ * The mobile Tools `Skills` sub-tab label resolves via `t('skillsTab')` in the
+ * `schedule` namespace (NotesAndLogsPane). `src/i18n.ts` has no onError /
+ * getMessageFallback, so a missing ja key would surface the raw key string in
+ * production and go undetected in CI. This test enforces en/ja parity for
+ * `skillsTab`, mirroring the todoTab parity test (Issue #1015).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const LOCALES_DIR = path.resolve(__dirname, '../../../locales');
+
+function loadSchedule(locale: string): Record<string, string> {
+  const filePath = path.join(LOCALES_DIR, locale, 'schedule.json');
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+describe('Skills sub-tab i18n key (Issue #1442)', () => {
+  it('en/schedule.json contains skillsTab', () => {
+    const en = loadSchedule('en');
+    expect(en.skillsTab).toBeTruthy();
+  });
+
+  it('ja/schedule.json contains skillsTab', () => {
+    const ja = loadSchedule('ja');
+    expect(ja.skillsTab).toBeTruthy();
+  });
+
+  it('skillsTab exists in both locales (parity)', () => {
+    const en = loadSchedule('en');
+    const ja = loadSchedule('ja');
+    expect(en).toHaveProperty('skillsTab');
+    expect(ja).toHaveProperty('skillsTab');
+  });
+});


### PR DESCRIPTION
## 概要
Issue #1442 の対応。モバイルの worktree 詳細「Tools」（NotesAndLogsPane）のサブタブに「Skills」を追加し、Note/Schedules/Agent/Timer/ToDo/Skills の 6 個を横スライド（横スクロール）で選べるようにする。#1441 の共通コンポーネントを再利用。

## 実装（5 ファイル / 1 commit）
- `NotesAndLogsPane.tsx`:
  - `SUB_TABS` に `skills` を追加（SubTab union・content switch も）
  - サブタブ行を `flex-1` 等分割 → **`overflow-x-auto scrollbar-hide` + 各ボタン `flex-shrink-0 whitespace-nowrap`** に変更（6 個が潰れず横スクロール。流用元 `WorktreeDetailRefactored.tsx:499-524`）
  - skills サブタブ内容として **#1441 の `WorktreeSkillsPane` を再利用**（この画面の `worktreeId` を渡す、`:215`）
- `locales/{en,ja}/schedule.json`: `skillsTab` 追加（en/ja パリティ）
- テスト: skills タブ描画/切替、320px 相当の横スクロールレイアウト固定（`flex-1` 不使用を検証）、`skillsTab` の en/ja パリティ

## 直列戦略の帰結（共通コンポーネント再利用）
`WorktreeSkillsPane.tsx` と `SkillInstallPanel` の worktreeId prop は #1441 が作成済みで、本 PR は**一切変更していない**（再利用のみ）。そのため変更は 5 ファイルとコンパクト。

## 配線の自己検証（grep -a）
本番マウント連鎖: `WorktreeSkillsPane → NotesAndLogsPane(:22 import, :215 描画) → WorktreeDetailMobile(:403) → WorktreeDetailRefactored(:71 MobileContent)`

## タッチ端末対応
サブタブは `onClick` のみで hover 依存の可視化を使わない（横スクロール含め全タブがタッチで操作可能）。

## E2E 破壊予防（前回 #1428 の教訓）
- ワーカー: 隔離ポート/DB で `NODE_ENV=development tsx server.ts` 起動 → `/`・`/worktrees/<id>` が 200
- **orchestrator も dev モードで独立再確認**: `base=200`、ALS クラッシュなし

## 検証
- tsc 0 / eslint（変更ファイル）0 / 対象+i18n+skills テスト 308 pass / build exit 0 / control-char guard pass（自 worktree 内）

Refs #1442