### PR TITLE
chore: gitignore /skills/（skill操作のランタイム状態）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ db.sqlite-journal
 server.log
 .claude_logs/
 /data/
+# Skill operation journal/locks/staging (Issue #1234). In local dev getConfigDir()
+# resolves to the repo cwd, so this service-owned runtime state lands at the repo root.
+/skills/
 /temp/
 /workspace/
 .playwright-mcp/


### PR DESCRIPTION
`#1234` が追加した skill 操作の journal / locks / staging 状態ディレクトリが `.gitignore` に未登録で、local dev サーバー起動時に repo 直下へ未追跡の `skills/` が出る問題を修正。

## 背景
- `getConfigDir()`（#119）は global install で `~/.commandmate`、**local（repo で `npm start`）では `process.cwd()`＝repo 直下**を返す。
- skill operation store（#1234）の状態 root は `getConfigDir()/skills`。よって local dev では `<repo>/skills`（journal/locks/staging）に service-owned ランタイム状態が出る。
- `data/`・`logs/`・`.commandmate/` は既に ignore 済みだが **`skills/` だけ未登録**だった（tracked 0 件）。

## 変更
- `.gitignore` に `/skills/` を追加（理由コメント付き）。

## 安全性
- `skills/` は tracked 0 件の純粋なランタイム状態（操作ジャーナル、secret なし・redaction 済み）。
- CommandMate の skill ソースは `src/lib/skills/` であり `/skills/`（root 限定）とは別物。
- `git check-ignore skills/` が IGNORED を返すことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaeUCbHKK4RHrGM3x3wtkD