### PR TITLE
chore(release): v0.12.0（バージョンbumpとCHANGELOG確定）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-22
+
 ### Added
 
 - **Agent Skills 配布契約（Skill manifest・Catalog・receipt・脅威モデル）を定義** (#1228): SKILL.md との互換性を保ったまま、CommandMate 固有の配布・Runtime metadata を同一 Skill root の `commandmate.skill.yaml` に分離する契約を確定した。`src/types/skills.ts` に4文書（manifest / Catalog / 検査結果 / installed receipt）の型、`src/lib/skills/` に schema_version 1 の fail-closed validator・厳格 SemVer 2.0・公開 JSON Schema・エラーコードを追加。Skill ID は lowercase ASCII slug（最大64文字・予約名・case/Unicode 衝突検出）、artifact は `tar.gz` / `<skill-id>-<version>.tar.gz` / `application/gzip` に固定（archive root は root 省略・`<skill-id>`・`<skill-id>-<version>` の3形のみ受理）、artifact 全体の SHA-256 は Catalog、個別 payload file の digest は manifest が持ち manifest 自身の digest は要求しない。tag ではなく resolved commit SHA を必須とし、receipt は timestamp・actor・machine absolute path・signed URL を持たない決定的な文書とした。権限は宣言であって enforcement ではないことを命名（`declared_permissions` / `declared_risk`）と UI 注記で区別し、実効 risk は宣言と算出の高い方とする。決定表と脅威モデルは [docs/design/agent-skills-distribution.md](./docs/design/agent-skills-distribution.md)、valid/invalid fixture は `tests/fixtures/skills/contract/` に置いた。本 Issue は契約定義のみで、Catalog 取得・download・install・UI は含まない。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
リリース v0.12.0 のための version bump（0.11.4→0.12.0）と CHANGELOG 確定（[Unreleased]→[0.12.0] - 2026-07-22）。

このマージ後、develop→main PR #1465 が本 bump を含むので、#1465 を squash マージ → tag v0.12.0 / GitHub Release 作成（publish.yml が npm publish をトリガー）→ main を develop へ backmerge、の順でリリースします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaeUCbHKK4RHrGM3x3wtkD