### PR TITLE
fix: submit検証つき共通送信ヘルパで貼り付けEnter吸収を解消 (#1469 #1470 #1471)

### DIFF
--- a/src/app/api/worktrees/[id]/terminal/route.ts
+++ b/src/app/api/worktrees/[id]/terminal/route.ts
@@ -18,6 +18,7 @@ import { getWorktreeById } from '@/lib/db';
 import { getDbInstance } from '@/lib/db/db-instance';
 import { hasSession, sendKeys, sendSpecialKeys } from '@/lib/tmux/tmux';
 import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
+import { sendMessageWithSubmitVerification } from '@/lib/cli-tools/submit-verified-sender';
 import { createLogger } from '@/lib/logger';
 import { COPILOT_SEND_ENTER_DELAY_MS } from '@/config/copilot-constants';
 
@@ -80,7 +81,7 @@ export async function POST(
       );
     }
 
-    // Send command to tmux session via sendKeys (non-blocking for all tools)
+    // Send command to tmux session (non-blocking for all tools).
     // Note: copilot sendMessage() was reverted due to waitForPrompt blocking issues (#559)
     if (cliToolId === 'copilot') {
       // Copilot CLI auto-enters multi-line mode when text exceeds pane width.
@@ -92,7 +93,21 @@ export async function POST(
       await new Promise(resolve => setTimeout(resolve, COPILOT_SEND_ENTER_DELAY_MS));
       await sendSpecialKeys(sessionName, ['Enter']);
     } else {
-      await sendKeys(sessionName, command);
+      // Issue #1470: the old `sendKeys(command)` batched body+C-m into a single
+      // send-keys, which TUIs (claude/codex/gemini/opencode/vibe-local/antigravity)
+      // treat as a bracketed paste that swallows the Enter — typed but unsent, yet
+      // this route still returned { success: true }. Delegate to the shared
+      // submit-verified helper so the body and Enter are separated and the submit
+      // is read-back verified. A bounded, quick verify profile keeps the route
+      // non-blocking (it must not re-introduce waitForPrompt-style blocking, #559);
+      // if submit cannot be confirmed the helper throws -> 500 (never a false success).
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message: command,
+        cliToolId,
+        verifyAttempts: 2,
+        verifyDelayMs: 200,
+      });
     }
 
     // Issue #405: Invalidate cache after sending command

--- a/src/lib/cli-tools/antigravity.ts
+++ b/src/lib/cli-tools/antigravity.ts
@@ -19,14 +19,12 @@ import {
   sendSpecialKey,
   capturePane,
 } from '../tmux/tmux';
-import { detectAndResendIfPastedText } from '../pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './submit-verified-sender';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
 import { stripAnsi } from '../detection/cli-patterns';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
-  TUI_TEXT_INPUT_WAIT_MS,
-  TUI_MESSAGE_PROCESSED_WAIT_MS,
   TUI_EXIT_WAIT_MS,
 } from '@/config/cli-tool-timing-config';
 
@@ -261,22 +259,13 @@ export class AntigravityTool extends BaseCLITool {
       // Verify agy is at a ready prompt before sending
       await this.waitForPrompt(sessionName);
 
-      // Send message text (without Enter)
-      await sendKeys(sessionName, message, false);
-
-      // Wait a moment for the text to be typed
-      await new Promise((resolve) => setTimeout(resolve, TUI_TEXT_INPUT_WAIT_MS));
-
-      // Send Enter key separately
-      await sendSpecialKey(sessionName, 'C-m');
-
-      // Wait a moment for the message to be processed
-      await new Promise((resolve) => setTimeout(resolve, TUI_MESSAGE_PROCESSED_WAIT_MS));
-
-      // Detect [Pasted text] and resend Enter for multi-line messages
-      if (message.includes('\n')) {
-        await detectAndResendIfPastedText(sessionName);
-      }
+      // Issue #1471: Body/Enter separation + read-back submit verification via the
+      // shared helper (replaces the old type -> C-m -> `\n`-gated paste recovery).
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message,
+        cliToolId: 'antigravity',
+      });
 
       // Invalidate cache after sending message (required so the poller re-reads)
       invalidateCache(sessionName);

--- a/src/lib/cli-tools/codex.ts
+++ b/src/lib/cli-tools/codex.ts
@@ -13,14 +13,12 @@ import {
   sendSpecialKey,
   capturePane,
 } from '../tmux/tmux';
-import { detectAndResendIfPastedText } from '../pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './submit-verified-sender';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
 import { isCodexPromptReady, getCodexActiveDialog, stripAnsi } from '../detection/cli-patterns';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
-  TUI_TEXT_INPUT_WAIT_MS,
-  TUI_MESSAGE_PROCESSED_WAIT_MS,
   TUI_EXIT_WAIT_MS,
   CODEX_DIALOG_SETTLE_MS,
 } from '@/config/cli-tool-timing-config';
@@ -250,23 +248,13 @@ export class CodexTool extends BaseCLITool {
       // Verify Codex is at prompt state before sending
       await this.waitForPrompt(sessionName);
 
-      // Send message to Codex (without Enter)
-      await sendKeys(sessionName, message, false);
-
-      // Wait a moment for the text to be typed
-      await new Promise((resolve) => setTimeout(resolve, TUI_TEXT_INPUT_WAIT_MS));
-
-      // Send Enter key separately
-      await sendSpecialKey(sessionName, 'C-m');
-
-      // Wait a moment for the message to be processed
-      await new Promise((resolve) => setTimeout(resolve, TUI_MESSAGE_PROCESSED_WAIT_MS));
-
-      // Issue #212: Detect [Pasted text] and resend Enter for multi-line messages
-      // MF-001: Single-line messages skip detection (+0ms overhead)
-      if (message.includes('\n')) {
-        await detectAndResendIfPastedText(sessionName);
-      }
+      // Issue #1471: Body/Enter separation + read-back submit verification via the
+      // shared helper (replaces the old type -> C-m -> `\n`-gated paste recovery).
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message,
+        cliToolId: 'codex',
+      });
 
       // Issue #405: Invalidate cache after sending message
       invalidateCache(sessionName);

--- a/src/lib/cli-tools/copilot.ts
+++ b/src/lib/cli-tools/copilot.ts
@@ -18,7 +18,7 @@ import {
   killSession,
   capturePane,
 } from '../tmux/tmux';
-import { detectAndResendIfPastedText } from '../pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './submit-verified-sender';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
 import { COPILOT_PROMPT_PATTERN, COPILOT_SELECTION_LIST_PATTERN, stripAnsi } from '../detection/cli-patterns';
 import { COPILOT_TEXT_INPUT_DELAY_MS, COPILOT_SEND_ENTER_DELAY_MS, COPILOT_MODEL_SWITCH_TIMEOUT_MS } from '@/config/copilot-constants';
@@ -274,22 +274,17 @@ export class CopilotTool extends BaseCLITool {
         return;
       }
 
-      // Send message to Copilot (without Enter)
-      await sendKeys(sessionName, message, false);
-
-      // Wait a moment for the text to be typed
-      await new Promise((resolve) => setTimeout(resolve, COPILOT_TEXT_INPUT_DELAY_MS));
-
-      // Send Enter key separately
-      await sendSpecialKey(sessionName, 'C-m');
-
-      // Wait a moment for the message to be processed
-      await new Promise((resolve) => setTimeout(resolve, COPILOT_SEND_ENTER_DELAY_MS));
-
-      // Detect [Pasted text] and resend Enter for multi-line messages
-      if (message.includes('\n')) {
-        await detectAndResendIfPastedText(sessionName);
-      }
+      // Issue #1471: Body/Enter separation + read-back submit verification via the
+      // shared helper (replaces the old type -> C-m -> `\n`-gated paste recovery).
+      // Copilot's own text-input / post-Enter delays are preserved. The selection
+      // list slash-command branch above is intentionally NOT routed through here.
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message,
+        cliToolId: 'copilot',
+        textInputWaitMs: COPILOT_TEXT_INPUT_DELAY_MS,
+        verifyDelayMs: COPILOT_SEND_ENTER_DELAY_MS,
+      });
 
       // Invalidate cache after sending message
       invalidateCache(sessionName);

--- a/src/lib/cli-tools/gemini.ts
+++ b/src/lib/cli-tools/gemini.ts
@@ -18,14 +18,12 @@ import {
   killSession,
   capturePane,
 } from '../tmux/tmux';
-import { detectAndResendIfPastedText } from '../pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './submit-verified-sender';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
 import { GEMINI_PROMPT_PATTERN, stripAnsi } from '../detection/cli-patterns';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
-  TUI_TEXT_INPUT_WAIT_MS,
-  TUI_MESSAGE_PROCESSED_WAIT_MS,
   TUI_INTERRUPT_SETTLE_MS,
   TUI_EXIT_WAIT_MS,
 } from '@/config/cli-tool-timing-config';
@@ -204,22 +202,13 @@ export class GeminiTool extends BaseCLITool {
       // Verify Gemini is at prompt state before sending
       await this.waitForPrompt(sessionName);
 
-      // Send message to Gemini (without Enter)
-      await sendKeys(sessionName, message, false);
-
-      // Wait a moment for the text to be typed
-      await new Promise((resolve) => setTimeout(resolve, TUI_TEXT_INPUT_WAIT_MS));
-
-      // Send Enter key separately
-      await sendSpecialKey(sessionName, 'C-m');
-
-      // Wait a moment for the message to be processed
-      await new Promise((resolve) => setTimeout(resolve, TUI_MESSAGE_PROCESSED_WAIT_MS));
-
-      // Detect [Pasted text] and resend Enter for multi-line messages
-      if (message.includes('\n')) {
-        await detectAndResendIfPastedText(sessionName);
-      }
+      // Issue #1471: Body/Enter separation + read-back submit verification via the
+      // shared helper (replaces the old type -> C-m -> `\n`-gated paste recovery).
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message,
+        cliToolId: 'gemini',
+      });
 
       // Issue #405: Invalidate cache after sending message
       invalidateCache(sessionName);

--- a/src/lib/cli-tools/opencode.ts
+++ b/src/lib/cli-tools/opencode.ts
@@ -15,11 +15,10 @@ import {
   hasSession,
   createSession,
   sendKeys,
-  sendSpecialKey,
   killSession,
   exactTarget,
 } from '../tmux/tmux';
-import { detectAndResendIfPastedText } from '../pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './submit-verified-sender';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
 import { ensureOpencodeConfig } from './opencode-config';
 import { execFile } from 'child_process';
@@ -27,8 +26,6 @@ import { promisify } from 'util';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
-  TUI_TEXT_INPUT_WAIT_MS,
-  TUI_MESSAGE_PROCESSED_WAIT_MS,
   OPENCODE_EXIT_WAIT_MS,
 } from '@/config/cli-tool-timing-config';
 
@@ -166,22 +163,13 @@ export class OpenCodeTool extends BaseCLITool {
     }
 
     try {
-      // Send message to OpenCode (without Enter)
-      await sendKeys(sessionName, message, false);
-
-      // Wait a moment for the text to be typed
-      await new Promise((resolve) => setTimeout(resolve, TUI_TEXT_INPUT_WAIT_MS));
-
-      // Send Enter key separately
-      await sendSpecialKey(sessionName, 'C-m');
-
-      // Wait a moment for the message to be processed
-      await new Promise((resolve) => setTimeout(resolve, TUI_MESSAGE_PROCESSED_WAIT_MS));
-
-      // Detect [Pasted text] and resend Enter for multi-line messages
-      if (message.includes('\n')) {
-        await detectAndResendIfPastedText(sessionName);
-      }
+      // Issue #1471: Body/Enter separation + read-back submit verification via the
+      // shared helper (replaces the old type -> C-m -> `\n`-gated paste recovery).
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message,
+        cliToolId: 'opencode',
+      });
 
       // Issue #405: Invalidate cache after sending message
       invalidateCache(sessionName);

--- a/src/lib/cli-tools/submit-verified-sender.ts
+++ b/src/lib/cli-tools/submit-verified-sender.ts
@@ -1,0 +1,237 @@
+/**
+ * Submit-verified message sender (Issues #1469, #1470, #1471).
+ *
+ * A single shared helper that replaces the seven near-identical
+ * "type body -> press Enter -> maybe recover paste" sequences previously
+ * duplicated across session-key-sender.ts and every cli-tools/*.ts sendMessage(),
+ * plus the terminal API route's raw `sendKeys(command)` batch send.
+ *
+ * Why this exists (root cause):
+ *   tmux `send-keys <body> C-m` batches the body and Enter into a SINGLE command.
+ *   ink/React TUIs (Claude Code, Codex, ...) treat the injected body as a
+ *   bracketed paste and swallow the trailing C-m as a newline inside the paste
+ *   buffer, so the message is typed but never submitted. The recovery that used
+ *   to guard this was gated on `message.includes('\n')` (single-line messages
+ *   skipped entirely), keyed off Claude's version-specific `[Pasted text #\d+`
+ *   string, and never verified that submit actually happened (fire-and-forget).
+ *
+ * This helper fixes all three:
+ *   1. Body and Enter are ALWAYS sent as separate tmux commands with a delay
+ *      between them (never a single body+C-m batch).
+ *   2. Recovery + verification apply to EVERY message (no `\n` gate).
+ *   3. After submit it reads the pane back and confirms the message actually
+ *      left the input box (empty input line) or the tool began generating.
+ *      If it is still pending it resends Enter, bounded; if it can never be
+ *      confirmed it THROWS (callers must not report success on a stuck send).
+ *
+ * The verification is intentionally NOT keyed off the version-specific
+ * `[Pasted text #\d+` placeholder. That placeholder is used only as one
+ * "still pending" positive signal (broadened to be version-resilient); the
+ * primary decision is "is the message still sitting on the input line?".
+ */
+
+import { sendKeys, sendSpecialKeys, capturePane } from '../tmux/tmux';
+import { invalidateCache } from '../tmux/tmux-capture-cache';
+import { stripAnsi, detectThinking } from '../detection/cli-patterns';
+import type { CLIToolType } from './types';
+import {
+  TUI_TEXT_INPUT_WAIT_MS,
+  TUI_MESSAGE_PROCESSED_WAIT_MS,
+} from '@/config/cli-tool-timing-config';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('cli-tools/submit-verified-sender');
+
+/**
+ * Version-resilient pasted-text placeholder.
+ *
+ * Broader than PASTED_TEXT_PATTERN (`/\[Pasted text #\d+/`) so it still matches
+ * when a CLI version drops the `#N` and renders `[Pasted text +46 lines]`
+ * (Issue #1469 condition 2). Used ONLY as a positive "still in the input box"
+ * signal — never as the sole submit gate — so applying it to every tool is safe:
+ * a tool that never renders it simply never matches.
+ */
+const PASTE_PLACEHOLDER_PATTERN = /\[Pasted text[\s#]/;
+
+/**
+ * Prompt input-line markers across the supported TUIs.
+ * claude/gemini/copilot: `>` or `❯`; codex: `›`; antigravity: `>`;
+ * vibe-local: `ctx:N% ❯`. Leading whitespace is tolerated (tmux padding).
+ */
+const INPUT_LINE_MARKER = /^\s*(?:ctx:\d+%\s*)?[>❯›]/;
+
+/** Lines of pane tail to inspect when verifying submit. */
+const VERIFY_WINDOW_LINES = 12;
+
+/** Default bounded read-back attempts before giving up (throwing). */
+const DEFAULT_VERIFY_ATTEMPTS = 4;
+
+/** Minimum fragment length used to decide the body is still on the input line. */
+const MIN_FRAGMENT_LENGTH = 3;
+const MAX_FRAGMENT_LENGTH = 24;
+
+export interface SubmitVerifiedSendParams {
+  /** tmux session name (already validated by the caller chain). */
+  sessionName: string;
+  /** Message body to type (sent verbatim, without a trailing newline). */
+  message: string;
+  /** CLI tool id — selects the tool-specific "generating" detector. */
+  cliToolId: CLIToolType;
+  /**
+   * ms to wait after typing the body before pressing Enter, so the TUI
+   * registers the input first. Default: TUI_TEXT_INPUT_WAIT_MS (100).
+   */
+  textInputWaitMs?: number;
+  /**
+   * Number of Enter presses for the INITIAL submit. Default 1.
+   * vibe-local uses 2 (IME mode: first Enter inserts a newline, the second
+   * submits) — see VIBE_LOCAL_DOUBLE_ENTER_WAIT_MS.
+   */
+  submitEnterCount?: number;
+  /** ms between the initial Enter presses when submitEnterCount > 1. */
+  interEnterWaitMs?: number;
+  /** Bounded read-back attempts. Default DEFAULT_VERIFY_ATTEMPTS (4). */
+  verifyAttempts?: number;
+  /**
+   * ms to wait before each read-back capture. Default
+   * TUI_MESSAGE_PROCESSED_WAIT_MS (200). Callers that must stay snappy
+   * (terminal route) can lower the attempts/delay to keep the total bounded.
+   */
+  verifyDelayMs?: number;
+}
+
+/**
+ * First non-blank fragment of the message, used to decide whether the body is
+ * still sitting on the input line. Only the first line matters because that is
+ * what a TUI shows on the prompt line before folding into a paste placeholder.
+ */
+function comparableFragment(message: string): string {
+  const firstLine = message
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return '';
+  return firstLine.slice(0, MAX_FRAGMENT_LENGTH);
+}
+
+/**
+ * Locate the active input line within the pane tail: the last line that begins
+ * with a prompt marker. Scanned bottom-up so a status-bar/footer line rendered
+ * BELOW the input box (antigravity's "? for shortcuts", vibe-local's status bar)
+ * does not hide the real input line above it.
+ */
+function findInputLine(windowLines: string[]): string | null {
+  for (let i = windowLines.length - 1; i >= 0; i--) {
+    if (INPUT_LINE_MARKER.test(windowLines[i])) {
+      return windowLines[i];
+    }
+  }
+  return null;
+}
+
+/**
+ * Decide whether a captured pane shows the message as submitted.
+ *
+ * Version-independent by design — does NOT require the paste placeholder:
+ *   A. The tool is generating a response          -> submitted.
+ *   B. A paste placeholder is on the input line    -> NOT submitted (Enter eaten).
+ *   C. The body fragment is still on the input line -> NOT submitted.
+ *   D. Otherwise (empty input line / moved to history) -> submitted.
+ *
+ * B and C are scoped to the input line only, so the user-message echo that a
+ * TUI prints into its history above the prompt never causes a false "pending".
+ */
+export function isSubmitted(output: string, cliToolId: CLIToolType, message: string): boolean {
+  const clean = stripAnsi(output);
+  const windowLines = clean.split('\n').slice(-VERIFY_WINDOW_LINES);
+  const windowStr = windowLines.join('\n');
+
+  // A. Actively generating a response => the message was accepted.
+  if (detectThinking(cliToolId, windowStr)) {
+    return true;
+  }
+
+  const inputLine = findInputLine(windowLines);
+  if (inputLine) {
+    // B. A paste placeholder is still folded on the input line => not submitted.
+    if (PASTE_PLACEHOLDER_PATTERN.test(inputLine)) {
+      return false;
+    }
+    // C. The typed body is still sitting on the input line => not submitted.
+    const fragment = comparableFragment(message);
+    if (fragment.length >= MIN_FRAGMENT_LENGTH && inputLine.includes(fragment)) {
+      return false;
+    }
+  }
+
+  // D. Input line is clear (or absent) and nothing is generating => submitted.
+  return true;
+}
+
+/**
+ * Type a message body and submit it, then verify the submit actually happened.
+ *
+ * The body and Enter are always separate tmux commands (never batched), so the
+ * TUI cannot swallow the Enter inside a bracketed-paste buffer. After the
+ * initial submit the pane is read back up to `verifyAttempts` times; each time
+ * it is still pending an extra Enter is sent. If submit can never be confirmed
+ * the function THROWS — callers must surface that as a failure, never as
+ * success (Issues #1469/#1470/#1471).
+ *
+ * @throws Error when submit cannot be confirmed within the bounded attempts.
+ */
+export async function sendMessageWithSubmitVerification(
+  params: SubmitVerifiedSendParams
+): Promise<void> {
+  const {
+    sessionName,
+    message,
+    cliToolId,
+    textInputWaitMs = TUI_TEXT_INPUT_WAIT_MS,
+    submitEnterCount = 1,
+    interEnterWaitMs = TUI_TEXT_INPUT_WAIT_MS,
+    verifyAttempts = DEFAULT_VERIFY_ATTEMPTS,
+    verifyDelayMs = TUI_MESSAGE_PROCESSED_WAIT_MS,
+  } = params;
+
+  // 1. Type the body only — never send Enter in the same tmux command.
+  await sendKeys(sessionName, message, false);
+
+  // 2. Let the TUI register the input before pressing Enter.
+  await new Promise((resolve) => setTimeout(resolve, textInputWaitMs));
+
+  // 3. Submit as a separate command (double Enter for vibe-local's IME mode).
+  for (let i = 0; i < Math.max(1, submitEnterCount); i++) {
+    await sendSpecialKeys(sessionName, ['Enter']);
+    if (i < submitEnterCount - 1) {
+      await new Promise((resolve) => setTimeout(resolve, interEnterWaitMs));
+    }
+  }
+
+  // 4. Read-back verification: confirm the message left the input box, resend
+  //    Enter while it is still pending, and throw if it never submits.
+  const attempts = Math.max(1, verifyAttempts);
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, verifyDelayMs));
+
+    const output = await capturePane(sessionName, { startLine: -VERIFY_WINDOW_LINES });
+    if (isSubmitted(output, cliToolId, message)) {
+      invalidateCache(sessionName);
+      return;
+    }
+
+    // Still typed-but-unsent — resend a single Enter and re-check.
+    logger.warn('submit-not-confirmed:resending-enter', {
+      sessionName,
+      cliToolId,
+      attempt,
+    });
+    await sendSpecialKeys(sessionName, ['Enter']);
+  }
+
+  invalidateCache(sessionName);
+  logger.error('submit-verification-failed', { sessionName, cliToolId, attempts });
+  throw new Error(
+    `Message submit could not be confirmed for session ${sessionName} after ${attempts} attempts (typed but unsent)`
+  );
+}

--- a/src/lib/cli-tools/vibe-local.ts
+++ b/src/lib/cli-tools/vibe-local.ts
@@ -17,15 +17,13 @@ import {
   sendSpecialKey,
   killSession,
 } from '../tmux/tmux';
-import { detectAndResendIfPastedText } from '../pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './submit-verified-sender';
 import { invalidateCache } from '../tmux/tmux-capture-cache';
 import { getDbInstance } from '../db/db-instance';
 import { getWorktreeById } from '../db';
 import { createLogger } from '@/lib/logger';
 import {
   TUI_SESSION_CREATE_WAIT_MS,
-  TUI_TEXT_INPUT_WAIT_MS,
-  TUI_MESSAGE_PROCESSED_WAIT_MS,
   TUI_INTERRUPT_SETTLE_MS,
   TUI_EXIT_WAIT_MS,
   VIBE_LOCAL_DOUBLE_ENTER_WAIT_MS,
@@ -149,26 +147,17 @@ export class VibeLocalTool extends BaseCLITool {
     }
 
     try {
-      // Send message to vibe-local (without Enter)
-      await sendKeys(sessionName, message, false);
-
-      // Wait a moment for the text to be typed
-      await new Promise((resolve) => setTimeout(resolve, TUI_TEXT_INPUT_WAIT_MS));
-
-      // vibe-local uses IME mode: first Enter creates a new line,
-      // second Enter on empty line submits the message.
-      // Send Enter twice with a short delay between.
-      await sendSpecialKey(sessionName, 'C-m');
-      await new Promise((resolve) => setTimeout(resolve, VIBE_LOCAL_DOUBLE_ENTER_WAIT_MS));
-      await sendSpecialKey(sessionName, 'C-m');
-
-      // Wait a moment for the message to be processed
-      await new Promise((resolve) => setTimeout(resolve, TUI_MESSAGE_PROCESSED_WAIT_MS));
-
-      // Detect [Pasted text] and resend Enter for multi-line messages
-      if (message.includes('\n')) {
-        await detectAndResendIfPastedText(sessionName);
-      }
+      // Issue #1471: Body/Enter separation + read-back submit verification via the
+      // shared helper. vibe-local's IME mode needs TWO Enter presses (first Enter
+      // inserts a newline, the second submits), preserved via submitEnterCount: 2
+      // + the same inter-press wait (VIBE_LOCAL_DOUBLE_ENTER_WAIT_MS).
+      await sendMessageWithSubmitVerification({
+        sessionName,
+        message,
+        cliToolId: 'vibe-local',
+        submitEnterCount: 2,
+        interEnterWaitMs: VIBE_LOCAL_DOUBLE_ENTER_WAIT_MS,
+      });
 
       // Issue #405: Invalidate cache after sending message
       invalidateCache(sessionName);

--- a/src/lib/session-key-sender.ts
+++ b/src/lib/session-key-sender.ts
@@ -19,7 +19,7 @@ import {
   CLAUDE_PROMPT_PATTERN,
   stripAnsi,
 } from './detection/cli-patterns';
-import { detectAndResendIfPastedText } from './pasted-text-helper';
+import { sendMessageWithSubmitVerification } from './cli-tools/submit-verified-sender';
 import { invalidateCache } from './tmux/tmux-capture-cache';
 import { getErrorMessage } from './errors';
 import { CLAUDE_ENV_SANITIZE_WAIT_MS, TUI_EXIT_WAIT_MS } from '@/config/cli-tool-timing-config';
@@ -143,15 +143,16 @@ export async function sendMessageToSession(
   // Stability delay after prompt detection
   await new Promise((resolve) => setTimeout(resolve, postPromptDelay));
 
-  // Send message using sendKeys consistently (CONS-001)
-  await sendKeys(sessionName, message, false);
-  await sendKeys(sessionName, '', true);
-
-  // Issue #212: Detect [Pasted text] and resend Enter for multi-line messages
-  // MF-001: Single-line messages skip detection (+0ms overhead)
-  if (message.includes('\n')) {
-    await detectAndResendIfPastedText(sessionName);
-  }
+  // Issue #1469: Body and Enter are sent as SEPARATE tmux commands (never a
+  // single body+C-m batch) and the submit is read-back verified. This replaces
+  // the old fire-and-forget `sendKeys(message,false)` + `sendKeys('',true)` that
+  // let Claude's ink TUI swallow the trailing C-m as a bracketed-paste newline,
+  // leaving the message typed but unsent. Throws if submit cannot be confirmed.
+  await sendMessageWithSubmitVerification({
+    sessionName,
+    message,
+    cliToolId: 'claude',
+  });
 
   // Issue #405: Invalidate cache after sending message
   invalidateCache(sessionName);

--- a/tests/unit/cli-tools/antigravity.test.ts
+++ b/tests/unit/cli-tools/antigravity.test.ts
@@ -18,8 +18,8 @@ vi.mock('@/lib/tmux/tmux', () => ({
   reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
-vi.mock('@/lib/pasted-text-helper', () => ({
-  detectAndResendIfPastedText: vi.fn().mockResolvedValue(undefined),
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/tmux/tmux-capture-cache', () => ({
@@ -255,10 +255,11 @@ describe('AntigravityTool', () => {
       await expect(tool.sendMessage('test-wt', 'hello')).rejects.toThrow(/does not exist/);
     });
 
-    it('should type the message, send Enter, and invalidate the capture cache', async () => {
+    it('should delegate to the submit-verified sender and invalidate the capture cache', async () => {
       vi.useFakeTimers();
       try {
-        const { hasSession, sendKeys, sendSpecialKey, capturePane } = await import('@/lib/tmux/tmux');
+        const { hasSession, capturePane } = await import('@/lib/tmux/tmux');
+        const { sendMessageWithSubmitVerification } = await import('@/lib/cli-tools/submit-verified-sender');
         const { invalidateCache } = await import('@/lib/tmux/tmux-capture-cache');
         vi.mocked(hasSession).mockResolvedValue(true);
         vi.mocked(capturePane).mockResolvedValue(IDLE_FOOTER);
@@ -267,8 +268,10 @@ describe('AntigravityTool', () => {
         await vi.advanceTimersByTimeAsync(20000);
         await promise;
 
-        expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello', false);
-        expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+        // Issue #1471: body/Enter separation + submit verification is delegated.
+        expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+          expect.objectContaining({ sessionName: SESSION, message: 'hello', cliToolId: 'antigravity' })
+        );
         // Contract: sendMessage MUST invalidate the capture cache.
         expect(invalidateCache).toHaveBeenCalledWith(SESSION);
       } finally {
@@ -276,11 +279,11 @@ describe('AntigravityTool', () => {
       }
     });
 
-    it('should resend Enter for multi-line (pasted) messages', async () => {
+    it('should apply submit verification to multi-line (pasted) messages too', async () => {
       vi.useFakeTimers();
       try {
         const { hasSession, capturePane } = await import('@/lib/tmux/tmux');
-        const { detectAndResendIfPastedText } = await import('@/lib/pasted-text-helper');
+        const { sendMessageWithSubmitVerification } = await import('@/lib/cli-tools/submit-verified-sender');
         vi.mocked(hasSession).mockResolvedValue(true);
         vi.mocked(capturePane).mockResolvedValue(IDLE_FOOTER);
 
@@ -288,7 +291,10 @@ describe('AntigravityTool', () => {
         await vi.advanceTimersByTimeAsync(20000);
         await promise;
 
-        expect(detectAndResendIfPastedText).toHaveBeenCalledWith(SESSION);
+        // No `\n` gate anymore — the helper runs for every message.
+        expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+          expect.objectContaining({ sessionName: SESSION, message: 'line1\nline2', cliToolId: 'antigravity' })
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/tests/unit/cli-tools/codex-pasted-text.test.ts
+++ b/tests/unit/cli-tools/codex-pasted-text.test.ts
@@ -1,7 +1,7 @@
 /**
- * Unit tests for CodexTool.sendMessage() - Pasted text detection
- * Issue #212: Pasted text detection for Codex CLI
- * Issue #393: Updated to use sendSpecialKey instead of direct exec()
+ * Unit tests for CodexTool.sendMessage() - submit-verified sending
+ * Issue #212 -> #1471: paste recovery + submit verification is now handled by the
+ * shared submit-verified sender, applied to EVERY message (no `\n` gate).
  *
  * Separate test file to avoid vi.mock affecting existing codex.test.ts
  * tests (SF-S3-002: isRunning test uses real tmux).
@@ -12,7 +12,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock tmux module
-// Issue #393: Added sendSpecialKey and sendSpecialKeys (codex.ts no longer uses child_process directly)
 vi.mock('@/lib/tmux/tmux', () => ({
   hasSession: vi.fn(),
   createSession: vi.fn(),
@@ -23,9 +22,9 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendSpecialKeys: vi.fn(),
 }));
 
-// Mock pasted-text-helper (MF-S2-002: codex.ts only imports the helper)
-vi.mock('@/lib/pasted-text-helper', () => ({
-  detectAndResendIfPastedText: vi.fn().mockResolvedValue(undefined),
+// Mock the shared submit-verified sender (Issue #1471: codex delegates to it)
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock sendSpecialKey from tmux (needed by base class)
@@ -35,12 +34,12 @@ vi.mock('@/lib/cli-tools/validation', () => ({
 
 import { CodexTool } from '@/lib/cli-tools/codex';
 import { hasSession, sendKeys, sendSpecialKey, capturePane } from '@/lib/tmux/tmux';
-import { detectAndResendIfPastedText } from '@/lib/pasted-text-helper';
+import { sendMessageWithSubmitVerification } from '@/lib/cli-tools/submit-verified-sender';
 
 const TEST_WORKTREE_ID = 'test-worktree';
 const TEST_SESSION_NAME = 'mcbd-codex-test-worktree';
 
-describe('CodexTool.sendMessage() - Pasted text detection (Issue #212)', () => {
+describe('CodexTool.sendMessage() - submit-verified sending (Issue #1471)', () => {
   let tool: CodexTool;
 
   beforeEach(() => {
@@ -49,6 +48,7 @@ describe('CodexTool.sendMessage() - Pasted text detection (Issue #212)', () => {
     vi.mocked(hasSession).mockResolvedValue(true);
     vi.mocked(sendKeys).mockResolvedValue();
     vi.mocked(sendSpecialKey).mockResolvedValue();
+    vi.mocked(sendMessageWithSubmitVerification).mockResolvedValue(undefined);
     // waitForPrompt needs capturePane to return output matching CODEX_PROMPT_PATTERN (›)
     vi.mocked(capturePane).mockResolvedValue('› ');
   });
@@ -57,60 +57,45 @@ describe('CodexTool.sendMessage() - Pasted text detection (Issue #212)', () => {
     vi.restoreAllMocks();
   });
 
-  // MF-001: Single-line messages should skip detection
-  it('should skip Pasted text detection for single-line messages', async () => {
+  // No `\n` gate anymore: single-line messages are verified too.
+  it('should delegate single-line messages to the submit-verified sender', async () => {
     await tool.sendMessage(TEST_WORKTREE_ID, 'hello');
 
-    // detectAndResendIfPastedText should NOT be called
-    expect(detectAndResendIfPastedText).not.toHaveBeenCalled();
+    expect(sendMessageWithSubmitVerification).toHaveBeenCalledTimes(1);
+    expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionName: TEST_SESSION_NAME,
+        message: 'hello',
+        cliToolId: 'codex',
+      })
+    );
   });
 
-  // Multi-line messages should trigger detection
-  it('should call detectAndResendIfPastedText for multi-line messages', async () => {
+  it('should delegate multi-line messages to the submit-verified sender', async () => {
     await tool.sendMessage(TEST_WORKTREE_ID, 'line1\nline2');
 
-    // detectAndResendIfPastedText should be called after sendSpecialKey(C-m)
-    expect(detectAndResendIfPastedText).toHaveBeenCalledWith(TEST_SESSION_NAME);
-    expect(detectAndResendIfPastedText).toHaveBeenCalledTimes(1);
+    expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionName: TEST_SESSION_NAME,
+        message: 'line1\nline2',
+        cliToolId: 'codex',
+      })
+    );
   });
 
-  // SF-003: Verify call order - sendKeys(message) -> sendSpecialKey(C-m) -> detectAndResendIfPastedText
-  // Issue #393: Updated from execAsync(C-m) to sendSpecialKey(C-m)
-  it('should call detectAndResendIfPastedText after sendSpecialKey(C-m)', async () => {
-    const callOrder: string[] = [];
-
-    vi.mocked(sendKeys).mockImplementation(async () => {
-      callOrder.push('sendKeys');
-    });
-
-    vi.mocked(sendSpecialKey).mockImplementation(async () => {
-      callOrder.push('sendSpecialKey');
-    });
-
-    vi.mocked(detectAndResendIfPastedText).mockImplementation(async () => {
-      callOrder.push('detectAndResendIfPastedText');
-    });
-
-    await tool.sendMessage(TEST_WORKTREE_ID, 'line1\nline2');
-
-    // Verify order: capturePane (waitForPrompt) -> sendKeys (message) -> sendSpecialKey (C-m Enter) -> detectAndResendIfPastedText
-    expect(callOrder).toContain('sendKeys');
-    expect(callOrder).toContain('sendSpecialKey');
-    expect(callOrder).toContain('detectAndResendIfPastedText');
-    const sendKeysIdx = callOrder.indexOf('sendKeys');
-    const sendSpecialKeyIdx = callOrder.indexOf('sendSpecialKey');
-    const pastedTextIdx = callOrder.indexOf('detectAndResendIfPastedText');
-    expect(sendKeysIdx).toBeLessThan(sendSpecialKeyIdx);
-    expect(sendSpecialKeyIdx).toBeLessThan(pastedTextIdx);
-  });
-
-  // Verify existing send flow is maintained
-  it('should maintain existing sendKeys + sendSpecialKey flow for message delivery', async () => {
+  // The raw body+C-m batch must never be issued directly by the tool anymore.
+  it('should not issue a batched body+Enter send-keys itself', async () => {
     await tool.sendMessage(TEST_WORKTREE_ID, 'single line');
 
-    // sendKeys should be called once for the message
-    expect(sendKeys).toHaveBeenCalledWith(TEST_SESSION_NAME, 'single line', false);
-    // sendSpecialKey should be called for C-m (Enter)
-    expect(sendSpecialKey).toHaveBeenCalledWith(TEST_SESSION_NAME, 'C-m');
+    // sendKeys is only used for dialog handling / launch, never `(session, msg, true)`.
+    expect(sendKeys).not.toHaveBeenCalledWith(TEST_SESSION_NAME, 'single line', true);
+  });
+
+  // waitForPrompt must still run before delegating (readiness gate preserved).
+  it('should verify prompt readiness before delegating the send', async () => {
+    await tool.sendMessage(TEST_WORKTREE_ID, 'hello');
+
+    expect(capturePane).toHaveBeenCalled();
+    expect(sendMessageWithSubmitVerification).toHaveBeenCalled();
   });
 });

--- a/tests/unit/cli-tools/codex-startup-dialog.test.ts
+++ b/tests/unit/cli-tools/codex-startup-dialog.test.ts
@@ -29,8 +29,8 @@ vi.mock('@/lib/tmux/tmux', () => ({
   reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
-vi.mock('@/lib/pasted-text-helper', () => ({
-  detectAndResendIfPastedText: vi.fn().mockResolvedValue(undefined),
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/cli-tools/validation', () => ({
@@ -49,6 +49,7 @@ vi.mock('util', async (importOriginal) => {
 
 import { CodexTool } from '@/lib/cli-tools/codex';
 import { hasSession, createSession, sendKeys, sendSpecialKey, capturePane, reconcileSessionGeometry } from '@/lib/tmux/tmux';
+import { sendMessageWithSubmitVerification } from '@/lib/cli-tools/submit-verified-sender';
 
 const WORKTREE_ID = 'test-worktree';
 const SESSION = 'mcbd-codex-test-worktree';
@@ -198,9 +199,10 @@ describe('CodexTool first-launch dialog handling (Issue #890)', () => {
       // both dialog frames.
       expect(vi.mocked(capturePane).mock.calls.length).toBeGreaterThanOrEqual(3);
 
-      // Message is delivered without Enter; Enter is sent separately as C-m.
-      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello world', false);
-      expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+      // Once the prompt is ready, sending is delegated to the submit-verified sender.
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: SESSION, message: 'hello world', cliToolId: 'codex' })
+      );
     });
   });
 
@@ -243,8 +245,9 @@ describe('CodexTool first-launch dialog handling (Issue #890)', () => {
       // Ready on the first poll -> no 15s timeout wait (regressed pattern would poll
       // ~30 times until the waitForPrompt timeout before sending anyway).
       expect(vi.mocked(capturePane).mock.calls.length).toBeLessThanOrEqual(2);
-      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello world', false);
-      expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: SESSION, message: 'hello world', cliToolId: 'codex' })
+      );
     });
   });
 
@@ -306,10 +309,11 @@ describe('CodexTool first-launch dialog handling (Issue #890)', () => {
         vi.useRealTimers();
       }
 
-      // No "2" prefix is injected; the message is delivered cleanly.
+      // No "2" prefix is injected; the message is delegated cleanly to the sender.
       expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '2', false);
-      expect(sendKeys).toHaveBeenCalledWith(SESSION, 'explain this branch', false);
-      expect(sendSpecialKey).toHaveBeenCalledWith(SESSION, 'C-m');
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: SESSION, message: 'explain this branch', cliToolId: 'codex' })
+      );
     });
   });
 
@@ -332,9 +336,9 @@ describe('CodexTool first-launch dialog handling (Issue #890)', () => {
         vi.useRealTimers();
       }
 
-      // The whole point: on timeout the message is NOT typed and Enter is NOT sent.
+      // The whole point: on timeout the send is never delegated (message not typed).
+      expect(sendMessageWithSubmitVerification).not.toHaveBeenCalled();
       expect(sendKeys).not.toHaveBeenCalledWith(SESSION, 'should never be typed', false);
-      expect(sendSpecialKey).not.toHaveBeenCalledWith(SESSION, 'C-m');
     });
   });
 });

--- a/tests/unit/cli-tools/gemini-prompt-detection.test.ts
+++ b/tests/unit/cli-tools/gemini-prompt-detection.test.ts
@@ -16,8 +16,8 @@ vi.mock('@/lib/tmux/tmux', () => ({
   reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
-vi.mock('@/lib/pasted-text-helper', () => ({
-  detectAndResendIfPastedText: vi.fn().mockResolvedValue(undefined),
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/cli-tools/validation', () => ({

--- a/tests/unit/cli-tools/opencode.test.ts
+++ b/tests/unit/cli-tools/opencode.test.ts
@@ -21,9 +21,9 @@ vi.mock('@/lib/cli-tools/opencode-config', () => ({
   ensureOpencodeConfig: vi.fn(),
 }));
 
-// Mock pasted-text-helper
-vi.mock('@/lib/pasted-text-helper', () => ({
-  detectAndResendIfPastedText: vi.fn(),
+// Mock submit-verified sender (Issue #1471: shared body/Enter + submit verification)
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock child_process (exec for BaseCLITool.isInstalled(), execFile for OpenCodeTool.startSession())
@@ -44,11 +44,10 @@ import {
   hasSession,
   createSession,
   sendKeys,
-  sendSpecialKey,
   killSession,
 } from '@/lib/tmux/tmux';
 import { ensureOpencodeConfig } from '@/lib/cli-tools/opencode-config';
-import { detectAndResendIfPastedText } from '@/lib/pasted-text-helper';
+import { sendMessageWithSubmitVerification } from '@/lib/cli-tools/submit-verified-sender';
 
 describe('OpenCodeTool', () => {
   let tool: OpenCodeTool;
@@ -154,45 +153,45 @@ describe('OpenCodeTool', () => {
         .rejects.toThrow('does not exist');
     });
 
-    it('should send message via sendKeys and Enter', async () => {
+    it('should delegate sending to the submit-verified sender', async () => {
       vi.mocked(hasSession).mockResolvedValue(true);
-      vi.mocked(sendKeys).mockResolvedValue(undefined);
-      vi.mocked(sendSpecialKey).mockResolvedValue(undefined);
 
-      vi.useFakeTimers();
-      const promise = tool.sendMessage('test-123', 'hello');
-      await vi.runAllTimersAsync();
-      vi.useRealTimers();
+      await tool.sendMessage('test-123', 'hello');
 
-      expect(sendKeys).toHaveBeenCalledWith('mcbd-opencode-test-123', 'hello', false);
-      expect(sendSpecialKey).toHaveBeenCalledWith('mcbd-opencode-test-123', 'C-m');
+      // Issue #1471: opencode delegates body/Enter separation + submit verification.
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionName: 'mcbd-opencode-test-123',
+          message: 'hello',
+          cliToolId: 'opencode',
+        })
+      );
     });
 
-    it('should call detectAndResendIfPastedText for multi-line messages', async () => {
+    it('should apply submit verification to multi-line messages', async () => {
       vi.mocked(hasSession).mockResolvedValue(true);
-      vi.mocked(sendKeys).mockResolvedValue(undefined);
-      vi.mocked(sendSpecialKey).mockResolvedValue(undefined);
-      vi.mocked(detectAndResendIfPastedText).mockResolvedValue(undefined);
 
-      vi.useFakeTimers();
-      const promise = tool.sendMessage('test-123', 'line1\nline2');
-      await vi.runAllTimersAsync();
-      vi.useRealTimers();
+      await tool.sendMessage('test-123', 'line1\nline2');
 
-      expect(detectAndResendIfPastedText).toHaveBeenCalledWith('mcbd-opencode-test-123');
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionName: 'mcbd-opencode-test-123',
+          message: 'line1\nline2',
+          cliToolId: 'opencode',
+        })
+      );
     });
 
-    it('should NOT call detectAndResendIfPastedText for single-line messages', async () => {
+    it('should apply submit verification to single-line messages too (no `\\n` gate)', async () => {
       vi.mocked(hasSession).mockResolvedValue(true);
-      vi.mocked(sendKeys).mockResolvedValue(undefined);
-      vi.mocked(sendSpecialKey).mockResolvedValue(undefined);
 
-      vi.useFakeTimers();
-      const promise = tool.sendMessage('test-123', 'single line');
-      await vi.runAllTimersAsync();
-      vi.useRealTimers();
+      await tool.sendMessage('test-123', 'single line');
 
-      expect(detectAndResendIfPastedText).not.toHaveBeenCalled();
+      // The old `message.includes('\n')` gate is gone — every message is verified.
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledTimes(1);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'single line', cliToolId: 'opencode' })
+      );
     });
   });
 

--- a/tests/unit/cli-tools/submit-verified-sender.test.ts
+++ b/tests/unit/cli-tools/submit-verified-sender.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for the shared submit-verified sender (Issues #1469, #1470, #1471).
+ *
+ * Covers, for every interactive tool:
+ *   - body and Enter are sent as SEPARATE tmux commands (never a batched
+ *     body+C-m send-keys),
+ *   - single-line / multi-line / long (paste-length) messages all confirm submit
+ *     (no `\n` gate),
+ *   - a typed-but-unsent message is recovered by resending Enter,
+ *   - an unconfirmable submit THROWS (never resolves as a silent success),
+ *   - vibe-local's IME double-Enter is preserved,
+ *   - verification does not depend on the version-specific `[Pasted text #N]`
+ *     string (broadened placeholder + read-back).
+ *
+ * cli-patterns is intentionally NOT mocked so the real per-tool "generating"
+ * detection and ANSI stripping are exercised.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/tmux/tmux', () => ({
+  sendKeys: vi.fn().mockResolvedValue(undefined),
+  sendSpecialKeys: vi.fn().mockResolvedValue(undefined),
+  capturePane: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('@/lib/tmux/tmux-capture-cache', () => ({
+  invalidateCache: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    withContext: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  }),
+}));
+
+import {
+  sendMessageWithSubmitVerification,
+  isSubmitted,
+} from '@/lib/cli-tools/submit-verified-sender';
+import { sendKeys, sendSpecialKeys, capturePane } from '@/lib/tmux/tmux';
+import { invalidateCache } from '@/lib/tmux/tmux-capture-cache';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+const SESSION = 'mcbd-claude-test-wt';
+/** Input line cleared -> the message left the box -> submitted. */
+const EMPTY_PROMPT = '❯ ';
+
+const INTERACTIVE_TOOLS: CLIToolType[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+  'copilot',
+  'vibe-local',
+  'antigravity',
+];
+
+const LONG_MESSAGE = 'x'.repeat(4000); // guaranteed to fold into a bracketed paste
+
+describe('submit-verified-sender', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sendKeys).mockResolvedValue(undefined);
+    vi.mocked(sendSpecialKeys).mockResolvedValue(undefined);
+    vi.mocked(invalidateCache).mockReturnValue(undefined);
+  });
+
+  // ---------------------------------------------------------------------------
+  // isSubmitted() — pure, version-independent decision logic
+  // ---------------------------------------------------------------------------
+  describe('isSubmitted()', () => {
+    it('treats an empty input line as submitted', () => {
+      expect(isSubmitted(EMPTY_PROMPT, 'claude', 'hello')).toBe(true);
+    });
+
+    it('treats an actively generating pane as submitted (no prompt line needed)', () => {
+      expect(isSubmitted('working… (esc to interrupt)', 'claude', 'hello')).toBe(true);
+    });
+
+    it('treats the message still on the input line as NOT submitted', () => {
+      expect(isSubmitted('❯ hello world stuck here', 'claude', 'hello world stuck here')).toBe(false);
+    });
+
+    it('treats a folded paste placeholder on the input line as NOT submitted', () => {
+      expect(isSubmitted('❯ [Pasted text #1 +40 lines]', 'claude', LONG_MESSAGE)).toBe(false);
+    });
+
+    it('is version-resilient: matches [Pasted text +N lines] without the #N', () => {
+      // Issue #1469 condition 2: a CLI version drift dropping `#N` must still be caught.
+      expect(isSubmitted('❯ [Pasted text +40 lines]', 'claude', LONG_MESSAGE)).toBe(false);
+    });
+
+    it('does not false-positive on the message echoed into history above an empty prompt', () => {
+      // After submit the TUI echoes the user message into history, then shows an
+      // empty prompt below it. The empty input line must win.
+      const pane = '❯ hello world\n  (assistant is composing)\n❯ ';
+      expect(isSubmitted(pane, 'claude', 'hello world')).toBe(true);
+    });
+
+    it('finds the input line even when a status-bar footer is rendered below it', () => {
+      // antigravity renders "? for shortcuts …" beneath the input box.
+      const pane = '❯ still pending message\n? for shortcuts   model';
+      expect(isSubmitted(pane, 'antigravity', 'still pending message')).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Body/Enter separation — the core regression guard
+  // ---------------------------------------------------------------------------
+  describe('body/Enter separation (Issue #1469/#1470 regression guard)', () => {
+    it('types the body without Enter, then submits Enter as a separate command', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(capturePane).mockResolvedValue(EMPTY_PROMPT);
+        const order: string[] = [];
+        vi.mocked(sendKeys).mockImplementation(async () => { order.push('sendKeys'); });
+        vi.mocked(sendSpecialKeys).mockImplementation(async () => { order.push('sendSpecialKeys'); });
+
+        const p = sendMessageWithSubmitVerification({ sessionName: SESSION, message: 'hello', cliToolId: 'claude' });
+        await vi.runAllTimersAsync();
+        await p;
+
+        // body typed with sendEnter=false
+        expect(sendKeys).toHaveBeenCalledWith(SESSION, 'hello', false);
+        // Enter sent separately (never a batched body+C-m send-keys)
+        expect(sendSpecialKeys).toHaveBeenCalledWith(SESSION, ['Enter']);
+        expect(sendKeys).not.toHaveBeenCalledWith(SESSION, 'hello', true);
+        expect(sendKeys).not.toHaveBeenCalledWith(SESSION, '', true);
+        // order: body first, Enter after
+        expect(order.indexOf('sendKeys')).toBeLessThan(order.indexOf('sendSpecialKeys'));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-tool submit confirmation for single / multi / long messages
+  // ---------------------------------------------------------------------------
+  describe.each(INTERACTIVE_TOOLS)('submit confirmation for %s', (cliToolId) => {
+    const cases: Array<[string, string]> = [
+      ['single-line', 'hello'],
+      ['multi-line', 'line1\nline2\nline3'],
+      ['long (paste-length)', LONG_MESSAGE],
+    ];
+
+    it.each(cases)('confirms submit for a %s message', async (_label, message) => {
+      vi.useFakeTimers();
+      try {
+        // Empty input line after submit => confirmed on the first read-back.
+        vi.mocked(capturePane).mockResolvedValue(EMPTY_PROMPT);
+
+        const submitEnterCount = cliToolId === 'vibe-local' ? 2 : 1;
+        const p = sendMessageWithSubmitVerification({ sessionName: SESSION, message, cliToolId, submitEnterCount });
+        await vi.runAllTimersAsync();
+        await expect(p).resolves.toBeUndefined();
+
+        // Read-back happened and cache was invalidated.
+        expect(capturePane).toHaveBeenCalled();
+        expect(invalidateCache).toHaveBeenCalledWith(SESSION);
+        // No `\n` gate: the body is always typed via a non-Enter send-keys.
+        expect(sendKeys).toHaveBeenCalledWith(SESSION, message, false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Recovery: typed-but-unsent -> resend Enter -> confirmed
+  // ---------------------------------------------------------------------------
+  describe('recovery of a typed-but-unsent message', () => {
+    it('resends Enter when the message is still on the input line, then confirms', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(capturePane)
+          .mockResolvedValueOnce('❯ hello world still here') // 1st read-back: NOT submitted
+          .mockResolvedValue(EMPTY_PROMPT);                   // after resend: submitted
+
+        const p = sendMessageWithSubmitVerification({
+          sessionName: SESSION,
+          message: 'hello world still here',
+          cliToolId: 'claude',
+        });
+        await vi.runAllTimersAsync();
+        await expect(p).resolves.toBeUndefined();
+
+        // Initial Enter + one recovery Enter = 2 sendSpecialKeys(['Enter']) calls.
+        const enterCalls = vi.mocked(sendSpecialKeys).mock.calls.filter(
+          (c) => c[0] === SESSION && Array.isArray(c[1]) && c[1][0] === 'Enter'
+        );
+        expect(enterCalls.length).toBeGreaterThanOrEqual(2);
+        expect(invalidateCache).toHaveBeenCalledWith(SESSION);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('recovers a folded paste placeholder and confirms once generating (version-resilient)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(capturePane)
+          .mockResolvedValueOnce('❯ [Pasted text +40 lines]') // NOT submitted (no #N, drift)
+          .mockResolvedValue('thinking… (esc to interrupt)');  // generating => submitted
+
+        const p = sendMessageWithSubmitVerification({ sessionName: SESSION, message: LONG_MESSAGE, cliToolId: 'claude' });
+        await vi.runAllTimersAsync();
+        await expect(p).resolves.toBeUndefined();
+
+        expect(invalidateCache).toHaveBeenCalledWith(SESSION);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // No silent success: unconfirmable submit throws
+  // ---------------------------------------------------------------------------
+  describe('unconfirmable submit', () => {
+    it('throws (never resolves) when the message stays on the input line', async () => {
+      vi.useFakeTimers();
+      try {
+        // Always shows the message on the input line -> never submitted.
+        vi.mocked(capturePane).mockResolvedValue('❯ stuck forever message');
+
+        const p = sendMessageWithSubmitVerification({
+          sessionName: SESSION,
+          message: 'stuck forever message',
+          cliToolId: 'claude',
+          verifyAttempts: 3,
+        });
+        const assertion = expect(p).rejects.toThrow(/could not be confirmed/i);
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        // Bounded: initial Enter + one resend per failed attempt.
+        const enterCalls = vi.mocked(sendSpecialKeys).mock.calls.filter(
+          (c) => c[0] === SESSION && Array.isArray(c[1]) && c[1][0] === 'Enter'
+        );
+        expect(enterCalls.length).toBe(1 + 3);
+        // Cache is still invalidated on the failure path.
+        expect(invalidateCache).toHaveBeenCalledWith(SESSION);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tool-specific semantics preserved
+  // ---------------------------------------------------------------------------
+  describe('tool-specific semantics', () => {
+    it('sends Enter twice for vibe-local IME submit (submitEnterCount: 2)', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(capturePane).mockResolvedValue('ctx:9% ❯ '); // empty vibe-local prompt
+
+        const p = sendMessageWithSubmitVerification({
+          sessionName: SESSION,
+          message: 'hello',
+          cliToolId: 'vibe-local',
+          submitEnterCount: 2,
+          interEnterWaitMs: 5,
+        });
+        await vi.runAllTimersAsync();
+        await p;
+
+        // The initial submit alone issues two Enter presses (before any recovery).
+        const enterCalls = vi.mocked(sendSpecialKeys).mock.calls.filter(
+          (c) => c[0] === SESSION && Array.isArray(c[1]) && c[1][0] === 'Enter'
+        );
+        expect(enterCalls.length).toBeGreaterThanOrEqual(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/tests/unit/lib/claude-session.test.ts
+++ b/tests/unit/lib/claude-session.test.ts
@@ -21,9 +21,9 @@ vi.mock('@/lib/tmux/tmux', () => ({
   reconcileSessionGeometry: vi.fn().mockResolvedValue(false),
 }));
 
-// Mock pasted-text-helper (Issue #212)
-vi.mock('@/lib/pasted-text-helper', () => ({
-  detectAndResendIfPastedText: vi.fn().mockResolvedValue(undefined),
+// Mock the shared submit-verified sender (Issue #1469: claude delegates to it)
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock fs/promises for isValidClaudePath (Issue #265)
@@ -77,7 +77,7 @@ import {
   CLAUDE_SESSION_ERROR_PATTERNS,
   CLAUDE_SESSION_ERROR_REGEX_PATTERNS,
 } from '@/lib/detection/cli-patterns';
-import { detectAndResendIfPastedText } from '@/lib/pasted-text-helper';
+import { sendMessageWithSubmitVerification } from '@/lib/cli-tools/submit-verified-sender';
 
 // ----- Shared test constants (DRY) -----
 const TEST_WORKTREE_ID = 'test-worktree';
@@ -395,7 +395,7 @@ describe('claude-session - Issue #152 improvements', () => {
       expect(callCount).toBeGreaterThanOrEqual(2);
     });
 
-    it('should use sendKeys for Enter instead of execAsync (CONS-001)', async () => {
+    it('should delegate body/Enter separation + submit verification to the shared sender (Issue #1469)', async () => {
       vi.mocked(capturePane).mockResolvedValue('> ');
 
       const promise = sendMessageToClaude(TEST_WORKTREE_ID, 'Hello Claude');
@@ -405,10 +405,16 @@ describe('claude-session - Issue #152 improvements', () => {
 
       await promise;
 
-      // Should call sendKeys twice: once for message, once for Enter
-      expect(sendKeys).toHaveBeenCalledTimes(2);
-      expect(sendKeys).toHaveBeenNthCalledWith(1, TEST_SESSION_NAME, 'Hello Claude', false);
-      expect(sendKeys).toHaveBeenNthCalledWith(2, TEST_SESSION_NAME, '', true);
+      // Issue #1469: the old `sendKeys(msg,false)` + `sendKeys('',true)` batch is gone.
+      // sendMessageToSession no longer types/Enters directly — it delegates.
+      expect(sendKeys).not.toHaveBeenCalledWith(TEST_SESSION_NAME, '', true);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionName: TEST_SESSION_NAME,
+          message: 'Hello Claude',
+          cliToolId: 'claude',
+        })
+      );
     });
 
     it('should throw error if session does not exist', async () => {
@@ -447,16 +453,16 @@ describe('claude-session - Issue #152 improvements', () => {
 
       const promise = sendMessageToClaude(TEST_WORKTREE_ID, 'Hello');
 
-      // sendKeys should NOT be called yet (waiting for stability delay)
-      expect(sendKeys).not.toHaveBeenCalled();
+      // The send (now delegated) should NOT happen yet (waiting for stability delay)
+      expect(sendMessageWithSubmitVerification).not.toHaveBeenCalled();
 
       // Advance through stability delay
       await vi.advanceTimersByTimeAsync(CLAUDE_POST_PROMPT_DELAY);
 
       await promise;
 
-      // Now sendKeys should have been called
-      expect(sendKeys).toHaveBeenCalledTimes(2);
+      // Now the delegated send should have happened exactly once
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledTimes(1);
     });
 
     it('should wait CLAUDE_POST_PROMPT_DELAY after waitForPrompt returns (Path B)', async () => {
@@ -476,15 +482,15 @@ describe('claude-session - Issue #152 improvements', () => {
       // Advance through waitForPrompt polling (one full poll cycle needed)
       await vi.advanceTimersByTimeAsync(CLAUDE_PROMPT_POLL_INTERVAL);
 
-      // sendKeys should NOT be called yet (waiting for stability delay)
-      expect(sendKeys).not.toHaveBeenCalled();
+      // The delegated send should NOT happen yet (waiting for stability delay)
+      expect(sendMessageWithSubmitVerification).not.toHaveBeenCalled();
 
       // Advance through stability delay
       await vi.advanceTimersByTimeAsync(CLAUDE_POST_PROMPT_DELAY);
 
       await promise;
 
-      expect(sendKeys).toHaveBeenCalledTimes(2);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -592,46 +598,48 @@ describe('claude-session - Issue #152 improvements', () => {
     });
   });
 
-  // Issue #212: Pasted text detection in sendMessageToClaude
-  describe('sendMessageToClaude() - Pasted text detection (Issue #212)', () => {
+  // Issue #1469: submit-verified send delegation (replaces the old #212 `\n`-gated
+  // paste detection — recovery + verification now apply to EVERY message).
+  describe('sendMessageToClaude() - submit-verified delegation (Issue #1469)', () => {
     beforeEach(() => {
       vi.mocked(hasSession).mockResolvedValue(true);
       vi.mocked(sendKeys).mockResolvedValue();
       vi.mocked(capturePane).mockResolvedValue('> ');
     });
 
-    // MF-001: Single-line messages should skip detection
-    it('should skip Pasted text detection for single-line messages', async () => {
+    // No `\n` gate anymore: single-line messages are verified too.
+    it('should delegate single-line messages to the submit-verified sender', async () => {
       const promise = sendMessageToClaude(TEST_WORKTREE_ID, 'hello');
       await vi.advanceTimersByTimeAsync(CLAUDE_POST_PROMPT_DELAY);
       await promise;
 
-      // detectAndResendIfPastedText should NOT be called for single-line
-      expect(detectAndResendIfPastedText).not.toHaveBeenCalled();
-      // Standard sendKeys should still be called (message + Enter)
-      expect(sendKeys).toHaveBeenCalledTimes(2);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledTimes(1);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: TEST_SESSION_NAME, message: 'hello', cliToolId: 'claude' })
+      );
     });
 
-    // Multi-line messages should trigger detection
-    it('should run Pasted text detection for multi-line messages', async () => {
+    it('should delegate multi-line messages to the submit-verified sender', async () => {
       const promise = sendMessageToClaude(TEST_WORKTREE_ID, 'line1\nline2');
       await vi.advanceTimersByTimeAsync(CLAUDE_POST_PROMPT_DELAY);
       await promise;
 
-      // detectAndResendIfPastedText should be called with session name
-      expect(detectAndResendIfPastedText).toHaveBeenCalledWith(TEST_SESSION_NAME);
-      expect(detectAndResendIfPastedText).toHaveBeenCalledTimes(1);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: TEST_SESSION_NAME, message: 'line1\nline2', cliToolId: 'claude' })
+      );
     });
 
-    // Existing flow should not be affected
-    it('should not affect existing message sending flow', async () => {
+    // The body must be passed verbatim to the sender (no direct batched send-keys).
+    it('should pass the full multi-line body to the sender without a batched send-keys', async () => {
       const promise = sendMessageToClaude(TEST_WORKTREE_ID, 'line1\nline2\nline3');
       await vi.advanceTimersByTimeAsync(CLAUDE_POST_PROMPT_DELAY);
       await promise;
 
-      // sendKeys order: message first, then Enter
-      expect(sendKeys).toHaveBeenNthCalledWith(1, TEST_SESSION_NAME, 'line1\nline2\nline3', false);
-      expect(sendKeys).toHaveBeenNthCalledWith(2, TEST_SESSION_NAME, '', true);
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'line1\nline2\nline3', cliToolId: 'claude' })
+      );
+      // No raw `sendKeys(session, '', true)` Enter batch is issued anymore.
+      expect(sendKeys).not.toHaveBeenCalledWith(TEST_SESSION_NAME, '', true);
     });
   });
 });

--- a/tests/unit/terminal-route.test.ts
+++ b/tests/unit/terminal-route.test.ts
@@ -39,9 +39,15 @@ vi.mock('@/lib/tmux/tmux', () => ({
   sendSpecialKeys: vi.fn(),
 }));
 
+// Issue #1470: the non-copilot branch delegates to the shared submit-verified sender.
+vi.mock('@/lib/cli-tools/submit-verified-sender', () => ({
+  sendMessageWithSubmitVerification: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { POST } from '@/app/api/worktrees/[id]/terminal/route';
 import { getWorktreeById } from '@/lib/db';
 import { hasSession, sendKeys } from '@/lib/tmux/tmux';
+import { sendMessageWithSubmitVerification } from '@/lib/cli-tools/submit-verified-sender';
 import { isCliToolType } from '@/lib/cli-tools/types';
 
 function createRequest(body: Record<string, unknown>): NextRequest {
@@ -60,17 +66,23 @@ describe('POST /api/worktrees/[id]/terminal', () => {
     vi.mocked(getWorktreeById).mockReturnValue({ id: 'wt-1', name: 'test', path: '/path' } as ReturnType<typeof getWorktreeById>);
     vi.mocked(hasSession).mockResolvedValue(true);
     vi.mocked(sendKeys).mockResolvedValue(undefined);
+    vi.mocked(sendMessageWithSubmitVerification).mockResolvedValue(undefined);
     mockSendMessage.mockResolvedValue(undefined);
   });
 
-  it('should send command successfully with valid cliToolId', async () => {
+  it('should send command successfully with valid cliToolId (delegated + submit-verified)', async () => {
     const req = createRequest({ cliToolId: 'claude', command: 'echo hello' });
     const res = await POST(req, defaultParams);
     const json = await res.json();
 
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(sendKeys).toHaveBeenCalledWith('mcbd-claude-wt-1', 'echo hello');
+    // Issue #1470: non-copilot tools delegate to the submit-verified sender with a
+    // bounded (non-blocking) verify profile — never a raw batched `sendKeys(command)`.
+    expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionName: 'mcbd-claude-wt-1', message: 'echo hello', cliToolId: 'claude' })
+    );
+    expect(sendKeys).not.toHaveBeenCalledWith('mcbd-claude-wt-1', 'echo hello');
   });
 
   it('should return 400 for invalid cliToolId (shell metacharacters)', async () => {
@@ -137,7 +149,7 @@ describe('POST /api/worktrees/[id]/terminal', () => {
   });
 
   it('should return 500 with fixed-string error on internal error', async () => {
-    vi.mocked(sendKeys).mockRejectedValue(new Error('internal tmux failure'));
+    vi.mocked(sendMessageWithSubmitVerification).mockRejectedValue(new Error('internal tmux failure'));
     const req = createRequest({ cliToolId: 'claude', command: 'echo hello' });
     const res = await POST(req, defaultParams);
     const json = await res.json();
@@ -146,6 +158,20 @@ describe('POST /api/worktrees/[id]/terminal', () => {
     // R4F002: Fixed-string error, no error.message exposure
     expect(json.error).toBe('Failed to send command to terminal');
     expect(json.error).not.toContain('internal tmux failure');
+  });
+
+  // Issue #1470: an unconfirmed submit must NOT be reported as success.
+  it('should NOT return { success: true } when submit cannot be confirmed', async () => {
+    vi.mocked(sendMessageWithSubmitVerification).mockRejectedValue(
+      new Error('Message submit could not be confirmed (typed but unsent)')
+    );
+    const req = createRequest({ cliToolId: 'codex', command: 'a long typed-but-unsent message' });
+    const res = await POST(req, defaultParams);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.success).toBeUndefined();
+    expect(json.error).toBe('Failed to send command to terminal');
   });
 
   // Issue #559: Copilot uses sendKeys directly (not sendMessage) to avoid waitForPrompt blocking
@@ -174,14 +200,31 @@ describe('POST /api/worktrees/[id]/terminal', () => {
       expect(mockSendMessage).not.toHaveBeenCalled();
     });
 
-    it('should use sendKeys for non-copilot tools too', async () => {
+    it('should delegate non-copilot tools to the submit-verified sender (no batched send-keys)', async () => {
       const req = createRequest({ cliToolId: 'claude', command: '/model' });
       const res = await POST(req, defaultParams);
       const json = await res.json();
 
       expect(res.status).toBe(200);
       expect(json.success).toBe(true);
-      expect(sendKeys).toHaveBeenCalledWith('mcbd-claude-wt-1', '/model');
+      // Issue #1470: regression guard — the old single `sendKeys(command)` batch
+      // (body + C-m in one send-keys) must be gone for non-copilot tools.
+      expect(sendMessageWithSubmitVerification).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: 'mcbd-claude-wt-1', message: '/model', cliToolId: 'claude' })
+      );
+      expect(sendKeys).not.toHaveBeenCalledWith('mcbd-claude-wt-1', '/model');
+      expect(sendKeys).not.toHaveBeenCalledWith('mcbd-claude-wt-1', '/model', true);
+    });
+
+    it('should keep the terminal-route verify bounded (non-blocking, #559)', async () => {
+      const req = createRequest({ cliToolId: 'gemini', command: 'hello world' });
+      await POST(req, defaultParams);
+
+      // The route passes a small, bounded verify profile so it never re-introduces
+      // long waitForPrompt-style blocking.
+      const call = vi.mocked(sendMessageWithSubmitVerification).mock.calls[0][0];
+      expect(call.verifyAttempts).toBeLessThanOrEqual(2);
+      expect(call.verifyDelayMs).toBeLessThanOrEqual(200);
     });
   });
 });


### PR DESCRIPTION
## 概要

`commandmate send`（および Timer / Web UI チャット / terminal API）で、tmux `send-keys` が本文＋Enter を単一コマンドで送ると ink/React TUI（Claude Code 等）が本文を bracketed paste 扱いし、直後の `C-m` を貼り付けバッファ内改行として消費するため、**メッセージが typed-but-unsent のまま submit されない**問題を、3 Issue 横断で一括修正する。

既存の貼り付け回復は次の3欠陥で穴だらけだった:
1. `message.includes('\n')` ゲートで**単一行メッセージを回復対象から除外**
2. Claude CLI 固有・版依存の `[Pasted text #\d+` 文字列照合に依存
3. **submit 未検証（fire-and-forget）**で、未 submit でも成功を返す

## 対応 Issue（1 PR に統合）

- Closes #1469 — claude 経路の Enter 吸収（本 PR で共通ヘルパを新設し解消）
- Closes #1470 — terminal API のバッチ送信（#947 の適用漏れ）
- Closes #1471 — 貼り付け回復の横断的欠陥（`\n` ゲート7箇所複製・Claude固有パターン共用・submit未検証）

> base が `develop` のため `Closes` では自動クローズされない。マージ後に手動クローズする。

## 変更点

- **新規 `src/lib/cli-tools/submit-verified-sender.ts`**（submit 検証つき共通送信ヘルパ）
  - 本文＝`sendKeys(msg,false)` → 遅延 → Enter＝`sendSpecialKeys(['Enter'])` と**分離送信**（単一 `send-keys` バッチを全経路から排除）
  - 貼り付け回復を**全メッセージへ適用**（`\n` ゲート撤廃）
  - **read-back で submit を検証**（入力欄が空 or generating へ遷移を確認）。未 submit なら Enter 再送、bounded retry で確定不能なら**明示 throw**（void 成功で返さない）
  - 版依存 `[Pasted text #\d+` 照合に依存しない検証ベース（プレースホルダは版耐性のある補助シグナルのみ）
- **claude (#1469)**: `session-key-sender.ts` をヘルパ経由へ
- **全ツール (#1471)**: codex / gemini / copilot / opencode / vibe-local / antigravity の `sendMessage()` をヘルパへ集約（`\n` ゲート7箇所の重複を解消）
- **terminal API (#1470)**: `terminal/route.ts` の else 分岐の生 `sendKeys(command)` を廃しヘルパへ委譲。bounded・非ブロッキングな検証で #559 の意図を維持し、送信失敗時に `{success:true}` を返さない

### ツール固有セマンティクスの維持（非回帰）
- vibe-local: IME 二重 Enter（`submitEnterCount: 2`）
- copilot: 選択リストを出す slash command 分岐は非委譲、通常送信の改行潰しは `send-user-message` 側で不変

## テスト

- 新規 `submit-verified-sender.test.ts`（33件）: `isSubmitted()` read-back（履歴エコー誤検知なし・footer 対応）、本文/Enter 分離の回帰ガード、**全7ツール × 単一行/複数行/長文**の submit 確定、typed-but-unsent 回復（Enter 再送・版耐性 folded paste）、確定不能時 throw、vibe-local 二重 Enter。
- 既存ツールテスト（codex/opencode/antigravity/gemini/claude-session）と terminal-route テストを新方式へ更新。

## 品質ゲート（オーケストレーターが worktree で実測）

| チェック | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `npm run test:unit` | ✅ 638 files / 11159 tests passed |
| `npm run build` | ✅ Compiled successfully |

## 補足

- 本 PR は「typed-but-unsent を submit 検証で恒久解消」する。実サーバでの live-send 実挙動（貼り付け化する長文が実際に submit されること）はマージ後の実機確認で最終検証する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
