### PR TITLE
feat: Skills ペインでスキル概要を表示 (#1479)

### DIFF
--- a/src/components/skills/WorktreeSkillsPane.tsx
+++ b/src/components/skills/WorktreeSkillsPane.tsx
@@ -109,6 +109,17 @@ export function WorktreeSkillsPane({ worktreeId, className = '' }: WorktreeSkill
     () => new Set(installed.skills.map((skill) => skill.skillId)),
     [installed.skills]
   );
+  // Phase 2 (#1479): the installed index carries no name or summary, so borrow
+  // them from the Catalog by id. Only Skills still listed in the Catalog resolve
+  // — an install whose Catalog entry has since disappeared falls back to its
+  // skillId with no summary. A permanent fix would persist these at install time.
+  const catalogInfoById = useMemo(
+    () =>
+      new Map(
+        catalog.skills.map((skill) => [skill.id, { name: skill.name, summary: skill.summary }])
+      ),
+    [catalog.skills]
+  );
   const selectedCatalogSkill = useMemo(
     () => catalog.skills.find((skill) => skill.id === selectedSkillId) ?? null,
     [catalog.skills, selectedSkillId]
@@ -209,26 +220,37 @@ export function WorktreeSkillsPane({ worktreeId, className = '' }: WorktreeSkill
             </Card>
           ) : (
             <ul className="space-y-2">
-              {installed.skills.map((skill) => (
-                <li key={skill.skillId}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedSkillId(skill.skillId)}
-                    data-testid={`worktree-skills-installed-${skill.skillId}`}
-                    className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="break-all text-sm font-semibold text-foreground">
-                        {skill.skillId}
-                      </span>
-                      <SkillRiskBadge risk={skill.effectiveRisk} />
-                    </div>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {t('worktreePane.version', { version: skill.version })}
-                    </p>
-                  </button>
-                </li>
-              ))}
+              {installed.skills.map((skill) => {
+                const catalogInfo = catalogInfoById.get(skill.skillId);
+                return (
+                  <li key={skill.skillId}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedSkillId(skill.skillId)}
+                      data-testid={`worktree-skills-installed-${skill.skillId}`}
+                      className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="break-all text-sm font-semibold text-foreground">
+                          {catalogInfo?.name ?? skill.skillId}
+                        </span>
+                        <SkillRiskBadge risk={skill.effectiveRisk} />
+                      </div>
+                      {catalogInfo?.summary && (
+                        <p
+                          className="mt-0.5 text-xs text-muted-foreground line-clamp-2"
+                          data-testid={`worktree-skills-installed-summary-${skill.skillId}`}
+                        >
+                          {catalogInfo.summary}
+                        </p>
+                      )}
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {t('worktreePane.version', { version: skill.version })}
+                      </p>
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </section>
@@ -288,6 +310,14 @@ export function WorktreeSkillsPane({ worktreeId, className = '' }: WorktreeSkill
                       <p className="mt-0.5 truncate text-xs text-muted-foreground">
                         {t('card.provider', { provider: skill.provider.name })}
                       </p>
+                      {skill.summary && (
+                        <p
+                          className="mt-1 text-xs text-muted-foreground line-clamp-2"
+                          data-testid={`worktree-skills-catalog-summary-${skill.id}`}
+                        >
+                          {skill.summary}
+                        </p>
+                      )}
                       <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                         {skill.compatibility && (
                           <SkillCompatibilityBadge status={skill.compatibility.status} />

--- a/tests/unit/components/skills/WorktreeSkillsPane.test.tsx
+++ b/tests/unit/components/skills/WorktreeSkillsPane.test.tsx
@@ -114,6 +114,47 @@ describe('WorktreeSkillsPane list', () => {
     expect(screen.getByTestId('worktree-skills-installed-empty')).toBeInTheDocument();
   });
 
+  it('shows each Catalog Skill summary in the DOM (Phase 1)', async () => {
+    routeFetch({ '/api/skills': CATALOG, '/api/worktrees/wt-1/skills': INSTALLED_EMPTY });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    // The summary is what tells a user what a Skill does before installing —
+    // assert the real text lands in the DOM, not merely that state updated.
+    const summary = await screen.findByTestId('worktree-skills-catalog-summary-release-helper');
+    expect(summary).toHaveTextContent('Walks an agent through the release checklist.');
+  });
+
+  it('borrows name and summary from the Catalog for installed Skills (Phase 2)', async () => {
+    routeFetch({ '/api/skills': CATALOG, '/api/worktrees/wt-1/skills': INSTALLED });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    const row = await screen.findByTestId('worktree-skills-installed-release-helper');
+    // The install index only carries a skillId; the Catalog supplies the name.
+    expect(row).toHaveTextContent('Release Helper');
+    expect(
+      screen.getByTestId('worktree-skills-installed-summary-release-helper')
+    ).toHaveTextContent('Walks an agent through the release checklist.');
+  });
+
+  it('falls back to the skillId with no summary when the Catalog lacks the installed Skill (Phase 2 limit)', async () => {
+    routeFetch({
+      '/api/skills': CATALOG,
+      '/api/worktrees/wt-1/skills': {
+        body: { worktreeId: 'wt-1', skills: [makeInstalled({ skillId: 'ghost-skill' })] },
+      },
+    });
+
+    render(<WorktreeSkillsPane worktreeId="wt-1" />);
+
+    const row = await screen.findByTestId('worktree-skills-installed-ghost-skill');
+    expect(row).toHaveTextContent('ghost-skill');
+    expect(
+      screen.queryByTestId('worktree-skills-installed-summary-ghost-skill')
+    ).not.toBeInTheDocument();
+  });
+
   it('surfaces an installed-list failure without falling back to an empty list', async () => {
     routeFetch({
       '/api/skills': CATALOG,


### PR DESCRIPTION
## 概要
worktree の Skills ペインで各スキルの概要（何ができるか）を表示。Phase 1（Catalog 節 summary）＋Phase 2（Installed 節の近似表示）。DB マイグレーション（Phase 3）は follow-up。

Closes #1479 （base=develop のためマージ後に手動クローズ）

## 変更
- `WorktreeSkillsPane.tsx`: Catalog 節に summary 1行表示、Installed 節は取得済み Catalog データから概要を近似表示。
- テスト追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)