### PR TITLE
feat: 削除操作に確認ダイアログを一貫導入 (#1487)

### DIFF
--- a/src/components/home/TodoWidget.tsx
+++ b/src/components/home/TodoWidget.tsx
@@ -17,6 +17,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button, Card, Checkbox, Input, Skeleton } from '@/components/ui';
+import { useConfirm } from '@/components/ui/ConfirmDialog';
 import { todoApi, type TodoItem } from '@/lib/api/todo-api';
 import { MAX_TODO_CONTENT_LENGTH } from '@/config/todo-config';
 
@@ -41,6 +42,8 @@ function todoRepoLabel(todo: TodoItem): string {
 
 export function TodoWidget() {
   const t = useTranslations('home');
+  const tCommon = useTranslations('common');
+  const confirm = useConfirm();
   const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
   const [selectedRepoId, setSelectedRepoId] = useState('');
   const [todos, setTodos] = useState<TodoItem[]>([]);
@@ -162,6 +165,14 @@ export function TodoWidget() {
   );
 
   const handleDelete = useCallback(async (todo: TodoItem) => {
+    if (
+      !(await confirm({
+        description: tCommon('confirmDelete', { name: todo.content }),
+        variant: 'danger',
+      }))
+    ) {
+      return;
+    }
     setError(null);
     try {
       // Use the todo's own repository id so cross-repo deletes don't 404.
@@ -170,7 +181,7 @@ export function TodoWidget() {
     } catch (err) {
       setError(err instanceof Error ? err.message : t('todo.errors.delete'));
     }
-  }, [t]);
+  }, [t, confirm, tCommon]);
 
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/worktree/AgentInstancesPane.tsx
+++ b/src/components/worktree/AgentInstancesPane.tsx
@@ -29,6 +29,7 @@ import {
 import { MIN_AGENT_INSTANCES } from '@/lib/agent-instances-validator';
 import { VibeLocalSettings } from '@/components/worktree/VibeLocalSettings';
 import { Spinner } from '@/components/ui/Spinner';
+import { useConfirm } from '@/components/ui/ConfirmDialog';
 import { TruncationTooltip } from '@/components/common/TruncationTooltip';
 import {
   DropdownMenu,
@@ -100,6 +101,8 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
   onVibeLocalContextWindowChange,
 }: AgentInstancesPaneProps) {
   const t = useTranslations('schedule');
+  const tCommon = useTranslations('common');
+  const confirm = useConfirm();
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -151,11 +154,20 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
   }, [addToolId, instances, persist]);
 
   const handleDelete = useCallback(
-    (id: string) => {
+    async (id: string) => {
       if (instances.length <= MIN_AGENT_INSTANCES) return;
+      const target = instances.find((inst) => inst.id === id);
+      if (
+        !(await confirm({
+          description: tCommon('confirmDelete', { name: target?.alias ?? '' }),
+          variant: 'danger',
+        }))
+      ) {
+        return;
+      }
       void persist(instances.filter((inst) => inst.id !== id));
     },
-    [instances, persist]
+    [instances, persist, confirm, tCommon]
   );
 
   const handleMove = useCallback(
@@ -296,7 +308,9 @@ export const AgentInstancesPane = memo(function AgentInstancesPane({
                   <DropdownMenuItem
                     data-testid={`agent-instance-delete-${inst.id}`}
                     disabled={atMin}
-                    onSelect={() => handleDelete(inst.id)}
+                    onSelect={() => {
+                      void handleDelete(inst.id);
+                    }}
                     className="text-danger-foreground focus:text-danger-foreground"
                   >
                     <Trash2 className="w-4 h-4" />

--- a/src/components/worktree/MemoPane.tsx
+++ b/src/components/worktree/MemoPane.tsx
@@ -22,6 +22,7 @@ import { MemoCard } from './MemoCard';
 import { MemoAddButton } from './MemoAddButton';
 import { MemoSearchBar } from './MemoSearchBar';
 import { Spinner } from '@/components/ui/Spinner';
+import { useConfirm } from '@/components/ui/ConfirmDialog';
 
 // ============================================================================
 // Types
@@ -56,6 +57,7 @@ export const MemoPane = memo(function MemoPane({
   const t = useTranslations('schedule');
   // Issue #1277: the error-state retry button reuses the shared common label.
   const tCommon = useTranslations('common');
+  const confirm = useConfirm();
 
   // State
   const [memos, setMemos] = useState<WorktreeMemo[]>([]);
@@ -146,6 +148,15 @@ export const MemoPane = memo(function MemoPane({
    */
   const handleDeleteMemo = useCallback(
     async (memoId: string) => {
+      const target = memos.find((m) => m.id === memoId);
+      if (
+        !(await confirm({
+          description: tCommon('confirmDelete', { name: target?.title ?? '' }),
+          variant: 'danger',
+        }))
+      ) {
+        return;
+      }
       try {
         await memoApi.delete(worktreeId, memoId);
         setMemos((prev) => prev.filter((m) => m.id !== memoId));
@@ -153,7 +164,7 @@ export const MemoPane = memo(function MemoPane({
         console.error('Failed to delete memo:', err);
       }
     },
-    [worktreeId]
+    [worktreeId, memos, confirm, tCommon]
   );
 
   /**

--- a/src/components/worktree/TodoPane.tsx
+++ b/src/components/worktree/TodoPane.tsx
@@ -24,6 +24,7 @@ import {
 import { MAX_TODO_CONTENT_LENGTH, MAX_TODO_DETAIL_LENGTH } from '@/config/todo-config';
 import { Modal } from '@/components/ui/Modal';
 import { CopyButton } from '@/components/common/CopyButton';
+import { useConfirm } from '@/components/ui/ConfirmDialog';
 
 /**
  * Restyle CopyButton for the light/dark TodoPane modal — its defaults assume a
@@ -57,6 +58,8 @@ export const TodoPane = React.memo(function TodoPane({
   className = '',
 }: TodoPaneProps) {
   const t = useTranslations('worktree');
+  const tCommon = useTranslations('common');
+  const confirm = useConfirm();
   const [todos, setTodos] = useState<WorktreeTodoItem[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(true);
@@ -145,6 +148,14 @@ export const TodoPane = React.memo(function TodoPane({
 
   const handleDelete = useCallback(
     async (todo: WorktreeTodoItem) => {
+      if (
+        !(await confirm({
+          description: tCommon('confirmDelete', { name: todo.content }),
+          variant: 'danger',
+        }))
+      ) {
+        return;
+      }
       setError(null);
       try {
         await worktreeTodoApi.remove(worktreeId, todo.id);
@@ -153,7 +164,7 @@ export const TodoPane = React.memo(function TodoPane({
         setError(err instanceof Error ? err.message : t('todo.deleteError'));
       }
     },
-    [worktreeId, t],
+    [worktreeId, t, confirm, tCommon],
   );
 
   const openEditor = useCallback((todo: WorktreeTodoItem) => {

--- a/tests/unit/components/home/TodoWidget.test.tsx
+++ b/tests/unit/components/home/TodoWidget.test.tsx
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TodoWidget } from '@/components/home/TodoWidget';
+import { ConfirmProvider } from '@/components/ui/ConfirmDialog';
 import { todoApi, type TodoItem } from '@/lib/api/todo-api';
 
 // Issue #1274: this component's wording resolves through the `home` namespace.
@@ -122,18 +123,40 @@ describe('TodoWidget (Issue #907)', () => {
     );
   });
 
-  it('deletes a todo using its own repositoryId', async () => {
+  it('deletes a todo using its own repositoryId after confirmation (Issue #1487)', async () => {
     mockedApi.remove.mockResolvedValue(undefined);
-    render(<TodoWidget />);
+    render(
+      <ConfirmProvider>
+        <TodoWidget />
+      </ConfirmProvider>,
+    );
     await screen.findByText('alpha task');
 
     // First delete button corresponds to the Alpha (repo-a) todo.
     const deleteButtons = screen.getAllByTestId('todo-delete');
     fireEvent.click(deleteButtons[0]);
+    fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
 
     await waitFor(() =>
       expect(mockedApi.remove).toHaveBeenCalledWith('repo-a', 't1'),
     );
+  });
+
+  it('does not delete a todo when the ConfirmDialog is cancelled (Issue #1487)', async () => {
+    mockedApi.remove.mockResolvedValue(undefined);
+    render(
+      <ConfirmProvider>
+        <TodoWidget />
+      </ConfirmProvider>,
+    );
+    await screen.findByText('alpha task');
+
+    fireEvent.click(screen.getAllByTestId('todo-delete')[0]);
+    fireEvent.click(await screen.findByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => expect(screen.queryByTestId('confirm-dialog')).toBeNull());
+    expect(mockedApi.remove).not.toHaveBeenCalled();
+    expect(screen.getByText('alpha task')).toBeInTheDocument();
   });
 
   it('creates a todo for the selected dropdown repository and refreshes via listAll', async () => {
@@ -223,7 +246,11 @@ describe('TodoWidget mobile layout (Issue #909)', () => {
   it('still toggles and deletes via each todo own repositoryId after the layout change', async () => {
     mockedApi.update.mockResolvedValue(TODOS[1]);
     mockedApi.remove.mockResolvedValue(undefined);
-    render(<TodoWidget />);
+    render(
+      <ConfirmProvider>
+        <TodoWidget />
+      </ConfirmProvider>,
+    );
     await screen.findByText('beta task');
 
     fireEvent.click(screen.getAllByTestId('todo-checkbox')[1]);
@@ -232,6 +259,7 @@ describe('TodoWidget mobile layout (Issue #909)', () => {
     );
 
     fireEvent.click(screen.getAllByTestId('todo-delete')[0]);
+    fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
     await waitFor(() =>
       expect(mockedApi.remove).toHaveBeenCalledWith('repo-a', 't1'),
     );

--- a/tests/unit/components/worktree/AgentInstancesPane.test.tsx
+++ b/tests/unit/components/worktree/AgentInstancesPane.test.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { AgentInstancesPane } from '@/components/worktree/AgentInstancesPane';
+import { ConfirmProvider } from '@/components/ui/ConfirmDialog';
 import {
   MAX_AGENT_INSTANCES,
   getCliToolDisplayName,
@@ -172,19 +173,39 @@ describe('AgentInstancesPane (Issue #869)', () => {
   });
 
   describe('delete instance', () => {
-    it('PATCHes the roster without the deleted instance (order re-normalized)', async () => {
+    it('PATCHes the roster without the deleted instance after confirmation (Issue #1487)', async () => {
       render(
-        <AgentInstancesPane
-          {...baseProps}
-          instances={[primary('claude', 0), primary('codex', 1), primary('gemini', 2)]}
-        />,
+        <ConfirmProvider>
+          <AgentInstancesPane
+            {...baseProps}
+            instances={[primary('claude', 0), primary('codex', 1), primary('gemini', 2)]}
+          />
+        </ConfirmProvider>,
       );
       openRowMenu('claude');
       fireEvent.click(screen.getByTestId('agent-instance-delete-claude'));
+      // Deletion is gated behind the shared ConfirmDialog.
+      fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
       await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
       const body = patchBody();
       expect(body.agentInstances.map((i) => i.id)).toEqual(['codex', 'gemini']);
       expect(body.agentInstances.map((i) => i.order)).toEqual([0, 1]);
+    });
+
+    it('does not PATCH when the delete ConfirmDialog is cancelled (Issue #1487)', async () => {
+      render(
+        <ConfirmProvider>
+          <AgentInstancesPane
+            {...baseProps}
+            instances={[primary('claude', 0), primary('codex', 1), primary('gemini', 2)]}
+          />
+        </ConfirmProvider>,
+      );
+      openRowMenu('claude');
+      fireEvent.click(screen.getByTestId('agent-instance-delete-claude'));
+      fireEvent.click(await screen.findByTestId('confirm-dialog-cancel'));
+      await waitFor(() => expect(screen.queryByTestId('confirm-dialog')).toBeNull());
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('disables delete at MIN (single instance) and shows the min hint', () => {
@@ -266,14 +287,17 @@ describe('AgentInstancesPane (Issue #869)', () => {
       mockFetch.mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
       const onInstancesChange = vi.fn();
       render(
-        <AgentInstancesPane
-          {...baseProps}
-          onInstancesChange={onInstancesChange}
-          instances={[primary('claude', 0), primary('codex', 1)]}
-        />,
+        <ConfirmProvider>
+          <AgentInstancesPane
+            {...baseProps}
+            onInstancesChange={onInstancesChange}
+            instances={[primary('claude', 0), primary('codex', 1)]}
+          />
+        </ConfirmProvider>,
       );
       openRowMenu('claude');
       fireEvent.click(screen.getByTestId('agent-instance-delete-claude'));
+      fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
       await waitFor(() =>
         expect(screen.getByTestId('agent-instances-error')).toBeInTheDocument(),
       );

--- a/tests/unit/components/worktree/MemoPane.test.tsx
+++ b/tests/unit/components/worktree/MemoPane.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { MemoPane } from '@/components/worktree/MemoPane';
+import { ConfirmProvider } from '@/components/ui/ConfirmDialog';
 import type { WorktreeMemo } from '@/types/models';
 
 // Issue #1277: this file asserts rendered wording (empty/loading/no-match copy,
@@ -239,9 +240,13 @@ describe('MemoPane', () => {
     });
   });
 
-  describe('Delete memo', () => {
-    it('should call delete API when delete is clicked', async () => {
-      render(<MemoPane {...defaultProps} />);
+  describe('Delete memo (Issue #1487: ConfirmDialog)', () => {
+    it('should call delete API after the ConfirmDialog is confirmed', async () => {
+      render(
+        <ConfirmProvider>
+          <MemoPane {...defaultProps} />
+        </ConfirmProvider>
+      );
 
       await waitFor(() => {
         expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(2);
@@ -250,13 +255,20 @@ describe('MemoPane', () => {
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
       fireEvent.click(deleteButtons[0]);
 
+      // The delete must be gated behind an explicit confirmation.
+      fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
+
       await waitFor(() => {
         expect(mockDelete).toHaveBeenCalledWith('worktree-1', 'memo-1');
       });
     });
 
-    it('should remove memo from list after deletion', async () => {
-      render(<MemoPane {...defaultProps} />);
+    it('should remove memo from list after confirmed deletion', async () => {
+      render(
+        <ConfirmProvider>
+          <MemoPane {...defaultProps} />
+        </ConfirmProvider>
+      );
 
       await waitFor(() => {
         expect(screen.getAllByTestId('memo-card')).toHaveLength(2);
@@ -264,10 +276,33 @@ describe('MemoPane', () => {
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
       fireEvent.click(deleteButtons[0]);
+      fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
 
       await waitFor(() => {
         expect(screen.getAllByTestId('memo-card')).toHaveLength(1);
       });
+    });
+
+    it('should NOT call delete API when the ConfirmDialog is cancelled', async () => {
+      render(
+        <ConfirmProvider>
+          <MemoPane {...defaultProps} />
+        </ConfirmProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('memo-card')).toHaveLength(2);
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[0]);
+      fireEvent.click(await screen.findByTestId('confirm-dialog-cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).toBeNull();
+      });
+      expect(mockDelete).not.toHaveBeenCalled();
+      expect(screen.getAllByTestId('memo-card')).toHaveLength(2);
     });
   });
 

--- a/tests/unit/components/worktree/TodoPane.test.tsx
+++ b/tests/unit/components/worktree/TodoPane.test.tsx
@@ -12,6 +12,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TodoPane } from '@/components/worktree/TodoPane';
+import { ConfirmProvider } from '@/components/ui/ConfirmDialog';
 import { worktreeTodoApi, type WorktreeTodoItem } from '@/lib/api/todo-api';
 
 // Hoisted so the vi.mock factory (itself hoisted above imports) can reference it.
@@ -131,13 +132,20 @@ describe('TodoPane', () => {
     expect(screen.getByTestId('todo-count-done')).toHaveTextContent('1');
   });
 
-  it('deletes a todo via worktreeTodoApi.remove', async () => {
+  it('deletes a todo via worktreeTodoApi.remove after the ConfirmDialog is confirmed (Issue #1487)', async () => {
     mockedApi.remove.mockResolvedValue(undefined);
-    render(<TodoPane worktreeId="wt-1" />);
+    render(
+      <ConfirmProvider>
+        <TodoPane worktreeId="wt-1" />
+      </ConfirmProvider>,
+    );
     await screen.findByText('first task');
 
     const deleteButtons = screen.getAllByTestId('todo-delete');
     fireEvent.click(deleteButtons[0]);
+
+    // A confirmation dialog must appear before any API call is made.
+    fireEvent.click(await screen.findByTestId('confirm-dialog-confirm'));
 
     await waitFor(() => {
       expect(mockedApi.remove).toHaveBeenCalledWith('wt-1', 't1');
@@ -145,6 +153,26 @@ describe('TodoPane', () => {
     await waitFor(() => {
       expect(screen.queryByText('first task')).not.toBeInTheDocument();
     });
+  });
+
+  it('does not delete when the ConfirmDialog is cancelled (Issue #1487)', async () => {
+    mockedApi.remove.mockResolvedValue(undefined);
+    render(
+      <ConfirmProvider>
+        <TodoPane worktreeId="wt-1" />
+      </ConfirmProvider>,
+    );
+    await screen.findByText('first task');
+
+    fireEvent.click(screen.getAllByTestId('todo-delete')[0]);
+    fireEvent.click(await screen.findByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).toBeNull();
+    });
+    expect(mockedApi.remove).not.toHaveBeenCalled();
+    // The item is still present because the delete was aborted.
+    expect(screen.getByText('first task')).toBeInTheDocument();
   });
 
   it('reorders todos via worktreeTodoApi.reorder when moving down', async () => {


### PR DESCRIPTION
## 概要
確認なしで即削除していた操作（Note / ToDo(worktree,Home) / エージェントインスタンス削除）に既存 `useConfirm`（ConfirmDialog）を適用。

Closes #1487 （base=develop のためマージ後に手動クローズ）

## 変更
- MemoPane / TodoPane / TodoWidget / AgentInstancesPane の各削除ハンドラに `confirm({variant:'danger'})` を追加（common.confirmDelete 流用、新抽象なし）。
- 独自確認を持つ群（External App/Git/Skill uninstall 等）は非対象。実DOMテスト追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)