### PR TITLE
fix: 端末オーバーレイの矢印ナビを検出非依存化（PC＋モバイル） (#1494, #1496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **端末オーバーレイの矢印ナビを検出非依存化（デスクトップ＋モバイル）** (#1494, #1496): `/help`・`/model` 等の未分類 TUI オーバーレイで ESC しか送れず ←/→/↑/↓/Enter が送れなかった問題を、`TerminalEscapeHatch` を Esc 専用から汎用ナビパッド（←/↑/↓/→/Enter/Esc、Codex は追加で `q`）へ拡張して解消した。`isUnclassifiedActive` ゲートは従来どおりで、選択リスト／プロンプト検出時は非表示。モバイルパスは `MobileTerminalTab` を独立モジュール化し、デスクトップと同一ゲート（`isUnclassifiedActive && !prompt.visible`）でハッチを描画してデスクトップと同等の到達性を与えた。
+
 ## [0.14.0] - 2026-07-24
 
 ### Added

--- a/src/components/worktree/MobileTerminalTab.tsx
+++ b/src/components/worktree/MobileTerminalTab.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+/**
+ * MobileTerminalTab (Issue #736, extracted for #1494/#1496)
+ *
+ * Mobile terminal tab content. Owns a per-(worktreeId, cliToolId) instance of
+ * `useTerminalPanePolling` — the same hook the PC split panes use (#728) —
+ * replacing the removed terminal reducer slice. Mounted only while the terminal
+ * tab is active, so the poller stops when the user is on another mobile tab (and
+ * the hook self-resets on a cliToolId change, mirroring the PC compositeKey reset).
+ *
+ * Issue #1494 / #1496: mobile previously rendered ONLY the read-only
+ * TerminalDisplay, so an unclassified TUI overlay (e.g. Claude `/help`) had no
+ * on-screen keys at all — the ESC hatch / navigation pad existed on desktop only.
+ * This renders the shared {@link TerminalEscapeHatch} navigation pad below the
+ * terminal under the same gate the PC footer uses, giving mobile parity for
+ * ←/→/↑/↓/Enter/Esc in detection-independent overlays.
+ */
+
+import { memo } from 'react';
+import { TerminalDisplay } from '@/components/worktree/TerminalDisplay';
+import { TerminalEscapeHatch } from '@/components/worktree/TerminalEscapeHatch';
+import { useTerminalPanePolling } from '@/hooks/useTerminalPanePolling';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+export interface MobileTerminalTabProps {
+  worktreeId: string;
+  cliToolId: CLIToolType;
+  /** Issue #874: agent instance id for this tab (defaults to primary === cliToolId). */
+  instanceId?: string;
+  disableAutoFollow?: boolean;
+}
+
+export const MobileTerminalTab = memo(function MobileTerminalTab({
+  worktreeId,
+  cliToolId,
+  instanceId,
+  disableAutoFollow,
+}: MobileTerminalTabProps) {
+  const { terminal, prompt, setAutoScroll, refresh } = useTerminalPanePolling({
+    worktreeId,
+    cliToolId,
+    instanceId,
+  });
+  // Issue #1172: compact the 1000-row layout padding for Claude/Codex (display only).
+  const compactTuiLayoutPadding = cliToolId === 'claude' || cliToolId === 'codex';
+
+  // Issue #1494 / #1496: detection-independent navigation hatch on mobile.
+  // `terminal.isUnclassifiedActive` is already false whenever a selection list /
+  // pager / prompt is detected server-side, so this surfaces the pad only for an
+  // otherwise-unreachable TUI overlay. `!prompt.visible` mirrors the PC
+  // `showEscapeHatch` gate so it stays hidden while a prompt panel is driving the
+  // session (e.g. the `/model` misdetection tracked in #1495).
+  const showEscapeHatch = terminal.isUnclassifiedActive && !prompt.visible;
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex-1 min-h-0">
+        <TerminalDisplay
+          output={terminal.output}
+          isActive={terminal.isRunning}
+          isThinking={terminal.isThinking}
+          autoScroll={terminal.autoScroll}
+          onScrollChange={setAutoScroll}
+          disableAutoFollow={disableAutoFollow}
+          compactTuiLayoutPadding={compactTuiLayoutPadding}
+          className="h-full"
+        />
+      </div>
+      {showEscapeHatch ? (
+        <div className="shrink-0 px-2 pt-1 pb-2">
+          <TerminalEscapeHatch
+            worktreeId={worktreeId}
+            cliToolId={cliToolId}
+            instanceId={instanceId}
+            onKeysSent={refresh}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+export default MobileTerminalTab;

--- a/src/components/worktree/TerminalEscapeHatch.tsx
+++ b/src/components/worktree/TerminalEscapeHatch.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 /**
- * TerminalEscapeHatch — detection-independent Esc/q safety net (Issue #1017, C-lite).
+ * TerminalEscapeHatch — detection-independent navigation safety net (Issue #1017, #1494).
  *
  * The read-only TerminalDisplay can only be driven through the selection window
  * (NavigationButtons / PromptPanel) or the special-keys API. When a CLI drops into
- * a TUI mode that status detection does not (yet) recognize, none of those surface
- * and the session becomes unreachable — exactly the failure this issue fixes for
- * the Codex pager (via CODEX_PAGER_FOOTER_PATTERN).
+ * a TUI overlay that status detection does NOT classify as a selection list
+ * (isUnclassifiedActive) — e.g. Claude's `/help` tab overlay — NavigationButtons is
+ * not rendered, so before #1494 only Esc was reachable and the ←/→ tab-switching
+ * those overlays rely on was impossible (Issue #1494: "ESC works, arrows don't").
  *
- * This component is the permanent insurance against the NEXT undetected TUI mode.
- * Esc is safe across supported CLIs; q is exposed only for Codex, where it is a
- * known pager quit key. The caller renders it only for a confirmed unclassified
- * state, never at a normal input prompt or over a detected prompt/navigation UI.
+ * This hatch is therefore a full navigation pad (←/↑/↓/→/Enter/Esc), not just Esc:
+ * it lets the user drive ANY unclassified overlay without depending on a footer
+ * pattern match (the detection-independent design intent of #1017). Esc is safe
+ * across supported CLIs; q is exposed only for Codex, where it is a known pager
+ * quit key. The caller renders it only for a confirmed unclassified state, never at
+ * a normal input prompt or over a detected prompt / selection-list UI, so Enter/q
+ * can never reach the composer or a live input line.
  */
 
 import { useCallback, useState } from 'react';
@@ -30,20 +34,47 @@ export interface TerminalEscapeHatchProps {
   onKeysSent?: () => void;
 }
 
-const ESCAPE_KEY: { key: NavigationKey; label: string; ariaLabel: string } =
-  { key: 'Escape', label: 'Esc', ariaLabel: 'Send Escape' };
-const CODEX_QUIT_KEY: { key: NavigationKey; label: string; ariaLabel: string } =
-  { key: 'q', label: 'q', ariaLabel: 'Send q (quit)' };
+interface HatchKeyDef {
+  key: NavigationKey;
+  /** Key-cap glyph / name shown inside the button. */
+  label: string;
+  /** Accessible name — the physical key's own name, used verbatim. */
+  ariaLabel: string;
+}
 
-const CODEX_ESCAPE_KEYS: ReadonlyArray<{ key: NavigationKey; label: string; ariaLabel: string }> = [
-  ESCAPE_KEY,
-  CODEX_QUIT_KEY,
+/* eslint-disable no-restricted-syntax -- i18n(#1271): these literals are physical
+   key notation — key-cap glyphs (◀ ▲ ▼ ▶ ↵) and the key's own name in the aria
+   label ("Send Left" / "Send Escape" / "Send q (quit)"). They are identical in
+   every locale and are not translatable prose. */
+
+/**
+ * Issue #1494: detection-independent navigation keys. Sent to any unclassified TUI
+ * overlay (e.g. Claude `/help`) whose footer does not match the selection-list
+ * pattern that would otherwise render NavigationButtons.
+ */
+const NAVIGATION_KEYS: ReadonlyArray<HatchKeyDef> = [
+  { key: 'Left', label: '◀', ariaLabel: 'Send Left' },
+  { key: 'Up', label: '▲', ariaLabel: 'Send Up' },
+  { key: 'Down', label: '▼', ariaLabel: 'Send Down' },
+  { key: 'Right', label: '▶', ariaLabel: 'Send Right' },
+  { key: 'Enter', label: '↵', ariaLabel: 'Send Enter' },
 ];
+
+const ESCAPE_KEY: HatchKeyDef = { key: 'Escape', label: 'Esc', ariaLabel: 'Send Escape' };
+const CODEX_QUIT_KEY: HatchKeyDef = { key: 'q', label: 'q', ariaLabel: 'Send q (quit)' };
+
+/* eslint-enable no-restricted-syntax */
 
 export function TerminalEscapeHatch({ worktreeId, cliToolId, instanceId, onKeysSent }: TerminalEscapeHatchProps) {
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const send = useSpecialKeys(worktreeId, cliToolId, instanceId, onKeysSent);
-  const escapeKeys = cliToolId === 'codex' ? CODEX_ESCAPE_KEYS : [ESCAPE_KEY];
+  // Base pad (arrows + Enter + Esc) for every CLI; Codex additionally gets the
+  // pager 'q'. 'q' stays Codex-only so it can never insert a literal 'q' at
+  // another CLI's input prompt.
+  const hatchKeys: ReadonlyArray<HatchKeyDef> =
+    cliToolId === 'codex'
+      ? [...NAVIGATION_KEYS, ESCAPE_KEY, CODEX_QUIT_KEY]
+      : [...NAVIGATION_KEYS, ESCAPE_KEY];
 
   const handleClick = useCallback(
     (key: NavigationKey) => {
@@ -58,12 +89,15 @@ export function TerminalEscapeHatch({ worktreeId, cliToolId, instanceId, onKeysS
     <div
       className="flex flex-wrap items-center gap-1.5 py-1.5 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/50 rounded-lg"
       role="toolbar"
-      aria-label="Terminal escape keys"
+      aria-label="Terminal navigation keys"
     >
-      <span className="text-xs text-amber-700 dark:text-amber-400 mx-2" title="Send an escape key when the terminal is stuck in a TUI mode">
-        Escape
+      <span
+        className="text-xs text-amber-700 dark:text-amber-400 mx-2"
+        title="Send navigation / escape keys when the terminal is stuck in a TUI overlay"
+      >
+        Navigate
       </span>
-      {escapeKeys.map(({ key, label, ariaLabel }) => (
+      {hatchKeys.map(({ key, label, ariaLabel }) => (
         <button
           key={key}
           type="button"

--- a/src/components/worktree/TerminalSplitPaneContent.tsx
+++ b/src/components/worktree/TerminalSplitPaneContent.tsx
@@ -286,12 +286,13 @@ export const TerminalSplitPaneContent = memo(function TerminalSplitPaneContent({
   const showNav = terminal.isSelectionListActive;
   const showPrompt = prompt.visible && !autoYesEnabled;
 
-  // Issue #1017 (C-lite): detection-independent Esc/q safety net. Shown only when
-  // the session is interactive but detection could not classify the frame
-  // (isUnclassifiedActive) — the "stuck in an unrecognized TUI mode" case — and no
-  // selection list / prompt panel is already driving it. Stays hidden during normal
-  // generation ('thinking_indicator') and at an idle input prompt ('ready'), so it
-  // is neither noisy nor able to insert a stray 'q' at the composer.
+  // Issue #1017 / #1494: detection-independent navigation safety net (←/→/↑/↓/Enter/
+  // Esc, plus Codex 'q'). Shown only when the session is interactive but detection
+  // could not classify the frame (isUnclassifiedActive) — the "stuck in an
+  // unrecognized TUI overlay" case such as Claude `/help`, where NavigationButtons is
+  // not rendered — and no selection list / prompt panel is already driving it. Stays
+  // hidden during normal generation ('thinking_indicator') and at an idle input prompt
+  // ('ready'), so Enter/'q' can never reach the composer.
   const showEscapeHatch =
     terminal.isUnclassifiedActive &&
     !showNav &&

--- a/src/components/worktree/WorktreeDetailMobile.tsx
+++ b/src/components/worktree/WorktreeDetailMobile.tsx
@@ -17,8 +17,7 @@
 
 import React, { memo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { TerminalDisplay } from '@/components/worktree/TerminalDisplay';
-import { useTerminalPanePolling } from '@/hooks/useTerminalPanePolling';
+import { MobileTerminalTab } from '@/components/worktree/MobileTerminalTab';
 import { HistoryPane } from '@/components/worktree/HistoryPane';
 import { type MobileTab } from '@/components/mobile/MobileTabBar';
 import { ErrorBoundary } from '@/components/error/ErrorBoundary';
@@ -200,43 +199,9 @@ interface MobileContentProps {
   onToggleInstanceVisible?: (instanceId: string) => void;
 }
 
-/**
- * [Issue #736] Mobile terminal tab content.
- *
- * Owns a per-(worktreeId, cliToolId) `useTerminalPanePolling` instance — the
- * same hook the PC split panes use (#728) — replacing the removed
- * terminal reducer slice. Mounted only while the terminal tab is
- * active, so the poller stops when the user is on another mobile tab (and the
- * hook self-resets on a cliToolId change, mirroring the PC compositeKey reset).
- */
-const MobileTerminalTab = memo(function MobileTerminalTab({
-  worktreeId,
-  cliToolId,
-  instanceId,
-  disableAutoFollow,
-}: {
-  worktreeId: string;
-  cliToolId: CLIToolType;
-  /** Issue #874: agent instance id for this tab (defaults to primary === cliToolId). */
-  instanceId?: string;
-  disableAutoFollow?: boolean;
-}) {
-  const { terminal, setAutoScroll } = useTerminalPanePolling({ worktreeId, cliToolId, instanceId });
-  // Issue #1172: compact the 1000-row layout padding for Claude/Codex (display only).
-  const compactTuiLayoutPadding = cliToolId === 'claude' || cliToolId === 'codex';
-  return (
-    <TerminalDisplay
-      output={terminal.output}
-      isActive={terminal.isRunning}
-      isThinking={terminal.isThinking}
-      autoScroll={terminal.autoScroll}
-      onScrollChange={setAutoScroll}
-      disableAutoFollow={disableAutoFollow}
-      compactTuiLayoutPadding={compactTuiLayoutPadding}
-      className="h-full"
-    />
-  );
-});
+// Issue #1494 / #1496: MobileTerminalTab moved to its own module so the mobile
+// terminal tab (now carrying the detection-independent navigation hatch) can be
+// unit-tested without the full mobile detail dependency graph. Imported above.
 
 /** Renders content based on active mobile tab */
 export const MobileContent = memo(function MobileContent({

--- a/tests/unit/components/worktree/MobileTerminalTab.test.tsx
+++ b/tests/unit/components/worktree/MobileTerminalTab.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for MobileTerminalTab navigation-hatch parity (Issue #1494 / #1496).
+ *
+ * Mobile previously rendered only the read-only TerminalDisplay, so an
+ * unclassified TUI overlay (e.g. Claude `/help`) had no on-screen keys at all.
+ * These tests assert the shared TerminalEscapeHatch navigation pad now appears on
+ * mobile under the same gate the PC footer uses, and drives the special-keys API.
+ *
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Stub the heavy read-only terminal surface; this suite only cares about the hatch.
+vi.mock('@/components/worktree/TerminalDisplay', () => ({
+  TerminalDisplay: () => <div data-testid="terminal-display" />,
+}));
+
+const { useTerminalPanePollingMock } = vi.hoisted(() => ({
+  useTerminalPanePollingMock: vi.fn(),
+}));
+vi.mock('@/hooks/useTerminalPanePolling', () => ({
+  useTerminalPanePolling: useTerminalPanePollingMock,
+}));
+
+import { MobileTerminalTab } from '@/components/worktree/MobileTerminalTab';
+
+interface PaneOverrides {
+  isUnclassifiedActive?: boolean;
+  isSelectionListActive?: boolean;
+  promptVisible?: boolean;
+}
+
+function mockPaneState({
+  isUnclassifiedActive = false,
+  isSelectionListActive = false,
+  promptVisible = false,
+}: PaneOverrides) {
+  useTerminalPanePollingMock.mockReturnValue({
+    terminal: {
+      output: 'output',
+      realtimeSnippet: 'output',
+      isRunning: true,
+      isThinking: false,
+      isSelectionListActive,
+      isPagerActive: false,
+      isUnclassifiedActive,
+      attaching: false,
+      autoScroll: true,
+    },
+    prompt: { visible: promptVisible, data: null, messageId: null, answering: false },
+    setAutoScroll: vi.fn(),
+    setPromptAnswering: vi.fn(),
+    clearPrompt: vi.fn(),
+    refresh: vi.fn(),
+  });
+}
+
+describe('MobileTerminalTab navigation hatch (Issue #1494 / #1496)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('shows the navigation hatch when the frame is unclassified (e.g. /help)', () => {
+    mockPaneState({ isUnclassifiedActive: true });
+    render(<MobileTerminalTab worktreeId="w-1" cliToolId="claude" />);
+    expect(screen.getByLabelText('Send Left')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Right')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Escape')).toBeInTheDocument();
+  });
+
+  it('hides the navigation hatch when the frame is classified/idle', () => {
+    mockPaneState({ isUnclassifiedActive: false });
+    render(<MobileTerminalTab worktreeId="w-1" cliToolId="claude" />);
+    expect(screen.queryByLabelText('Send Left')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Send Escape')).not.toBeInTheDocument();
+  });
+
+  it('hides the navigation hatch while a prompt panel is driving the session (parity with PC, /model=#1495)', () => {
+    mockPaneState({ isUnclassifiedActive: true, promptVisible: true });
+    render(<MobileTerminalTab worktreeId="w-1" cliToolId="claude" />);
+    expect(screen.queryByLabelText('Send Left')).not.toBeInTheDocument();
+  });
+
+  it('sends the arrow key through the special-keys API from the mobile hatch', async () => {
+    mockPaneState({ isUnclassifiedActive: true });
+    render(<MobileTerminalTab worktreeId="w-1" cliToolId="claude" instanceId="claude" />);
+    fireEvent.click(screen.getByLabelText('Send Right'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/worktrees/w-1/special-keys');
+    expect(JSON.parse((options as RequestInit).body as string)).toEqual({
+      cliToolId: 'claude',
+      keys: ['Right'],
+    });
+  });
+});

--- a/tests/unit/components/worktree/TerminalEscapeHatch.test.tsx
+++ b/tests/unit/components/worktree/TerminalEscapeHatch.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Tests for TerminalEscapeHatch (Issue #1017, C-lite safety net)
+ * Tests for TerminalEscapeHatch (Issue #1017 safety net, extended to a
+ * detection-independent navigation pad in Issue #1494).
  *
  * @vitest-environment jsdom
  */
@@ -22,26 +23,47 @@ describe('TerminalEscapeHatch', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders the Esc and q escape keys', () => {
+  // Issue #1494: the hatch is the on-screen way to drive an unclassified overlay
+  // (e.g. Claude `/help`) where NavigationButtons is not rendered, so it must
+  // expose the arrow / Enter keys, not just Esc.
+  it('renders the arrow, Enter and Escape navigation keys (Issue #1494)', () => {
+    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="claude" />);
+    expect(screen.getByLabelText('Send Left')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Up')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Down')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Right')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Enter')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send Escape')).toBeInTheDocument();
+  });
+
+  it('renders the Esc and q keys for Codex', () => {
     render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="codex" />);
     expect(screen.getByLabelText('Send Escape')).toBeInTheDocument();
     expect(screen.getByLabelText('Send q (quit)')).toBeInTheDocument();
   });
 
-  it('renders Escape only for Claude so q cannot reach the input prompt', () => {
+  it('exposes q only for Codex so it cannot reach another CLI input prompt', () => {
     render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="claude" />);
     expect(screen.getByLabelText('Send Escape')).toBeInTheDocument();
     expect(screen.queryByLabelText('Send q (quit)')).not.toBeInTheDocument();
   });
 
-  it('sends Escape via the special-keys API', async () => {
-    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="codex" />);
-    fireEvent.click(screen.getByLabelText('Send Escape'));
+  it.each([
+    ['Send Left', 'Left'],
+    ['Send Right', 'Right'],
+    ['Send Enter', 'Enter'],
+    ['Send Escape', 'Escape'],
+  ])('sends %s via the special-keys API as key %s (Issue #1494)', async (ariaLabel, expectedKey) => {
+    render(<TerminalEscapeHatch worktreeId="w-1" cliToolId="claude" />);
+    fireEvent.click(screen.getByLabelText(ariaLabel));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     const [url, options] = fetchMock.mock.calls[0];
     expect(url).toBe('/api/worktrees/w-1/special-keys');
-    expect(JSON.parse((options as RequestInit).body as string)).toEqual({ cliToolId: 'codex', keys: ['Escape'] });
+    expect(JSON.parse((options as RequestInit).body as string)).toEqual({
+      cliToolId: 'claude',
+      keys: [expectedKey],
+    });
   });
 
   it('sends q and targets a non-primary instance (Issue #869)', async () => {


### PR DESCRIPTION
## 概要

`/help`・`/model` 等の未分類 TUI オーバーレイで、ESC は効くのに ←/→/↑/↓/Enter が送れない問題を、検出パターンに依存しない汎用ナビハッチで解消する。デスクトップ（#1494）とモバイル（#1496）の両方に適用。

## 変更

- **`TerminalEscapeHatch`**: Esc 専用 → 汎用ナビパッド（←/↑/↓/→/Enter/Esc、Codex は追加で `q`）。`isUnclassifiedActive` ゲートは従来どおり（選択リスト／プロンプト検出時は非表示なので Enter/q が composer に届かない）。
- **`MobileTerminalTab`（新規モジュール）**: `WorktreeDetailMobile` からインライン定義を切り出し。`useTerminalPanePolling` の `terminal.isUnclassifiedActive` / `prompt.visible` を読み、デスクトップと同一ゲート（`isUnclassifiedActive && !prompt.visible`）でハッチを描画。→ モバイルにも #1017 の安全網＋矢印ナビを付与。
- テスト: `TerminalEscapeHatch.test.tsx`（ナビキー送信）＋ `MobileTerminalTab.test.tsx`（mobile ゲート描画）。

## 品質ゲート（worktree 内）

- ESLint ✅ / tsc --noEmit ✅ / test:unit ✅ (11279) / build ✅

## Closes

Closes #1494
Closes #1496

> base=develop のため自動クローズされない。マージ後にオーケストレーターが手動クローズする。