### PR TITLE
fix: Auto-Yes が Claude /model を誤自動応答しデフォルトモデルを変更する不具合を修正 (#1495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-Yes が Claude `/model` オーバーレイを誤って自動応答しデフォルトモデルを変更する不具合を修正** (#1495): `/model` の番号付きモデル一覧を `detectMultipleChoicePrompt` が本物の multiple_choice と誤検出し、Auto-Yes が Enter 確定して既定モデルを無断変更していた。実機 Claude Code v2.1.218 のフッタ「Enter to set as default …」を検出したら `detectPrompt` を非プロンプト扱いにして Auto-Yes を停止し、あわせて `CLAUDE_SELECTION_LIST_FOOTER` に同フッタを追加して `/model` を Claude selection list（NavigationButtons＋ESC ハッチ／`hasActivePrompt=false`）へ再分類する。権限確認・trust ダイアログ・AskUserQuestion・Gemini `/model` 等の本物のプロンプトは非回帰（実キャプチャ fixture で検証）。
+
 ## [0.14.0] - 2026-07-24
 
 ### Added

--- a/src/lib/detection/cli-patterns.ts
+++ b/src/lib/detection/cli-patterns.ts
@@ -505,6 +505,24 @@ export const OPENCODE_PROCESSING_INDICATOR = /esc interrupt/;
 export const OPENCODE_SELECTION_LIST_PATTERN = /^\s*(Select\s+(model|provider)|Connect\s+a\s+provider)/m;
 
 /**
+ * [Issue #1495] Footer signature of Claude Code's `/model` local-settings overlay.
+ * Verified against a real Claude Code v2.1.218 capture, the footer reads:
+ *   "Enter to set as default · s to use this session only · Esc to cancel"
+ *
+ * The overlay renders a ❯-marked numbered model list ("1. Default … 5. Haiku")
+ * under a "Select model" header that detectMultipleChoicePrompt() otherwise
+ * matches as a genuine multiple_choice prompt — which let Auto-Yes Enter-confirm
+ * a selection and silently change the user's default model. This "set as default"
+ * phrasing is unique to the model picker: genuine confirmation prompts never
+ * contain it (the trust dialog uses "Enter to confirm · Esc to cancel", Bash-tool
+ * approvals use "Esc to cancel · Tab to amend", AskUserQuestion uses
+ * "Enter to select · … to navigate"), so it is a safe exclusion signal.
+ *
+ * Linear pattern, no nested quantifiers — ReDoS safe (S4-001).
+ */
+export const CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN = /Enter\s+to\s+set\s+as\s+default\b/i;
+
+/**
  * Claude CLI selection list footer pattern
  * Detects Claude CLI's interactive selection prompts that require
  * arrow key navigation and Enter to select/toggle.
@@ -512,9 +530,16 @@ export const OPENCODE_SELECTION_LIST_PATTERN = /^\s*(Select\s+(model|provider)|C
  * Matches footer instruction lines (known variants):
  *   "Enter to select · Tab/Arrow keys to navigate · Esc to cancel"
  *   "Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel"
- *   "Enter to confirm · Esc to exit"  (/model command)
+ *   "Enter to confirm · Esc to exit"  (legacy /model command footer)
+ *   "Enter to set as default · s to use this session only · Esc to cancel"
+ *     (/model command footer as of Claude Code v2.1.218 — Issue #1495)
+ *
+ * The "set as default" branch lets status-detector classify the `/model` overlay
+ * as a Claude selection list (NavigationButtons + ESC hatch, hasActivePrompt=false)
+ * once detectPrompt() no longer reports it as a prompt (see
+ * CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN).
  */
-export const CLAUDE_SELECTION_LIST_FOOTER = /Enter\s+to\s+(?:select\s+.*to\s+navigate|confirm\s+·\s+Esc)/;
+export const CLAUDE_SELECTION_LIST_FOOTER = /Enter\s+to\s+(?:select\s+.*to\s+navigate|confirm\s+·\s+Esc|set\s+as\s+default)/;
 
 /**
  * OpenCode TUI separator pattern (Issue #379)

--- a/src/lib/detection/prompt-detect-multiple-choice.ts
+++ b/src/lib/detection/prompt-detect-multiple-choice.ts
@@ -3,6 +3,7 @@
 import type { DetectPromptOptions, PromptDetectionResult } from './types';
 import type { SubmitMode } from '@/types/models';
 import { normalizeTuiFrameForDetection } from './tui-detection-frame';
+import { CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN } from './cli-patterns';
 
 // ============================================================================
 // Constants
@@ -645,6 +646,26 @@ export function detectMultipleChoicePrompt(
     }
   }
   const scanWindow = lines.slice(scanStart, effectiveEnd);
+
+  // [Issue #1495] Claude `/model` local-settings overlay guard.
+  // The `/model` overlay renders a ❯-marked numbered model list ("1. Default …
+  // 5. Haiku") under a "Select model" header, which the option-collection logic
+  // below would otherwise return as a genuine multiple_choice prompt. Auto-Yes
+  // (detectAndRespondToPrompt) calls detectPrompt() directly and would resolve +
+  // Enter-confirm the default option — silently changing the user's default model.
+  // The overlay-unique "Enter to set as default …" footer never appears in real
+  // confirmation prompts (permission dialogs, the trust dialog, AskUserQuestion),
+  // so bailing out here stops Auto-Yes without touching any real-prompt path. The
+  // overlay is modal — no genuine prompt can be active at the same time, and the
+  // Claude TUI repaints the overlay away on close, so a stale footer cannot linger
+  // in the captured pane. status-detector then reclassifies it as a Claude
+  // selection list via CLAUDE_SELECTION_LIST_FOOTER (NavigationButtons + ESC hatch).
+  for (const rawLine of scanWindow) {
+    if (CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN.test(rawLine)) {
+      return noPromptResult(output);
+    }
+  }
+
   // Single-pass footer detection: identify both confirmation footer presence and
   // specific "press number to confirm" variant in one iteration (Issue #616).
   let hasConfirmationFooter = false;

--- a/tests/fixtures/claude-model-overlay.ts
+++ b/tests/fixtures/claude-model-overlay.ts
@@ -1,0 +1,55 @@
+/**
+ * Real capture of Claude Code v2.1.218's `/model` local-settings overlay.
+ *
+ * Captured via tmux (120x40) from an actual `claude` v2.1.218 session for
+ * Issue #1495. The ❯-marked numbered model list ("1. Default … 5. Haiku") under
+ * the "Select model" header is what detectMultipleChoicePrompt() previously
+ * mis-detected as a real multiple_choice prompt, causing Auto-Yes to Enter-confirm
+ * a selection and silently change the user's default model.
+ *
+ * The decisive, overlay-unique footer is:
+ *   "Enter to set as default · s to use this session only · Esc to cancel"
+ *
+ * Do not hand-edit — regenerate from a fresh capture if the Claude TUI changes.
+ */
+export const CLAUDE_MODEL_OVERLAY_V2_1_218 = `
+╭─── Claude Code v2.1.218 ─────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                    │ Tips for getting started                                        │
+│                 Welcome back Kota!                 │ Ask Claude to create a new app or clone a repository            │
+│                                                    │ ─────────────────────────────────────────────────────────────── │
+│                       ▐▛███▜▌                      │ What's new                                                      │
+│                      ▝▜█████▛▘                     │ Changed \`/code-review\` to run as a background subagent, so rev… │
+│                        ▘▘ ▝▝                       │ Added screen-reader announcements of deleted text for word and… │
+│   Opus 4.8 (1M context) with xh… · Claude Max ·    │ Fixed Windows paths with \`\\u\`-prefixed segments (like \`C:\\User… │
+│   newtons.boiled.clock@gmail.com's Organization    │ /release-notes for more                                         │
+│        /…/scratchpad/model-capture-workdir         │                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+
+
+
+
+
+
+
+
+
+
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+   Select model
+   Switch between Claude models. Your pick becomes the default for new sessions. For other/previous model names,
+   specify with --model.
+
+   ❯ 1. Default (recommended) ✔  Opus 4.8 with 1M context · Best for everyday, complex tasks
+     2. Opus                     Opus 4.8 with 1M context · Best for everyday, complex tasks
+     3. Fable                    Fable 5 · Most capable for your hardest and longest-running tasks
+     4. Sonnet                   Sonnet 5 · Efficient for routine tasks
+     5. Haiku                    Haiku 4.5 · Fastest for quick answers
+
+   ◉ xHigh effort ←/→ to adjust
+
+   Use /fast to turn on Fast mode (Opus 4.8).
+
+   Enter to set as default · s to use this session only · Esc to cancel
+`;

--- a/tests/unit/detection-model-overlay-1495.test.ts
+++ b/tests/unit/detection-model-overlay-1495.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Issue #1495: Auto-Yes must not auto-answer Claude's `/model` local-settings
+ * overlay (which would silently change the user's default model).
+ *
+ * Root cause (verified on Claude Code v2.1.218, see fixture): the `/model`
+ * overlay renders a ❯-marked numbered model list under a "Select model" header,
+ * which detectMultipleChoicePrompt() mis-detected as a real multiple_choice
+ * prompt. Auto-Yes (detectAndRespondToPrompt) calls detectPrompt() directly and
+ * would resolve + Enter-confirm the default option.
+ *
+ * Fix:
+ *   A) detectMultipleChoicePrompt() bails out when the overlay-unique footer
+ *      "Enter to set as default …" is present → detectPrompt returns isPrompt=false
+ *      → Auto-Yes skips, and the false `prompt_detected` status is gone.
+ *   B) status-detector classifies the overlay as a Claude selection list
+ *      (reason=claude_selection_list, hasActivePrompt=false) so NavigationButtons /
+ *      ESC hatch are available and the sidebar no longer shows a fake prompt.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { detectPrompt, resetDetectPromptCache } from '@/lib/detection/prompt-detector';
+import { detectSessionStatus, STATUS_REASON } from '@/lib/detection/status-detector';
+import { resolveAutoAnswer } from '@/lib/polling/auto-yes-resolver';
+import {
+  buildDetectPromptOptions,
+  CLAUDE_SELECTION_LIST_FOOTER,
+  CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN,
+} from '@/lib/detection/cli-patterns';
+import { isMultipleChoicePrompt } from '../helpers/prompt-type-guards';
+import { CLAUDE_MODEL_OVERLAY_V2_1_218 } from '../fixtures/claude-model-overlay';
+
+// Genuine Claude confirm-footer multiple_choice prompt (question adjacent to the
+// numbered options). MUST remain detected — its footer ("Enter to confirm · Esc
+// to cancel") shares the word "Enter"/"confirm"/"Esc" with the overlay footer but
+// NOT the "set as default" signature, so the guard must not exclude it.
+const CLAUDE_CONFIRM_FOOTER_PROMPT = [
+  ' Is this a project you trust?',
+  ' ❯ 1. Yes, I trust this folder',
+  '   2. No, exit',
+  '',
+  ' Enter to confirm · Esc to cancel',
+].join('\n');
+
+// Genuine Claude permission prompt (Bash tool confirmation footer). MUST remain
+// a detected multiple_choice prompt so Auto-Yes still answers it.
+const CLAUDE_PERMISSION_PROMPT = [
+  '⏺ Bash(git status)',
+  '─'.repeat(45),
+  'Do you want to proceed?',
+  '❯ 1. Yes',
+  "  2. Yes, and don't ask again for git in <path>",
+  '  3. No',
+  '',
+  '  Esc to cancel · Tab to amend →',
+].join('\n');
+
+describe('Issue #1495: Claude /model overlay must not be auto-answered', () => {
+  beforeEach(() => {
+    resetDetectPromptCache();
+  });
+
+  describe('cli-patterns: model-overlay footer signature', () => {
+    it('CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN matches the real /model footer', () => {
+      expect(
+        CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN.test(
+          'Enter to set as default · s to use this session only · Esc to cancel',
+        ),
+      ).toBe(true);
+    });
+
+    it('CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN does NOT match genuine prompt footers', () => {
+      // Trust dialog / generic confirm
+      expect(CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN.test('Enter to confirm · Esc to cancel')).toBe(false);
+      // Bash-tool permission footer
+      expect(CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN.test('Esc to cancel · Tab to amend →')).toBe(false);
+      // AskUserQuestion footer
+      expect(
+        CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN.test('Enter to select · ↑/↓ to navigate · Esc to cancel'),
+      ).toBe(false);
+      // /config footer
+      expect(CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN.test('Type to filter · Enter/↓ to select · Esc to clear')).toBe(false);
+    });
+
+    it('CLAUDE_SELECTION_LIST_FOOTER matches the real /model footer (change B)', () => {
+      expect(
+        CLAUDE_SELECTION_LIST_FOOTER.test(
+          'Enter to set as default · s to use this session only · Esc to cancel',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('change A: detectPrompt does not treat /model as an answerable prompt', () => {
+    it('returns isPrompt=false for the real /model overlay (claude options)', () => {
+      const result = detectPrompt(CLAUDE_MODEL_OVERLAY_V2_1_218, buildDetectPromptOptions('claude'));
+      expect(result.isPrompt).toBe(false);
+      expect(result.promptData).toBeUndefined();
+    });
+
+    it('Auto-Yes cannot resolve an answer for the /model overlay', () => {
+      const result = detectPrompt(CLAUDE_MODEL_OVERLAY_V2_1_218, buildDetectPromptOptions('claude'));
+      // detectAndRespondToPrompt returns 'no_prompt' at the !promptData guard,
+      // so resolveAutoAnswer is never reached. Assert the precondition directly.
+      expect(result.promptData).toBeUndefined();
+      // And defensively: even if a caller forced resolution, there is nothing to resolve.
+      if (result.promptData) {
+        expect(resolveAutoAnswer(result.promptData)).toBeNull();
+      }
+    });
+  });
+
+  describe('change B: status-detector classifies /model as a selection list', () => {
+    it('returns waiting/claude_selection_list with hasActivePrompt=false', () => {
+      const st = detectSessionStatus(CLAUDE_MODEL_OVERLAY_V2_1_218, 'claude');
+      expect(st.status).toBe('waiting');
+      expect(st.reason).toBe(STATUS_REASON.CLAUDE_SELECTION_LIST);
+      expect(st.hasActivePrompt).toBe(false);
+    });
+
+    it('does NOT report prompt_detected for /model (acceptance criterion 3)', () => {
+      const st = detectSessionStatus(CLAUDE_MODEL_OVERLAY_V2_1_218, 'claude');
+      expect(st.reason).not.toBe(STATUS_REASON.PROMPT_DETECTED);
+    });
+  });
+
+  describe('non-regression: genuine Claude multiple_choice prompts still auto-answerable', () => {
+    it('confirm-footer prompt ("Enter to confirm · Esc to cancel") is still detected', () => {
+      const result = detectPrompt(CLAUDE_CONFIRM_FOOTER_PROMPT, buildDetectPromptOptions('claude'));
+      expect(result.isPrompt).toBe(true);
+      expect(result.promptData?.type).toBe('multiple_choice');
+      if (isMultipleChoicePrompt(result.promptData)) {
+        expect(result.promptData.options.length).toBeGreaterThanOrEqual(2);
+        expect(resolveAutoAnswer(result.promptData)).toBe('1');
+      }
+    });
+
+    it('Bash permission prompt is still detected and resolves to Yes', () => {
+      const result = detectPrompt(CLAUDE_PERMISSION_PROMPT, buildDetectPromptOptions('claude'));
+      expect(result.isPrompt).toBe(true);
+      expect(result.promptData?.type).toBe('multiple_choice');
+      if (isMultipleChoicePrompt(result.promptData)) {
+        const def = result.promptData.options.find(o => o.isDefault);
+        expect(def?.label).toBe('Yes');
+        expect(resolveAutoAnswer(result.promptData)).toBe('1');
+      }
+    });
+
+    it('status-detector still reports prompt_detected for a genuine permission prompt', () => {
+      const st = detectSessionStatus(CLAUDE_PERMISSION_PROMPT, 'claude');
+      expect(st.status).toBe('waiting');
+      expect(st.reason).toBe(STATUS_REASON.PROMPT_DETECTED);
+      expect(st.hasActivePrompt).toBe(true);
+    });
+  });
+
+  describe('non-regression: Gemini /model dialog (different footer) still detected', () => {
+    it('Gemini Select Model dialog remains a multiple_choice prompt', () => {
+      const output = [
+        '> /model',
+        '',
+        '',
+        'Select Model',
+        '',
+        '● 1. Auto (Gemini 3)',
+        '     Let Gemini CLI decide the best model for the task: gemini-3.1-pro, gemini-3-flash',
+        '  2. Auto (Gemini 2.5)',
+        '     Let Gemini CLI decide the best model for the task: gemini-2.5-pro, gemini-2.5-flash',
+        '  3. Manual',
+        '     Manually select a model',
+        '',
+        '(Press Esc to close)',
+      ].join('\n');
+      const result = detectPrompt(output);
+      expect(result.isPrompt).toBe(true);
+      expect(result.promptData?.type).toBe('multiple_choice');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Auto-Yes 有効中に Claude TUI で `/model` を開くと、番号付きモデル一覧を通常の確認プロンプトと誤認して選択肢を Enter 確定し、**ユーザーの意図しないデフォルトモデル変更**が起きていた（`/model` の Enter＝「デフォルトとして設定」）。

## 原因

Auto-Yes（`detectAndRespondToPrompt`）は `detectPrompt()` を直接呼ぶ（status-detector を経由しない）。`detectMultipleChoicePrompt()` が `/model` の `❯` マーク付き番号リストを本物の `multiple_choice` と誤検出していた。

## 修正

- **A**: `detectMultipleChoicePrompt` に、`/model` オーバーレイ固有フッタ `CLAUDE_MODEL_OVERLAY_FOOTER_PATTERN`（`Enter to set as default …`、実機 v2.1.218 で検証）を検出したら `noPromptResult` で早期 return するガードを追加。→ `detectPrompt` が非プロンプトを返し Auto-Yes が停止。
- **B**: `CLAUDE_SELECTION_LIST_FOOTER` に `set as default` を追加。→ status-detector が `/model` を Claude selection list（NavigationButtons＋ESC ハッチ、`hasActivePrompt=false`）へ再分類。サイドバーの偽 `waiting` 表示も解消。

## 非回帰（実キャプチャ fixture で検証）

権限確認プロンプト・trust ダイアログ・AskUserQuestion・**Gemini `/model`**（フッタが異なる）はいずれも従来どおり `multiple_choice` として検出・自動応答可能。

## 品質ゲート（worktree 内）

ESLint ✅ / tsc --noEmit ✅ / test:unit ✅ (11282) / build ✅

## Closes

Closes #1495

> base=develop のため自動クローズされない。マージ後に手動クローズする。