### PR TITLE
fix: 未分類 TUI が5秒静止でナビハッチが消える不具合を修正 (#1497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **端末オーバーレイの矢印ナビを検出非依存化（デスクトップ＋モバイル）** (#1494, #1496): `/help`・`/model` 等の未分類 TUI オーバーレイで ESC しか送れず ←/→/↑/↓/Enter が送れなかった問題を、`TerminalEscapeHatch` を Esc 専用から汎用ナビパッド（←/↑/↓/→/Enter/Esc、Codex は追加で `q`）へ拡張して解消した。`isUnclassifiedActive` ゲートは従来どおりで、選択リスト／プロンプト検出時は非表示。モバイルパスは `MobileTerminalTab` を独立モジュール化し、デスクトップと同一ゲート（`isUnclassifiedActive && !prompt.visible`）でハッチを描画してデスクトップと同等の到達性を与えた。
+- **未分類 TUI が5秒静止でナビハッチ消滅する不具合を修正** (#1497): 未分類オーバーレイ（`/help` 等）が静止すると Auto-Yes の `lastServerResponseTimestamp` 更新後に `ready`/`no_recent_output` へ降格し、`isUnclassifiedActive` が落ちてナビハッチ（#1017/#1494）が消えていた。真の idle プロンプト（`❯`）は降格前に `input_prompt` として分類されるため、`no_recent_output` フォールバックは未分類フレームでしか起きない。よって `current-output-builder` の `isUnclassifiedActive` ゲートを `ready`/`no_recent_output` も含めるよう緩和し、静止中もハッチを表示し続ける。実キャプチャ fixture ＋ stale timestamp で単体テスト（真の idle 非回帰込み）。
 
 ## [0.14.0] - 2026-07-24
 

--- a/src/lib/session/current-output-builder.ts
+++ b/src/lib/session/current-output-builder.ts
@@ -100,8 +100,17 @@ export async function buildCurrentOutput(
   const isSelectionListActive =
     statusResult.status === 'waiting' && SELECTION_LIST_REASONS.has(statusResult.reason);
   const isPagerActive = statusResult.reason === STATUS_REASON.CODEX_PAGER;
+  // Issue #1497: the detection-independent nav hatch (#1017/#1494) is gated on
+  // isUnclassifiedActive. A static, unrecognized TUI overlay (e.g. Claude `/help`)
+  // whose frame stops changing degrades from `running`/`default` to `ready`/
+  // `no_recent_output` once the Auto-Yes poller has stamped lastOutputTimestamp
+  // (its sole writer, auto-yes-poller.ts). That is still an interactive-but-
+  // unclassified frame — a real idle prompt (`❯`) is classified earlier as
+  // `input_prompt`, never as `no_recent_output` — so treat the timed-out fallback
+  // as unclassified too and keep the hatch open instead of stranding the user.
   const isUnclassifiedActive =
-    statusResult.status === 'running' && statusResult.reason === STATUS_REASON.DEFAULT;
+    (statusResult.status === 'running' && statusResult.reason === STATUS_REASON.DEFAULT) ||
+    (statusResult.status === 'ready' && statusResult.reason === STATUS_REASON.NO_RECENT_OUTPUT);
 
   const realtimeSnippet = lines.slice(-100).join('\n');
   const autoYesState = getAutoYesState(worktreeId, cliToolId, instanceId);

--- a/tests/fixtures/claude-help-overlay.ts
+++ b/tests/fixtures/claude-help-overlay.ts
@@ -1,0 +1,38 @@
+/**
+ * Synthetic Claude Code `/help` overlay frame (Issue #1497).
+ *
+ * Models a static, unclassified TUI overlay: the full-screen help view replaces
+ * the composer, so the frame contains
+ *   - no thinking spinner / "esc to interrupt" status bar (not `running`),
+ *   - no numbered / yes-no prompt (not `waiting`),
+ *   - and — critically — no `❯`/`>` input line (not `ready`/`input_prompt`).
+ *
+ * detectSessionStatus() therefore cannot positively classify it and reaches the
+ * time-based heuristic (status-detector step 4). With no lastOutputTimestamp it
+ * stays `running`/`default`; once the Auto-Yes poller has stamped a stale
+ * timestamp it degrades to `ready`/`no_recent_output` — the path that used to
+ * hide the detection-independent nav hatch (#1017/#1494) and strand the user.
+ */
+export function buildClaudeHelpOverlayFrame(): string {
+  return [
+    'Claude Code — Help',
+    '',
+    'Usage Modes',
+    ' • Interactive:  claude',
+    ' • One-off:      claude -p "your question"',
+    '',
+    'Slash Commands',
+    ' /help      Show this help view',
+    ' /clear     Clear the current conversation',
+    ' /model     Switch the active model',
+    ' /config    Open configuration',
+    '',
+    'Keyboard Shortcuts',
+    ' Ctrl+C     Cancel the current input',
+    ' Ctrl+D     Exit Claude Code',
+    ' Shift+Tab  Cycle permission modes',
+    ' Up / Down  Navigate input history',
+    '',
+    'Press Esc to close this help view',
+  ].join('\n');
+}

--- a/tests/fixtures/claude-help-overlay.ts
+++ b/tests/fixtures/claude-help-overlay.ts
@@ -1,10 +1,16 @@
 /**
- * Synthetic Claude Code `/help` overlay frame (Issue #1497).
+ * Real Claude Code `/help` overlay frame (Issue #1497).
  *
- * Models a static, unclassified TUI overlay: the full-screen help view replaces
+ * Captured from a live Claude Code **v2.1.218** session (`tmux capture-pane -p`)
+ * with `/help` open. Only the absolute worktree path on the banner line was
+ * generalized to `~/worktree`; every other line is verbatim.
+ *
+ * It is a static, unclassified TUI overlay: the full-screen help view replaces
  * the composer, so the frame contains
- *   - no thinking spinner / "esc to interrupt" status bar (not `running`),
+ *   - no thinking spinner / "esc to interrupt" status bar (not `running`/thinking),
  *   - no numbered / yes-no prompt (not `waiting`),
+ *   - a footer "Esc to cancel" that does NOT match CLAUDE_SELECTION_LIST_FOOTER
+ *     ("Enter to select…/confirm · Esc/set as default"), so not a selection list,
  *   - and — critically — no `❯`/`>` input line (not `ready`/`input_prompt`).
  *
  * detectSessionStatus() therefore cannot positively classify it and reaches the
@@ -15,24 +21,36 @@
  */
 export function buildClaudeHelpOverlayFrame(): string {
   return [
-    'Claude Code — Help',
     '',
-    'Usage Modes',
-    ' • Interactive:  claude',
-    ' • One-off:      claude -p "your question"',
+    ' ▐▛███▜▌   Claude Code v2.1.218',
+    '▝▜█████▛▘  Opus 4.8 (1M context) with xhigh effort · Claude Max',
+    '  ▘▘ ▝▝    ~/worktree',
     '',
-    'Slash Commands',
-    ' /help      Show this help view',
-    ' /clear     Clear the current conversation',
-    ' /model     Switch the active model',
-    ' /config    Open configuration',
     '',
-    'Keyboard Shortcuts',
-    ' Ctrl+C     Cancel the current input',
-    ' Ctrl+D     Exit Claude Code',
-    ' Shift+Tab  Cycle permission modes',
-    ' Up / Down  Navigate input history',
     '',
-    'Press Esc to close this help view',
+    '',
+    '▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔',
+    '   Help  General   Commands   Custom commands',
+    '',
+    '',
+    '   Claude understands your codebase, makes edits with your permission, and executes commands — right from your terminal.',
+    '',
+    '   New here? Run /powerup to learn the features most people miss.',
+    '',
+    '   Shortcuts',
+    '   ! for shell mode          double tap esc to clear input        ctrl + shift + _ to undo',
+    '   / for commands            shift + tab to auto-accept edits     ctrl + z to suspend',
+    '   @ for file paths          ctrl + o for verbose output          ctrl + v to paste images',
+    '   /btw for side question    ctrl + t to toggle tasks             opt + p to switch model',
+    '                             \\⏎ for newline                       opt + o to toggle fast mode',
+    '                                                                  ctrl + s to stash prompt',
+    '                                                                  ctrl + g to edit in $EDITOR',
+    '                                                                  /keybindings to customize',
+    '',
+    '   For more help: https://code.claude.com/docs/en/overview',
+    '',
+    '   Something else? Use /feedback to report bugs or request features.',
+    '',
+    '   Esc to cancel',
   ].join('\n');
 }

--- a/tests/unit/detection-help-overlay-1497.test.ts
+++ b/tests/unit/detection-help-overlay-1497.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #1497: a static, unclassified `/help` overlay must keep the
+ * detection-independent nav hatch (#1017/#1494) gated open even after it
+ * degrades to ready/no_recent_output — and a true idle prompt must NOT.
+ *
+ * This exercises the detector (detectSessionStatus) DIRECTLY against a real
+ * Claude Code v2.1.218 `/help` capture (see fixture), complementing the
+ * buildCurrentOutput integration test. It also pins the invariant the fix in
+ * current-output-builder relies on: the `no_recent_output` fallback only fires
+ * for a frame with no positive classification and no `❯` input line, so a real
+ * idle prompt is classified as input_prompt BEFORE the time heuristic.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectSessionStatus } from '@/lib/detection/status-detector';
+import { buildClaudeHelpOverlayFrame } from '../fixtures/claude-help-overlay';
+
+const HELP_FRAME = buildClaudeHelpOverlayFrame();
+// Stamped by the Auto-Yes poller (auto-yes-poller.ts); older than the 5s
+// STALE_OUTPUT_THRESHOLD_MS so the time-based heuristic fires.
+const STALE_TS = new Date(Date.now() - 60_000);
+
+describe('Issue #1497: real /help overlay classification (detectSessionStatus)', () => {
+  it('with no lastOutputTimestamp: running/default (unclassified — hatch gate open)', () => {
+    const st = detectSessionStatus(HELP_FRAME, 'claude');
+    expect(st.status).toBe('running');
+    expect(st.reason).toBe('default');
+    expect(st.hasActivePrompt).toBe(false);
+  });
+
+  it('with a stale lastOutputTimestamp: degrades to ready/no_recent_output (the frame that hid the hatch)', () => {
+    const st = detectSessionStatus(HELP_FRAME, 'claude', STALE_TS);
+    expect(st.status).toBe('ready');
+    expect(st.reason).toBe('no_recent_output');
+    expect(st.hasActivePrompt).toBe(false);
+  });
+
+  it('the /help footer "Esc to cancel" is NOT misread as a selection list or a prompt', () => {
+    // Neither a stale nor a fresh timestamp should ever turn /help into a
+    // waiting/prompt frame — it has no numbered options and no selection footer.
+    expect(detectSessionStatus(HELP_FRAME, 'claude').status).not.toBe('waiting');
+    expect(detectSessionStatus(HELP_FRAME, 'claude', STALE_TS).status).not.toBe('waiting');
+  });
+
+  it('non-regression: a true idle input prompt is classified input_prompt BEFORE the time heuristic', () => {
+    // The invariant the #1497 fix depends on: even with a stale timestamp, a
+    // visible `❯` idle prompt stays ready/input_prompt (never no_recent_output),
+    // so widening isUnclassifiedActive to no_recent_output cannot leak the hatch
+    // to a real idle prompt.
+    const idleFrame = 'Some earlier output\n────────────\n❯\n';
+    const st = detectSessionStatus(idleFrame, 'claude', STALE_TS);
+    expect(st.status).toBe('ready');
+    expect(st.reason).toBe('input_prompt');
+  });
+});

--- a/tests/unit/lib/current-output-builder.test.ts
+++ b/tests/unit/lib/current-output-builder.test.ts
@@ -21,7 +21,9 @@ vi.mock('@/lib/polling/auto-yes-manager', () => ({
 }));
 
 import { captureSessionOutput } from '@/lib/session/cli-session';
+import { getLastServerResponseTimestamp } from '@/lib/polling/auto-yes-manager';
 import { buildCurrentOutput } from '@/lib/session/current-output-builder';
+import { buildClaudeHelpOverlayFrame } from '../../fixtures/claude-help-overlay';
 
 describe('buildCurrentOutput Issue #1167 frame', () => {
   beforeEach(() => {
@@ -41,6 +43,55 @@ describe('buildCurrentOutput Issue #1167 frame', () => {
     expect(payload.promptData?.type).toBe('multiple_choice');
     expect(payload.sessionStatus).toBe('waiting');
     expect(payload.sessionStatusReason).toBe('prompt_detected');
+    expect(payload.isUnclassifiedActive).toBe(false);
+  });
+});
+
+describe('buildCurrentOutput Issue #1497 no_recent_output degrade', () => {
+  // The stale timestamp is the value the Auto-Yes poller stamps into
+  // lastServerResponseTimestamp (auto-yes-poller.ts). Older than
+  // STALE_OUTPUT_THRESHOLD_MS (5s) so the time-based heuristic fires.
+  const staleTimestamp = Date.now() - 60_000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getLastServerResponseTimestamp).mockReturnValue(staleTimestamp);
+  });
+
+  it('keeps the nav hatch gated open for a static /help overlay that degraded to ready/no_recent_output', async () => {
+    // A real unclassified TUI overlay that stopped changing: detection falls
+    // through to the time heuristic and, with a stale timestamp, degrades to
+    // ready/no_recent_output — the frame that used to hide the nav hatch (#1017).
+    vi.mocked(captureSessionOutput).mockResolvedValue(buildClaudeHelpOverlayFrame());
+
+    const payload = await buildCurrentOutput(
+      {} as Database.Database,
+      'wt-1',
+      'claude',
+      'claude-2',
+    );
+
+    expect(payload.sessionStatus).toBe('ready');
+    expect(payload.sessionStatusReason).toBe('no_recent_output');
+    // The fix: the timed-out unclassified frame still gates the hatch open.
+    expect(payload.isUnclassifiedActive).toBe(true);
+  });
+
+  it('does NOT gate the hatch open at a true idle input prompt even with a stale timestamp (non-regression)', async () => {
+    // A genuine idle prompt (`❯`) is classified as input_prompt at step 3,
+    // before the time heuristic — so it must stay ready/input_prompt and the
+    // hatch must remain hidden (Enter/`q` can never reach the composer).
+    vi.mocked(captureSessionOutput).mockResolvedValue('Some previous output\n───\n❯\n');
+
+    const payload = await buildCurrentOutput(
+      {} as Database.Database,
+      'wt-1',
+      'claude',
+      'claude-2',
+    );
+
+    expect(payload.sessionStatus).toBe('ready');
+    expect(payload.sessionStatusReason).toBe('input_prompt');
     expect(payload.isUnclassifiedActive).toBe(false);
   });
 });


### PR DESCRIPTION
## 概要

未分類 TUI オーバーレイ（`/help` 等）を開いたまま画面が静止すると、約5秒後に `ready`/`no_recent_output` へ降格して `isUnclassifiedActive` が落ち、ナビハッチ（#1017/#1494）が消えて脱出手段が失われる不具合を修正する。

## 原因

`detectSessionStatus` の時間ヒューリスティック（`status-detector.ts:726`）が、Auto-Yes ポーラーが `lastServerResponseTimestamp` を stamp した後、5秒以上出力変化の無い未分類フレームを `ready`/`no_recent_output` に降格する。`isUnclassifiedActive`（`current-output-builder.ts`）は `running`/`default` を要求するためゲートが閉じる。

## 修正

`current-output-builder` の `isUnclassifiedActive` を `ready`/`no_recent_output` も含めるよう緩和。真の idle プロンプト（`❯`）は降格前に `input_prompt` として分類される（`status-detector.ts:714`、`no_recent_output` フォールバック :726 より先）ため、`no_recent_output` はプロンプト非表示の未分類フレームでしか起きない。よってハッチを開いたままにしても真の idle 非回帰。

## テスト

実キャプチャ `/help` fixture（`claude-help-overlay.ts`）＋ stale timestamp で:
- `/help` 静止（`ready`/`no_recent_output`）→ `isUnclassifiedActive=true`（ハッチ継続表示）
- 真の idle（`❯`）→ `ready`/`input_prompt` → `isUnclassifiedActive=false`（ハッチ非表示、非回帰）

## 品質ゲート（develop マージ済み状態）

ESLint ✅ / tsc ✅ / test:unit ✅ (11292) / build ✅

## Closes

Closes #1497

> base=develop のため自動クローズされない。マージ後に手動クローズする。