### PR TITLE
feat(skills): orchestrate監視レシピを実行可能Skill化 (#1512)

### DIFF
--- a/.claude/skills/orchestrate-monitor/SKILL.md
+++ b/.claude/skills/orchestrate-monitor/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: orchestrate-monitor
+description: /orchestrate のワーカー監視レシピ（capture 解析・状態判定・介入判断・完了検証）を、bash 3.2 互換の実行可能スクリプトと fixture ベーステストとして資産化したもの。並列ワーカーを監督するときに使う。
+allowed-tools: Bash(.claude/skills/orchestrate-monitor/scripts/*), Bash(git worktree list), Bash(tmux *)
+---
+
+# orchestrate-monitor
+
+`/orchestrate`（`/pm-auto-issue2dev` の並列運用）で実証済みの**ワーカー監視レシピ**を、
+オペレータ／セッションメモリに滞留していた暗黙知から取り出し、**テスト済みスクリプト**にしたもの。
+判定ロジック（生成中判定・STARTED ガード・prompt 分類・完了検証）は fixture ベースの単体テストで
+固定されているので、プロンプトから再発明するのではなく、この中核を移植して使える。
+
+> **なぜ Skill 化するか**: 監視ノウハウは実運用の失敗から学ばれたが、バージョン管理外にあり再現・移転不能だった。
+> 同種の誤報（未起動 idle の COMPLETE 誤報／検証ガード自身の偽陽性）が複数回再発したため、テストで封じる。
+
+## 構成
+
+```
+.claude/skills/orchestrate-monitor/
+├── SKILL.md
+└── scripts/
+    ├── monitor-lib.sh       # 共有ヘルパー（JSON scalar 抽出・アンカー検出・違反カウント）
+    ├── classify-state.sh    # capture --json 1 ポーリング → 状態トークン
+    ├── verify-completion.sh # STARTED ガード付き完了判定（回帰#1）
+    ├── verify-scope.sh      # 偽陽性しないスコープ検証（回帰#2）
+    ├── quality-gate.sh      # exit code を実測する品質ゲート
+    └── monitor.sh           # オペレータ用監視ループ（temp ファイル状態）
+```
+
+テスト: `tests/unit/skills/orchestrate-monitor/`（fixture は実 `capture --json` 形状に忠実）。
+`npm run test:unit` に含まれ、`bash -n` 構文チェックも `syntax.test.ts` として同梱される。
+
+## 使い方
+
+```bash
+# 1 つ以上の worktree-id を監督する
+CM="npx commandmate@latest" \
+  .claude/skills/orchestrate-monitor/scripts/monitor.sh \
+  --interval 20 --idle-threshold 8 <worktree-id> [<worktree-id> ...]
+
+# 中核だけを個別に使う（Claude が監督中に呼ぶのはこちら）
+commandmate capture <id> --json > poll.json
+.claude/skills/orchestrate-monitor/scripts/classify-state.sh --json poll.json
+#   -> NOT_RUNNING | RATE_LIMIT | GENERATING | PROMPT | IDLE
+```
+
+`monitor.sh` の `count_commits` / `count_uncommitted` は運用の checkout に合わせて配線するフック。
+既定は 0 を返す（ループ単体で動く）ので、実運用では worker の作業ツリーに向ける。
+
+---
+
+## 監視レシピと根拠（どの失敗から学んだか）
+
+各ルールは実運用の失敗に紐づく。カッコ内はセッションメモリの出所。
+
+### 状態検知（`classify-state.sh` / `monitor-lib.sh`）
+
+1. **主シグナルは `commandmate capture <id> --json`**。参照フィールドは `content` / `realtimeSnippet`。
+   `output` / `text` は**存在しない**（`src/lib/session/current-output-builder.ts` の payload で確認）。
+2. **生成中アンカーは `↓ [0-9]`**（トークンカウンタ `↓ 1.4k tokens`）と `Waiting for [0-9]+ background agent`。
+   - `[0-9]+m [0-9]+s` は**使わない**：完了後の集計行 `✻ Brewed for 8m 55s` に誤マッチし、
+     終了済みセッションを永久に「生成中」と誤判定する（`feedback_orchestrate_monitor_recipe`）。
+     → 回帰 fixture: `idle-brewed-summary.json` は IDLE に分類される。
+   - **`isGenerating` フィールドに依存しない**：これは `sessionStatus==running && thinking_indicator` の
+     狭い条件でしか true にならず、生成中でも false になりうる。だから text アンカーを一次シグナルにする
+     （`feedback_orchestrate_monitor_started_guard`）。→ fixture `generating-bg-agent.json` は
+     `isGenerating:false` でもアンカーで GENERATING。
+3. **STARTED ガード**：生成アンカーを一度も観測していない idle を COMPLETE と誤報しない。
+   `commits=0 かつ uncommitted=0` は**完了ではなく未起動の兆候**（`send` がタスクを composer に残し
+   Enter 未確定で worker が起動しない）（`feedback_orchestrate_monitor_started_guard`）。
+   → 回帰#1: `verify-completion.sh`、fixture 相当は `verify-completion.test.ts`。
+4. **AskUserQuestion 停滞**：`❯ 1. Submit answers` は製品の prompt 検出（`isPromptWaiting`）に**非マッチ**。
+   text marker `❯ [0-9]+\.` で PROMPT と判定する（`feedback_orchestrate_askuserquestion_and_ci_522`）。
+   → fixture `prompt-submit-answers.json`（`isPromptWaiting:false` でも PROMPT）。
+
+### 介入・自動復旧（`monitor.sh`）
+
+5. **権限プロンプト自動承認**：worker 停滞の主因は Claude Code 権限プロンプト。Enter 自動承認を**サイレント＋
+   カウンタ化**し、通知を氾濫させない（`feedback_worker_permission_prompt_autoapprove` /
+   `feedback_orchestrate_monitor_recipe`）。承認は commit 必須ゲート（＝完了検証）とセットで扱う。
+6. **Rate limit は待たず即 "a" 送信**で再開。「1M context credits 必須」ブロッカーは credits 有効化＋"a"
+   （`feedback_rate_limit_immediate_retry` / `feedback_orchestrate_1m_context_credits`）。
+7. **完了待機は `commandmate wait <id> --on-prompt human`**。既定は prompt 検出で即返るため監督ループが
+   空回りする（`feedback_orchestrate_wait_on_prompt_human`）。
+
+### 完了検証（`verify-completion.sh` / `verify-scope.sh`）
+
+8. **merge 成否は state=MERGED を確認してから Issue close**（未マージ Issue の誤クローズ防止）
+   （`feedback_orchestrate_changelog_conflict_close_guard`）。
+9. **スコープ完遂は受入ゲートでなく grep 実数で検証**。NUL 混入ファイルで grep がバイナリ扱いするため
+   `grep -a` を使う（`feedback_orchestrate_scope_completeness` / `reference_grep_blind_nul_test_file`）。
+10. **検証ガード自身の偽陽性に注意**（回帰#2、`verify-scope.sh`）：
+    - 禁止パターンが**散文・コメント中**に出現しただけで違反と数える誤報
+      （bare `npx commandmate` が「なぜ @latest が必要か」を説明する文に一致した実例）。
+      → コメント行（`^[[:space:]]*#`）を除外する。fixture `scope-clean.txt` は CLEAN。
+    - `grep -c ... || echo 0` は無マッチ時に `0\n2` 相当の二行を作り数値テストを壊す
+      （`feedback_sed_grep_guard_false_pass`）。→ `grep -c` の出力をそのまま使う。
+    - grep 実数で under-delivery を疑ったら**必ず該当行を目視してから**差し戻す。
+
+### スクリプト品質（実装制約）
+
+11. **bash 3.2 互換**（macOS 既定の `/bin/bash` は 3.2.57）：連想配列 `declare -A` 不可・`mapfile` 不可・
+    `${var,,}` 不可。状態は**整数 index の並列配列と temp ファイル**で持つ
+    （`feedback_monitor_bash32_no_assoc_arrays`）。CI は `syntax.test.ts` が `bash -n` を回す。
+12. **ループ変数に `path` 等の特殊名を使わない**：zsh/bash で `path` は `PATH` に tie され、curl/tmux が
+    command not found 化して health check が偽陰性になる（`feedback_zsh_path_loop_var_clobbers_path`）。
+13. **品質ゲートで exit code を隠さない**（`quality-gate.sh`）：`cmd | grep ...` は `$?` を grep に渡し
+    非ゼロ終了を隠す。vitest は「全テスト緑・Unhandled Rejection で exit 1」を出しうる。
+    `cmd > log 2>&1; echo $?` で実測する（`feedback_quality_gate_grep_hides_exit_code`）。
+
+---
+
+## 回帰テスト（red→green で固定した 2 パターン）
+
+| # | 誤報 | 出所 | ガード | テスト |
+|---|------|------|--------|--------|
+| 1 | 未起動 idle を COMPLETE と誤報 | `feedback_orchestrate_monitor_started_guard` | `verify-completion.sh` の STARTED ガード | `verify-completion.test.ts` |
+| 2 | 検証ガード自身の偽陽性（散文一致・`\|\| echo 0`） | 同上 / `feedback_sed_grep_guard_false_pass` | `verify-scope.sh` のコメント除外＋素の `grep -c` | `verify-scope.test.ts` |
+
+いずれも naive 実装で red（本 Skill 初回コミット）→ ガード実装で green にした。
+
+## fixture の作り方（実機採取）
+
+fixture は**使い捨てセッションで capture** する。実 worker session は composer 残テキストで汚染され
+流用不可（`feedback_orchestrate_sibling_fold_and_real_tui_capture`）。
+
+```bash
+commandmate capture <throwaway-id> --json | tee tests/unit/skills/orchestrate-monitor/fixtures/<name>.json
+```

--- a/.claude/skills/orchestrate-monitor/scripts/classify-state.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/classify-state.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# classify-state — reduce a single `commandmate capture <id> --json` poll to one
+# per-poll state token.
+#
+# Output (stdout): NOT_RUNNING | RATE_LIMIT | GENERATING | PROMPT | IDLE
+#
+# Signal priority (each learned from the recipe, see SKILL.md § "根拠"):
+#   1. isRunning=false            -> NOT_RUNNING (session_not_running)
+#   2. rate-limit / credits banner-> RATE_LIMIT  (send "a" immediately, no sleep)
+#   3. generation anchor ↓ [0-9]  -> GENERATING  (NOT isGenerating, NOT `Xm Ys`)
+#   4. prompt (waiting / marker)  -> PROMPT       (incl. AskUserQuestion)
+#   5. otherwise                  -> IDLE
+set -u
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$SCRIPT_DIR/monitor-lib.sh"
+
+JSON_FILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) shift; JSON_FILE=${1:-};;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+  shift
+done
+if [ -z "$JSON_FILE" ] || [ ! -f "$JSON_FILE" ]; then
+  echo "classify-state: --json <file> required" >&2
+  exit 2
+fi
+
+running=$(ml_json_scalar "$JSON_FILE" isRunning)
+if [ "$running" = "false" ]; then
+  echo NOT_RUNNING
+  exit 0
+fi
+
+if ml_has_rate_limit "$JSON_FILE"; then
+  echo RATE_LIMIT
+  exit 0
+fi
+
+if ml_has_gen_anchor "$JSON_FILE"; then
+  echo GENERATING
+  exit 0
+fi
+
+prompt_waiting=$(ml_json_scalar "$JSON_FILE" isPromptWaiting)
+session_status=$(ml_json_scalar "$JSON_FILE" sessionStatus)
+if [ "$prompt_waiting" = "true" ] || [ "$session_status" = "waiting" ] || ml_has_prompt_marker "$JSON_FILE"; then
+  echo PROMPT
+  exit 0
+fi
+
+echo IDLE

--- a/.claude/skills/orchestrate-monitor/scripts/monitor-lib.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/monitor-lib.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# orchestrate-monitor — shared helper functions.
+#
+# bash 3.2 compatible on purpose (macOS ships /bin/bash 3.2.57):
+#   - no associative arrays (`declare -A`)
+#   - no `mapfile` / `readarray`
+#   - no `${var,,}` case conversion
+# Cross-poll state is passed as arguments or held in temp files by callers,
+# never in an associative array.
+#
+# Learned-from (see SKILL.md § "根拠"):
+#   feedback_monitor_bash32_no_assoc_arrays, feedback_orchestrate_monitor_recipe,
+#   feedback_orchestrate_monitor_started_guard, feedback_sed_grep_guard_false_pass.
+
+# Extract a top-level scalar from a pretty-printed (2-space indent) JSON file.
+# capture --json emits `JSON.stringify(payload, null, 2)`, so top-level keys are
+# indented by exactly two spaces; anchoring on that avoids colliding with the
+# nested keys inside `autoYes`/`promptData`.
+# Usage: ml_json_scalar <file> <key>  ->  prints the value, quotes/comma stripped.
+ml_json_scalar() {
+  ml__file=$1
+  ml__key=$2
+  sed -n "s/^  \"${ml__key}\"[[:space:]]*:[[:space:]]*\(.*\)/\1/p" "$ml__file" \
+    | head -1 \
+    | sed 's/[[:space:]]*$//; s/,$//; s/^"//; s/"$//'
+}
+
+# Generation anchor.
+# The reliable "still generating" signal is the token counter (`↓ 1.4k tokens`)
+# or a background-agent wait line — NOT the `isGenerating` field (it is only true
+# for the narrow thinking_indicator status) and NOT `[0-9]+m [0-9]+s`, which also
+# matches the *completion* summary line `✻ Brewed for 8m 55s` and would pin a
+# finished session as "generating" forever.
+# `↓` is emitted literally by JSON.stringify (no \u escaping), so a raw grep over
+# the --json file matches inside content/realtimeSnippet without JSON decoding.
+ml_has_gen_anchor() {
+  grep -aqE '↓ [0-9]|Waiting for [0-9]+ background agent' "$1"
+}
+
+# Rate-limit / credits banners observed in Claude/Codex TUIs. On a hit the
+# recipe is to send "a" immediately (do not sleep) to resume.
+ml_has_rate_limit() {
+  grep -aqiE 'usage limit reached|rate.?limit|rate_limit_error|429 too many requests|context credits' "$1"
+}
+
+# Selection/approval prompt markers, including AskUserQuestion's
+# "❯ 1. Submit answers", which the product prompt detector does NOT flag as
+# isPromptWaiting — so a text-marker check is required to avoid mistaking a
+# blocked question for idle.
+ml_has_prompt_marker() {
+  grep -aqE '❯ [0-9]+\.|Do you want to (proceed|make this edit)' "$1"
+}
+
+# Count real violations of a forbidden pattern, ignoring comment lines.
+# Two deliberate choices, both learned from guard false-reports:
+#   1. Comment lines (`^[[:space:]]*#`) are excluded so a pattern that appears in
+#      explanatory prose is not counted as a real occurrence
+#      (feedback_orchestrate_monitor_started_guard: the bare-`npx commandmate`
+#      grep flagged a sentence that was *describing* the rule).
+#   2. Plain `grep -c` is used and its "0" on no-match is kept as-is. We never
+#      write `grep -c ... || echo 0`, which appends a second "0" and yields the
+#      two-line "0\n0" that breaks a later numeric test
+#      (feedback_sed_grep_guard_false_pass).
+ml_count_violations() {
+  ml__file=$1
+  ml__pat=$2
+  grep -vE '^[[:space:]]*#' "$ml__file" | grep -cE "$ml__pat"
+}

--- a/.claude/skills/orchestrate-monitor/scripts/monitor.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/monitor.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# monitor.sh — supervise one or more orchestrate workers with the tested
+# decision core (classify-state.sh / verify-completion.sh).
+#
+# This is the operator entrypoint. The per-poll classification and the
+# completion decision live in separate, unit-tested scripts; this file only
+# owns the loop, the cross-poll state, and the interventions. It is checked by
+# `bash -n` in the test suite and written for bash 3.2 (macOS /bin/bash):
+#   - no associative arrays: per-worker state is held in integer-indexed
+#     parallel arrays and in temp files under $STATE_DIR
+#   - loop variables are never named `path` (that special-var name clobbers PATH
+#     under zsh/bash and breaks curl/tmux lookups; feedback_zsh_path_loop_var)
+#
+# Usage:
+#   monitor.sh [--interval 20] [--idle-threshold 8] [--session-prefix cm] \
+#              <worktree-id> [<worktree-id> ...]
+#
+# Env:
+#   CM  — commandmate launcher (default: "npx commandmate@latest"; pinned so the
+#         npx cache cannot resume a stale binary).
+set -u
+
+INTERVAL=20
+IDLE_THRESHOLD=8          # 150s+ of idle at 20s polls; xhigh workers think long
+SESSION_PREFIX="cm"
+CM=${CM:-"npx commandmate@latest"}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --interval) shift; INTERVAL=${1:-20};;
+    --idle-threshold) shift; IDLE_THRESHOLD=${1:-8};;
+    --session-prefix) shift; SESSION_PREFIX=${1:-cm};;
+    --) shift; break;;
+    -*) echo "monitor.sh: unknown flag $1" >&2; exit 2;;
+    *) break;;
+  esac
+  shift
+done
+
+if [ $# -eq 0 ]; then
+  echo "monitor.sh: at least one worktree-id is required" >&2
+  exit 2
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+CLASSIFY="$SCRIPT_DIR/classify-state.sh"
+VERIFY="$SCRIPT_DIR/verify-completion.sh"
+
+STATE_DIR=$(mktemp -d -t cm-monitor.XXXXXX)
+cleanup() { rm -rf "$STATE_DIR"; }
+trap cleanup EXIT
+
+# Integer-indexed parallel arrays (bash 3.2 has no associative arrays).
+IDS=("$@")
+n_ids=${#IDS[@]}
+
+i=0
+while [ "$i" -lt "$n_ids" ]; do
+  wid=${IDS[$i]}
+  echo "0" > "$STATE_DIR/$wid.streak"
+  echo "0" > "$STATE_DIR/$wid.started"
+  echo "0" > "$STATE_DIR/$wid.approvals"
+  i=$((i + 1))
+done
+
+# read_state <worktree-id> <suffix> -> echoes stored value (0 if missing)
+read_state() {
+  cat "$STATE_DIR/$1.$2" 2>/dev/null || echo 0
+}
+
+# count_uncommitted <worktree-id>: best-effort change count. Left to the operator
+# to wire to the worker's checkout; returns 0 here so the loop stays runnable.
+count_uncommitted() {
+  echo 0
+}
+count_commits() {
+  echo 0
+}
+
+echo "monitor: watching $n_ids worker(s), interval=${INTERVAL}s, idle-threshold=${IDLE_THRESHOLD}"
+
+done_count=0
+while [ "$done_count" -lt "$n_ids" ]; do
+  done_count=0
+  i=0
+  while [ "$i" -lt "$n_ids" ]; do
+    wid=${IDS[$i]}
+    i=$((i + 1))
+
+    if [ -f "$STATE_DIR/$wid.done" ]; then
+      done_count=$((done_count + 1))
+      continue
+    fi
+
+    poll="$STATE_DIR/$wid.poll.json"
+    if ! $CM capture "$wid" --json > "$poll" 2>/dev/null; then
+      # Transient empty/parse frame (redraw): do not advance the idle streak,
+      # do not treat as idle (feedback_orchestrate_monitor_recipe).
+      echo "monitor[$wid]: capture failed, skipping poll"
+      continue
+    fi
+
+    state=$("$CLASSIFY" --json "$poll")
+
+    started=$(read_state "$wid" started)
+    streak=$(read_state "$wid" streak)
+
+    case "$state" in
+      GENERATING)
+        echo "1" > "$STATE_DIR/$wid.started"
+        echo "0" > "$STATE_DIR/$wid.streak"
+        ;;
+      RATE_LIMIT)
+        # Resume immediately; never sleep through a rate limit.
+        echo "monitor[$wid]: rate limit -> sending 'a'"
+        tmux send-keys -t "${SESSION_PREFIX}-${wid}" a Enter 2>/dev/null || true
+        echo "0" > "$STATE_DIR/$wid.streak"
+        ;;
+      PROMPT)
+        # Silent auto-approve + counter, so the notifier is not flooded.
+        approvals=$(read_state "$wid" approvals)
+        approvals=$((approvals + 1))
+        echo "$approvals" > "$STATE_DIR/$wid.approvals"
+        tmux send-keys -t "${SESSION_PREFIX}-${wid}" Enter 2>/dev/null || true
+        echo "0" > "$STATE_DIR/$wid.streak"
+        ;;
+      NOT_RUNNING|IDLE)
+        streak=$((streak + 1))
+        echo "$streak" > "$STATE_DIR/$wid.streak"
+        ;;
+    esac
+
+    verdict=$("$VERIFY" \
+      --started "$(read_state "$wid" started)" \
+      --state "$state" \
+      --idle-streak "$(read_state "$wid" streak)" \
+      --idle-threshold "$IDLE_THRESHOLD" \
+      --commits "$(count_commits "$wid")" \
+      --uncommitted "$(count_uncommitted "$wid")")
+
+    case "$verdict" in
+      COMPLETE)
+        echo "monitor[$wid]: COMPLETE (approvals=$(read_state "$wid" approvals))"
+        touch "$STATE_DIR/$wid.done"
+        done_count=$((done_count + 1))
+        ;;
+      NOT_STARTED)
+        if [ "$(read_state "$wid" streak)" -ge "$IDLE_THRESHOLD" ]; then
+          echo "monitor[$wid]: NOT_STARTED — idle with no work; check the composer / Enter"
+        fi
+        ;;
+    esac
+  done
+
+  [ "$done_count" -lt "$n_ids" ] && sleep "$INTERVAL"
+done
+
+echo "monitor: all $n_ids worker(s) complete"

--- a/.claude/skills/orchestrate-monitor/scripts/quality-gate.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/quality-gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# quality-gate — run a command and judge PASS/FAIL by its REAL exit code.
+#
+# Output (stdout): PASS | FAIL:<code>     (log path is printed on stderr)
+# Usage: quality-gate.sh [--log <file>] -- <command> [args...]
+#
+# Never pipe the command into grep to decide pass/fail. `cmd | grep ...` hands $?
+# to grep and hides a non-zero exit — vitest can print "Tests 100 passed" yet
+# exit 1 on an Unhandled Rejection, and a grep summary would call that a PASS
+# (feedback_quality_gate_grep_hides_exit_code). So we run `cmd > log 2>&1` and
+# read `$?` directly; grep, if any, is for human summaries only.
+set -u
+LOG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log) shift; LOG=${1:-};;
+    --) shift; break;;
+    *) break;;
+  esac
+  shift
+done
+
+if [ $# -eq 0 ]; then
+  echo "quality-gate: no command given (use -- <command>)" >&2
+  exit 2
+fi
+if [ -z "$LOG" ]; then
+  LOG=$(mktemp -t cm-qgate.XXXXXX)
+fi
+
+"$@" > "$LOG" 2>&1
+code=$?
+
+echo "log: $LOG" >&2
+if [ "$code" -eq 0 ]; then
+  echo PASS
+else
+  echo "FAIL:$code"
+fi

--- a/.claude/skills/orchestrate-monitor/scripts/verify-completion.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/verify-completion.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# verify-completion — NAIVE baseline (no STARTED guard).
+# Output: COMPLETE | WORKING
+set -u
+state=""; idle_streak=0; idle_threshold=5; started=0; commits=0; uncommitted=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --started) shift; started=${1:-0};;
+    --state) shift; state=${1:-};;
+    --idle-streak) shift; idle_streak=${1:-0};;
+    --idle-threshold) shift; idle_threshold=${1:-5};;
+    --commits) shift; commits=${1:-0};;
+    --uncommitted) shift; uncommitted=${1:-0};;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+  shift
+done
+
+if [ "$idle_streak" -ge "$idle_threshold" ]; then
+  echo COMPLETE
+else
+  echo WORKING
+fi

--- a/.claude/skills/orchestrate-monitor/scripts/verify-completion.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/verify-completion.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
-# verify-completion — NAIVE baseline (no STARTED guard).
-# Output: COMPLETE | WORKING
+# verify-completion — decide whether a worker is done, with the STARTED guard.
+#
+# Output (stdout): COMPLETE | NOT_STARTED | WORKING
+#
+# The STARTED guard exists because worker monitoring once reported an *unstarted*
+# session as COMPLETE (feedback_orchestrate_monitor_started_guard): `commandmate
+# send` left the task text in the composer with Enter unconfirmed, the worker
+# never generated, the idle streak climbed, and a guard without this check
+# emitted `COMPLETE commits=0 uncommitted=0`. Rules:
+#   - `--started` is 1 only after a generation anchor was observed at least once.
+#   - `commits=0 && uncommitted=0` is the signature of an unsent task, not a
+#     finished one: a worker that did anything leaves at least uncommitted changes.
 set -u
 state=""; idle_streak=0; idle_threshold=5; started=0; commits=0; uncommitted=0
 while [ $# -gt 0 ]; do
@@ -16,8 +26,35 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+# STARTED guard: never call an unstarted, work-free session COMPLETE.
+if [ "$started" != "1" ]; then
+  if [ "$commits" -eq 0 ] && [ "$uncommitted" -eq 0 ]; then
+    echo NOT_STARTED
+  else
+    # Work exists but we never latched the anchor (e.g. a very fast worker or a
+    # missed poll): not complete, keep watching rather than false-complete.
+    echo WORKING
+  fi
+  exit 0
+fi
+
+# A live signal means the worker is still busy regardless of the idle streak.
+case "$state" in
+  GENERATING|PROMPT|PROMPT_LIVE|RATE_LIMIT)
+    echo WORKING
+    exit 0
+    ;;
+esac
+
+# Idle and started: only COMPLETE with evidence of real work. A started worker
+# that is idle yet shows zero work is suspicious (e.g. it crashed on launch), so
+# report NOT_STARTED rather than a false COMPLETE.
 if [ "$idle_streak" -ge "$idle_threshold" ]; then
-  echo COMPLETE
+  if [ "$commits" -gt 0 ] || [ "$uncommitted" -gt 0 ]; then
+    echo COMPLETE
+  else
+    echo NOT_STARTED
+  fi
 else
   echo WORKING
 fi

--- a/.claude/skills/orchestrate-monitor/scripts/verify-scope.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/verify-scope.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# verify-scope — NAIVE baseline (counts every match, including prose/comments,
+# and uses the `|| echo 0` idiom). Output: CLEAN | VIOLATIONS:<n>
+set -u
+TARGET=""
+PATTERN='npx commandmate([^@]|$)'
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --file) shift; TARGET=${1:-};;
+    --pattern) shift; PATTERN=${1:-};;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+  shift
+done
+if [ -z "$TARGET" ] || [ ! -f "$TARGET" ]; then
+  echo "verify-scope: --file <path> required" >&2; exit 2
+fi
+
+n=$(grep -cE "$PATTERN" "$TARGET" || echo 0)
+if [ "$n" -eq 0 ]; then
+  echo CLEAN
+else
+  echo "VIOLATIONS:$n"
+fi

--- a/.claude/skills/orchestrate-monitor/scripts/verify-scope.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/verify-scope.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
-# verify-scope — NAIVE baseline (counts every match, including prose/comments,
-# and uses the `|| echo 0` idiom). Output: CLEAN | VIOLATIONS:<n>
+# verify-scope — under-delivery / scope guard that does NOT false-positive.
+#
+# Output (stdout): CLEAN | VIOLATIONS:<n>
+#
+# Scope completion is verified by grep count, not by trusting an acceptance gate
+# (feedback_orchestrate_monitor_recipe item 10). But the guard itself has
+# false-reported twice (feedback_orchestrate_monitor_started_guard): it counted
+# a forbidden pattern that appeared only in *explanatory prose*, and it used the
+# `grep -c ... || echo 0` idiom that yields a two-line "0\n0". Both are handled
+# in ml_count_violations: comment lines are excluded and the count is taken as-is.
+#
+# Default pattern: a bare `npx commandmate` invocation missing the `@latest` pin.
 set -u
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$SCRIPT_DIR/monitor-lib.sh"
+
 TARGET=""
 PATTERN='npx commandmate([^@]|$)'
 while [ $# -gt 0 ]; do
@@ -13,10 +26,11 @@ while [ $# -gt 0 ]; do
   shift
 done
 if [ -z "$TARGET" ] || [ ! -f "$TARGET" ]; then
-  echo "verify-scope: --file <path> required" >&2; exit 2
+  echo "verify-scope: --file <path> required" >&2
+  exit 2
 fi
 
-n=$(grep -cE "$PATTERN" "$TARGET" || echo 0)
+n=$(ml_count_violations "$TARGET" "$PATTERN")
 if [ "$n" -eq 0 ]; then
   echo CLEAN
 else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **orchestrate 監視レシピを実行可能 Skill 化** (#1512): `/orchestrate` 運用で実証済みの監視ノウハウ（capture 解析・状態判定・介入判断・完了/スコープ検証）を、セッションメモリ依存から `.claude/skills/orchestrate-monitor/`（SKILL.md＋bash 3.2 互換スクリプト群）へ資産化した。判定ロジックを fixture ベースで単体テスト化し、既知の誤報2パターン（未起動 idle の COMPLETE 誤報／検証ガード自身の偽陽性）を回帰テストで固定。CI で `bash -n` 構文チェックを回す。#1452 Harness Pack の移植元となる自家用 Skill（公式カタログ配布は後続 #1513）。
+
 ## [0.14.1] - 2026-07-24
 
 ### Fixed

--- a/tests/unit/skills/orchestrate-monitor/classify-state.test.ts
+++ b/tests/unit/skills/orchestrate-monitor/classify-state.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.join(
+  process.cwd(),
+  '.claude/skills/orchestrate-monitor/scripts/classify-state.sh',
+);
+const FIXTURES = fileURLToPath(new URL('./fixtures', import.meta.url));
+
+function classify(fixture: string): string {
+  return execFileSync('bash', [SCRIPT, '--json', path.join(FIXTURES, fixture)], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+describe('classify-state on real capture --json shapes', () => {
+  it('NOT_RUNNING when the session is not running', () => {
+    expect(classify('not-running.json')).toBe('NOT_RUNNING');
+  });
+
+  it('GENERATING on the token-counter anchor (↓ 1.4k tokens)', () => {
+    expect(classify('generating-token-anchor.json')).toBe('GENERATING');
+  });
+
+  it('GENERATING on a background-agent wait even when isGenerating is false', () => {
+    // Faithful to the recipe: the text anchor — not the isGenerating field —
+    // is the reliable "still busy" signal.
+    expect(classify('generating-bg-agent.json')).toBe('GENERATING');
+  });
+
+  it('IDLE on the completion summary (must not match `Brewed for 8m 55s`)', () => {
+    // Anchor trap: `[0-9]+m [0-9]+s` would match the summary line and pin a
+    // finished session as generating forever; `↓ [0-9]` avoids it. The `↑`
+    // token line must not be read as the `↓` anchor either.
+    expect(classify('idle-brewed-summary.json')).toBe('IDLE');
+  });
+
+  it('PROMPT on a yes/no approval prompt (isPromptWaiting=true)', () => {
+    expect(classify('prompt-yes-no.json')).toBe('PROMPT');
+  });
+
+  it('PROMPT on AskUserQuestion even when isPromptWaiting=false', () => {
+    // `❯ 1. Submit answers` is not flagged as isPromptWaiting by the product,
+    // so a text-marker check is required or the blocked question reads as idle.
+    expect(classify('prompt-submit-answers.json')).toBe('PROMPT');
+  });
+
+  it('RATE_LIMIT on a usage-limit banner', () => {
+    expect(classify('rate-limit.json')).toBe('RATE_LIMIT');
+  });
+});

--- a/tests/unit/skills/orchestrate-monitor/fixtures/generating-bg-agent.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/generating-bg-agent.json
@@ -1,0 +1,25 @@
+{
+  "isRunning": true,
+  "cliToolId": "claude",
+  "sessionStatus": "running",
+  "sessionStatusReason": "default",
+  "content": "⏺ Dispatching workers\n",
+  "realtimeSnippet": "⏺ Dispatching workers\n\n· Waiting for 3 background agents to finish (esc to interrupt)",
+  "lineCount": 210,
+  "lastCapturedLine": 208,
+  "isComplete": false,
+  "isGenerating": false,
+  "thinking": false,
+  "thinkingMessage": null,
+  "isPromptWaiting": false,
+  "promptData": null,
+  "autoYes": {
+    "enabled": true,
+    "expiresAt": 1790000000000
+  },
+  "isSelectionListActive": false,
+  "isPagerActive": false,
+  "isUnclassifiedActive": true,
+  "lastServerResponseTimestamp": 1790000000000,
+  "serverPollerActive": true
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/generating-token-anchor.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/generating-token-anchor.json
@@ -1,0 +1,25 @@
+{
+  "isRunning": true,
+  "cliToolId": "claude",
+  "sessionStatus": "running",
+  "sessionStatusReason": "thinking_indicator",
+  "content": "⏺ Reading src/lib/session/current-output-builder.ts\n",
+  "realtimeSnippet": "⏺ Reading src/lib/session/current-output-builder.ts\n\n· Cerebrating… (esc to interrupt)\n  ↓ 1.4k tokens",
+  "lineCount": 152,
+  "lastCapturedLine": 150,
+  "isComplete": false,
+  "isGenerating": true,
+  "thinking": true,
+  "thinkingMessage": "Claude is thinking...",
+  "isPromptWaiting": false,
+  "promptData": null,
+  "autoYes": {
+    "enabled": true,
+    "expiresAt": 1790000000000
+  },
+  "isSelectionListActive": false,
+  "isPagerActive": false,
+  "isUnclassifiedActive": false,
+  "lastServerResponseTimestamp": 1790000000000,
+  "serverPollerActive": true
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/idle-brewed-summary.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/idle-brewed-summary.json
@@ -1,0 +1,25 @@
+{
+  "isRunning": true,
+  "cliToolId": "claude",
+  "sessionStatus": "ready",
+  "sessionStatusReason": "no_recent_output",
+  "content": "",
+  "realtimeSnippet": "⏺ Done. All unit tests pass and the build is green.\n\n✻ Brewed for 8m 55s · ↑ 2.1k tokens\n\nIMPL_COMPLETED\n\n> ",
+  "lineCount": 320,
+  "lastCapturedLine": 320,
+  "isComplete": false,
+  "isGenerating": false,
+  "thinking": false,
+  "thinkingMessage": null,
+  "isPromptWaiting": false,
+  "promptData": null,
+  "autoYes": {
+    "enabled": true,
+    "expiresAt": 1790000000000
+  },
+  "isSelectionListActive": false,
+  "isPagerActive": false,
+  "isUnclassifiedActive": false,
+  "lastServerResponseTimestamp": 1790000000000,
+  "serverPollerActive": true
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/not-running.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/not-running.json
@@ -1,0 +1,8 @@
+{
+  "isRunning": false,
+  "content": "",
+  "lineCount": 0,
+  "cliToolId": "claude",
+  "sessionStatus": "idle",
+  "sessionStatusReason": "session_not_running"
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/prompt-submit-answers.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/prompt-submit-answers.json
@@ -1,0 +1,25 @@
+{
+  "isRunning": true,
+  "cliToolId": "claude",
+  "sessionStatus": "ready",
+  "sessionStatusReason": "no_recent_output",
+  "content": "",
+  "realtimeSnippet": "⏺ Which library should we use?\n\n  Use arrows, then Enter.\n❯ 1. Submit answers\n  2. Edit answers",
+  "lineCount": 205,
+  "lastCapturedLine": 205,
+  "isComplete": false,
+  "isGenerating": false,
+  "thinking": false,
+  "thinkingMessage": null,
+  "isPromptWaiting": false,
+  "promptData": null,
+  "autoYes": {
+    "enabled": true,
+    "expiresAt": 1790000000000
+  },
+  "isSelectionListActive": false,
+  "isPagerActive": false,
+  "isUnclassifiedActive": true,
+  "lastServerResponseTimestamp": 1790000000000,
+  "serverPollerActive": true
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/prompt-yes-no.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/prompt-yes-no.json
@@ -1,0 +1,28 @@
+{
+  "isRunning": true,
+  "cliToolId": "claude",
+  "sessionStatus": "waiting",
+  "sessionStatusReason": "input_prompt",
+  "content": "",
+  "realtimeSnippet": "⏺ Bash(rm -rf build/)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell Claude what to do differently",
+  "lineCount": 188,
+  "lastCapturedLine": 188,
+  "isComplete": true,
+  "isGenerating": false,
+  "thinking": false,
+  "thinkingMessage": null,
+  "isPromptWaiting": true,
+  "promptData": {
+    "type": "yes_no",
+    "question": "Do you want to proceed?"
+  },
+  "autoYes": {
+    "enabled": true,
+    "expiresAt": 1790000000000
+  },
+  "isSelectionListActive": true,
+  "isPagerActive": false,
+  "isUnclassifiedActive": false,
+  "lastServerResponseTimestamp": 1790000000000,
+  "serverPollerActive": true
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/rate-limit.json
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/rate-limit.json
@@ -1,0 +1,25 @@
+{
+  "isRunning": true,
+  "cliToolId": "claude",
+  "sessionStatus": "ready",
+  "sessionStatusReason": "no_recent_output",
+  "content": "",
+  "realtimeSnippet": "⏺ Continuing...\n\nClaude usage limit reached. Your limit will reset at 3pm (Asia/Tokyo).\n\n> ",
+  "lineCount": 240,
+  "lastCapturedLine": 240,
+  "isComplete": false,
+  "isGenerating": false,
+  "thinking": false,
+  "thinkingMessage": null,
+  "isPromptWaiting": false,
+  "promptData": null,
+  "autoYes": {
+    "enabled": true,
+    "expiresAt": 1790000000000
+  },
+  "isSelectionListActive": false,
+  "isPagerActive": false,
+  "isUnclassifiedActive": false,
+  "lastServerResponseTimestamp": 1790000000000,
+  "serverPollerActive": true
+}

--- a/tests/unit/skills/orchestrate-monitor/fixtures/scope-clean.txt
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/scope-clean.txt
@@ -1,0 +1,5 @@
+# Recipe: always pin the launcher with `npx commandmate@latest ...`.
+# Note: a bare `npx commandmate` (without @latest) pins whatever version the
+# npx cache already holds, which is exactly the failure this guard forbids.
+RUN npx commandmate@latest start --daemon
+RUN npx commandmate@latest status --all

--- a/tests/unit/skills/orchestrate-monitor/fixtures/scope-violation.txt
+++ b/tests/unit/skills/orchestrate-monitor/fixtures/scope-violation.txt
@@ -1,0 +1,3 @@
+# Deploy step below forgot to pin the launcher version.
+RUN npx commandmate start --daemon
+RUN npx commandmate@latest status --all

--- a/tests/unit/skills/orchestrate-monitor/quality-gate.test.ts
+++ b/tests/unit/skills/orchestrate-monitor/quality-gate.test.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.join(
+  process.cwd(),
+  '.claude/skills/orchestrate-monitor/scripts/quality-gate.sh',
+);
+
+function gate(inner: string): string {
+  return execFileSync('bash', [SCRIPT, '--', 'bash', '-c', inner], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+describe('quality-gate judges by real exit code, not by grepping output', () => {
+  it('reports FAIL when the command exits non-zero despite a "passed" line', () => {
+    // The exact trap: green-looking stdout, non-zero exit (vitest + Unhandled
+    // Rejection). A grep summary would call this PASS.
+    expect(gate('echo "Tests 100 passed"; exit 1')).toBe('FAIL:1');
+  });
+
+  it('reports PASS only when the command exits zero', () => {
+    expect(gate('echo "Tests 100 passed"; exit 0')).toBe('PASS');
+  });
+});

--- a/tests/unit/skills/orchestrate-monitor/syntax.test.ts
+++ b/tests/unit/skills/orchestrate-monitor/syntax.test.ts
@@ -1,0 +1,25 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPTS_DIR = path.join(
+  process.cwd(),
+  '.claude/skills/orchestrate-monitor/scripts',
+);
+
+const shellScripts = readdirSync(SCRIPTS_DIR).filter((f) => f.endsWith('.sh'));
+
+describe('orchestrate-monitor scripts pass bash -n (bash 3.2 syntax gate)', () => {
+  it('finds the shell scripts to check', () => {
+    // Guard against an empty glob silently passing the whole suite.
+    expect(shellScripts.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(shellScripts)('bash -n %s', (file) => {
+    // Throws (non-zero exit) if the script has a syntax error.
+    execFileSync('bash', ['-n', path.join(SCRIPTS_DIR, file)], {
+      encoding: 'utf8',
+    });
+  });
+});

--- a/tests/unit/skills/orchestrate-monitor/verify-completion.test.ts
+++ b/tests/unit/skills/orchestrate-monitor/verify-completion.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.join(
+  process.cwd(),
+  '.claude/skills/orchestrate-monitor/scripts/verify-completion.sh',
+);
+
+function verify(args: string[]): string {
+  return execFileSync('bash', [SCRIPT, ...args], { encoding: 'utf8' }).trim();
+}
+
+describe('verify-completion STARTED guard', () => {
+  // Regression #1 (named in Issue #1512): an unstarted worker must never be
+  // reported COMPLETE. `commandmate send` can leave the task in the composer
+  // with Enter unconfirmed, so the worker never generates; the idle streak then
+  // climbs and the naive baseline emits COMPLETE with commits=0 uncommitted=0.
+  // The signature of an *unsent* task — no generation anchor ever observed AND
+  // zero work — must classify as NOT_STARTED.
+  it('reports NOT_STARTED for an idle worker that never started with no work', () => {
+    const out = verify([
+      '--started', '0',
+      '--state', 'IDLE',
+      '--idle-streak', '10',
+      '--idle-threshold', '5',
+      '--commits', '0',
+      '--uncommitted', '0',
+    ]);
+    expect(out).toBe('NOT_STARTED');
+  });
+
+  it('reports COMPLETE only when the worker started and produced work', () => {
+    const out = verify([
+      '--started', '1',
+      '--state', 'IDLE',
+      '--idle-streak', '10',
+      '--idle-threshold', '5',
+      '--commits', '2',
+      '--uncommitted', '0',
+    ]);
+    expect(out).toBe('COMPLETE');
+  });
+
+  it('counts uncommitted-only work as evidence of a real completion', () => {
+    const out = verify([
+      '--started', '1',
+      '--state', 'IDLE',
+      '--idle-streak', '8',
+      '--idle-threshold', '5',
+      '--commits', '0',
+      '--uncommitted', '3',
+    ]);
+    expect(out).toBe('COMPLETE');
+  });
+
+  it('treats a started worker with zero work + idle as NOT_STARTED, not COMPLETE', () => {
+    const out = verify([
+      '--started', '1',
+      '--state', 'IDLE',
+      '--idle-streak', '10',
+      '--idle-threshold', '5',
+      '--commits', '0',
+      '--uncommitted', '0',
+    ]);
+    expect(out).toBe('NOT_STARTED');
+  });
+
+  it('stays WORKING while still generating', () => {
+    const out = verify([
+      '--started', '1',
+      '--state', 'GENERATING',
+      '--idle-streak', '0',
+      '--idle-threshold', '5',
+      '--commits', '1',
+      '--uncommitted', '1',
+    ]);
+    expect(out).toBe('WORKING');
+  });
+
+  it('stays WORKING when idle streak has not reached the threshold', () => {
+    const out = verify([
+      '--started', '1',
+      '--state', 'IDLE',
+      '--idle-streak', '2',
+      '--idle-threshold', '5',
+      '--commits', '1',
+      '--uncommitted', '0',
+    ]);
+    expect(out).toBe('WORKING');
+  });
+});

--- a/tests/unit/skills/orchestrate-monitor/verify-scope.test.ts
+++ b/tests/unit/skills/orchestrate-monitor/verify-scope.test.ts
@@ -1,0 +1,32 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.join(
+  process.cwd(),
+  '.claude/skills/orchestrate-monitor/scripts/verify-scope.sh',
+);
+const FIXTURES = fileURLToPath(new URL('./fixtures', import.meta.url));
+
+function scope(file: string): string {
+  return execFileSync('bash', [SCRIPT, '--file', path.join(FIXTURES, file)], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+describe('verify-scope guard is false-positive-safe', () => {
+  // Regression #2 (named in Issue #1512): the verification guard's own false
+  // positive. A grep that counts a forbidden pattern occurring in explanatory
+  // prose/comments — or that uses `grep -c ... || echo 0` — reports a
+  // violation where there is none. A file whose only bare `npx commandmate`
+  // mention is inside comments, with every real invocation pinned to @latest,
+  // must be CLEAN.
+  it('does NOT flag a bare pattern that only appears in comments/prose', () => {
+    expect(scope('scope-clean.txt')).toBe('CLEAN');
+  });
+
+  it('flags a real bare invocation on a non-comment line', () => {
+    expect(scope('scope-violation.txt')).toBe('VIOLATIONS:1');
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1512。`/orchestrate` 運用で実証済みの**監視レシピ**（オペレータ/セッションメモリに滞留していた暗黙知）を、実行可能スクリプト＋fixture ベーステストつきのリポジトリ内 Skill として資産化する。

## 変更点

- `.claude/skills/orchestrate-monitor/`（SKILL.md ＋ `scripts/`）を新規追加
  - `scripts/`: `classify-state.sh` / `monitor.sh` / `monitor-lib.sh` / `quality-gate.sh` / `verify-completion.sh` / `verify-scope.sh`
  - 監視ループ中核（capture 解析・状態判定・介入判断・完了/スコープ検証）を実行可能スクリプトに分離
- `tests/unit/skills/orchestrate-monitor/`: 判定ロジックの fixture ベース単体テスト（5 ファイル / 24 tests）
  - fixtures: `generating-token-anchor` / `generating-bg-agent` / `idle-brewed-summary` / `not-running` / `prompt-submit-answers` / `prompt-yes-no` / `rate-limit` ほか
- **既知の誤報2パターンの回帰テスト**:
  1. 未起動 idle（commits=0 かつ uncommitted=0）の COMPLETE 誤報 → `verify-completion.sh` の STARTED ガード（`verify-completion.test.ts`）
  2. 検証ガード自身の偽陽性（禁止パターンが散文/指示文中に出現しただけで違反計上）→ `verify-scope.sh`（`verify-scope.test.ts`）
- SKILL.md にレシピの根拠（どの失敗＝どのセッションメモリから学んだか）を明記
- 実装制約: **bash 3.2 互換**（`declare -A` 不可・状態は temp ファイル）、CI で `bash -n`（`syntax.test.ts`）、品質ゲートは exit code を隠さない方式

## 検証（オーケストレーターが worktree で独立実行）

| チェック | 結果 |
|---|---|
| `npm run lint` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npm run test:unit`（全体） | 655 files / 11354 tests / exit 0 |
| `npm run build` | exit 0 |
| `bash -n`（全 6 スクリプト） | OK |
| orchestrate-monitor 単体スイート | 5 files / 24 tests / exit 0 |

## 補足

- 公式 Skill カタログ（commandmate-skills）への登録・配布は後続 #1513（本 PR のスコープ外）。
- 手動受入「実機 orchestrate 1 運用を本 Skill の監視のみで完走・誤報0」は運用フェーズで実施（本オーケストレーション自体がその dogfooding の第一歩）。

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7BxVwiQ7xL8BkaLLKxXtR