### PR TITLE
feat(editor): Markdown/テキスト編集で Tab インデント・Shift+Tab アウトデントを可能にする (#1518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **orchestrate 監視レシピを実行可能 Skill 化** (#1512): `/orchestrate` 運用で実証済みの監視ノウハウ（capture 解析・状態判定・介入判断・完了/スコープ検証）を、セッションメモリ依存から `.claude/skills/orchestrate-monitor/`（SKILL.md＋bash 3.2 互換スクリプト群）へ資産化した。判定ロジックを fixture ベースで単体テスト化し、既知の誤報2パターン（未起動 idle の COMPLETE 誤報／検証ガード自身の偽陽性）を回帰テストで固定。CI で `bash -n` 構文チェックを回す。#1452 Harness Pack の移植元となる自家用 Skill（公式カタログ配布は後続 #1513）。
+- **Markdown/テキスト編集で Tab インデント・Shift+Tab アウトデントを可能に** (#1518): 素の `<textarea>` に自前実装した。インデント計算は純関数 `src/lib/editor/indent.ts`（複数行選択は各行を字下げして選択を維持、単一行はタブストップ揃え、CRLF の `\r` を保持、空行はスキップ）。挿入は常に **2 スペース固定**でタブ文字を入れない（同じエディタが YAML を編集するため）が、アウトデントは既存ファイル中の先頭タブも 1 単位として除去する。適用は `document.execCommand('insertText')` を第一手にして **Ctrl+Z 1 手で戻る**ようにし、非対応環境では React state ＋ `setSelectionRange()` 復元へフォールバックする。`handleKeyDown` が textarea とルート div の両方に張られて 1 打鍵で 2 回発火していた既存不具合をガードで解消（副産物として Ctrl+S の二重発火も解消）。キーボードトラップ回避として **Ctrl+M**（Cmd+M は macOS のウィンドウ最小化と衝突するため不採用）で Tab をフォーカス移動へ戻すトグルを追加し、no-op な Shift+Tab は既定動作に委ねる。モバイル向けに `MarkdownToolbar` へ 44px のインデント/アウトデントボタンを追加し、`keyboard-shortcuts` に `editor` scope を新設（未登録だった Ctrl+S / Ctrl+Shift+F も登録）。
 
 ### Changed
 

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -97,7 +97,8 @@
 | `src/lib/utils.ts` | 汎用ユーティリティ関数（debounce、truncateString、escapeHtml等）。汎用ユーティリティ（withTimeout追加: Issue #627） |
 | `src/config/editable-extensions.ts` | 編集可能ファイル拡張子設定。編集可能拡張子定義・バリデーション（EDITABLE_EXTENSIONS, EXTENSION_VALIDATORS, isEditableExtension, validateContent）。.yaml/.yml 追加・YAML危険タグバリデーション（Issue #646）。TEXT_MAX_SIZE_BYTES を 2MB に引き上げ・PUT/GET 共通定数化（Issue #723） |
 | `src/config/file-operations.ts` | 再帰削除の安全設定 |
-| `src/types/markdown-editor.ts` | マークダウンエディタ関連型定義（Issue #389: LOCAL_STORAGE_KEY_AUTO_SAVE='commandmate:md-editor-auto-save'、AUTO_SAVE_DEBOUNCE_MS=3000定数追加） |
+| `src/types/markdown-editor.ts` | マークダウンエディタ関連型定義（Issue #389: LOCAL_STORAGE_KEY_AUTO_SAVE='commandmate:md-editor-auto-save'、AUTO_SAVE_DEBOUNCE_MS=3000定数追加）。Issue #1518: INDENT_UNIT=2スペース、LOCAL_STORAGE_KEY_TAB_MOVES_FOCUS 追加 |
+| `src/lib/editor/indent.ts` | textarea のインデント計算純関数（Issue #1518: applyIndent/applyOutdent、IndentEdit を返し DOM 非依存。複数行選択は行頭に unit 挿入・単一行はタブストップ揃え、アウトデントは先頭タブも1文字として除去、削るものが無く選択も無い場合は null（WCAG 2.1.2 の逃げ道）、CRLF は \n 基準で行頭算出し \r 保持、空行はスキップ＝Markdown の hard break 化を防ぐ） |
 | `src/hooks/useContextMenu.ts` | コンテキストメニュー状態管理フック（MouseEvent/TouchEvent対応） |
 | `src/hooks/useExitAnimation.ts` | exit（消滅）アニメーション用アンマウント遅延フック（Issue #1114）。`useExitAnimation(open, duration)` → `{shouldRender, isExiting}`。閉要求後もduration ms描画を維持しexitアニメ再生を保証、再openでタイマー解除。Modal/Toast/ContextMenuで共用 |
 | `src/hooks/useFileOperations.ts` | ファイル操作フック（Issue #162: move操作の状態管理、MoveTarget型、UIロジック分離） |

--- a/locales/en/keyboardShortcuts.json
+++ b/locales/en/keyboardShortcuts.json
@@ -3,7 +3,8 @@
   "scopes": {
     "global": "Global",
     "terminal": "Terminal",
-    "composer": "Composer"
+    "composer": "Composer",
+    "editor": "File editor"
   },
   "shortcuts": {
     "commandPalette": "Open command palette",
@@ -12,6 +13,11 @@
     "navigateList": "Move selection up / down",
     "terminalSearch": "Search terminal output",
     "sendMessage": "Send message",
-    "composerNewline": "Insert a new line"
+    "composerNewline": "Insert a new line",
+    "editorIndent": "Indent line or selection",
+    "editorOutdent": "Outdent line or selection",
+    "editorTabFocus": "Toggle whether Tab moves focus",
+    "editorSave": "Save file",
+    "editorFullscreen": "Toggle fullscreen editor"
   }
 }

--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -296,7 +296,11 @@
     "editorOnly": "Editor only",
     "previewOnly": "Preview only",
     "enterFullscreen": "Enter fullscreen (Ctrl+Shift+F)",
-    "exitFullscreen": "Exit fullscreen (ESC)"
+    "exitFullscreen": "Exit fullscreen (ESC)",
+    "indent": "Indent (Tab)",
+    "outdent": "Outdent (Shift+Tab)",
+    "tabMovesFocusOn": "Tab moves focus (Ctrl+M to indent instead)",
+    "tabMovesFocusOff": "Tab indents (Ctrl+M to move focus instead)"
   },
   "actions": {
     "copyPath": "Copy path",

--- a/locales/ja/keyboardShortcuts.json
+++ b/locales/ja/keyboardShortcuts.json
@@ -3,7 +3,8 @@
   "scopes": {
     "global": "グローバル",
     "terminal": "ターミナル",
-    "composer": "入力欄"
+    "composer": "入力欄",
+    "editor": "ファイルエディタ"
   },
   "shortcuts": {
     "commandPalette": "コマンドパレットを開く",
@@ -12,6 +13,11 @@
     "navigateList": "選択を上下に移動",
     "terminalSearch": "ターミナル出力を検索",
     "sendMessage": "メッセージを送信",
-    "composerNewline": "改行を挿入"
+    "composerNewline": "改行を挿入",
+    "editorIndent": "行・選択範囲をインデント",
+    "editorOutdent": "行・選択範囲をアウトデント",
+    "editorTabFocus": "Tab キーのフォーカス移動を切り替え",
+    "editorSave": "ファイルを保存",
+    "editorFullscreen": "全画面エディタを切り替え"
   }
 }

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -296,7 +296,11 @@
     "editorOnly": "エディタのみ",
     "previewOnly": "プレビューのみ",
     "enterFullscreen": "全画面にする (Ctrl+Shift+F)",
-    "exitFullscreen": "全画面を終了 (ESC)"
+    "exitFullscreen": "全画面を終了 (ESC)",
+    "indent": "インデント (Tab)",
+    "outdent": "アウトデント (Shift+Tab)",
+    "tabMovesFocusOn": "Tab はフォーカス移動 (Ctrl+M でインデントに切替)",
+    "tabMovesFocusOff": "Tab はインデント (Ctrl+M でフォーカス移動に切替)"
   },
   "actions": {
     "copyPath": "パスをコピー",

--- a/src/components/worktree/MarkdownEditor.tsx
+++ b/src/components/worktree/MarkdownEditor.tsx
@@ -56,6 +56,7 @@ import { useSwipeGesture } from '@/hooks/useSwipeGesture';
 import { useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import { Z_INDEX } from '@/config/z-index';
 import { COPY_FEEDBACK_RESET_MS } from '@/config/ui-feedback-config';
+import { applyIndent, applyOutdent, type IndentEdit } from '@/lib/editor/indent';
 import type { EditorProps, EditorFileType, ViewMode } from '@/types/markdown-editor';
 import {
   VIEW_MODE_STRATEGIES,
@@ -63,6 +64,8 @@ import {
   LOCAL_STORAGE_KEY_SPLIT_RATIO,
   LOCAL_STORAGE_KEY_MAXIMIZED,
   LOCAL_STORAGE_KEY_AUTO_SAVE,
+  LOCAL_STORAGE_KEY_TAB_MOVES_FOCUS,
+  INDENT_UNIT,
   AUTO_SAVE_DEBOUNCE_MS,
   PREVIEW_DEBOUNCE_MS,
   FILE_SIZE_LIMITS,
@@ -286,6 +289,8 @@ export const MarkdownEditor = memo(function MarkdownEditor({
   const beforeUnloadRef = useRef<((e: BeforeUnloadEvent) => void) | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentAreaRef = useRef<HTMLDivElement>(null);
+  /** Selection to restore once a fallback-path indent has re-rendered. */
+  const pendingSelectionRef = useRef<{ start: number; end: number } | null>(null);
 
   // Mobile detection
   const isMobile = useIsMobile();
@@ -330,6 +335,15 @@ export const MarkdownEditor = memo(function MarkdownEditor({
   // Auto-save setting with localStorage persistence
   const { value: isAutoSaveEnabled, setValue: setAutoSaveEnabled } = useLocalStorageState({
     key: LOCAL_STORAGE_KEY_AUTO_SAVE,
+    defaultValue: false,
+    validate: isValidBoolean,
+  });
+
+  // Issue #1518: WCAG 2.1.2 escape hatch — when on, Tab keeps its default
+  // focus-move behaviour instead of indenting. Escape is already taken (it
+  // exits fullscreen), so the toggle is Ctrl+M.
+  const { value: tabMovesFocus, setValue: setTabMovesFocus } = useLocalStorageState({
+    key: LOCAL_STORAGE_KEY_TAB_MOVES_FOCUS,
     defaultValue: false,
     validate: isValidBoolean,
   });
@@ -603,6 +617,12 @@ export const MarkdownEditor = memo(function MarkdownEditor({
    */
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // This handler is bound to both the textarea and the root div, so a
+      // keystroke inside the textarea would otherwise run it twice — one Tab
+      // press indenting twice, one Ctrl+S saving twice (Issue #1518).
+      // Events from anywhere else still reach it via the root div.
+      if (e.target === textareaRef.current && e.currentTarget !== e.target) return;
+
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
         if (isAutoSaveEnabled) {
@@ -631,6 +651,121 @@ export const MarkdownEditor = memo(function MarkdownEditor({
     [saveContent, isAutoSaveEnabled, saveNow, onSave, filePath, toggleFullscreen, exitFullscreen, isMaximized]
   );
 
+  /**
+   * Apply a computed indent/outdent edit to the textarea (Issue #1518).
+   *
+   * `execCommand('insertText')` is the first choice because it goes through the
+   * browser's own editing pipeline: one Ctrl+Z reverts the indent, and the
+   * resulting input event drives `handleContentChange`, so preview, dirty state
+   * and auto-save stay wired up with no extra plumbing.
+   */
+  const applyEditorEdit = useCallback(
+    (edit: IndentEdit) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      if (edit.value === textarea.value) {
+        textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+        return;
+      }
+
+      textarea.focus();
+      textarea.setSelectionRange(edit.replaceStart, edit.replaceEnd);
+
+      let insertedNatively = false;
+      try {
+        insertedNatively =
+          typeof document.execCommand === 'function' &&
+          document.execCommand('insertText', false, edit.replacement);
+      } catch {
+        insertedNatively = false;
+      }
+
+      if (insertedNatively) {
+        textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+        return;
+      }
+
+      // Fallback where execCommand is unavailable (jsdom, older engines): drive
+      // React state and restore the caret after the controlled re-render, since
+      // replacing the value would otherwise park it at the end.
+      pendingSelectionRef.current = { start: edit.selectionStart, end: edit.selectionEnd };
+      setContent(edit.value);
+      updatePreview(edit.value);
+    },
+    [updatePreview]
+  );
+
+  const handleIndent = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    applyEditorEdit(
+      applyIndent(textarea.value, textarea.selectionStart, textarea.selectionEnd, INDENT_UNIT)
+    );
+  }, [applyEditorEdit]);
+
+  const handleOutdent = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const edit = applyOutdent(
+      textarea.value,
+      textarea.selectionStart,
+      textarea.selectionEnd,
+      INDENT_UNIT
+    );
+    if (edit) applyEditorEdit(edit);
+  }, [applyEditorEdit]);
+
+  const handleToggleTabMovesFocus = useCallback(() => {
+    setTabMovesFocus((prev) => !prev);
+  }, [setTabMovesFocus]);
+
+  /**
+   * Textarea-only key handling: Tab indent / Shift+Tab outdent plus the Ctrl+M
+   * escape-hatch toggle. Other shortcuts fall through to {@link handleKeyDown}.
+   */
+  const handleTextareaKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Ctrl, never Cmd: Cmd+M minimises the window on macOS.
+      if (e.ctrlKey && !e.metaKey && !e.altKey && (e.key === 'm' || e.key === 'M')) {
+        e.preventDefault();
+        handleToggleTabMovesFocus();
+        return;
+      }
+
+      if (e.key === 'Tab' && !tabMovesFocus && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const textarea = e.currentTarget;
+        const edit = e.shiftKey
+          ? applyOutdent(textarea.value, textarea.selectionStart, textarea.selectionEnd, INDENT_UNIT)
+          : applyIndent(textarea.value, textarea.selectionStart, textarea.selectionEnd, INDENT_UNIT);
+
+        // A null outdent means there was nothing to remove: leave the default
+        // backwards focus move alone so the editor is never a keyboard trap.
+        if (edit) {
+          e.preventDefault();
+          applyEditorEdit(edit);
+        }
+        return;
+      }
+
+      handleKeyDown(e);
+    },
+    [tabMovesFocus, handleToggleTabMovesFocus, applyEditorEdit, handleKeyDown]
+  );
+
+  // Restore the selection a fallback-path edit asked for, once the controlled
+  // textarea has re-rendered with the new value.
+  useEffect(() => {
+    const pending = pendingSelectionRef.current;
+    if (!pending) return;
+    pendingSelectionRef.current = null;
+
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus();
+    textarea.setSelectionRange(pending.start, pending.end);
+  }, [content]);
+
   /** Shared line number gutter + textarea rendering (DRY: used by both mobile and desktop layouts) */
   const renderEditorInner = useCallback((showFocusRing: boolean) => (
     <>
@@ -648,14 +783,14 @@ export const MarkdownEditor = memo(function MarkdownEditor({
         data-testid="markdown-editor-textarea"
         value={content}
         onChange={handleContentChange}
-        onKeyDown={handleKeyDown}
+        onKeyDown={handleTextareaKeyDown}
         onScroll={handleEditorScroll}
         className={`flex-1 py-4 pr-4 pl-3 font-mono text-sm resize-none bg-surface text-foreground focus:outline-none leading-[1.5rem]${showFocusRing ? ' focus:ring-2 focus:ring-ring focus:ring-inset' : ''}`}
         placeholder={isTextMode ? tWorktree('editor.placeholder') : tWorktree('editor.placeholderMarkdown')}
         spellCheck={false}
       />
     </>
-  ), [lineCount, content, handleContentChange, handleKeyDown, handleEditorScroll, isTextMode, tWorktree]);
+  ), [lineCount, content, handleContentChange, handleTextareaKeyDown, handleEditorScroll, isTextMode, tWorktree]);
 
   // Global ESC key handler for maximized mode
   useEffect(() => {
@@ -870,6 +1005,10 @@ export const MarkdownEditor = memo(function MarkdownEditor({
         onSave={saveContent}
         onClose={onClose ? handleClose : undefined}
         hideViewModeToggle={isTextMode}
+        onIndent={handleIndent}
+        onOutdent={handleOutdent}
+        tabMovesFocus={tabMovesFocus}
+        onToggleTabMovesFocus={handleToggleTabMovesFocus}
       />
 
       {/* ESC hint when maximized */}

--- a/src/components/worktree/MarkdownToolbar.tsx
+++ b/src/components/worktree/MarkdownToolbar.tsx
@@ -26,6 +26,9 @@ import {
   Minimize2,
   Copy,
   Check,
+  IndentIncrease,
+  IndentDecrease,
+  Keyboard,
 } from 'lucide-react';
 import type { ViewMode } from '@/types/markdown-editor';
 import { Button } from '@/components/ui';
@@ -67,6 +70,14 @@ export interface MarkdownToolbarProps {
   onClose?: () => void;
   /** Hide view mode toggle buttons (for text-only mode, Issue #646) */
   hideViewModeToggle?: boolean;
+  /** Indent the editor selection (Issue #1518; the only route on touch devices) */
+  onIndent: () => void;
+  /** Outdent the editor selection (Issue #1518) */
+  onOutdent: () => void;
+  /** Whether Tab moves focus instead of indenting */
+  tabMovesFocus: boolean;
+  /** Toggle the Tab-moves-focus accessibility setting */
+  onToggleTabMovesFocus: () => void;
 }
 
 // ============================================================================
@@ -90,8 +101,15 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
   onSave,
   onClose,
   hideViewModeToggle,
+  onIndent,
+  onOutdent,
+  tabMovesFocus,
+  onToggleTabMovesFocus,
 }: MarkdownToolbarProps) {
   const t = useTranslations('worktree');
+  // Keeping the textarea focused is what makes these buttons work at all: they
+  // act on its live selection, and a focus loss would collapse it (Issue #1518).
+  const keepEditorFocus = (e: React.MouseEvent) => e.preventDefault();
   return (
     <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-muted">
       {/* File path and dirty indicator */}
@@ -157,6 +175,45 @@ export const MarkdownToolbar = memo(function MarkdownToolbar({
             </button>
           </div>
         )}
+
+        {/* Indent / outdent (Issue #1518). Sized to the 44px minimum tap
+            target because touch keyboards have no Tab key. */}
+        <Button
+          variant="ghost"
+          data-testid="editor-indent-button"
+          onMouseDown={keepEditorFocus}
+          onClick={onIndent}
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
+          title={t('editor.indent')}
+          aria-label={t('editor.indent')}
+        >
+          <IndentIncrease className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          data-testid="editor-outdent-button"
+          onMouseDown={keepEditorFocus}
+          onClick={onOutdent}
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
+          title={t('editor.outdent')}
+          aria-label={t('editor.outdent')}
+        >
+          <IndentDecrease className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          data-testid="editor-tab-focus-toggle"
+          onMouseDown={keepEditorFocus}
+          onClick={onToggleTabMovesFocus}
+          aria-pressed={tabMovesFocus}
+          className={`flex min-h-[44px] min-w-[44px] items-center justify-center p-1.5 hover:bg-muted rounded ${
+            tabMovesFocus ? 'text-accent-600 dark:text-accent-400' : 'text-muted-foreground hover:text-foreground'
+          }`}
+          title={tabMovesFocus ? t('editor.tabMovesFocusOn') : t('editor.tabMovesFocusOff')}
+          aria-label={tabMovesFocus ? t('editor.tabMovesFocusOn') : t('editor.tabMovesFocusOff')}
+        >
+          <Keyboard className="h-4 w-4" />
+        </Button>
 
         {/* Copy content button */}
         <Button

--- a/src/config/keyboard-shortcuts.ts
+++ b/src/config/keyboard-shortcuts.ts
@@ -14,7 +14,7 @@
  */
 
 /** Grouping bucket for a shortcut in the help overlay. */
-export type ShortcutScope = 'global' | 'terminal' | 'composer';
+export type ShortcutScope = 'global' | 'terminal' | 'composer' | 'editor';
 
 /** Placeholder key cap that renders as ⌘ (macOS) or Ctrl (everywhere else). */
 export const MOD_KEY_TOKEN = 'MOD';
@@ -33,6 +33,7 @@ export const SHORTCUT_SCOPES: readonly ShortcutScope[] = [
   'global',
   'terminal',
   'composer',
+  'editor',
 ] as const;
 
 /**
@@ -40,6 +41,7 @@ export const SHORTCUT_SCOPES: readonly ShortcutScope[] = [
  *   - command palette toggle + Escape (CommandPalette.tsx)
  *   - terminal search (TerminalDisplay.tsx)
  *   - composer submit / newline (MessageInput.tsx)
+ *   - file editor indent / outdent / save / fullscreen (MarkdownEditor.tsx)
  */
 export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   { id: 'commandPalette', keys: [MOD_KEY_TOKEN, 'K'], scope: 'global' },
@@ -49,6 +51,13 @@ export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   { id: 'terminalSearch', keys: [MOD_KEY_TOKEN, 'F'], scope: 'terminal' },
   { id: 'sendMessage', keys: ['↵'], scope: 'composer' },
   { id: 'composerNewline', keys: ['Shift', '↵'], scope: 'composer' },
+  { id: 'editorIndent', keys: ['Tab'], scope: 'editor' },
+  { id: 'editorOutdent', keys: ['Shift', 'Tab'], scope: 'editor' },
+  // Literal Ctrl, not MOD_KEY_TOKEN: Cmd+M minimises the window on macOS, so the
+  // binding is Ctrl+M on every platform (Issue #1518).
+  { id: 'editorTabFocus', keys: ['Ctrl', 'M'], scope: 'editor' },
+  { id: 'editorSave', keys: [MOD_KEY_TOKEN, 'S'], scope: 'editor' },
+  { id: 'editorFullscreen', keys: [MOD_KEY_TOKEN, 'Shift', 'F'], scope: 'editor' },
 ] as const;
 
 /**

--- a/src/lib/editor/indent.ts
+++ b/src/lib/editor/indent.ts
@@ -1,0 +1,166 @@
+/**
+ * Textarea indent / outdent computation (Issue #1518)
+ *
+ * Pure functions: they take the current textarea value plus the selection and
+ * return the edit to apply. Keeping them free of DOM access lets the editor
+ * apply the result through `document.execCommand('insertText')` (so a single
+ * Ctrl+Z undoes it) and fall back to React state where that is unavailable.
+ *
+ * @module lib/editor/indent
+ */
+
+/** A computed replacement plus the selection to restore afterwards. */
+export interface IndentEdit {
+  /** Start offset of the range to replace in the original value. */
+  replaceStart: number;
+  /** End offset of the range to replace in the original value. */
+  replaceEnd: number;
+  /** Text to write over `[replaceStart, replaceEnd)`. */
+  replacement: string;
+  /** Selection start to restore after applying. */
+  selectionStart: number;
+  /** Selection end to restore after applying. */
+  selectionEnd: number;
+  /** The full value after applying the replacement. */
+  value: string;
+}
+
+/** Offset of the first character of the line containing `offset`. */
+function lineStartAt(value: string, offset: number): number {
+  return value.lastIndexOf('\n', offset - 1) + 1;
+}
+
+/** Offset just past the last character of the line containing `offset`. */
+function lineEndAt(value: string, offset: number): number {
+  const next = value.indexOf('\n', offset);
+  return next === -1 ? value.length : next;
+}
+
+/**
+ * The line range a selection acts on. A selection that ends exactly at a line
+ * start (the usual result of selecting whole lines) does not drag the following
+ * line into the operation.
+ */
+function blockRange(
+  value: string,
+  selStart: number,
+  selEnd: number
+): { start: number; end: number } {
+  const effectiveEnd =
+    selEnd > selStart && selEnd > 0 && value[selEnd - 1] === '\n' ? selEnd - 1 : selEnd;
+  return { start: lineStartAt(value, selStart), end: lineEndAt(value, effectiveEnd) };
+}
+
+function buildEdit(
+  value: string,
+  replaceStart: number,
+  replaceEnd: number,
+  replacement: string,
+  selectionStart: number,
+  selectionEnd: number
+): IndentEdit {
+  return {
+    replaceStart,
+    replaceEnd,
+    replacement,
+    selectionStart,
+    selectionEnd,
+    value: value.slice(0, replaceStart) + replacement + value.slice(replaceEnd),
+  };
+}
+
+/** True for a line with no content — `''`, or `'\r'` on a CRLF file. */
+function isBlankLine(line: string): boolean {
+  return line === '' || line === '\r';
+}
+
+/**
+ * Indent the selection by one `unit`.
+ *
+ * A selection spanning several lines prefixes every non-blank line in the range
+ * and keeps the whole block selected. Otherwise `unit`-aligned spaces are
+ * inserted at the caret (replacing any selection), so pressing Tab mid-word
+ * lands on the next tab stop rather than always adding `unit.length` spaces.
+ *
+ * Blank lines are skipped: in Markdown a line holding only spaces is a hard
+ * line break, so padding them would change how the document renders.
+ */
+export function applyIndent(
+  value: string,
+  selStart: number,
+  selEnd: number,
+  unit: string
+): IndentEdit {
+  const isMultiLine = selEnd > selStart && value.slice(selStart, selEnd).includes('\n');
+
+  if (!isMultiLine) {
+    const column = selStart - lineStartAt(value, selStart);
+    const spaces = unit.length - (column % unit.length);
+    const replacement = ' '.repeat(spaces);
+    const caret = selStart + replacement.length;
+    return buildEdit(value, selStart, selEnd, replacement, caret, caret);
+  }
+
+  const { start, end } = blockRange(value, selStart, selEnd);
+  const replacement = value
+    .slice(start, end)
+    .split('\n')
+    .map((line) => (isBlankLine(line) ? line : unit + line))
+    .join('\n');
+
+  return buildEdit(value, start, end, replacement, start, start + replacement.length);
+}
+
+/**
+ * Remove up to one `unit` of leading whitespace from the start of `line`.
+ * A leading tab counts as one unit so that files already indented with tabs can
+ * still be outdented, even though we only ever insert spaces.
+ */
+function outdentLine(line: string, unit: string): string {
+  if (line.startsWith('\t')) return line.slice(1);
+
+  let removed = 0;
+  while (removed < unit.length && line[removed] === ' ') {
+    removed += 1;
+  }
+  return line.slice(removed);
+}
+
+/**
+ * Outdent the selection by one `unit`.
+ *
+ * Returns `null` when there is nothing to remove and no selection — the caller
+ * then lets the browser's default Shift+Tab run, which is the escape hatch out
+ * of the textarea required by WCAG 2.1.2 (No Keyboard Trap).
+ *
+ * Lines without leading whitespace are left alone rather than skipping the
+ * whole operation, so outdenting a mixed block does not fail on one flush line.
+ */
+export function applyOutdent(
+  value: string,
+  selStart: number,
+  selEnd: number,
+  unit: string
+): IndentEdit | null {
+  const { start, end } = blockRange(value, selStart, selEnd);
+  const original = value.slice(start, end);
+  const replacement = original
+    .split('\n')
+    .map((line) => outdentLine(line, unit))
+    .join('\n');
+
+  if (replacement === original) {
+    return selStart === selEnd ? null : buildEdit(value, start, end, replacement, selStart, selEnd);
+  }
+
+  if (selStart === selEnd) {
+    const removedBeforeCaret = Math.min(
+      original.length - replacement.length,
+      Math.max(0, selStart - start)
+    );
+    const caret = selStart - removedBeforeCaret;
+    return buildEdit(value, start, end, replacement, caret, caret);
+  }
+
+  return buildEdit(value, start, end, replacement, start, start + replacement.length);
+}

--- a/src/types/markdown-editor.ts
+++ b/src/types/markdown-editor.ts
@@ -280,6 +280,20 @@ export const LOCAL_STORAGE_KEY_AUTO_SAVE = 'commandmate:md-editor-auto-save';
 export const AUTO_SAVE_DEBOUNCE_MS = 3000;
 
 /**
+ * Local storage key for the "Tab moves focus" accessibility toggle (Issue #1518)
+ */
+export const LOCAL_STORAGE_KEY_TAB_MOVES_FOCUS = 'commandmate:md-editor-tab-moves-focus';
+
+/**
+ * Indent unit inserted by Tab (Issue #1518).
+ *
+ * Spaces, never a tab character: the same textarea edits YAML in text mode and
+ * YAML forbids tabs, and a literal tab renders at the browser's default 8-column
+ * `tab-size` which breaks Markdown nested lists.
+ */
+export const INDENT_UNIT = '  ';
+
+/**
  * Default editor layout state
  */
 export const DEFAULT_LAYOUT_STATE: EditorLayoutState = {

--- a/tests/e2e/fixtures/markdown-editor-helpers.ts
+++ b/tests/e2e/fixtures/markdown-editor-helpers.ts
@@ -1,0 +1,151 @@
+/**
+ * E2E fixtures for the markdown editor indent specs (Issue #1518)
+ *
+ * The indent behaviour has to be proven with *real* key presses: the unit tests
+ * use `fireEvent`, and this repo has been burned before by keyboard handling
+ * that was green under `fireEvent` yet dead in a browser. Reaching the editor
+ * needs a worktree, which the E2E server deliberately has none of
+ * (playwright.config.ts pins an empty scan root), so — following the
+ * terminal-split fixtures — the worktree API is mocked in the browser instead
+ * of seeded on the server. That also keeps these specs from making worktrees
+ * visible to the destructive specs running in parallel.
+ */
+
+import type { Page, Route } from '@playwright/test';
+
+/** Worktree id scoped to these specs so it cannot collide with other suites. */
+export const E2E_EDITOR_WORKTREE = 'e2e-editor-indent';
+
+/** Fixture file served by the mocked file API. */
+export const E2E_EDITOR_FILE = 'indent-fixture.md';
+
+/** Initial content of the fixture. Deliberately free of MARP frontmatter,
+ *  which would route the file to the slides editor instead. */
+export const E2E_EDITOR_CONTENT = 'alpha\nbeta\n';
+
+/** Editor state persisted in localStorage; cleared so every test starts equal. */
+const EDITOR_STORAGE_KEYS = [
+  'commandmate:md-editor-view-mode',
+  'commandmate:md-editor-split-ratio',
+  'commandmate:md-editor-maximized',
+  'commandmate:md-editor-auto-save',
+  'commandmate:md-editor-tab-moves-focus',
+  'commandmate.worktree.filePanelCollapsed',
+  `commandmate.worktree.activeActivity-${E2E_EDITOR_WORKTREE}`,
+];
+
+function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+const WORKTREE = {
+  id: E2E_EDITOR_WORKTREE,
+  name: 'E2E editor indent',
+  path: `/tmp/${E2E_EDITOR_WORKTREE}`,
+  repositoryPath: `/tmp/${E2E_EDITOR_WORKTREE}-repo`,
+  repositoryName: 'e2e-repo',
+  repositoryDisplayName: 'E2E Repo',
+  description: 'E2E markdown indent worktree',
+  selectedAgents: ['claude'],
+  cliToolId: 'claude',
+  status: 'ready',
+  sessionStatusByCli: {
+    claude: { isRunning: false, isWaitingForResponse: false, isProcessing: false },
+  },
+  gitStatus: {
+    currentBranch: 'main',
+    initialBranch: 'main',
+    isBranchMismatch: false,
+    commitHash: 'e2e0000',
+    isDirty: false,
+  },
+};
+
+const EMPTY_OUTPUT = {
+  isRunning: false,
+  cliToolId: 'claude',
+  isGenerating: false,
+  isPromptWaiting: false,
+  content: '',
+  fullOutput: '',
+  realtimeSnippet: '',
+  thinking: false,
+  isSelectionListActive: false,
+};
+
+/**
+ * Serve every `/api/...` request for this spec. Unhandled paths get an empty
+ * but well-formed body so no fetch is left pending.
+ */
+export async function mockEditorApi(page: Page): Promise<void> {
+  await page.addInitScript((keys: string[]) => {
+    for (const key of keys) window.localStorage.removeItem(key);
+  }, EDITOR_STORAGE_KEYS);
+
+  await page.route(
+    (url) => url.pathname.startsWith('/api/'),
+    async (route) => {
+      const { pathname } = new URL(route.request().url());
+
+      if (pathname.endsWith('/api/worktrees')) {
+        return fulfillJson(route, [WORKTREE]);
+      }
+
+      const detailMatch = pathname.match(/\/api\/worktrees\/([^/]+)(\/.*)?$/);
+      if (detailMatch) {
+        const sub = detailMatch[2] ?? '';
+
+        if (sub === '') return fulfillJson(route, WORKTREE);
+        if (sub.startsWith('/tree')) {
+          return fulfillJson(route, {
+            path: '',
+            name: '',
+            parentPath: null,
+            items: [
+              {
+                name: E2E_EDITOR_FILE,
+                type: 'file',
+                size: E2E_EDITOR_CONTENT.length,
+                extension: 'md',
+                mtime: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+          });
+        }
+        if (sub.startsWith(`/files/${E2E_EDITOR_FILE}`)) {
+          if (route.request().method() === 'PUT') {
+            return fulfillJson(route, { success: true, path: E2E_EDITOR_FILE });
+          }
+          return fulfillJson(route, {
+            success: true,
+            path: E2E_EDITOR_FILE,
+            content: E2E_EDITOR_CONTENT,
+            extension: 'md',
+            worktreePath: WORKTREE.path,
+            totalBytes: E2E_EDITOR_CONTENT.length,
+          });
+        }
+        if (sub.startsWith('/current-output')) return fulfillJson(route, EMPTY_OUTPUT);
+        if (sub.startsWith('/slash-commands')) return fulfillJson(route, { groups: [] });
+        if (
+          sub.startsWith('/messages') ||
+          sub.startsWith('/memos') ||
+          sub.startsWith('/execution-logs') ||
+          sub.startsWith('/schedules')
+        ) {
+          return fulfillJson(route, []);
+        }
+        return fulfillJson(route, {});
+      }
+
+      if (pathname.includes('/repositories') || pathname.includes('/tools')) {
+        return fulfillJson(route, []);
+      }
+      return fulfillJson(route, {});
+    }
+  );
+}

--- a/tests/e2e/markdown-editor.spec.ts
+++ b/tests/e2e/markdown-editor.spec.ts
@@ -5,7 +5,13 @@
  * Phase 5 - Task 5.1
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import {
+  mockEditorApi,
+  E2E_EDITOR_WORKTREE,
+  E2E_EDITOR_FILE,
+  E2E_EDITOR_CONTENT,
+} from './fixtures/markdown-editor-helpers';
 
 test.describe('Markdown Editor', () => {
   /**
@@ -376,6 +382,155 @@ test.describe('Markdown Editor', () => {
       const dirtyIndicator = page.locator('[data-testid="dirty-indicator"]');
       // Note: This may still show if there's an error, so we check visibility
       // The actual save test would need a proper backend setup
+    });
+  });
+
+  /**
+   * Issue #1518: Tab indent / Shift+Tab outdent, driven by real key presses.
+   *
+   * The unit suite uses `fireEvent`, which can dispatch to an element that is
+   * not focused and so hide keyboard bugs entirely. These tests type into a
+   * real browser: they assert the value changes, that focus *stays* in the
+   * textarea, that one Ctrl+Z reverts the edit, and that Ctrl+M hands Tab back
+   * to focus navigation.
+   */
+  test.describe('Tab Indentation (Issue #1518)', () => {
+    // The dev server compiles the worktree route on first hit.
+    test.describe.configure({ timeout: 90_000 });
+
+    /** Open the fixture file and return the (visible) editor textarea. */
+    async function openEditor(page: Page): Promise<Locator> {
+      await mockEditorApi(page);
+      await page.goto(`/worktrees/${E2E_EDITOR_WORKTREE}`);
+
+      // Files is the default activity, so the tree appears on its own once the
+      // page hydrates. Clicking the activity button here would toggle it shut.
+      const treeItem = page.locator(`[data-testid="tree-item-${E2E_EDITOR_FILE}"]`);
+      await expect(treeItem).toBeVisible({ timeout: 60_000 });
+      await treeItem.click();
+
+      // .md files mount in preview mode, which hides the editor pane.
+      const editorViewButton = page.locator('[data-testid="view-mode-editor"]');
+      await expect(editorViewButton).toBeVisible({ timeout: 30_000 });
+      await editorViewButton.click();
+
+      const textarea = page.locator('[data-testid="markdown-editor-textarea"]');
+      await expect(textarea).toBeVisible({ timeout: 30_000 });
+      await expect(textarea).toHaveValue(E2E_EDITOR_CONTENT);
+      return textarea;
+    }
+
+    /** Place the caret without relying on platform-specific Home/End keys. */
+    async function setCaret(textarea: Locator, start: number, end = start) {
+      await textarea.evaluate(
+        (el, range) => {
+          const field = el as HTMLTextAreaElement;
+          field.focus();
+          field.setSelectionRange(range.start, range.end);
+        },
+        { start, end }
+      );
+    }
+
+    function focusedTestId(page: Page) {
+      return page.evaluate(() => document.activeElement?.getAttribute('data-testid') ?? null);
+    }
+
+    test('indents with Tab and keeps focus in the textarea', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+
+      await page.keyboard.press('Tab');
+
+      await expect(textarea).toHaveValue('  alpha\nbeta\n');
+      expect(await focusedTestId(page)).toBe('markdown-editor-textarea');
+      expect(await textarea.inputValue()).not.toContain('\t');
+    });
+
+    test('applies exactly one indent per Tab press', async ({ page }) => {
+      // Regression: handleKeyDown is bound to both the textarea and the root
+      // div, so an unguarded handler indents twice for one keystroke.
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+
+      await page.keyboard.press('Tab');
+
+      await expect(textarea).toHaveValue('  alpha\nbeta\n');
+    });
+
+    test('reverts an indent with a single undo', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+
+      await page.keyboard.press('Tab');
+      await expect(textarea).toHaveValue('  alpha\nbeta\n');
+
+      await page.keyboard.press('ControlOrMeta+z');
+
+      await expect(textarea).toHaveValue(E2E_EDITOR_CONTENT);
+    });
+
+    test('outdents with Shift+Tab', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+      await page.keyboard.press('Tab');
+      await expect(textarea).toHaveValue('  alpha\nbeta\n');
+
+      await page.keyboard.press('Shift+Tab');
+
+      await expect(textarea).toHaveValue(E2E_EDITOR_CONTENT);
+      expect(await focusedTestId(page)).toBe('markdown-editor-textarea');
+    });
+
+    test('indents a multi-line selection and keeps it selected', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0, E2E_EDITOR_CONTENT.length);
+
+      await page.keyboard.press('Tab');
+
+      await expect(textarea).toHaveValue('  alpha\n  beta\n');
+      const selection = await textarea.evaluate((el) => {
+        const field = el as HTMLTextAreaElement;
+        return { start: field.selectionStart, end: field.selectionEnd };
+      });
+      expect(selection.start).toBe(0);
+      expect(selection.end).toBeGreaterThan(0);
+    });
+
+    test('Ctrl+M gives Tab back to focus navigation', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+
+      await page.keyboard.press('Control+m');
+      await expect(page.locator('[data-testid="editor-tab-focus-toggle"]')).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+
+      await page.keyboard.press('Tab');
+
+      await expect(textarea).toHaveValue(E2E_EDITOR_CONTENT);
+      expect(await focusedTestId(page)).not.toBe('markdown-editor-textarea');
+    });
+
+    test('Shift+Tab with nothing to remove escapes the textarea', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+
+      await page.keyboard.press('Shift+Tab');
+
+      await expect(textarea).toHaveValue(E2E_EDITOR_CONTENT);
+      expect(await focusedTestId(page)).not.toBe('markdown-editor-textarea');
+    });
+
+    test('indents from the toolbar button without losing the caret', async ({ page }) => {
+      const textarea = await openEditor(page);
+      await setCaret(textarea, 0);
+
+      await page.click('[data-testid="editor-indent-button"]');
+
+      await expect(textarea).toHaveValue('  alpha\nbeta\n');
+      expect(await focusedTestId(page)).toBe('markdown-editor-textarea');
     });
   });
 });

--- a/tests/unit/components/MarkdownEditor.test.tsx
+++ b/tests/unit/components/MarkdownEditor.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, createEvent } from '@testing-library/react';
 import { MarkdownEditor } from '@/components/worktree/MarkdownEditor';
 import { ToastProvider } from '@/components/common/Toast';
 import { ConfirmProvider } from '@/components/ui/ConfirmDialog';
@@ -1617,6 +1617,227 @@ def hello():
         expect(screen.getByTestId('markdown-preview-toc-toggle')).toBeInTheDocument();
       });
       expect(screen.queryByTestId('markdown-preview-toc')).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Issue #1518: Tab indent / Shift+Tab outdent.
+   *
+   * jsdom has no `document.execCommand`, so the plain cases exercise the React
+   * fallback path; the native path is covered by stubbing execCommand and
+   * asserting the textarea is handed the right replacement range.
+   */
+  describe('Tab indentation (Issue #1518)', () => {
+    // An earlier suite swaps in a getItem stub that ignores the backing store and
+    // survives clearAllMocks; reset restores vi.fn's original implementation.
+    beforeEach(() => {
+      localStorageMock.getItem.mockReset();
+    });
+
+    /** Put the caret / selection where the test needs it before pressing Tab. */
+    function selectRange(textarea: HTMLTextAreaElement, start: number, end: number) {
+      textarea.focus();
+      textarea.setSelectionRange(start, end);
+    }
+
+    async function renderWithContent(value: string) {
+      render(<MarkdownEditor {...defaultProps} />);
+      await waitForEditorReady();
+      const textarea = screen.getByTestId('markdown-editor-textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value } });
+      return textarea;
+    }
+
+    it('inserts two spaces at the caret and keeps focus in the textarea', async () => {
+      const textarea = await renderWithContent('hello');
+      selectRange(textarea, 0, 0);
+
+      fireEvent.keyDown(textarea, { key: 'Tab' });
+
+      await waitFor(() => expect(textarea.value).toBe('  hello'));
+      expect(textarea.value).not.toContain('\t');
+      expect(document.activeElement).toBe(textarea);
+      expect(textarea.selectionStart).toBe(2);
+    });
+
+    it('applies exactly one indent per keystroke (double-application regression)', async () => {
+      // handleKeyDown is bound to the textarea AND the root div, so the same
+      // native event reaches two handlers. One press must still indent once.
+      const textarea = await renderWithContent('hello');
+      selectRange(textarea, 0, 0);
+
+      fireEvent.keyDown(textarea, { key: 'Tab' });
+
+      await waitFor(() => expect(textarea.value).toBe('  hello'));
+      expect(textarea.value).not.toBe('    hello');
+    });
+
+    it('saves once per Ctrl+S despite the handler being bound twice', async () => {
+      const textarea = await renderWithContent('Modified content');
+
+      fireEvent.keyDown(textarea, { key: 's', ctrlKey: true });
+
+      await waitFor(() => {
+        const puts = mockFetch.mock.calls.filter((call) => call[1]?.method === 'PUT');
+        expect(puts).toHaveLength(1);
+      });
+    });
+
+    it('indents every line of a multi-line selection and keeps it selected', async () => {
+      const value = 'one\ntwo';
+      const textarea = await renderWithContent(value);
+      selectRange(textarea, 0, value.length);
+
+      fireEvent.keyDown(textarea, { key: 'Tab' });
+
+      await waitFor(() => expect(textarea.value).toBe('  one\n  two'));
+      expect(textarea.selectionStart).toBe(0);
+      expect(textarea.selectionEnd).toBe('  one\n  two'.length);
+    });
+
+    it('outdents on Shift+Tab', async () => {
+      const textarea = await renderWithContent('    deep');
+      selectRange(textarea, 8, 8);
+
+      fireEvent.keyDown(textarea, { key: 'Tab', shiftKey: true });
+
+      await waitFor(() => expect(textarea.value).toBe('  deep'));
+    });
+
+    it('lets Shift+Tab move focus when there is nothing to outdent', async () => {
+      const textarea = await renderWithContent('flush');
+      selectRange(textarea, 3, 3);
+
+      const event = createEvent.keyDown(textarea, { key: 'Tab', shiftKey: true });
+      fireEvent(textarea, event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(textarea.value).toBe('flush');
+    });
+
+    it('uses execCommand so a single Ctrl+Z undoes the indent', async () => {
+      const execCommand = vi.fn().mockReturnValue(true);
+      Object.defineProperty(document, 'execCommand', {
+        value: execCommand,
+        configurable: true,
+        writable: true,
+      });
+
+      try {
+        const textarea = await renderWithContent('hello');
+        selectRange(textarea, 0, 0);
+
+        fireEvent.keyDown(textarea, { key: 'Tab' });
+
+        expect(execCommand).toHaveBeenCalledTimes(1);
+        expect(execCommand).toHaveBeenCalledWith('insertText', false, '  ');
+        // The native path must not also write React state, or the edit lands twice.
+        expect(textarea.value).toBe('hello');
+      } finally {
+        delete (document as { execCommand?: unknown }).execCommand;
+      }
+    });
+
+    it('falls back to React state when execCommand reports failure', async () => {
+      const execCommand = vi.fn().mockReturnValue(false);
+      Object.defineProperty(document, 'execCommand', {
+        value: execCommand,
+        configurable: true,
+        writable: true,
+      });
+
+      try {
+        const textarea = await renderWithContent('hello');
+        selectRange(textarea, 0, 0);
+
+        fireEvent.keyDown(textarea, { key: 'Tab' });
+
+        await waitFor(() => expect(textarea.value).toBe('  hello'));
+        expect(textarea.selectionStart).toBe(2);
+      } finally {
+        delete (document as { execCommand?: unknown }).execCommand;
+      }
+    });
+
+    it('marks the file dirty so preview and auto-save stay wired up', async () => {
+      const textarea = await renderWithContent('hello');
+      selectRange(textarea, 0, 0);
+
+      fireEvent.keyDown(textarea, { key: 'Tab' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dirty-indicator')).toBeInTheDocument();
+      });
+    });
+
+    it('indents from the toolbar button without stealing focus from the textarea', async () => {
+      const textarea = await renderWithContent('hello');
+      selectRange(textarea, 0, 0);
+
+      fireEvent.click(screen.getByTestId('editor-indent-button'));
+
+      await waitFor(() => expect(textarea.value).toBe('  hello'));
+      expect(document.activeElement).toBe(textarea);
+    });
+
+    it('outdents from the toolbar button', async () => {
+      const textarea = await renderWithContent('    deep');
+      selectRange(textarea, 8, 8);
+
+      fireEvent.click(screen.getByTestId('editor-outdent-button'));
+
+      await waitFor(() => expect(textarea.value).toBe('  deep'));
+    });
+
+    it('Ctrl+M gives Tab back to focus navigation and persists the choice', async () => {
+      const textarea = await renderWithContent('hello');
+      selectRange(textarea, 0, 0);
+
+      fireEvent.keyDown(textarea, { key: 'm', ctrlKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('editor-tab-focus-toggle')).toHaveAttribute(
+          'aria-pressed',
+          'true'
+        );
+      });
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'commandmate:md-editor-tab-moves-focus',
+        'true'
+      );
+
+      const event = createEvent.keyDown(textarea, { key: 'Tab' });
+      fireEvent(textarea, event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(textarea.value).toBe('hello');
+    });
+
+    it('restores the persisted Tab-moves-focus setting on mount', async () => {
+      localStorageMock.setItem('commandmate:md-editor-tab-moves-focus', 'true');
+
+      const textarea = await renderWithContent('hello');
+      selectRange(textarea, 0, 0);
+
+      const event = createEvent.keyDown(textarea, { key: 'Tab' });
+      fireEvent(textarea, event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(textarea.value).toBe('hello');
+    });
+
+    it('indents yaml text mode without inserting a tab character', async () => {
+      render(<MarkdownEditor worktreeId="test-worktree-123" filePath="config.yaml" />);
+      await waitForEditorReady();
+
+      const textarea = screen.getByTestId('markdown-editor-textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: 'key:\nvalue' } });
+      selectRange(textarea, 5, 5);
+
+      fireEvent.keyDown(textarea, { key: 'Tab' });
+
+      await waitFor(() => expect(textarea.value).toBe('key:\n  value'));
+      expect(textarea.value).not.toContain('\t');
     });
   });
 });

--- a/tests/unit/lib/editor/indent.test.ts
+++ b/tests/unit/lib/editor/indent.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the indent/outdent pure functions (Issue #1518).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { applyIndent, applyOutdent, type IndentEdit } from '@/lib/editor/indent';
+import { INDENT_UNIT } from '@/types/markdown-editor';
+
+/** Apply an edit the way the editor does, so `value` and the slice agree. */
+function applied(value: string, edit: IndentEdit): string {
+  return value.slice(0, edit.replaceStart) + edit.replacement + value.slice(edit.replaceEnd);
+}
+
+describe('applyIndent', () => {
+  it('inserts a full unit at the start of a line', () => {
+    const edit = applyIndent('hello', 0, 0, INDENT_UNIT);
+    expect(edit.value).toBe('  hello');
+    expect(edit.replacement).toBe('  ');
+    expect(edit.selectionStart).toBe(2);
+    expect(edit.selectionEnd).toBe(2);
+  });
+
+  it('aligns to the next tab stop from an odd column', () => {
+    // caret after "h" (column 1) -> only 1 space to reach column 2
+    const edit = applyIndent('hello', 1, 1, INDENT_UNIT);
+    expect(edit.value).toBe('h ello');
+    expect(edit.replacement).toBe(' ');
+    expect(edit.selectionStart).toBe(2);
+  });
+
+  it('computes the column from the current line, not the document start', () => {
+    const value = 'ab\ncdef';
+    // caret after "cde" -> column 3 -> 1 space
+    const edit = applyIndent(value, 6, 6, INDENT_UNIT);
+    expect(edit.replacement).toBe(' ');
+    expect(edit.value).toBe('ab\ncde f');
+  });
+
+  it('replaces a single-line selection with the indent', () => {
+    const edit = applyIndent('abcd', 1, 3, INDENT_UNIT);
+    expect(edit.value).toBe('a d');
+    expect(edit.selectionStart).toBe(2);
+    expect(edit.selectionEnd).toBe(2);
+  });
+
+  it('indents every line of a multi-line selection and keeps the block selected', () => {
+    const value = 'one\ntwo\nthree';
+    const edit = applyIndent(value, 0, value.length, INDENT_UNIT);
+    expect(edit.value).toBe('  one\n  two\n  three');
+    expect(edit.selectionStart).toBe(0);
+    expect(edit.selectionEnd).toBe(edit.value.length);
+  });
+
+  it('expands a partial multi-line selection to whole lines', () => {
+    const value = 'one\ntwo\nthree';
+    // from inside "one" to inside "two"
+    const edit = applyIndent(value, 2, 5, INDENT_UNIT);
+    expect(edit.value).toBe('  one\n  two\nthree');
+    expect(edit.replaceStart).toBe(0);
+  });
+
+  it('does not pull in the next line when the selection ends at a line start', () => {
+    const value = 'one\ntwo\nthree';
+    const edit = applyIndent(value, 0, 4, INDENT_UNIT);
+    expect(edit.value).toBe('  one\ntwo\nthree');
+  });
+
+  it('skips blank lines so Markdown hard breaks are not created', () => {
+    const value = 'one\n\ntwo';
+    const edit = applyIndent(value, 0, value.length, INDENT_UNIT);
+    expect(edit.value).toBe('  one\n\n  two');
+  });
+
+  it('preserves CRLF line endings', () => {
+    const value = 'one\r\ntwo\r\n';
+    const edit = applyIndent(value, 0, value.length, INDENT_UNIT);
+    expect(edit.value).toBe('  one\r\n  two\r\n');
+  });
+
+  it('never inserts a tab character', () => {
+    const edit = applyIndent('x\ny', 0, 3, INDENT_UNIT);
+    expect(edit.replacement).not.toContain('\t');
+  });
+
+  it('produces a value consistent with its replacement range', () => {
+    const value = 'alpha\nbeta';
+    const edit = applyIndent(value, 0, value.length, INDENT_UNIT);
+    expect(applied(value, edit)).toBe(edit.value);
+  });
+});
+
+describe('applyOutdent', () => {
+  it('removes one unit from the caret line', () => {
+    const edit = applyOutdent('    deep', 6, 6, INDENT_UNIT);
+    expect(edit?.value).toBe('  deep');
+    expect(edit?.selectionStart).toBe(4);
+  });
+
+  it('removes only the available spaces when fewer than a unit', () => {
+    const edit = applyOutdent(' x', 2, 2, INDENT_UNIT);
+    expect(edit?.value).toBe('x');
+    expect(edit?.selectionStart).toBe(1);
+  });
+
+  it('clamps the caret to the line start when it sits inside the removed run', () => {
+    const edit = applyOutdent('    deep', 1, 1, INDENT_UNIT);
+    expect(edit?.value).toBe('  deep');
+    expect(edit?.selectionStart).toBe(0);
+  });
+
+  it('removes a leading tab as a single unit', () => {
+    const edit = applyOutdent('\tdeep', 5, 5, INDENT_UNIT);
+    expect(edit?.value).toBe('deep');
+  });
+
+  it('returns null with no selection and nothing to remove (keyboard escape hatch)', () => {
+    expect(applyOutdent('flush', 3, 3, INDENT_UNIT)).toBeNull();
+  });
+
+  it('outdents each line of a multi-line selection and keeps the block selected', () => {
+    const value = '  one\n  two';
+    const edit = applyOutdent(value, 0, value.length, INDENT_UNIT);
+    expect(edit?.value).toBe('one\ntwo');
+    expect(edit?.selectionStart).toBe(0);
+    expect(edit?.selectionEnd).toBe('one\ntwo'.length);
+  });
+
+  it('skips lines without leading whitespace instead of failing the block', () => {
+    const value = '  one\ntwo\n  three';
+    const edit = applyOutdent(value, 0, value.length, INDENT_UNIT);
+    expect(edit?.value).toBe('one\ntwo\nthree');
+  });
+
+  it('handles mixed tab and space indentation in one block', () => {
+    const value = '\tone\n    two';
+    const edit = applyOutdent(value, 0, value.length, INDENT_UNIT);
+    expect(edit?.value).toBe('one\n  two');
+  });
+
+  it('preserves CRLF line endings', () => {
+    const value = '  one\r\n  two\r\n';
+    const edit = applyOutdent(value, 0, value.length, INDENT_UNIT);
+    expect(edit?.value).toBe('one\r\ntwo\r\n');
+  });
+
+  it('returns a no-op edit (not null) when a selection has nothing to remove', () => {
+    const value = 'one\ntwo';
+    const edit = applyOutdent(value, 0, value.length, INDENT_UNIT);
+    expect(edit).not.toBeNull();
+    expect(edit?.value).toBe(value);
+  });
+
+  it('produces a value consistent with its replacement range', () => {
+    const value = '    alpha\n    beta';
+    const edit = applyOutdent(value, 0, value.length, INDENT_UNIT)!;
+    expect(applied(value, edit)).toBe(edit.value);
+  });
+});


### PR DESCRIPTION
## 概要

#1518 を実装する。Markdown / text モードの編集面（素の `<textarea>`）で **Tab インデント / Shift+Tab アウトデント**を可能にし、あわせて a11y（キーボードトラップ回避）とモバイルの逃げ道を用意する。

## 変更内容

### インデント計算は純関数に切り出す（新規 `src/lib/editor/indent.ts`）

`applyIndent` / `applyOutdent` が `IndentEdit` を返す形にして、コンポーネント側の差分を薄く保つ。

- **複数行選択**: 各行を字下げし、変更ブロック全体の選択を維持
- **単一行 / 選択なし**: タブストップ揃え
- **アウトデント**: 先頭空白が無い行はスキップ。既存ファイル中の**先頭タブは 1 単位として除去**
- **CRLF**: `\n` 基準で行頭を算出し `\r` を保持
- **空行はスキップ**（padding すると Markdown の hard break になってしまうため）

### 挿入は常に 2 スペース（`INDENT_UNIT`）

タブ文字は挿入しない。**同じ textarea が text モードで YAML を編集する**ため（YAML はタブ禁止）。

### Issue 本文が名指しした罠への対応

| 罠 | 対応 |
|---|---|
| **1. 二重適用** | `handleKeyDown` が textarea とルート div の**両方**に張られ 1 打鍵で 2 回発火していた。`e.target === textareaRef.current && e.currentTarget !== e.target` でガードし、Tab は textarea 専用ハンドラで処理。**副産物として Ctrl+S の二重発火も解消** |
| **2. native undo の破壊** | `document.execCommand('insertText')` を第一手にして **Ctrl+Z 1 手で戻る**。非対応環境（jsdom 含む）は React state ＋ `setSelectionRange()` 復元へフォールバック。**両経路ともテスト済み** |
| **3. キャレット/選択のジャンプ** | フォールバック経路で再描画後に `setSelectionRange()` 復元 |
| **4. キーボードトラップ（WCAG 2.1.2）** | **Ctrl+M** で Tab をフォーカス移動へ戻すトグル（localStorage 永続）。Cmd+M は macOS のウィンドウ最小化と衝突するため不採用。加えて no-op な Shift+Tab は `null` を返して既定動作に委ねる |
| **5. タブ文字ではなくスペース** | 2 スペース固定（上記） |
| **6. モバイルに Tab キーが無い** | `MarkdownToolbar` に 44px のインデント/アウトデントボタン＋トグル。`onMouseDown` の `preventDefault` で **textarea の選択を保持** |
| **7. CRLF / 既存タブ混在** | 上記のとおり対応 |

### その他

- `src/config/keyboard-shortcuts.ts` に **`editor` scope を新設**し indent / outdent / トグルを登録。**未登録だった Ctrl+S / Ctrl+Shift+F も登録**
- i18n は `locales/{en,ja}/worktree.json` と `locales/{en,ja}/keyboardShortcuts.json` の**両方**に追加

### 後続 #1519 との競合回避

`MarkdownEditor.tsx` の **`isMobilePortrait` / `useFullscreen` / `commandmate:md-editor-maximized` / タブ切替まわりは一切触っていない**（#1519 の担当領域）。インデント計算を純関数へ切り出したのも、この競合面を最小化する狙い。

## 検証

| チェック | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `npm run test:unit` | ✅ exit 0（656 files / 11426 tests） |
| `npm run build` | ✅ exit 0 |

### e2e を「実際に走る」状態にした

Issue 本文の警告どおり、本リポジトリは過去に **lint / tsc / unit が全緑なのにキーボード操作が全滅していた**前例がある。したがって unit 緑では完了としていない。

- 隔離 Playwright サーバは **worktree が 0 件**なので、そのままではエディタに到達できず e2e が**黙ってスキップ**される状態だった。`tests/e2e/fixtures/markdown-editor-helpers.ts` を追加してブラウザ内で `/api/` をモックし、**実キー入力で 8 本の e2e が実際に走る**ようにした
- カバーしている内容: 値の変化 / **フォーカスが textarea に残ること** / **1 打鍵で 1 回だけ適用**されること / **Ctrl+Z 1 手で戻る**こと / Ctrl+M 後はフォーカス移動に戻ること

### テストが空振りでないことの確認（mutation check）

- dedupe ガードを外す → Ctrl+S のテストが **PUT 2 回**で落ちる
- `execCommand` フォールバックを強制 → single-undo のテストが落ちる

Refs #1518

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGRy3L1G6rSKT9SuExtAzH
