### PR TITLE
chore: release v0.15.0（バージョンbumpとCHANGELOG確定）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-26
+
+> **Highlight**: モバイルとリポジトリ登録まわりの体験を厚くしたリリース。**リポジトリ登録の Local Path を GUI で選べる**ようになり（`CM_BROWSE_ROOTS` 新設、認証必須のディレクトリ一覧 API 込み）、**Markdown 編集で Tab インデント**が効くようになり、**モバイルの Markdown 閲覧/編集が1画面に統合**された。あわせて GitPane の ahead/behind が「なぜ数字が出ないのか」を説明するようになり（🔄 が実際に `git fetch` するよう変更、最終 fetch 時刻とバッジを追加）、新規ブランチの既定エージェントを実際に使う3件へ絞った。並列オーケストレーション運用中に発見した監視 Skill の欠陥5件と、モバイル統合の回帰1件も同時に修正している。
+
 ### Added
 
 - **orchestrate 監視レシピを実行可能 Skill 化** (#1512): `/orchestrate` 運用で実証済みの監視ノウハウ（capture 解析・状態判定・介入判断・完了/スコープ検証）を、セッションメモリ依存から `.claude/skills/orchestrate-monitor/`（SKILL.md＋bash 3.2 互換スクリプト群）へ資産化した。判定ロジックを fixture ベースで単体テスト化し、既知の誤報2パターン（未起動 idle の COMPLETE 誤報／検証ガード自身の偽陽性）を回帰テストで固定。CI で `bash -n` 構文チェックを回す。#1452 Harness Pack の移植元となる自家用 Skill（公式カタログ配布は後続 #1513）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandmate",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandmate",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandmate",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "A local control plane for agent CLIs — orchestration and visibility for Claude Code, Codex, Gemini CLI, and more across Git worktrees",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## 概要

v0.15.0 リリースのためのバージョン更新を develop に取り込む PR。**コード変更は含まない**（版と CHANGELOG のみ）。

この後 `develop → main` のリリース PR を別途作成する。

## バージョン

**0.14.1 → 0.15.0（minor）**

`### Added` にユーザー向けの新機能が 3 件（#1517 / #1518 / #1519）含まれるため minor とした。リポジトリの慣例（v0.14.0 = Added あり→minor、v0.14.1 = Fixed のみ→patch）と整合する。

## 変更ファイル（3 件のみ）

| ファイル | 内容 |
|---|---|
| `package.json` | `0.14.1` → `0.15.0` |
| `package-lock.json` | 同上（root と `packages[""]` の 2 箇所。`npm version --no-git-tag-version` で整合） |
| `CHANGELOG.md` | `## [0.15.0] - 2026-07-26` を Highlight つきで挿入、`[Unreleased]` を空に |

## このリリースに入るもの

### Added
- **orchestrate 監視レシピを実行可能 Skill 化** (#1512)
- **Markdown/テキスト編集で Tab インデント・Shift+Tab アウトデント** (#1518)
- **リポジトリ登録の Local Path を GUI フォルダ選択に対応（`CM_BROWSE_ROOTS` 導入）** (#1517)
- **モバイルの Markdown 閲覧/編集を1画面に統合** (#1519)

### Changed
- **ブランチ追加時のデフォルトエージェントを claude / codex / antigravity の3件に変更** (#1516)

### Fixed
- **モバイルの Markdown アクションシートが本文の裏に描画され全アクションがタップできない不具合** (#1528)
- **GitPane の ahead/behind が「リモート先行なのに ↓0」「チップごと消える」問題** (#1515)
- **orchestrate-monitor の状態判定が実セッションで機能しない問題（計5件）** (#1522)

## 品質チェック

| チェック | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `npx tsc --noEmit` | ✅ exit 0 |
| `npm run test:unit` | ✅ exit 0（666 files / 11567 tests） |
| `npm run build` | ✅ exit 0 |

初回の `test:unit` で `monitor-resend.test.ts` が 2 件落ちたが、**#1527 で起票済みの既知 flaky**。本 PR の差分は上記 3 ファイルのみで `.claude/skills/` に未接触であり、単独実行 4/4 green・フルスイート再実行 666 files 全緑を確認済み（#1527 に頻度データを追記した）。

## 実機 UAT 済み

本リリース内容は稼働環境（ポート 3000）で確認済み:

- **#1516**: 新規ブランチのタブが Claude / Codex / Antigravity の3件、設定済み worktree は不変
- **#1519**: レンダリング済み Markdown 表示 / ビュワー⇄編集の相互切替 / **モード切替で再 fetch しない**（fetch 回数で実測）/ シートの4機能到達可能 / 両モードでワンタップ最大化 / 最大化中もクローズ可 / 44px / 非Markdown 非退行 / PC 非退行
- **#1515**: 🔄 が `POST /git/fetch` を実行し「Last fetch」が更新される
- **#1517**: `Browse…` → `/api/fs/browse` で picker が開き、手入力欄も健在

## スラッシュコマンドカタログについて（Phase 1.5 スキップ）

リリース手順の Phase 1.5（`npm run catalog:refresh`）は**意図的に実施していない**。

`--check` の結果、追加候補 109 件の中に **#1503 で削除したばかりの幻コマンドが含まれていた**ため:

```
+ [claude] /cost        — Alias for /usage
+ [claude] /pr-comments — Removed in v2.1.91      ← 説明文自体が「削除済み」
+ [claude] /agents      — 実行するとリマインダーを表示するだけのスタブ
```

公式 docs のテーブルに残っているため、リコンサイルエンジンが「新規コマンド」として再追加してしまう。手順書は「リリース PR の diff で人手レビューするのが安全ゲート」と定めており、その判定に基づきスキップした。カタログ更新は別途対応する。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGRy3L1G6rSKT9SuExtAzH
