### PR TITLE
fix(test): monitor-resend.test.ts の判定を壁時計 timeout から切り離す (#1527)

### DIFF
--- a/.claude/skills/orchestrate-monitor/SKILL.md
+++ b/.claude/skills/orchestrate-monitor/SKILL.md
@@ -57,6 +57,10 @@ NOT_RUNNING → is_retrying(→GENERATING) → PROMPT → GENERATING → RATE_LI
 `monitor.sh` の `count_commits` / `count_uncommitted` は運用の checkout に合わせて配線するフック。
 既定は 0 を返す（ループ単体で動く）ので、実運用では worker の作業ツリーに向ける。
 `--resend-message` / `--max-resends` はリトライ枯渇死からの再送設定（既定 `continue` / 2 回）。
+`--max-polls N` は N 回ポーリングしたら（ワーカーが未完了でも）exit 0 で抜ける停止条件。既定 0 =
+全ワーカーが COMPLETE になるまで回り続ける（運用時の挙動は従来どおり）。判定ロジックには一切
+関与せず、ループを外部から kill せずに決定論的に終わらせるためのもの（#1527 の単体テストと、
+`--max-polls 1` の 1 回だけ様子を見るプローブで使う）。
 
 ---
 

--- a/.claude/skills/orchestrate-monitor/scripts/monitor.sh
+++ b/.claude/skills/orchestrate-monitor/scripts/monitor.sh
@@ -22,8 +22,17 @@
 #
 # Usage:
 #   monitor.sh [--interval 20] [--idle-threshold 8] [--session-prefix cm] \
-#              [--resend-message continue] [--max-resends 2] \
+#              [--resend-message continue] [--max-resends 2] [--max-polls 0] \
 #              <worktree-id> [<worktree-id> ...]
+#
+#   --max-polls N  stop after N poll rounds and exit 0 even if workers are still
+#                  working; 0 (default) keeps polling until every worker is
+#                  COMPLETE, i.e. the operator behaviour is unchanged. A bounded
+#                  run ends on its own instead of having to be killed from the
+#                  outside, which is what lets the loop be tested deterministically
+#                  (Issue #1527) and doubles as a one-shot `--max-polls 1` probe.
+#                  It only adds a stop condition — no state or intervention rule
+#                  looks at it.
 #
 # Env:
 #   CM  — commandmate launcher (default: "npx commandmate@latest"; pinned so the
@@ -35,6 +44,7 @@ IDLE_THRESHOLD=8          # 150s+ of idle at 20s polls; xhigh workers think long
 SESSION_PREFIX="cm"
 RESEND_MESSAGE="continue"  # sent after the CLI exhausts its own retries
 MAX_RESENDS=2
+MAX_POLLS=0               # 0 = poll until every worker is COMPLETE (operator default)
 CM=${CM:-"npx commandmate@latest"}
 
 while [ $# -gt 0 ]; do
@@ -44,6 +54,7 @@ while [ $# -gt 0 ]; do
     --session-prefix) shift; SESSION_PREFIX=${1:-cm};;
     --resend-message) shift; RESEND_MESSAGE=${1:-continue};;
     --max-resends) shift; MAX_RESENDS=${1:-2};;
+    --max-polls) shift; MAX_POLLS=${1:-0};;
     --) shift; break;;
     -*) echo "monitor.sh: unknown flag $1" >&2; exit 2;;
     *) break;;
@@ -95,6 +106,7 @@ count_commits() {
 
 echo "monitor: watching $n_ids worker(s), interval=${INTERVAL}s, idle-threshold=${IDLE_THRESHOLD}, max-resends=${MAX_RESENDS}"
 
+poll_round=0
 done_count=0
 while [ "$done_count" -lt "$n_ids" ]; do
   done_count=0
@@ -198,6 +210,16 @@ while [ "$done_count" -lt "$n_ids" ]; do
         ;;
     esac
   done
+
+  poll_round=$((poll_round + 1))
+  # Deterministic stop for bounded runs: end the loop from the inside after
+  # MAX_POLLS rounds rather than relying on something outside to kill it. Checked
+  # after the completion tally so a run that finishes on its final round still
+  # reports "all complete"; skipped entirely when MAX_POLLS is 0.
+  if [ "$done_count" -lt "$n_ids" ] && [ "$MAX_POLLS" -gt 0 ] && [ "$poll_round" -ge "$MAX_POLLS" ]; then
+    echo "monitor: reached --max-polls ($MAX_POLLS) after $poll_round poll round(s); stopping"
+    exit 0
+  fi
 
   [ "$done_count" -lt "$n_ids" ] && sleep "$INTERVAL"
 done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **orchestrate-monitor の `monitor-resend.test.ts` が壁時計 timeout に判定を委ねていた問題を修正** (#1527): ループが COMPLETE 以外で終わらないため、テストは `spawnSync` の 2.5 秒 timeout で監視ループを kill し、その時点までに何ポーリング進めたかで判定していた。マシン負荷次第で 2 回目のポーリングに届かず「`resend budget spent` を含むこと」が低頻度で落ちる一方、否定的アサーション2件（`expect(tmuxCalls).toEqual([])`）は**ループが0回でも無条件で PASS** する偽の緑だった。(1) `monitor.sh` に `--max-polls N`（既定 0 = 従来どおり全ワーカー COMPLETE まで継続）を追加し、ループが内側から決定論的に exit 0 できるようにした。停止条件のみの追加で状態判定・介入条件は不変、bash 3.2 互換も維持。(2) テスト側は `--interval 0` ＋ `--idle-threshold 1` ＋ ケースごとに必要なポーリング回数を定数化し、**launcher shim の呼び出し回数・exit 0・`--max-polls` 到達ログを検証してからでないと空を主張しない** gate を通す。ループを1回で打ち切る／必ず介入する変異を注入すると当該テストが実際に赤くなることを確認済み。実行時間も 12.5s → 2.8s に短縮した。
+
 ## [0.15.0] - 2026-07-26
 
 > **Highlight**: モバイルとリポジトリ登録まわりの体験を厚くしたリリース。**リポジトリ登録の Local Path を GUI で選べる**ようになり（`CM_BROWSE_ROOTS` 新設、認証必須のディレクトリ一覧 API 込み）、**Markdown 編集で Tab インデント**が効くようになり、**モバイルの Markdown 閲覧/編集が1画面に統合**された。あわせて GitPane の ahead/behind が「なぜ数字が出ないのか」を説明するようになり（🔄 が実際に `git fetch` するよう変更、最終 fetch 時刻とバッジを追加）、新規ブランチの既定エージェントを実際に使う3件へ絞った。並列オーケストレーション運用中に発見した監視 Skill の欠陥5件と、モバイル統合の回帰1件も同時に修正している。

--- a/tests/unit/skills/orchestrate-monitor/monitor-resend.test.ts
+++ b/tests/unit/skills/orchestrate-monitor/monitor-resend.test.ts
@@ -11,87 +11,179 @@ const MONITOR = path.join(
 );
 const FIXTURES = fileURLToPath(new URL('./fixtures', import.meta.url));
 
+/**
+ * Loop parameters shared by every case below.
+ *
+ * The decision core counts *polls*, not seconds: the idle streak is incremented
+ * once per poll, so with `--idle-threshold 1` the very first poll that classifies
+ * IDLE is already actionable and the number of polls is the only thing that
+ * decides how far a scenario gets. `--interval 0` therefore takes the wall clock
+ * out of the test completely, and `--max-polls` (Issue #1527) ends the run from
+ * the inside — the loop otherwise never exits, because count_commits /
+ * count_uncommitted are stubbed to 0 so no worker is ever COMPLETE.
+ *
+ * This replaces the previous design, where the loop was killed by a 2.5s
+ * spawnSync timeout: how many polls it managed depended on machine load, which
+ * made the escalation assertion (needs a 2nd poll) racy under parallel test runs,
+ * and left the two `toEqual([])` assertions passing even for a loop that had run
+ * zero polls. Each case now names the polls it needs and proves they happened —
+ * see expectPolls().
+ */
+const INTERVAL_SEC = 0;
+const IDLE_THRESHOLD = 1;
+
+/**
+ * Safety net only: orders of magnitude above the real runtime (a bounded run is
+ * a handful of subprocess spawns). No assertion depends on it — if it ever fires,
+ * expectPolls() reports it as a failure instead of silently shortening the loop.
+ */
+const HARD_TIMEOUT_MS = 15_000;
+
 interface RunResult {
   stdout: string;
+  status: number | null;
+  signal: NodeJS.Signals | null;
   /** One line per `tmux ...` invocation the loop made. */
   tmuxCalls: string[];
+  /** One line per `$CM capture ...` invocation, i.e. one per poll performed. */
+  captureCalls: string[];
+}
+
+function logLines(file: string): string[] {
+  return readFileSync(file, 'utf8').split('\n').filter(Boolean);
 }
 
 /**
- * Run the loop against a fixed capture frame with `tmux` and the commandmate
- * launcher replaced by shims, then stop it. The loop only exits on COMPLETE — and
- * with count_commits/count_uncommitted stubbed to 0 it never gets there — so it is
- * terminated on a timeout, which is also what exercises the EXIT trap.
+ * Run the loop against a fixed capture frame for exactly `polls` rounds, with
+ * `tmux` and the commandmate launcher replaced by logging shims. The loop stops
+ * itself via --max-polls, which also exercises the EXIT trap on the normal path.
  */
-function runLoop(fixture: string, extraArgs: string[] = []): RunResult {
+function runLoop(fixture: string, polls: number, extraArgs: string[] = []): RunResult {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'monitor-resend-'));
   const tmuxLog = path.join(dir, 'tmux.log');
+  const captureLog = path.join(dir, 'capture.log');
   const tmuxShim = path.join(dir, 'tmux');
   const cmShim = path.join(dir, 'fake-cm');
 
   writeFileSync(tmuxShim, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${tmuxLog}"\nexit 0\n`);
-  writeFileSync(cmShim, `#!/bin/sh\ncat "${path.join(FIXTURES, fixture)}"\n`);
+  // Logs its own invocation before serving the frame, so the test can count the
+  // polls the loop really made instead of trusting the loop's own stdout.
+  writeFileSync(
+    cmShim,
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> "${captureLog}"\ncat "${path.join(FIXTURES, fixture)}"\n`,
+  );
   chmodSync(tmuxShim, 0o755);
   chmodSync(cmShim, 0o755);
   writeFileSync(tmuxLog, '');
+  writeFileSync(captureLog, '');
 
   const proc = spawnSync(
     'bash',
-    [MONITOR, '--interval', '1', '--idle-threshold', '1', ...extraArgs, 'w1'],
+    [
+      MONITOR,
+      '--interval',
+      String(INTERVAL_SEC),
+      '--idle-threshold',
+      String(IDLE_THRESHOLD),
+      '--max-polls',
+      String(polls),
+      ...extraArgs,
+      'w1',
+    ],
     {
       encoding: 'utf8',
-      timeout: 2500,
+      timeout: HARD_TIMEOUT_MS,
       env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ''}`, CM: cmShim },
     },
   );
 
   return {
     stdout: proc.stdout ?? '',
-    tmuxCalls: readFileSync(tmuxLog, 'utf8').split('\n').filter(Boolean),
+    status: proc.status,
+    signal: proc.signal,
+    tmuxCalls: logLines(tmuxLog),
+    captureCalls: logLines(captureLog),
   };
+}
+
+/**
+ * Gate for every assertion below, and the whole point of Issue #1527: prove the
+ * loop actually completed `polls` rounds before believing anything it did or did
+ * not do. It exited through its own --max-polls branch (status 0, no signal), the
+ * launcher shim was called once per round, and no round bailed out early as an
+ * unparseable frame. Without this, `expect(tmuxCalls).toEqual([])` is equally
+ * satisfied by a loop that never looked at the pane at all.
+ */
+function expectPolls(run: RunResult, polls: number): void {
+  expect({ status: run.status, signal: run.signal }).toEqual({ status: 0, signal: null });
+  expect(run.captureCalls).toEqual(Array.from({ length: polls }, () => 'capture w1 --json'));
+  expect(run.stdout).toContain(
+    `reached --max-polls (${polls}) after ${polls} poll round(s)`,
+  );
+  expect(run.stdout).not.toContain('capture failed');
 }
 
 describe('monitor.sh recovers from retry exhaustion (Issue #1522, defect 4)', () => {
   it('resends once the CLI has given up and fallen back to an idle prompt', () => {
-    const { stdout, tmuxCalls } = runLoop('live-api-error-exhausted.json', [
-      '--max-resends',
-      '1',
-      '--resend-message',
-      'resume please',
-    ]);
+    const MAX_RESENDS = 1;
+    const RESEND_MESSAGE = 'resume please';
+    // Poll 1: IDLE + terminal API error, the streak reaches IDLE_THRESHOLD ->
+    //         resend (1/1), which resets the streak to 0.
+    // Poll 2: the streak reaches the threshold again, budget is spent -> escalate.
+    const POLLS = MAX_RESENDS + 1;
 
-    expect(tmuxCalls.some((c) => c.includes('send-keys') && c.includes('resume please'))).toBe(
-      true,
-    );
-    expect(tmuxCalls.some((c) => c.includes('-t cm-w1'))).toBe(true);
-    expect(stdout).toContain('resending (1/1)');
-    // Capped, then escalated instead of typing into the pane forever.
-    expect(stdout).toContain('resend budget spent');
-    expect(tmuxCalls.filter((c) => c.includes('resume please'))).toHaveLength(1);
+    const run = runLoop('live-api-error-exhausted.json', POLLS, [
+      '--max-resends',
+      String(MAX_RESENDS),
+      '--resend-message',
+      RESEND_MESSAGE,
+    ]);
+    expectPolls(run, POLLS);
+
+    expect(run.stdout).toContain(`resending (1/${MAX_RESENDS})`);
+    // Capped, then escalated instead of typing into the pane forever: the second
+    // poll is now guaranteed to have happened, so this is no longer a race.
+    expect(run.stdout).toContain('resend budget spent');
+    expect(run.tmuxCalls).toEqual([`send-keys -t cm-w1 ${RESEND_MESSAGE} Enter`]);
   }, 20_000);
 
   it('never intervenes while the CLI is still inside its own backoff', () => {
     // The production harm: input sent mid-backoff is queued, then delivered once
     // the retry succeeds, pushing the worker into work it was never asked to do.
-    const { stdout, tmuxCalls } = runLoop('live-retrying-529.json');
-    expect(tmuxCalls).toEqual([]);
-    expect(stdout).not.toContain('rate limit');
-    expect(stdout).not.toContain('resending');
+    // Three polls: at IDLE_THRESHOLD 1 any intervening branch would fire on the
+    // first look at this frame, and two more rounds cover a streak-driven one.
+    const POLLS = 3;
+    const run = runLoop('live-retrying-529.json', POLLS);
+    expectPolls(run, POLLS);
+
+    expect(run.tmuxCalls).toEqual([]);
+    expect(run.stdout).not.toContain('rate limit');
+    expect(run.stdout).not.toContain('resending');
+    // The frame was treated as a live, started worker: had it classified as idle
+    // or not-running, the streak would have crossed the threshold and reported
+    // NOT_STARTED. That keeps the empty-tmuxCalls claim about *this* state.
+    expect(run.stdout).not.toContain('NOT_STARTED');
   }, 20_000);
 
   it('never intervenes on a healthy worker whose pane shows rate-limiter source', () => {
     // The 5th defect at loop level: this frame used to classify as RATE_LIMIT and
     // get an `a` typed into it.
-    const { stdout, tmuxCalls } = runLoop('live-generating-rate-limit-source.json');
-    expect(tmuxCalls).toEqual([]);
-    expect(stdout).not.toContain("sending 'a'");
+    const POLLS = 3;
+    const run = runLoop('live-generating-rate-limit-source.json', POLLS);
+    expectPolls(run, POLLS);
+
+    expect(run.tmuxCalls).toEqual([]);
+    expect(run.stdout).not.toContain("sending 'a'");
+    expect(run.stdout).not.toContain('NOT_STARTED');
   }, 20_000);
 
   it('still sends "a" on a genuine usage-limit banner', () => {
-    const { stdout, tmuxCalls } = runLoop('rate-limit.json');
-    expect(stdout).toContain("rate limit -> sending 'a'");
-    expect(tmuxCalls.some((c) => c.includes('send-keys') && c.includes('-t cm-w1 a Enter'))).toBe(
-      true,
-    );
+    // RATE_LIMIT is acted on immediately, so a single poll is the whole scenario.
+    const POLLS = 1;
+    const run = runLoop('rate-limit.json', POLLS);
+    expectPolls(run, POLLS);
+
+    expect(run.stdout).toContain("rate limit -> sending 'a'");
+    expect(run.tmuxCalls).toEqual(['send-keys -t cm-w1 a Enter']);
   }, 20_000);
 });


### PR DESCRIPTION
## 概要

`tests/unit/skills/orchestrate-monitor/monitor-resend.test.ts` が **壁時計 timeout に判定を委ねていた** 問題を修正する（#1527）。

監視ループは COMPLETE でしか終了しないため、テストは `spawnSync` の 2.5 秒 timeout でループを kill し、**その時点までに何ポーリング進めたか**で結果を判定していた。このため:

1. 肯定的アサーション（2 ポーリング目でしか出ない `resend budget spent`）が負荷次第で落ちる
2. **否定的アサーション 2 件（`expect(tmuxCalls).toEqual([])`）はループが 0 回でも無条件 PASS する** ＝ 空振りの緑

2 は #1522 の defect 3 / defect 5（健全なワーカーへ入力を注入した実害）の回帰ガードなので、より深刻だった。

## 変更内容

Issue の **案B（決定論的終了）＋案A（出力待ち）の併用**で実装。

### 1. `monitor.sh` に `--max-polls N` を追加

N 回ポーリングしたらループの**内側から** `exit 0` する停止条件。既定 `0` = 全ワーカー COMPLETE まで継続（運用時の挙動は不変）。

- 状態判定・介入条件には一切関与しない**停止条件のみ**の追加
- bash 3.2 互換を維持
- 完了タリーの後に評価するので、最終ラウンドで完了した run は従来どおり "all complete" を報告する

### 2. テストを poll 数ベースの決定論的判定へ

- `--interval 0` ＋ `--idle-threshold 1` で壁時計を判定から排除。`spawnSync` の timeout は保険のみ（15s、どのアサーションも依存しない）
- ケースごとに必要な poll 数を定数化し、コメントで根拠を明示
- **`expectPolls()` ゲートを全アサーションの前段に導入**: exit status 0 / signal なし・launcher shim の呼び出し回数が期待 poll 数と一致・`--max-polls` 到達ログの存在を確認してからでないと、何も主張させない

これにより「ループが 0 回でも `toEqual([])` は満たされる」構造的欠陥が塞がれる。

## 検証（オーケストレーター実施・worker の自己申告とは独立）

### 修正前の再現

develop HEAD 基点の worktree で、**単独初回実行で再現**した（Issue は「低頻度」としていたが、実際にはもっと出やすい）:

```
AssertionError: expected '…' to contain 'resend budget spent'  (monitor-resend.test.ts:69)
exit=1 / Tests 1 failed | 3 passed
```

### ミューテーション試験（ゲートが機能している証明）

隔離した worktree で `monitor.sh` に故意の変異を注入し、テストが**実際に赤くなる**ことを確認:

| 変異 | 期待 | 結果 |
|------|------|------|
| なし（対照） | 全 green | **4 passed / exit 0** |
| 毎ポーリング必ず介入する | 否定アサーションが赤 | **4 failed** |
| `--max-polls` を無視し 1 ポーリングで打ち切る（＝旧来の空振り条件） | poll 数不足のケースが赤 | **3 failed / 1 passed**（passed は本来 1 ポーリングで完結する rate-limit ケースのみ＝正しい挙動） |

旧テストでは 2 番目・3 番目の変異はいずれも**緑のまま素通り**していた。

### 負荷下での安定性（Issue の完了条件）

8 並列の CPU バーナーを回した状態で対象テストを 10 回連続実行:

```
10 pass / 0 fail (of 10) under 8-way load
```

実行時間も 12.5s → 約 2.8s に短縮。

### 品質ゲート（exit code 実測）

| チェック | 結果 |
|---------|------|
| `npm run lint` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npm run test:unit` | exit 0（666 files / 11567 tests 全 pass） |
| `npm run build` | exit 0 |
| `CI=true` での skill テスト | exit 0（8 files / 86 tests） |

## 完了条件の充足

- [x] `monitor-resend.test.ts` の判定が CPU 負荷に依存しない（壁時計 timeout に判定を委ねない）
- [x] 否定的アサーション 2 件が「ループが実際にまわった」ことを確認してから空を主張する
- [x] 負荷をかけた状態で連続実行しても安定して green
- [x] `interval` / `idle-threshold` と期待イテレーション回数の関係がテスト内で明示される

Refs #1527
