### PR TITLE
feat(db): verification_runs / verification_gate_results テーブル追加（migration v49）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **検証ゲートの実行結果を永続化する `verification_runs` / `verification_gate_results` テーブルと DB アクセサを追加** (#1542): exit code を持つ実行記録は `execution_logs`（スケジュール実行）と `assistant_executions`（非対話アシスタント）にしか無く、インタラクティブなエージェント作業は `chat_messages` しか残らないため「終わった」と「要求を満たした」を区別できなかった。migration **v49** で 1 検証試行 = `verification_runs` 1行 / その中の 1 コマンド = `verification_gate_results` 1行として記録する。gate results は run に `ON DELETE CASCADE`（run 抜きの gate 行は記録ではなくノイズであるため）。status / trigger の語彙は writer 側の検証だけでなく DB の CHECK 制約で固定した — この表の存在意義は語彙が区別する内容そのものであり、typo が新しい status 値として着地すると誰も query しないバケツが黙って生まれる。run の `not_started`（作業証跡ゼロでそもそも検証対象が無い）は `failed`（判定した上で不合格）と別値、`error` はゲート実行以前の内部エラー、gate の `skipped` は意図的スキップで理由を `log_tail` に残す（スキップが PASS と読まれないため）。`task_id` は Phase 2（#1545）の `tasks` 到着まで FK を張らない自由カラムとした（存在しない表への REFERENCES は `foreign_keys` ON 下で全 INSERT を失敗させる）。アクセサ `src/lib/db/verification-db.ts` は create* が `running` で開き finish* が閉じる二段構成とし（途中クラッシュを recoverable な `running` 行として残すため）、finish* は対象行が無ければ throw する（黙って no-op にすると、記録していない verdict を記録したと呼び出し側が信じる — まさにこの表が防ぐべき失敗）。`listVerificationRuns` は `started_at DESC, id DESC` で、同一 ms の tie でも順序が全順序になるよう id を tiebreak に使う。id tiebreak 削除・`?? null` を `||` 化（exit code 0 が NULL に化ける）・finish* の存在チェック削除・CHECK 制約削除・CASCADE 削除・index 削除・feed の ORDER BY 差し替え 3種・gate の run スコープ喪失、計 11 種の変異注入でテストが実際に赤くなることを確認済み。
+
 ## [0.16.0] - 2026-07-29
 
 > **Highlight**: **Skill 配布 MVP を「入れられる」から「運用できる」へ引き上げたリリース。** 導入先 Agent の対応状況を manifest の申告だけでなく CommandMate 側の実測で裏付ける互換 matrix（#1246）、どの worktree に何が入っていて導入時のままかを横断確認する監査 dashboard と receipt からの reindex（#1248、DB migration v48）、Skill 導入を review 可能な commit / draft PR に載せる専用 git workflow（#1247）を追加した。あわせて、uninstall した Skill を再 install すると **exit 0 で「Installed」と報告しながら 1 バイトも書かれない** journal replay の欠陥（#1552）を修正し、対になる uninstall 経路の同型欠陥も同時に塞いだ。

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -193,6 +193,7 @@
 | `src/lib/db/memo-db.ts` | メモ管理CRUD（Issue #479） |
 | `src/lib/db/worktree-todo-db.ts` | ブランチ（worktree）単位 ToDo CRUD＋reorder（getTodosByWorktreeId/createTodo/updateTodo/deleteTodo/reorderTodos）。memo-db パターン踏襲・worktree_id キー・ON DELETE CASCADE。db.ts バレルは getWorktreeTodoById 等にエイリアスして repository todo-db と衝突回避（Issue #1015）。Issue #1032で status 3状態（todo/doing/done）を真値化・done は派生。Issue #1034（migration v39）で detail フィールド追加（既定 ''、createTodo/updateTodo/mapTodoRow で受理） |
 | `src/lib/db/template-db.ts` | レポートテンプレートCRUD操作（getAllTemplates, getTemplateById, createTemplate, updateTemplate, deleteTemplate, getTemplateCount）（Issue #618） |
+| `src/lib/db/verification-db.ts` | 検証ゲート実行結果の永続化（createVerificationRun/finishVerificationRun/createGateResult/finishGateResult/getVerificationRun/listVerificationRuns）。create* は running で開き finish* が閉じる（途中クラッシュを running 行として残すため）。finish* は対象行が無ければ throw（黙って no-op にすると記録していない verdict を記録したと信じられる）。list は `started_at DESC, id DESC`（同 ms tie で順序が崩れないよう id を tiebreak に使う）・既定 limit 20（Issue #1542、migration v49） |
 | `src/lib/polling/prompt-dedup.ts` | プロンプト重複検出（SHA-256ハッシュキャッシュ）（Issue #565） |
 | `src/lib/polling/response-dedup.ts` | assistant応答の重複検出（SHA-256ハッシュキャッシュ、isDuplicateResponse/clearResponseHashCache）。alternate screen 系ツールは行数カーソルが使えないため内容ハッシュで代替（Issue #1268）。キャッシュは stopPolling() でクリア＝1ポーリングサイクル（1ターン）限り。次ターンで同一内容の応答が来たら保存する（永続化すると #1268 の再発） |
 | `src/lib/response-extractor.ts` | レスポンス抽出ロジック（resolveExtractionStartIndex, isOpenCodeComplete）（Issue #479）、Copilot分岐追加（Issue #565）。Issue #988: antigravity分岐追加（branch 2a'＝user echoアンカー優先、未検出時lastCapturedLineフォールバック） |
@@ -435,6 +436,7 @@
 | `src/lib/db/migrations/v45-skill-installations.ts` | `skill_installations` テーブル（#1235） |
 | `src/lib/db/migrations/v46-skill-installations-cascade.ts` | `skill_installations` に `worktree_id` FK + `ON DELETE CASCADE` を付与（table rebuild）、既存 dangling 行も一掃（#1430） |
 | `src/lib/db/migrations/v48-skill-operations-audit-index.ts` | `skill_operations` に `from_version`/`to_version` を追加し、横断 feed 用 `(recorded_at DESC, id DESC)` と `(result, recorded_at DESC)` を index 化。`ALTER TABLE` のため既存行は NULL 遷移で読める（#1248） |
+| `src/lib/db/migrations/v49-verification-runs.ts` | `verification_runs` / `verification_gate_results` テーブル。gate results は run に `ON DELETE CASCADE`。status/trigger は CHECK で語彙固定（run の `not_started`＝作業証跡ゼロ、`error`＝ゲート実行以前の内部エラー、gate の `skipped`＝意図的スキップで理由は log_tail）。`task_id` は Phase 2（#1545）の tasks 到着まで FK 無しの自由カラム（#1542） |
 | `src/lib/skills/startup-reconcile.ts` | 起動時 reconciliation の assembly。`server.ts` から `await import()` で遅延読込し reconciler へ port（payload probe / reindex）を注入。receipt からの reindex もここで実装（#1428、server-only） |
 | `src/lib/skills/plan-sweeper.ts` | install/uninstall plan cache と snapshot store を 60秒ごと（＋token アクセス時）に sweep する `unref()` 済み timer。route から lazy 起動（#1429、server-only） |
 | `src/lib/skills/git-workflow.ts` | Skill 導入の branch/commit/push flow。prepare（plan 生成前に branch 確定）→ apply（receipt 由来 pathspec だけを stage/commit）。clean-index 前提・active session ガード・commit message / PR 本文生成・prepared target store（#1247、server-only） |

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -189,3 +189,26 @@ export type {
   UpsertPushSubscriptionInput,
   PushNotificationKind,
 } from './push-subscriptions-db';
+
+// verification-db (verification gate runs, Issue #1542)
+export {
+  createVerificationRun,
+  finishVerificationRun,
+  createGateResult,
+  finishGateResult,
+  getVerificationRun,
+  listVerificationRuns,
+} from './verification-db';
+export type {
+  VerificationRun,
+  VerificationRunWithGates,
+  VerificationGateResult,
+  VerificationTrigger,
+  VerificationRunStatus,
+  VerificationRunTerminalStatus,
+  VerificationGateStatus,
+  VerificationGateTerminalStatus,
+  CreateVerificationRunInput,
+  CreateGateResultInput,
+  FinishGateResultPatch,
+} from './verification-db';

--- a/src/lib/db/migrations/index.ts
+++ b/src/lib/db/migrations/index.ts
@@ -31,6 +31,7 @@ import { v45_migrations } from './v45-skill-installations';
 import { v46_migrations } from './v46-skill-installations-cascade';
 import { v47_migrations } from './v47-skill-installations-roots';
 import { v48_migrations } from './v48-skill-operations-audit-index';
+import { v49_migrations } from './v49-verification-runs';
 
 /**
  * Complete ordered list of all migrations.
@@ -67,4 +68,5 @@ export const migrations: Migration[] = [
   ...v46_migrations,
   ...v47_migrations,
   ...v48_migrations,
+  ...v49_migrations,
 ];

--- a/src/lib/db/migrations/runner.ts
+++ b/src/lib/db/migrations/runner.ts
@@ -24,7 +24,7 @@ export interface Migration {
  * Current schema version
  * Increment this when adding new migrations
  */
-export const CURRENT_SCHEMA_VERSION = 48;
+export const CURRENT_SCHEMA_VERSION = 49;
 
 /**
  * Get current schema version from database

--- a/src/lib/db/migrations/v49-verification-runs.ts
+++ b/src/lib/db/migrations/v49-verification-runs.ts
@@ -1,0 +1,88 @@
+/**
+ * Migration v49: verification_runs / verification_gate_results (Issue #1542).
+ *
+ * The first place an *interactive* agent's work gets a recorded verdict.
+ * `execution_logs` already stores status + exit_code + result, but only for
+ * scheduled executions; interactive sessions leave nothing behind but
+ * `chat_messages`, so "the agent finished" has never been distinguishable from
+ * "the agent produced something that passes".
+ *
+ * One run per verification attempt, one gate result per command inside it.
+ * Gate results cascade with their run: a run is the only thing that gives a
+ * gate result meaning, so an orphan row is not a record, it is noise.
+ *
+ * Both status vocabularies are CHECK-constrained rather than validated in the
+ * writer alone. The distinctions they encode are the point of the table and a
+ * typo that lands as a new status value would silently create a bucket nothing
+ * queries:
+ *   run.not_started — the work-evidence gate failed (no commits, no diff);
+ *                     distinct from `failed`, which means the work was judged.
+ *   run.error       — the runner broke before any gate ran (bad config, spawn
+ *                     failure); no verdict was reached about the work at all.
+ *   gate.skipped    — deliberately not run (e.g. skipInPrimaryCheckout); the
+ *                     reason belongs in log_tail so a skip is never mistaken
+ *                     for a pass.
+ *
+ * `task_id` is a free column, not a foreign key: the `tasks` table arrives in
+ * Phase 2 (#1545). Declaring a REFERENCES clause against a table that does not
+ * exist yet would make every insert fail once foreign_keys is ON.
+ *
+ * Timestamps are epoch milliseconds (INTEGER), matching v44 onward.
+ */
+
+import type { Migration } from './runner';
+
+export const v49_migrations: Migration[] = [
+  {
+    version: 49,
+    name: 'add-verification-runs',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS verification_runs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          worktree_id TEXT NOT NULL,
+          instance_id TEXT,
+          task_id TEXT,
+          trigger TEXT NOT NULL CHECK (trigger IN ('manual','wait','api','task')),
+          status TEXT NOT NULL CHECK (status IN ('running','passed','failed','not_started','error','cancelled')),
+          base_ref TEXT,
+          started_at INTEGER NOT NULL,
+          finished_at INTEGER
+        );
+      `);
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS verification_gate_results (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          run_id INTEGER NOT NULL REFERENCES verification_runs(id) ON DELETE CASCADE,
+          gate_id TEXT NOT NULL,
+          command TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN ('running','passed','failed','timeout','skipped','error')),
+          exit_code INTEGER,
+          duration_ms INTEGER,
+          log_tail TEXT,
+          started_at INTEGER NOT NULL,
+          finished_at INTEGER
+        );
+      `);
+
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_verification_runs_worktree
+          ON verification_runs(worktree_id, started_at DESC);
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_verification_gate_results_run
+          ON verification_gate_results(run_id);
+      `);
+    },
+    down: (db) => {
+      // Child first, mirroring the dependency direction. Under
+      // PRAGMA foreign_keys = ON (how db-instance.ts opens the database) the
+      // reverse order also works today, but only because the cascade absorbs
+      // the parent's implicit DELETE — that is a property of the cascade, not
+      // of DROP TABLE.
+      db.exec('DROP TABLE IF EXISTS verification_gate_results;');
+      db.exec('DROP TABLE IF EXISTS verification_runs;');
+    },
+  },
+];

--- a/src/lib/db/verification-db.ts
+++ b/src/lib/db/verification-db.ts
@@ -1,0 +1,322 @@
+/**
+ * Verification run database operations (Issue #1542, migration v49).
+ *
+ * Persists the outcome of a verification gate run: one `verification_runs` row
+ * per attempt, one `verification_gate_results` row per command inside it.
+ *
+ * Both create* functions open a record in `running` state and both finish*
+ * functions close it. That split is deliberate: a run that crashes mid-flight
+ * leaves a `running` row behind, which is recoverable evidence, whereas a
+ * single write-on-completion would leave nothing at all.
+ *
+ * The finish* functions throw when the target row does not exist. A silent
+ * no-op would let a caller believe it recorded a verdict it never recorded —
+ * exactly the failure this table exists to make impossible.
+ */
+
+import Database from 'better-sqlite3';
+
+/** What caused a verification run to start. */
+export type VerificationTrigger = 'manual' | 'wait' | 'api' | 'task';
+
+/**
+ * Overall verdict of a run.
+ *
+ * `not_started` = the work-evidence gate failed (no commits, no uncommitted
+ * changes), so there was nothing to verify. `error` = the runner broke before
+ * any gate produced a verdict (bad config, spawn failure); distinct from
+ * `failed`, which means the work was judged and found wanting.
+ */
+export type VerificationRunStatus =
+  | 'running'
+  | 'passed'
+  | 'failed'
+  | 'not_started'
+  | 'error'
+  | 'cancelled';
+
+/** Statuses a run can be closed with. `running` is an opening state only. */
+export type VerificationRunTerminalStatus = Exclude<VerificationRunStatus, 'running'>;
+
+/**
+ * Verdict of a single gate.
+ *
+ * `skipped` = deliberately not run (e.g. skipInPrimaryCheckout); the reason
+ * belongs in `logTail` so a skip is never read as a pass.
+ */
+export type VerificationGateStatus =
+  | 'running'
+  | 'passed'
+  | 'failed'
+  | 'timeout'
+  | 'skipped'
+  | 'error';
+
+/** Statuses a gate result can be closed with. */
+export type VerificationGateTerminalStatus = Exclude<VerificationGateStatus, 'running'>;
+
+/** One verification attempt against a worktree. */
+export interface VerificationRun {
+  id: number;
+  worktreeId: string;
+  /** Agent instance the run is attributed to; null for worktree-level runs. */
+  instanceId: string | null;
+  /** Free column until the `tasks` table lands in Phase 2 (#1545). No FK. */
+  taskId: string | null;
+  trigger: VerificationTrigger;
+  status: VerificationRunStatus;
+  /** Git ref the work was diffed against; null when the run did not need one. */
+  baseRef: string | null;
+  startedAt: Date;
+  finishedAt: Date | null;
+}
+
+/** One command executed inside a run. */
+export interface VerificationGateResult {
+  id: number;
+  runId: number;
+  gateId: string;
+  command: string;
+  status: VerificationGateStatus;
+  exitCode: number | null;
+  durationMs: number | null;
+  logTail: string | null;
+  startedAt: Date;
+  finishedAt: Date | null;
+}
+
+/** A run together with its gate results, in execution order. */
+export interface VerificationRunWithGates extends VerificationRun {
+  gates: VerificationGateResult[];
+}
+
+/** Fields needed to open a run. */
+export interface CreateVerificationRunInput {
+  worktreeId: string;
+  trigger: VerificationTrigger;
+  instanceId?: string | null;
+  taskId?: string | null;
+  baseRef?: string | null;
+}
+
+/** Fields needed to open a gate result. */
+export interface CreateGateResultInput {
+  gateId: string;
+  command: string;
+}
+
+/** Outcome written when a gate finishes. Omitted fields are stored as NULL. */
+export interface FinishGateResultPatch {
+  status: VerificationGateTerminalStatus;
+  exitCode?: number | null;
+  durationMs?: number | null;
+  logTail?: string | null;
+}
+
+interface VerificationRunRow {
+  id: number;
+  worktree_id: string;
+  instance_id: string | null;
+  task_id: string | null;
+  trigger: string;
+  status: string;
+  base_ref: string | null;
+  started_at: number;
+  finished_at: number | null;
+}
+
+interface VerificationGateResultRow {
+  id: number;
+  run_id: number;
+  gate_id: string;
+  command: string;
+  status: string;
+  exit_code: number | null;
+  duration_ms: number | null;
+  log_tail: string | null;
+  started_at: number;
+  finished_at: number | null;
+}
+
+const RUN_COLUMNS = `
+  id, worktree_id, instance_id, task_id, trigger, status, base_ref, started_at, finished_at
+`;
+
+const GATE_COLUMNS = `
+  id, run_id, gate_id, command, status, exit_code, duration_ms, log_tail, started_at, finished_at
+`;
+
+function mapRunRow(row: VerificationRunRow): VerificationRun {
+  return {
+    id: row.id,
+    worktreeId: row.worktree_id,
+    instanceId: row.instance_id,
+    taskId: row.task_id,
+    trigger: row.trigger as VerificationTrigger,
+    status: row.status as VerificationRunStatus,
+    baseRef: row.base_ref,
+    startedAt: new Date(row.started_at),
+    finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
+  };
+}
+
+function mapGateRow(row: VerificationGateResultRow): VerificationGateResult {
+  return {
+    id: row.id,
+    runId: row.run_id,
+    gateId: row.gate_id,
+    command: row.command,
+    status: row.status as VerificationGateStatus,
+    exitCode: row.exit_code,
+    durationMs: row.duration_ms,
+    logTail: row.log_tail,
+    startedAt: new Date(row.started_at),
+    finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
+  };
+}
+
+/** Open a run in `running` state. */
+export function createVerificationRun(
+  db: Database.Database,
+  input: CreateVerificationRunInput
+): VerificationRun {
+  const now = Date.now();
+  const info = db
+    .prepare(`
+      INSERT INTO verification_runs (
+        worktree_id, instance_id, task_id, trigger, status, base_ref, started_at, finished_at
+      )
+      VALUES (?, ?, ?, ?, 'running', ?, ?, NULL)
+    `)
+    .run(
+      input.worktreeId,
+      input.instanceId ?? null,
+      input.taskId ?? null,
+      input.trigger,
+      input.baseRef ?? null,
+      now
+    );
+
+  const row = db
+    .prepare(`SELECT ${RUN_COLUMNS} FROM verification_runs WHERE id = ?`)
+    .get(Number(info.lastInsertRowid)) as VerificationRunRow | undefined;
+
+  if (!row) {
+    throw new Error('Failed to persist verification run');
+  }
+  return mapRunRow(row);
+}
+
+/** Close a run with its final verdict, stamping `finished_at`. */
+export function finishVerificationRun(
+  db: Database.Database,
+  runId: number,
+  status: VerificationRunTerminalStatus
+): void {
+  const info = db
+    .prepare('UPDATE verification_runs SET status = ?, finished_at = ? WHERE id = ?')
+    .run(status, Date.now(), runId);
+
+  if (info.changes === 0) {
+    throw new Error(`Verification run ${runId} not found`);
+  }
+}
+
+/** Open a gate result under an existing run, in `running` state. */
+export function createGateResult(
+  db: Database.Database,
+  runId: number,
+  input: CreateGateResultInput
+): VerificationGateResult {
+  const now = Date.now();
+  const info = db
+    .prepare(`
+      INSERT INTO verification_gate_results (
+        run_id, gate_id, command, status, exit_code, duration_ms, log_tail, started_at, finished_at
+      )
+      VALUES (?, ?, ?, 'running', NULL, NULL, NULL, ?, NULL)
+    `)
+    .run(runId, input.gateId, input.command, now);
+
+  const row = db
+    .prepare(`SELECT ${GATE_COLUMNS} FROM verification_gate_results WHERE id = ?`)
+    .get(Number(info.lastInsertRowid)) as VerificationGateResultRow | undefined;
+
+  if (!row) {
+    throw new Error('Failed to persist verification gate result');
+  }
+  return mapGateRow(row);
+}
+
+/** Close a gate result with its outcome, stamping `finished_at`. */
+export function finishGateResult(
+  db: Database.Database,
+  gateResultId: number,
+  patch: FinishGateResultPatch
+): void {
+  const info = db
+    .prepare(`
+      UPDATE verification_gate_results
+      SET status = ?, exit_code = ?, duration_ms = ?, log_tail = ?, finished_at = ?
+      WHERE id = ?
+    `)
+    .run(
+      patch.status,
+      patch.exitCode ?? null,
+      patch.durationMs ?? null,
+      patch.logTail ?? null,
+      Date.now(),
+      gateResultId
+    );
+
+  if (info.changes === 0) {
+    throw new Error(`Verification gate result ${gateResultId} not found`);
+  }
+}
+
+/** Fetch a run with its gate results, or null when the run does not exist. */
+export function getVerificationRun(
+  db: Database.Database,
+  runId: number
+): VerificationRunWithGates | null {
+  const runRow = db
+    .prepare(`SELECT ${RUN_COLUMNS} FROM verification_runs WHERE id = ?`)
+    .get(runId) as VerificationRunRow | undefined;
+
+  if (!runRow) {
+    return null;
+  }
+
+  const gateRows = db
+    .prepare(`
+      SELECT ${GATE_COLUMNS} FROM verification_gate_results
+      WHERE run_id = ?
+      ORDER BY started_at ASC, id ASC
+    `)
+    .all(runId) as VerificationGateResultRow[];
+
+  return { ...mapRunRow(runRow), gates: gateRows.map(mapGateRow) };
+}
+
+/**
+ * Most recent runs for a worktree, newest first.
+ *
+ * `id DESC` breaks ties: runs started within the same millisecond are common
+ * enough that without it the "newest first" contract would be unordered.
+ */
+export function listVerificationRuns(
+  db: Database.Database,
+  worktreeId: string,
+  limit = 20
+): VerificationRun[] {
+  const rows = db
+    .prepare(`
+      SELECT ${RUN_COLUMNS} FROM verification_runs
+      WHERE worktree_id = ?
+      ORDER BY started_at DESC, id DESC
+      LIMIT ?
+    `)
+    .all(worktreeId, limit) as VerificationRunRow[];
+
+  return rows.map(mapRunRow);
+}

--- a/tests/unit/db/migration-v49-verification-runs.test.ts
+++ b/tests/unit/db/migration-v49-verification-runs.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for migration v49 (verification_runs / verification_gate_results, Issue #1542).
+ *
+ * 1. Fresh DB end state — both tables, both indexes, nullability.
+ * 2. The CHECK vocabularies actually reject unknown values (the constraints are
+ *    the reason the statuses mean anything).
+ * 3. ON DELETE CASCADE fires under the pragma the app runs with.
+ * 4. Upgrade of an existing pre-v49 database, and rollback.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  runMigrations,
+  rollbackMigrations,
+  getCurrentVersion,
+  CURRENT_SCHEMA_VERSION,
+} from '@/lib/db/db-migrations';
+
+function tableNames(db: Database.Database): string[] {
+  return (
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all() as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function indexNames(db: Database.Database, table: string): string[] {
+  return (
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?")
+      .all(table) as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function insertRun(
+  db: Database.Database,
+  overrides: { trigger?: string; status?: string } = {}
+): number {
+  const info = db
+    .prepare(
+      `INSERT INTO verification_runs
+        (worktree_id, instance_id, task_id, trigger, status, base_ref, started_at, finished_at)
+       VALUES ('wt-1', NULL, NULL, ?, ?, 'origin/develop', 1800000000000, NULL)`
+    )
+    .run(overrides.trigger ?? 'manual', overrides.status ?? 'running');
+  return Number(info.lastInsertRowid);
+}
+
+function insertGate(db: Database.Database, runId: number, status = 'running'): number {
+  const info = db
+    .prepare(
+      `INSERT INTO verification_gate_results
+        (run_id, gate_id, command, status, exit_code, duration_ms, log_tail, started_at, finished_at)
+       VALUES (?, 'lint', 'npm run lint', ?, NULL, NULL, NULL, 1800000000000, NULL)`
+    )
+    .run(runId, status);
+  return Number(info.lastInsertRowid);
+}
+
+function openMigrated(): Database.Database {
+  const db = new Database(':memory:');
+  // db-instance.ts enables this before migrations; cascade is silently inert
+  // on a raw connection, which would make the cascade tests vacuous.
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+describe('migration v49: fresh DB end state', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = openMigrated();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates both verification tables', () => {
+    expect(tableNames(db)).toEqual(
+      expect.arrayContaining(['verification_runs', 'verification_gate_results'])
+    );
+  });
+
+  it('creates the worktree feed and run lookup indexes', () => {
+    expect(indexNames(db, 'verification_runs')).toContain('idx_verification_runs_worktree');
+    expect(indexNames(db, 'verification_gate_results')).toContain(
+      'idx_verification_gate_results_run'
+    );
+  });
+
+  it('reaches the current schema version', () => {
+    expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(49);
+  });
+
+  it('requires worktree_id, trigger, status and started_at but nothing else', () => {
+    const info = db.pragma('table_info(verification_runs)') as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const required = info.filter((c) => c.notnull === 1).map((c) => c.name);
+    expect(required.sort()).toEqual(['started_at', 'status', 'trigger', 'worktree_id']);
+  });
+
+  it('leaves task_id free of a foreign key, since the tasks table lands in Phase 2', () => {
+    const fks = db.pragma('foreign_key_list(verification_runs)') as Array<{ from: string }>;
+    expect(fks.map((fk) => fk.from)).not.toContain('task_id');
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO verification_runs
+            (worktree_id, task_id, trigger, status, started_at)
+           VALUES ('wt-1', 'task-does-not-exist', 'task', 'running', 1800000000000)`
+        )
+        .run()
+    ).not.toThrow();
+  });
+
+  it('keeps the worktree feed off a full table scan', () => {
+    const plan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT id FROM verification_runs WHERE worktree_id = 'wt-1'
+         ORDER BY started_at DESC, id DESC LIMIT 20`
+      )
+      .all() as Array<{ detail: string }>;
+    expect(plan.map((row) => row.detail).join(' ')).toContain('idx_verification_runs_worktree');
+  });
+});
+
+describe('migration v49: status vocabularies are enforced by the database', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = openMigrated();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('accepts every documented run status', () => {
+    for (const status of ['running', 'passed', 'failed', 'not_started', 'error', 'cancelled']) {
+      expect(() => insertRun(db, { status })).not.toThrow();
+    }
+  });
+
+  it('accepts every documented trigger', () => {
+    for (const trigger of ['manual', 'wait', 'api', 'task']) {
+      expect(() => insertRun(db, { trigger })).not.toThrow();
+    }
+  });
+
+  it('accepts every documented gate status', () => {
+    const runId = insertRun(db);
+    for (const status of ['running', 'passed', 'failed', 'timeout', 'skipped', 'error']) {
+      expect(() => insertGate(db, runId, status)).not.toThrow();
+    }
+  });
+
+  it('rejects an unknown run status', () => {
+    expect(() => insertRun(db, { status: 'succeeded' })).toThrow(/CHECK constraint failed/);
+  });
+
+  it('rejects an unknown trigger', () => {
+    expect(() => insertRun(db, { trigger: 'cron' })).toThrow(/CHECK constraint failed/);
+  });
+
+  it('rejects an unknown gate status', () => {
+    const runId = insertRun(db);
+    expect(() => insertGate(db, runId, 'aborted')).toThrow(/CHECK constraint failed/);
+  });
+
+  it('rejects an unknown status on UPDATE, not only on INSERT', () => {
+    const runId = insertRun(db);
+    expect(() =>
+      db.prepare('UPDATE verification_runs SET status = ? WHERE id = ?').run('done', runId)
+    ).toThrow(/CHECK constraint failed/);
+  });
+});
+
+describe('migration v49: gate results are bound to their run', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = openMigrated();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('cascades gate results when the run is deleted', () => {
+    const runId = insertRun(db);
+    insertGate(db, runId);
+    insertGate(db, runId);
+
+    db.prepare('DELETE FROM verification_runs WHERE id = ?').run(runId);
+
+    const remaining = db
+      .prepare('SELECT COUNT(*) AS n FROM verification_gate_results WHERE run_id = ?')
+      .get(runId) as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+
+  it('refuses a gate result whose run does not exist', () => {
+    expect(() => insertGate(db, 9999)).toThrow(/FOREIGN KEY constraint failed/);
+  });
+});
+
+describe('migration v49: upgrade path and rollback', () => {
+  it('upgrades an existing pre-v49 database without touching its rows', () => {
+    const db = openMigrated();
+    try {
+      db.prepare(
+        "INSERT INTO worktrees (id, name, path, updated_at) VALUES ('wt-1', 'wt', '/tmp/wt-1', 1)"
+      ).run();
+
+      rollbackMigrations(db, 48);
+      expect(getCurrentVersion(db)).toBe(48);
+      expect(tableNames(db)).not.toContain('verification_runs');
+
+      runMigrations(db);
+
+      expect(getCurrentVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+      expect(tableNames(db)).toEqual(
+        expect.arrayContaining(['verification_runs', 'verification_gate_results'])
+      );
+      const worktrees = db.prepare('SELECT COUNT(*) AS n FROM worktrees').get() as { n: number };
+      expect(worktrees.n).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('down() drops both tables, child before parent', () => {
+    const db = openMigrated();
+    try {
+      const runId = insertRun(db);
+      insertGate(db, runId);
+
+      expect(() => rollbackMigrations(db, 48)).not.toThrow();
+
+      expect(tableNames(db)).not.toContain('verification_runs');
+      expect(tableNames(db)).not.toContain('verification_gate_results');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('re-running runMigrations is a no-op', () => {
+    const db = openMigrated();
+    try {
+      const runId = insertRun(db);
+      expect(() => runMigrations(db)).not.toThrow();
+      const rows = db.prepare('SELECT COUNT(*) AS n FROM verification_runs').get() as { n: number };
+      expect(rows.n).toBe(1);
+      expect(runId).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/tests/unit/db/verification-db.test.ts
+++ b/tests/unit/db/verification-db.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for verification-db (Issue #1542).
+ *
+ * Covers the full CRUD surface, cascade deletion, feed ordering/limit, and the
+ * two ways a write can be wrong without anyone noticing: a status outside the
+ * CHECK vocabulary, and a finish* call against a row that is not there.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/db/db-migrations';
+import {
+  createVerificationRun,
+  finishVerificationRun,
+  createGateResult,
+  finishGateResult,
+  getVerificationRun,
+  listVerificationRuns,
+  type VerificationRunTerminalStatus,
+  type VerificationTrigger,
+  type VerificationGateTerminalStatus,
+} from '@/lib/db/verification-db';
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  // Mirrors db-instance.ts. Without it ON DELETE CASCADE never fires and the
+  // cascade assertions below would pass against a table that kept its rows.
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+/** Overwrite started_at so ordering assertions do not depend on clock spacing. */
+function setStartedAt(runId: number, startedAt: number): void {
+  db.prepare('UPDATE verification_runs SET started_at = ? WHERE id = ?').run(startedAt, runId);
+}
+
+describe('createVerificationRun', () => {
+  it('opens a run in running state with no finish timestamp', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    expect(run.id).toBeGreaterThan(0);
+    expect(run.worktreeId).toBe('wt-1');
+    expect(run.trigger).toBe('manual');
+    expect(run.status).toBe('running');
+    expect(run.finishedAt).toBeNull();
+    expect(run.startedAt).toBeInstanceOf(Date);
+    expect(run.startedAt.getTime()).toBeGreaterThan(0);
+  });
+
+  it('defaults the optional columns to null rather than empty strings', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'wait' });
+
+    expect(run.instanceId).toBeNull();
+    expect(run.taskId).toBeNull();
+    expect(run.baseRef).toBeNull();
+  });
+
+  it('persists instance, task and base ref when supplied', () => {
+    const run = createVerificationRun(db, {
+      worktreeId: 'wt-1',
+      trigger: 'task',
+      instanceId: 'codex-2',
+      taskId: 'task-abc',
+      baseRef: 'origin/develop',
+    });
+
+    const reloaded = getVerificationRun(db, run.id);
+    expect(reloaded?.instanceId).toBe('codex-2');
+    expect(reloaded?.taskId).toBe('task-abc');
+    expect(reloaded?.baseRef).toBe('origin/develop');
+  });
+
+  it('assigns distinct ids to concurrent runs on the same worktree', () => {
+    const a = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const b = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    expect(b.id).not.toBe(a.id);
+  });
+
+  it('rejects a trigger outside the vocabulary instead of storing it', () => {
+    expect(() =>
+      createVerificationRun(db, {
+        worktreeId: 'wt-1',
+        trigger: 'cron' as VerificationTrigger,
+      })
+    ).toThrow(/CHECK constraint failed/);
+
+    const rows = db.prepare('SELECT COUNT(*) AS n FROM verification_runs').get() as { n: number };
+    expect(rows.n).toBe(0);
+  });
+});
+
+describe('finishVerificationRun', () => {
+  it.each<VerificationRunTerminalStatus>([
+    'passed',
+    'failed',
+    'not_started',
+    'error',
+    'cancelled',
+  ])('records the %s verdict and stamps finished_at', (status) => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    finishVerificationRun(db, run.id, status);
+
+    const reloaded = getVerificationRun(db, run.id);
+    expect(reloaded?.status).toBe(status);
+    expect(reloaded?.finishedAt).toBeInstanceOf(Date);
+    expect(reloaded!.finishedAt!.getTime()).toBeGreaterThanOrEqual(reloaded!.startedAt.getTime());
+  });
+
+  it('throws when the run does not exist, rather than silently recording nothing', () => {
+    expect(() => finishVerificationRun(db, 4242, 'passed')).toThrow(/4242 not found/);
+  });
+
+  it('does not close a different run when the id is wrong', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    expect(() => finishVerificationRun(db, run.id + 1, 'failed')).toThrow();
+
+    expect(getVerificationRun(db, run.id)?.status).toBe('running');
+  });
+
+  it('rejects a status outside the vocabulary', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    expect(() =>
+      finishVerificationRun(db, run.id, 'done' as VerificationRunTerminalStatus)
+    ).toThrow(/CHECK constraint failed/);
+    expect(getVerificationRun(db, run.id)?.status).toBe('running');
+  });
+});
+
+describe('createGateResult / finishGateResult', () => {
+  it('opens a gate result in running state with an empty outcome', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    const gate = createGateResult(db, run.id, { gateId: 'lint', command: 'npm run lint' });
+
+    expect(gate.runId).toBe(run.id);
+    expect(gate.gateId).toBe('lint');
+    expect(gate.command).toBe('npm run lint');
+    expect(gate.status).toBe('running');
+    expect(gate.exitCode).toBeNull();
+    expect(gate.durationMs).toBeNull();
+    expect(gate.logTail).toBeNull();
+    expect(gate.finishedAt).toBeNull();
+  });
+
+  it('records a passing gate, keeping exit code 0 as 0', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const gate = createGateResult(db, run.id, { gateId: 'lint', command: 'npm run lint' });
+
+    finishGateResult(db, gate.id, {
+      status: 'passed',
+      exitCode: 0,
+      durationMs: 0,
+      logTail: 'ok',
+    });
+
+    const stored = getVerificationRun(db, run.id)!.gates[0];
+    expect(stored.status).toBe('passed');
+    // A `|| null` here would store NULL and turn "exited 0" into "no exit code".
+    expect(stored.exitCode).toBe(0);
+    expect(stored.durationMs).toBe(0);
+    expect(stored.logTail).toBe('ok');
+    expect(stored.finishedAt).toBeInstanceOf(Date);
+  });
+
+  it('records a failing gate with its non-zero exit code and log tail', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const gate = createGateResult(db, run.id, { gateId: 'test', command: 'npm run test:unit' });
+
+    finishGateResult(db, gate.id, {
+      status: 'failed',
+      exitCode: 1,
+      durationMs: 12345,
+      logTail: 'Errors  1 error',
+    });
+
+    const stored = getVerificationRun(db, run.id)!.gates[0];
+    expect(stored.status).toBe('failed');
+    expect(stored.exitCode).toBe(1);
+    expect(stored.durationMs).toBe(12345);
+    expect(stored.logTail).toBe('Errors  1 error');
+  });
+
+  it('records a skipped gate with a reason and no exit code', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const gate = createGateResult(db, run.id, { gateId: 'build', command: 'npm run build' });
+
+    finishGateResult(db, gate.id, {
+      status: 'skipped',
+      logTail: 'skipInPrimaryCheckout',
+    });
+
+    const stored = getVerificationRun(db, run.id)!.gates[0];
+    expect(stored.status).toBe('skipped');
+    expect(stored.exitCode).toBeNull();
+    expect(stored.durationMs).toBeNull();
+    expect(stored.logTail).toBe('skipInPrimaryCheckout');
+  });
+
+  it('throws when the gate result does not exist', () => {
+    expect(() => finishGateResult(db, 4242, { status: 'passed' })).toThrow(/4242 not found/);
+  });
+
+  it('rejects a gate status outside the vocabulary', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const gate = createGateResult(db, run.id, { gateId: 'lint', command: 'npm run lint' });
+
+    expect(() =>
+      finishGateResult(db, gate.id, {
+        status: 'aborted' as VerificationGateTerminalStatus,
+      })
+    ).toThrow(/CHECK constraint failed/);
+    expect(getVerificationRun(db, run.id)!.gates[0].status).toBe('running');
+  });
+
+  it('refuses to attach a gate result to a run that does not exist', () => {
+    expect(() =>
+      createGateResult(db, 9999, { gateId: 'lint', command: 'npm run lint' })
+    ).toThrow(/FOREIGN KEY constraint failed/);
+  });
+});
+
+describe('getVerificationRun', () => {
+  it('returns null for an unknown run', () => {
+    expect(getVerificationRun(db, 1)).toBeNull();
+  });
+
+  it('returns an empty gate list for a run that has not executed a gate yet', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+
+    expect(getVerificationRun(db, run.id)?.gates).toEqual([]);
+  });
+
+  it('returns gate results in execution order', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const lint = createGateResult(db, run.id, { gateId: 'lint', command: 'npm run lint' });
+    const tsc = createGateResult(db, run.id, { gateId: 'tsc', command: 'npx tsc --noEmit' });
+    const test = createGateResult(db, run.id, { gateId: 'test', command: 'npm run test:unit' });
+
+    const gates = getVerificationRun(db, run.id)!.gates;
+    expect(gates.map((g) => g.id)).toEqual([lint.id, tsc.id, test.id]);
+    expect(gates.map((g) => g.gateId)).toEqual(['lint', 'tsc', 'test']);
+  });
+
+  it('does not mix in gate results belonging to another run', () => {
+    const runA = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const runB = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    createGateResult(db, runA.id, { gateId: 'lint', command: 'npm run lint' });
+    createGateResult(db, runB.id, { gateId: 'build', command: 'npm run build' });
+
+    expect(getVerificationRun(db, runA.id)!.gates.map((g) => g.gateId)).toEqual(['lint']);
+    expect(getVerificationRun(db, runB.id)!.gates.map((g) => g.gateId)).toEqual(['build']);
+  });
+
+  it('deletes a run\'s gate results with the run (ON DELETE CASCADE)', () => {
+    const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const survivor = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    createGateResult(db, run.id, { gateId: 'lint', command: 'npm run lint' });
+    createGateResult(db, run.id, { gateId: 'tsc', command: 'npx tsc --noEmit' });
+    createGateResult(db, survivor.id, { gateId: 'lint', command: 'npm run lint' });
+
+    db.prepare('DELETE FROM verification_runs WHERE id = ?').run(run.id);
+
+    expect(getVerificationRun(db, run.id)).toBeNull();
+    const orphans = db
+      .prepare('SELECT COUNT(*) AS n FROM verification_gate_results WHERE run_id = ?')
+      .get(run.id) as { n: number };
+    expect(orphans.n).toBe(0);
+    // The cascade must be scoped to the deleted run, not the table.
+    expect(getVerificationRun(db, survivor.id)!.gates).toHaveLength(1);
+  });
+});
+
+describe('listVerificationRuns', () => {
+  it('returns runs newest first by started_at, not by insertion id', () => {
+    const newest = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const oldest = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'wait' });
+    const middle = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'api' });
+    // started_at deliberately disagrees with id order: the lowest id is the
+    // newest run. Ordering by id alone would pass every other assertion here.
+    setStartedAt(newest.id, 1_800_000_002_000);
+    setStartedAt(oldest.id, 1_800_000_000_000);
+    setStartedAt(middle.id, 1_800_000_001_000);
+
+    const runs = listVerificationRuns(db, 'wt-1');
+
+    expect(runs.map((r) => r.id)).toEqual([newest.id, middle.id, oldest.id]);
+    expect(runs.map((r) => r.trigger)).toEqual(['manual', 'api', 'wait']);
+  });
+
+  it('breaks started_at ties by newest id, so the order is total', () => {
+    const first = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const second = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    const third = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    for (const id of [first.id, second.id, third.id]) {
+      setStartedAt(id, 1_800_000_000_000);
+    }
+
+    expect(listVerificationRuns(db, 'wt-1').map((r) => r.id)).toEqual([
+      third.id,
+      second.id,
+      first.id,
+    ]);
+  });
+
+  it('only returns runs for the requested worktree', () => {
+    const mine = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+    createVerificationRun(db, { worktreeId: 'wt-2', trigger: 'manual' });
+
+    const runs = listVerificationRuns(db, 'wt-1');
+
+    expect(runs.map((r) => r.id)).toEqual([mine.id]);
+  });
+
+  it('returns an empty list for a worktree with no runs', () => {
+    createVerificationRun(db, { worktreeId: 'wt-2', trigger: 'manual' });
+
+    expect(listVerificationRuns(db, 'wt-1')).toEqual([]);
+  });
+
+  it('caps the result at 20 runs by default, keeping the newest', () => {
+    const ids: number[] = [];
+    for (let i = 0; i < 25; i += 1) {
+      const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+      // Descending started_at: the earliest-inserted run is the newest, so a
+      // cap that keeps the highest ids would drop exactly the wrong 5.
+      setStartedAt(run.id, 1_800_000_025_000 - i * 1000);
+      ids.push(run.id);
+    }
+
+    const runs = listVerificationRuns(db, 'wt-1');
+
+    expect(runs).toHaveLength(20);
+    expect(runs.map((r) => r.id)).toEqual(ids.slice(0, 20));
+  });
+
+  it('honours an explicit limit', () => {
+    for (let i = 0; i < 5; i += 1) {
+      const run = createVerificationRun(db, { worktreeId: 'wt-1', trigger: 'manual' });
+      setStartedAt(run.id, 1_800_000_000_000 + i * 1000);
+    }
+
+    expect(listVerificationRuns(db, 'wt-1', 2)).toHaveLength(2);
+  });
+
+  it('carries the finished verdict, so a caller can read the feed without a join', () => {
+    const run = createVerificationRun(db, {
+      worktreeId: 'wt-1',
+      trigger: 'wait',
+      baseRef: 'origin/develop',
+    });
+    finishVerificationRun(db, run.id, 'not_started');
+
+    const [listed] = listVerificationRuns(db, 'wt-1');
+
+    expect(listed.status).toBe('not_started');
+    expect(listed.trigger).toBe('wait');
+    expect(listed.baseRef).toBe('origin/develop');
+    expect(listed.finishedAt).toBeInstanceOf(Date);
+  });
+});

--- a/tests/unit/lib/db-migrations.test.ts
+++ b/tests/unit/lib/db-migrations.test.ts
@@ -33,8 +33,8 @@ describe('db-migrations', () => {
   });
 
   describe('CURRENT_SCHEMA_VERSION', () => {
-    it('should be 48 after Migration #48 (skill_operations audit index, #1248)', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(48);
+    it('should be 49 after Migration #49 (verification_runs, #1542)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(49);
     });
   });
 


### PR DESCRIPTION
## 概要

Issue #1542（親 #1539 / Phase 1-2）。検証ゲートの実行結果を永続化するテーブルと DB アクセサを追加する。

## 変更内容

- `src/lib/db/migrations/v49-verification-runs.ts`: `verification_runs` / `verification_gate_results` の 2 テーブル + インデックス 2 本
- `src/lib/db/migrations/index.ts` に登録、`CURRENT_SCHEMA_VERSION` を 48 → 49
- `src/lib/db/verification-db.ts`: アクセサ 6 種（create/finish run・create/finish gate result・get・list）
- `src/lib/db/db.ts` バレルから再エクスポート（Phase 1-3 の gate-runner が消費できるよう配線まで実施）
- 単体テスト 2 ファイル / 50 ケース

## Issue 本文からの逸脱

Issue 本文は「現在の最新は v47」として **v48** での追加を指示していたが、develop には既に
`v48-skill-operations-audit-index.ts` が存在したため、**v49** として実装した（実測を正とする）。

## 検証

worktree `commandmate-issue-1542` で exit code を直接測定（grep にパイプせず）:

| ゲート | 結果 |
|--------|------|
| `npm run lint` | PASS (exit 0) |
| `npx tsc --noEmit` | PASS (exit 0) |
| `npm run test:unit` | PASS (exit 0) — 679 files / 11833 tests |
| `npm run build` | PASS (exit 0) |

新規テストの非空振り性を変異注入で確認済み:
- `started_at DESC` → `ASC`: 2 件 red
- `ON DELETE CASCADE` 削除: 2 件 red

## スコープ外

ゲート実行ロジック（#1543）、tasks テーブルおよび `task_id` への FK（Phase 2-1）

Refs #1542