### PR TITLE
feat(skills): 検証ゲート Skill cmate-verify と .commandmate/verify.yaml v1 仕様を追加

### DIFF
--- a/.agents/skills/cmate-verify/SKILL.md
+++ b/.agents/skills/cmate-verify/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: cmate-verify
+description: リポジトリの検証ゲート（lint / typecheck / test / build 等）を .commandmate/verify.yaml に宣言し、worktree の cwd で逐次実行して exit code で合否を判定する。verify.yaml が無いリポジトリでは CI 定義から起案する。作業完了を主張する前の検証や、並列ワーカーの完了判定に使う。
+allowed-tools: Bash(.claude/skills/cmate-verify/scripts/*), Bash(.agents/skills/cmate-verify/scripts/*), Bash(git worktree list), Read, Write, Glob, Grep
+---
+
+# cmate-verify
+
+「このリポジトリで何が通れば合格か」を `.commandmate/verify.yaml` に宣言し、
+**実 exit code で** 判定するランナー。CommandMate の検証ゲート機能（Phase 1 以降）の
+設定形式 v1 を、製品実装より先に実地検証するための先行 Skill である。
+
+正準仕様は CommandMate リポジトリの [`docs/design/verification-config.md`](../../../docs/design/verification-config.md)。
+Phase 1 の製品ローダは同じ仕様を一般的な YAML パーサで実装するので、この Skill で書いた
+verify.yaml はそのまま引き継げる。
+
+> **なぜ exit code か**: `cmd | grep ...` は `$?` を grep に渡して非ゼロ終了を隠す。vitest は
+> 全テスト緑でも Unhandled Rejection で exit 1 を出しうるので、出力を grep した要約は
+> それを PASS と報告してしまう。ゲートは必ず `sh -c "$cmd" > log 2>&1` で走らせ `$?` を直接読む。
+
+## 構成
+
+```
+cmate-verify/
+├── SKILL.md
+└── scripts/
+    ├── verify-run.sh        # ゲート実行ランナー（bash 3.2 互換）
+    └── tests/
+        ├── run-tests.sh     # fixture ベーステスト（bash + git だけで動く）
+        └── fixtures/*.yaml
+```
+
+`scripts/tests/run-tests.sh` は vitest に依存しない。Node の無い導入先でも
+`bash scripts/tests/run-tests.sh` だけで検証できる（CommandMate 本体では
+`tests/unit/skills/cmate-verify/` の薄いラッパが `npm run test:unit` から同じ suite を回す）。
+
+## 手順 1: init（`.commandmate/verify.yaml` が無い場合）
+
+**コードを書かず、リポジトリをスキャンしてゲートを起案し、ユーザーの確認を得てから書き出す。**
+検出優先順位は次のとおり。上位が見つかったら下位は補助として扱う。
+
+1. **`.github/workflows/*.yml` の CI ジョブ** — そのリポジトリにおける「何が通れば合格か」の
+   既存の定義。`run:` の各ステップが第一候補。
+2. **`package.json` の `scripts`** — `lint` / `test` / `test:unit` / `typecheck` / `build` 系。
+3. **`Makefile` のターゲット** — `make lint` / `make test` 等。
+4. **言語マニフェスト** — `Cargo.toml`（`cargo clippy` / `cargo test`）、`pyproject.toml`
+   （`ruff` / `pytest` / `mypy`）、`go.mod`（`go vet` / `go test ./...`）等。
+
+起案時の注意:
+
+- 実行時間の長いゲートには `timeoutSec` を明示する（既定は 600 秒）。
+- ゲートの並び順がそのまま実行順になる。速いゲートを先に置くと失敗が早く読める
+  （途中で失敗しても残りは実行されるので、順序は打ち切りではなく可読性のための選択）。
+- **デプロイ・publish・リリース・外形変更を伴うコマンドはゲートにしない。** ゲートは
+  何度でも安全に再実行できるものに限る。
+- 起案結果は「どこから拾ったか」（CI ジョブ名 / npm script 名）とセットで提示し、
+  **ユーザーの確認を得てから** `.commandmate/verify.yaml` を書き出す。
+
+書き出したら、その場で 1 回実行して `RESULT passed` になることまで確認する。
+
+## 手順 2: run（verify.yaml がある場合）
+
+```bash
+.claude/skills/cmate-verify/scripts/verify-run.sh --cwd <worktree-path>
+```
+
+主なオプション:
+
+| オプション | 意味 |
+|---|---|
+| `--config <path>` | 既定は `<cwd>/.commandmate/verify.yaml` |
+| `--cwd <path>` | ゲートを実行する worktree。既定はカレントディレクトリ |
+| `--base-ref <ref>` | work-evidence の基準。`options.baseRef` より優先 |
+| `--gates id1,id2` | 一部のゲートだけ実行する。存在しない id は設定エラー |
+| `--skip-work-evidence` | 未着手ガードを飛ばす |
+
+出力は stdout に 1 ゲート 1 行、最終行が判定:
+
+```
+GATE work-evidence PASS commits=3 uncommitted=2
+GATE lint PASS exit=0 duration=12s
+GATE unit FAIL exit=1 duration=45s
+RESULT failed
+```
+
+失敗ゲートのログ末尾は **stderr** に出る（stdout をパース可能に保つため）。
+
+| RESULT | exit code | 意味 |
+|---|---|---|
+| `passed` | 0 | 実行した全ゲートが PASS |
+| — | 2 | 設定エラー（verify.yaml 不正 / ファイル無し / git でない cwd 等） |
+| `failed` | 20 | 1 つ以上のゲートが FAIL または TIMEOUT |
+| `not_started` | 21 | work-evidence が「作業の痕跡ゼロ」と判定（コマンド系ゲートは走らない） |
+| `skipped` | 22 | 実行したコマンド系ゲートが 0 件（メイン checkout での skip） |
+
+**`skipped` を `passed` と読まないこと。** 何も検証していない状態であり、緑ではない。
+
+## verify.yaml の書き方
+
+```yaml
+# .commandmate/verify.yaml — v1
+version: 1
+gates:
+  - id: lint
+    command: "npm run lint"
+    timeoutSec: 600
+  - id: typecheck
+    command: "npx tsc --noEmit"
+  - id: unit
+    command: "npm run test:unit"
+    timeoutSec: 1800
+options:
+  baseRef: origin/develop
+  skipInPrimaryCheckout: true
+  maxLogTailBytes: 8192
+```
+
+このランナーは awk / sed で読むため、**YAML のサブセットしか受け付けない**:
+
+- インデントは 2 スペース固定（タブは不可）
+- 値は 1 行スカラーのみ。アンカー / エイリアス（`&` `*`）・複数行文字列（`|` `>`）・
+  フロースタイル（`[...]` `{...}`）は拒否する
+- 行内コメントは無し。`#` で始まる行のみコメント
+- `key:` の**最初のコロン**で分割するので、値の中のコロンはそのまま書ける
+
+**制約に反する verify.yaml は「best-effort で解釈」せず exit 2 で拒否する。**
+黙って一部を読み飛ばすと「設定したつもりのゲートが走っていないのに passed」になるため。
+Phase 1 の製品ローダは一般的な YAML パーサを使うが、この形式で書いておけば両方で読める。
+
+各フィールドの型・既定値・範囲は `docs/design/verification-config.md` の仕様表が正準。
+
+## 組み込みゲート work-evidence
+
+コマンド系ゲートより先に、**そもそも作業が行われたか**を判定する。
+
+- PASS 条件: `merge-base(baseRef, HEAD)..HEAD` のコミット数 > 0 **または**
+  `git status --porcelain` が非空
+- 両方 0 なら `RESULT not_started` (exit 21)。コマンド系ゲートは 1 つも実行しない
+
+未起動のセッションを「全ゲート PASS」と誤報告しないためのガードである
+（変更ゼロのリポジトリでは lint も typecheck も当然通る）。
+
+## メイン checkout での skip
+
+`options.skipInPrimaryCheckout`（既定 `true`）が有効なとき、**プライマリ checkout では
+コマンド系ゲートを実行しない**。プライマリ checkout は稼働中サーバの cwd になっている
+ことがあり、その足元で build / test を回すと動いている画面を壊す。判定は
+`git rev-parse --git-dir` と `--git-common-dir` が同じ実パスを指すかで行う。
+
+検証は linked worktree で回すこと。
+
+## テスト
+
+```bash
+bash .claude/skills/cmate-verify/scripts/tests/run-tests.sh
+# ... ok - / not ok - の行が並び、最後に
+# tests: 123 passed, 0 failed
+```
+
+fixture は `scripts/tests/fixtures/*.yaml`。カバーしているのは
+全 PASS / 1 ゲート FAIL / timeout / work-evidence の not_started / 設定ファイル無し
+の 5 ケースに加えて、対になる反証ケース（同じ設定が linked worktree では実行される、
+`--skip-work-evidence` を付ければ同じ clean repo でも実行される）と、18 種の設定エラー、
+アサーションヘルパ自身の自己検査。
+
+判定が空振りしていないことは変異注入で確認してある（`set -m` の除去 → orphan 検出が赤 /
+失敗時の打ち切り → 継続実行の assert が赤 / work-evidence の OR を AND に → 33 件赤 /
+全 skip を passed と報告 → skip 判定が赤 / プライマリ判定の無効化 → 6 件赤）。
+`MIN_ASSERTIONS` はケースが黙って落ちたときに 0 failed で緑にならないための下限である。

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/all-pass.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/all-pass.yaml
@@ -1,0 +1,11 @@
+# Every gate passes. skipInPrimaryCheckout is false because the test sandboxes
+# are created with `git init` and are therefore primary checkouts.
+version: 1
+gates:
+  - id: first
+    command: echo first-ok
+  - id: second
+    command: "true"
+    timeoutSec: 30
+options:
+  skipInPrimaryCheckout: false

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-anchor.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-anchor.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+    command: &lint echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-block-scalar.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-block-scalar.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: |
+      echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-duplicate-id.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-duplicate-id.yaml
@@ -1,0 +1,6 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+  - id: a
+    command: echo hi again

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-flow.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-flow.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+    command: [echo, hi]

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-gate-key.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-gate-key.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+    retries: 3

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-indent.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-indent.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+     command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-invalid-id.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-invalid-id.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: Lint_Gate
+    command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-missing-command.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-missing-command.yaml
@@ -1,0 +1,3 @@
+version: 1
+gates:
+  - id: a

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-missing-id.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-missing-id.yaml
@@ -1,0 +1,3 @@
+version: 1
+gates:
+  - command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-no-gates.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-no-gates.yaml
@@ -1,0 +1,3 @@
+version: 1
+options:
+  baseRef: origin/main

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-no-version.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-no-version.yaml
@@ -1,0 +1,3 @@
+gates:
+  - id: a
+    command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-option-key.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-option-key.yaml
@@ -1,0 +1,6 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+options:
+  parallel: true

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-option-value.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-option-value.yaml
@@ -1,0 +1,6 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+options:
+  skipInPrimaryCheckout: maybe

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-reserved-id.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-reserved-id.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: work-evidence
+    command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-tab.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-tab.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+	command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-range.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-range.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+    timeoutSec: 99999

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-type.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-type.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+    timeoutSec: ten

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-version.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/bad-version.yaml
@@ -1,0 +1,4 @@
+version: 2
+gates:
+  - id: a
+    command: echo hi

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/default-options.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/default-options.yaml
@@ -1,0 +1,5 @@
+# No options: block at all, so every default applies (skipInPrimaryCheckout=true).
+version: 1
+gates:
+  - id: sidefx
+    command: touch "$CMATE_VERIFY_TEST_MARKER"

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/one-fail.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/one-fail.yaml
@@ -1,0 +1,13 @@
+# The middle gate prints a green-looking summary and exits non-zero: the exact
+# shape that a grep-based verdict would call PASS. `after` proves that the run
+# continues past a failure so one invocation reports every finding.
+version: 1
+gates:
+  - id: ok
+    command: echo fine
+  - id: broken
+    command: echo "Tests 100 passed"; exit 3
+  - id: after
+    command: echo ran-after-failure
+options:
+  skipInPrimaryCheckout: false

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/parsing.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/parsing.yaml
@@ -1,0 +1,14 @@
+# Comments, blank lines, quoted and unquoted scalars, and values that contain
+# a colon and a hash.
+
+version: 1
+
+gates:
+  # only the first colon separates key from value
+  - id: quoted
+    command: "echo hash:# and colon"
+  - id: unquoted
+    command: sh -c "echo a:b"
+options:
+  skipInPrimaryCheckout: false
+  maxLogTailBytes: 4096

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/side-effect.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/side-effect.yaml
@@ -1,0 +1,7 @@
+# Single observable gate: the marker file is the evidence that gates really ran.
+version: 1
+gates:
+  - id: sidefx
+    command: touch "$CMATE_VERIFY_TEST_MARKER"
+options:
+  skipInPrimaryCheckout: false

--- a/.agents/skills/cmate-verify/scripts/tests/fixtures/timeout.yaml
+++ b/.agents/skills/cmate-verify/scripts/tests/fixtures/timeout.yaml
@@ -1,0 +1,13 @@
+# `slow` outlives its timeout. It backgrounds a child that carries a per-run
+# token in its argv before blocking, so killing only the direct child would
+# leave that token visible in `ps`: the orphan probe in run-tests.sh is what
+# makes the process-group kill testable. The marker would only appear at +4144s.
+version: 1
+gates:
+  - id: slow
+    command: sh -c "sleep 4143; : cmate-verify-orphan-probe $CMATE_VERIFY_TEST_MARKER" & sleep 4144; touch "$CMATE_VERIFY_TEST_MARKER"
+    timeoutSec: 1
+  - id: after
+    command: echo ran-after-timeout
+options:
+  skipInPrimaryCheckout: false

--- a/.agents/skills/cmate-verify/scripts/tests/run-tests.sh
+++ b/.agents/skills/cmate-verify/scripts/tests/run-tests.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# cmate-verify — fixture-based test suite for verify-run.sh.
+#
+# Self-contained on purpose: the skill is distributed to repositories that have
+# no vitest (and no Node), so the suite must run with nothing but bash + git.
+# `tests/unit/skills/cmate-verify/verify-run.test.ts` is a thin wrapper that runs
+# this file so the same assertions also gate `npm run test:unit`.
+#
+# Output is TAP-ish (`ok - ...` / `not ok - ...`) plus a final
+# `# tests: N passed, M failed`. Exit 0 only when M is 0 and enough assertions ran.
+#
+# bash 3.2 compatible: no `declare -A`, no `mapfile`, no `${var,,}`.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+RUNNER="$SCRIPT_DIR/../verify-run.sh"
+FIXTURES="$SCRIPT_DIR/fixtures"
+BASE_BRANCH="cmate-verify-base"
+
+# Floor on the assertion count. A suite that silently stops running cases would
+# otherwise exit 0 with "0 failed" — the same empty-glob trap the orchestrate-monitor
+# syntax test guards against.
+MIN_ASSERTIONS=100
+
+[ -f "$RUNNER" ] || { echo "run-tests: runner not found: $RUNNER" >&2; exit 2; }
+[ -d "$FIXTURES" ] || { echo "run-tests: fixtures not found: $FIXTURES" >&2; exit 2; }
+
+TMPBASE=${TMPDIR:-/tmp}
+TMPBASE=${TMPBASE%/}
+SANDBOX=$(mktemp -d "$TMPBASE/cmate-verify-tests.XXXXXX") || exit 2
+trap 'rm -rf "$SANDBOX"' EXIT
+
+TOTAL_PASS=0
+TOTAL_FAIL=0
+RUN_SEQ=0
+RC=0
+OUT=""
+ERR=""
+
+ok() { TOTAL_PASS=$((TOTAL_PASS + 1)); echo "ok - $1"; }
+notok() { TOTAL_FAIL=$((TOTAL_FAIL + 1)); echo "not ok - $1"; }
+
+assert_eq() { # name expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else notok "$1 (expected [$2], got [$3])"; fi
+}
+# -e is mandatory: a needle that starts with "--" (e.g. "--cwd is not a directory")
+# is otherwise parsed by grep as an option and silently never matches.
+assert_has() { # name file needle
+  if grep -Fq -e "$3" "$2"; then ok "$1"; else notok "$1 (not found in $2: $3)"; fi
+}
+assert_lacks() { # name file needle
+  if grep -Fq -e "$3" "$2"; then notok "$1 (unexpectedly found in $2: $3)"; else ok "$1"; fi
+}
+assert_file_present() { # name path
+  if [ -e "$2" ]; then ok "$1"; else notok "$1 (missing: $2)"; fi
+}
+assert_file_absent() { # name path
+  if [ -e "$2" ]; then notok "$1 (unexpectedly exists: $2)"; else ok "$1"; fi
+}
+assert_le() { # name actual limit
+  if [ "$2" -le "$3" ]; then ok "$1"; else notok "$1 ($2 > $3)"; fi
+}
+
+count_procs() { # pattern -> number of live processes whose argv contains it
+  ps -A -o args= 2>/dev/null | grep -F -e "$1" | grep -v grep | wc -l | tr -d ' '
+}
+
+# Polls instead of sleeping a fixed time: it removes the kill/probe race without
+# weakening the assertion, because a surviving orphan lives far longer than the
+# poll window.
+wait_for_no_procs() { # pattern seconds -> final count
+  wp_left=$2
+  while [ "$wp_left" -gt 0 ]; do
+    wp_n=$(count_procs "$1")
+    [ "$wp_n" -eq 0 ] && break
+    sleep 1
+    wp_left=$((wp_left - 1))
+  done
+  count_procs "$1"
+}
+
+run_verify() { # sets RC / OUT / ERR
+  RUN_SEQ=$((RUN_SEQ + 1))
+  OUT="$SANDBOX/out.$RUN_SEQ"
+  ERR="$SANDBOX/err.$RUN_SEQ"
+  bash "$RUNNER" "$@" > "$OUT" 2> "$ERR"
+  RC=$?
+}
+
+# new_repo <name> — a primary checkout whose HEAD equals $BASE_BRANCH.
+new_repo() {
+  nr_dir="$SANDBOX/$1"
+  mkdir -p "$nr_dir"
+  git init -q --template= "$nr_dir" >/dev/null 2>&1
+  git -C "$nr_dir" config user.email "test@example.invalid"
+  git -C "$nr_dir" config user.name "cmate-verify test"
+  git -C "$nr_dir" config commit.gpgsign false
+  git -C "$nr_dir" commit -q --allow-empty -m base
+  git -C "$nr_dir" branch -f "$BASE_BRANCH"
+  echo "$nr_dir"
+}
+
+new_marker() {
+  RUN_SEQ=$((RUN_SEQ + 1))
+  echo "$SANDBOX/marker.$RUN_SEQ"
+}
+
+echo "# cmate-verify fixture suite"
+
+# --- 0. harness self-check ----------------------------------------------------
+# Every assertion below is only worth its green if a wrong expectation is really
+# recorded as a failure. Each probe runs in a subshell so its counter mutations
+# do not leak into the real totals.
+probe=$(TOTAL_FAIL=0; assert_eq p a b >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_eq counts a mismatch as a failure" "1" "$probe"
+probe=$(TOTAL_PASS=0; assert_eq p a a >/dev/null; echo "$TOTAL_PASS")
+assert_eq "harness: assert_eq counts a match as a pass" "1" "$probe"
+echo "needle" > "$SANDBOX/probe.txt"
+probe=$(TOTAL_FAIL=0; assert_has p "$SANDBOX/probe.txt" "absent-string" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_has counts a missing needle as a failure" "1" "$probe"
+probe=$(TOTAL_FAIL=0; assert_lacks p "$SANDBOX/probe.txt" "needle" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_lacks counts a present needle as a failure" "1" "$probe"
+probe=$(TOTAL_FAIL=0; assert_file_absent p "$SANDBOX/probe.txt" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_file_absent counts an existing file as a failure" "1" "$probe"
+probe=$(TOTAL_FAIL=0; assert_file_present p "$SANDBOX/no-such-file" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_file_present counts a missing file as a failure" "1" "$probe"
+
+# --- 1. every gate passes -----------------------------------------------------
+repo=$(new_repo worked)
+git -C "$repo" commit -q --allow-empty -m work
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "all-pass: exit code is 0" "0" "$RC"
+assert_has "all-pass: work-evidence counts the commit" "$OUT" "GATE work-evidence PASS commits=1 uncommitted=0"
+assert_has "all-pass: first gate passes" "$OUT" "GATE first PASS exit=0 duration="
+assert_has "all-pass: second gate passes" "$OUT" "GATE second PASS exit=0 duration="
+assert_has "all-pass: verdict is passed" "$OUT" "RESULT passed"
+
+# --- 2. one gate fails, the rest still run ------------------------------------
+run_verify --config "$FIXTURES/one-fail.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "one-fail: exit code is 20" "20" "$RC"
+assert_has "one-fail: gate before the failure passes" "$OUT" "GATE ok PASS exit=0 duration="
+assert_has "one-fail: green-looking output with exit 3 is a FAIL" "$OUT" "GATE broken FAIL exit=3 duration="
+assert_has "one-fail: execution continues past the failure" "$OUT" "GATE after PASS exit=0 duration="
+assert_has "one-fail: verdict is failed" "$OUT" "RESULT failed"
+assert_has "one-fail: the failing gate output is reported on stderr" "$ERR" "Tests 100 passed"
+assert_lacks "one-fail: stdout stays parseable (no log tail)" "$OUT" "Tests 100 passed"
+
+# --- 3. timeout ---------------------------------------------------------------
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+export CMATE_VERIFY_TEST_MARKER
+started=$(date +%s)
+run_verify --config "$FIXTURES/timeout.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+elapsed=$(( $(date +%s) - started ))
+assert_eq "timeout: exit code is 20" "20" "$RC"
+assert_has "timeout: the slow gate is reported as TIMEOUT" "$OUT" "GATE slow TIMEOUT exit=124 duration="
+assert_has "timeout: execution continues past the timeout" "$OUT" "GATE after PASS exit=0 duration="
+assert_has "timeout: verdict is failed" "$OUT" "RESULT failed"
+# The gate would touch the marker at +4144s; the elapsed bound proves we did not
+# wait it out rather than killing it.
+assert_file_absent "timeout: the killed gate never reached its side effect" "$marker"
+assert_le "timeout: the run ends well before the gate would have finished" "$elapsed" "15"
+# The gate backgrounded a child carrying this run's marker path in its argv.
+# Killing only the direct child would leave it running for over an hour, so a
+# zero count here is what proves the whole process group was killed. The probe
+# is scoped to this run's marker so an orphan leaked by an earlier run cannot
+# fail (or mask) this one.
+orphans=$(wait_for_no_procs "cmate-verify-orphan-probe $marker" 5)
+assert_eq "timeout: no orphan survives the kill" "0" "$orphans"
+
+# --- 4. work-evidence -> not_started ------------------------------------------
+clean=$(new_repo clean)
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/side-effect.yaml" --cwd "$clean" --base-ref "$BASE_BRANCH"
+assert_eq "not_started: exit code is 21" "21" "$RC"
+assert_has "not_started: work-evidence reports zero work" "$OUT" "GATE work-evidence FAIL commits=0 uncommitted=0"
+assert_has "not_started: verdict is not_started" "$OUT" "RESULT not_started"
+assert_lacks "not_started: no command gate is reported" "$OUT" "GATE sidefx"
+assert_file_absent "not_started: no command gate is executed" "$marker"
+
+# --- 5. missing config file ---------------------------------------------------
+run_verify --config "$SANDBOX/there-is-no-such-file.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "missing-config: exit code is 2" "2" "$RC"
+assert_has "missing-config: the path is named on stderr" "$ERR" "config file not found"
+assert_lacks "missing-config: no verdict is emitted" "$OUT" "RESULT"
+
+# --- 6. work-evidence also passes on uncommitted changes ----------------------
+echo scratch > "$clean/untracked.txt"
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/side-effect.yaml" --cwd "$clean" --base-ref "$BASE_BRANCH"
+assert_eq "uncommitted: exit code is 0" "0" "$RC"
+assert_has "uncommitted: work-evidence passes on a dirty tree alone" "$OUT" "GATE work-evidence PASS commits=0 uncommitted=1"
+assert_file_present "uncommitted: the command gate ran" "$marker"
+rm -f "$clean/untracked.txt"
+
+# --- 7. --skip-work-evidence bypasses the not_started guard -------------------
+# Pairs with case 4: same repo, same config, only the flag differs. Without this
+# the not_started assertions could be passing for the wrong reason.
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/side-effect.yaml" --cwd "$clean" --base-ref "$BASE_BRANCH" --skip-work-evidence
+assert_eq "skip-work-evidence: exit code is 0" "0" "$RC"
+assert_has "skip-work-evidence: the gate is reported as skipped" "$OUT" "GATE work-evidence SKIP reason=flag"
+assert_has "skip-work-evidence: verdict is passed" "$OUT" "RESULT passed"
+assert_file_present "skip-work-evidence: the command gate ran" "$marker"
+
+# --- 8. primary checkout is skipped by default --------------------------------
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/default-options.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "primary-checkout: exit code is 22" "22" "$RC"
+assert_has "primary-checkout: the gate is skipped" "$OUT" "GATE sidefx SKIP reason=primary-checkout"
+assert_has "primary-checkout: verdict is skipped, not passed" "$OUT" "RESULT skipped"
+assert_lacks "primary-checkout: an all-skipped run is never reported as passed" "$OUT" "RESULT passed"
+assert_file_absent "primary-checkout: no command runs in the primary checkout" "$marker"
+
+# --- 9. the same config runs in a linked worktree ------------------------------
+# Pairs with case 8: identical fixture, identical defaults, only the checkout kind
+# differs — so case 8 cannot be green because of a broken config.
+linked="$SANDBOX/linked"
+git -C "$repo" worktree add -q "$linked" -b cmate-verify-linked >/dev/null 2>&1
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/default-options.yaml" --cwd "$linked" --base-ref "$BASE_BRANCH"
+assert_eq "linked-worktree: exit code is 0" "0" "$RC"
+assert_has "linked-worktree: the gate is not skipped" "$OUT" "GATE sidefx PASS exit=0 duration="
+assert_has "linked-worktree: verdict is passed" "$OUT" "RESULT passed"
+assert_file_present "linked-worktree: the command gate ran" "$marker"
+
+# --- 10. --gates selection ----------------------------------------------------
+run_verify --config "$FIXTURES/one-fail.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH" --gates ok,after
+assert_eq "gates-subset: exit code is 0" "0" "$RC"
+assert_has "gates-subset: a selected gate runs" "$OUT" "GATE ok PASS exit=0 duration="
+assert_lacks "gates-subset: an unselected gate does not run" "$OUT" "GATE broken"
+assert_has "gates-subset: verdict is passed" "$OUT" "RESULT passed"
+
+run_verify --config "$FIXTURES/one-fail.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH" --gates ok,nosuch
+assert_eq "gates-unknown: a typo is a config error, not a silent pass" "2" "$RC"
+assert_has "gates-unknown: the unknown id is named" "$ERR" "unknown gate id: nosuch"
+assert_lacks "gates-unknown: no verdict is emitted" "$OUT" "RESULT"
+
+# --- 11. parsing of comments, quotes and embedded colons ----------------------
+run_verify --config "$FIXTURES/parsing.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "parsing: exit code is 0" "0" "$RC"
+assert_has "parsing: a quoted command keeps its hash and colon" "$OUT" "GATE quoted PASS exit=0 duration="
+assert_has "parsing: an unquoted command keeps its embedded quotes" "$OUT" "GATE unquoted PASS exit=0 duration="
+assert_has "parsing: verdict is passed" "$OUT" "RESULT passed"
+
+# --- 12. git context errors ---------------------------------------------------
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo"
+assert_eq "base-ref: an unresolvable default is a config error" "2" "$RC"
+assert_has "base-ref: the fix is spelled out" "$ERR" "cannot determine baseRef"
+
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo" --base-ref no/such/ref
+assert_eq "base-ref: an unknown ref is a config error" "2" "$RC"
+assert_has "base-ref: the bad ref is named" "$ERR" "baseRef does not resolve to a commit"
+
+mkdir -p "$SANDBOX/not-a-repo"
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$SANDBOX/not-a-repo" --base-ref "$BASE_BRANCH"
+assert_eq "non-git cwd: exit code is 2" "2" "$RC"
+assert_has "non-git cwd: the path is named" "$ERR" "not a git repository"
+
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$SANDBOX/no-such-directory" --base-ref "$BASE_BRANCH"
+assert_eq "missing cwd: exit code is 2" "2" "$RC"
+assert_has "missing cwd: the path is named" "$ERR" "--cwd is not a directory"
+
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH" --bogus
+assert_eq "unknown argument: exit code is 2" "2" "$RC"
+
+# --- 13. rejected configs -----------------------------------------------------
+# Every one of these must be a config error (exit 2) AND must not emit a verdict:
+# a malformed config that reported `passed` would be the worst possible failure.
+assert_rejected() { # fixture expected-message
+  run_verify --config "$FIXTURES/$1" --cwd "$repo" --base-ref "$BASE_BRANCH"
+  assert_eq "reject $1: exit code is 2" "2" "$RC"
+  assert_has "reject $1: explains why" "$ERR" "$2"
+  assert_lacks "reject $1: emits no verdict" "$OUT" "RESULT"
+}
+
+assert_rejected bad-version.yaml "version must be 1"
+assert_rejected bad-no-version.yaml "missing top-level"
+assert_rejected bad-duplicate-id.yaml "duplicate gate id: a"
+assert_rejected bad-reserved-id.yaml "gate id is reserved: work-evidence"
+assert_rejected bad-invalid-id.yaml "invalid gate id: Lint_Gate"
+assert_rejected bad-timeout-range.yaml "timeoutSec must be 1..7200"
+assert_rejected bad-timeout-type.yaml "timeoutSec must be an integer"
+assert_rejected bad-missing-command.yaml "gate is missing command:"
+assert_rejected bad-missing-id.yaml "gate is missing id:"
+assert_rejected bad-gate-key.yaml "unknown gate key: retries"
+assert_rejected bad-option-key.yaml "unknown options key: parallel"
+assert_rejected bad-option-value.yaml "skipInPrimaryCheckout must be true or false"
+assert_rejected bad-flow.yaml "flow-style values are not supported"
+assert_rejected bad-anchor.yaml "anchors/aliases are not supported"
+assert_rejected bad-block-scalar.yaml "block scalars are not supported"
+assert_rejected bad-indent.yaml "indentation must be a multiple of 2 spaces"
+assert_rejected bad-tab.yaml "tab characters are not allowed"
+assert_rejected bad-no-gates.yaml "no gates are defined"
+
+# --- summary ------------------------------------------------------------------
+total=$((TOTAL_PASS + TOTAL_FAIL))
+echo "# tests: $TOTAL_PASS passed, $TOTAL_FAIL failed"
+if [ "$total" -lt "$MIN_ASSERTIONS" ]; then
+  echo "not ok - suite ran only $total assertions (expected at least $MIN_ASSERTIONS)"
+  exit 1
+fi
+[ "$TOTAL_FAIL" -eq 0 ] || exit 1
+exit 0

--- a/.agents/skills/cmate-verify/scripts/verify-run.sh
+++ b/.agents/skills/cmate-verify/scripts/verify-run.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# cmate-verify / verify-run — run the gates declared in .commandmate/verify.yaml
+# and judge each one by its REAL exit code.
+#
+# Usage:
+#   verify-run.sh [--config <path>] [--cwd <worktree-path>] [--base-ref <ref>]
+#                 [--gates id1,id2] [--skip-work-evidence]
+#
+# stdout is machine-readable, one line per gate plus a final verdict:
+#   GATE work-evidence PASS commits=3 uncommitted=2
+#   GATE lint PASS exit=0 duration=12s
+#   GATE unit FAIL exit=1 duration=45s
+#   RESULT failed
+# Failing output tails and diagnostics go to stderr so stdout stays parseable.
+#
+# Exit code: passed=0 / config error=2 / failed=20 / not_started=21 / skipped=22.
+#
+# Never decide pass/fail by grepping a command's output: `cmd | grep ...` hands $?
+# to grep and hides a non-zero exit — vitest can print "Tests 100 passed" and still
+# exit 1 on an Unhandled Rejection. Each gate is run as `sh -c "$cmd" > log 2>&1`
+# and `$?` is read directly (same discipline as orchestrate-monitor/quality-gate.sh).
+#
+# bash 3.2 compatible on purpose (macOS ships /bin/bash 3.2.57): no `declare -A`,
+# no `mapfile`/`readarray`, no `${var,,}`. macOS also has no timeout(1), so the
+# per-gate timeout is a watchdog subshell over a job-controlled process group.
+set -u
+
+TAB=$(printf '\t')
+
+EXIT_PASSED=0
+EXIT_CONFIG=2
+EXIT_FAILED=20
+EXIT_NOT_STARTED=21
+EXIT_SKIPPED=22
+
+DEFAULT_TIMEOUT_SEC=600
+MAX_TIMEOUT_SEC=7200
+DEFAULT_MAX_LOG_TAIL_BYTES=8192
+MAX_LOG_TAIL_BYTES_LIMIT=1048576
+# Grace period between SIGTERM and SIGKILL for a timed-out gate.
+KILL_GRACE_SEC=5
+
+CONFIG=""
+CWD=""
+BASE_REF_OPT=""
+GATES_OPT=""
+SKIP_WORK_EVIDENCE=0
+
+usage() {
+  sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die_config() {
+  echo "verify-run: $1" >&2
+  exit "$EXIT_CONFIG"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --config) shift; CONFIG=${1:-}; [ -n "$CONFIG" ] || die_config "--config requires a path";;
+    --cwd) shift; CWD=${1:-}; [ -n "$CWD" ] || die_config "--cwd requires a path";;
+    --base-ref) shift; BASE_REF_OPT=${1:-}; [ -n "$BASE_REF_OPT" ] || die_config "--base-ref requires a ref";;
+    --gates) shift; GATES_OPT=${1:-}; [ -n "$GATES_OPT" ] || die_config "--gates requires a comma-separated list";;
+    --skip-work-evidence) SKIP_WORK_EVIDENCE=1;;
+    -h|--help) usage; exit 0;;
+    *) die_config "unknown argument: $1";;
+  esac
+  shift
+done
+
+if [ -z "$CWD" ]; then CWD=$PWD; fi
+[ -d "$CWD" ] || die_config "--cwd is not a directory: $CWD"
+CWD=$(cd "$CWD" && pwd)
+
+if [ -z "$CONFIG" ]; then CONFIG="$CWD/.commandmate/verify.yaml"; fi
+[ -f "$CONFIG" ] || die_config "config file not found: $CONFIG"
+
+TMPBASE=${TMPDIR:-/tmp}
+TMPBASE=${TMPBASE%/}
+WORKDIR=$(mktemp -d "$TMPBASE/cmate-verify.XXXXXX") || die_config "cannot create a temporary directory under $TMPBASE"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- YAML subset parser -------------------------------------------------------
+# Emits one TSV record per parsed item; the free-form field (a gate command) is
+# always last so `read -r kind a b rest` cannot split it. Anything the bash subset
+# forbids becomes an ERR record instead of a best-effort guess.
+AWK_PARSER='
+function err(msg) { printf "ERR\tline %d: %s\n", NR, msg }
+function trim(s) { sub(/^[ ]+/, "", s); sub(/[ ]+$/, "", s); return s }
+function unquote(s,   q) {
+  if (length(s) >= 2) {
+    q = substr(s, 1, 1)
+    if ((q == "\"" || q == SQ) && substr(s, length(s), 1) == q)
+      return substr(s, 2, length(s) - 2)
+  }
+  return s
+}
+function splitkv(s) {
+  KV_I = index(s, ":")
+  if (KV_I == 0) return 0
+  KV_K = trim(substr(s, 1, KV_I - 1))
+  KV_V = trim(substr(s, KV_I + 1))
+  if (KV_K !~ /^[A-Za-z][A-Za-z0-9]*$/) return 0
+  return 1
+}
+function checkvalue(key, v,   c) {
+  if (v == "") { err(key ": has an empty value"); return 0 }
+  c = substr(v, 1, 1)
+  if (c == "&" || c == "*") { err(key ": YAML anchors/aliases are not supported"); return 0 }
+  if (c == "[" || c == "{") { err(key ": flow-style values are not supported"); return 0 }
+  if (v ~ /^[|>][-+0-9]*$/) { err(key ": block scalars are not supported"); return 0 }
+  return 1
+}
+function gatekv(s) {
+  if (!splitkv(s)) { err("expected \"key: value\" inside a gate"); return }
+  if (!checkvalue(KV_K, KV_V)) return
+  if (KV_K == "id") {
+    if (gid != "") { err("duplicate id: in one gate"); return }
+    gid = unquote(KV_V)
+  } else if (KV_K == "command") {
+    if (gcmd != "") { err("duplicate command: in one gate"); return }
+    gcmd = unquote(KV_V)
+  } else if (KV_K == "timeoutSec") {
+    if (gto != "") { err("duplicate timeoutSec: in one gate"); return }
+    gto = unquote(KV_V)
+  } else {
+    err("unknown gate key: " KV_K)
+  }
+}
+function flushgate() {
+  if (!gate_open) return
+  if (gid == "") err("gate is missing id:")
+  if (gcmd == "") err("gate is missing command:")
+  if (gid != "" && gcmd != "") {
+    printf "GATE\t%s\t%s\t%s\n", gid, (gto == "" ? "-" : gto), gcmd
+    ngates++
+  }
+  gid = ""; gcmd = ""; gto = ""; gate_open = 0
+}
+BEGIN { SQ = sprintf("%c", 39); section = ""; gate_open = 0; ngates = 0; nversion = 0 }
+{
+  line = $0
+  sub(/\r$/, "", line)
+  if (index(line, "\t") > 0) { err("tab characters are not allowed"); next }
+  if (line ~ /^[ ]*$/) next
+  if (line ~ /^[ ]*#/) next
+  match(line, /^ */)
+  ind = RLENGTH
+  if (ind % 2 != 0) { err("indentation must be a multiple of 2 spaces"); next }
+  body = substr(line, ind + 1)
+
+  if (ind == 0) {
+    flushgate()
+    if (!splitkv(body)) { err("expected \"key: value\" at the top level"); next }
+    if (KV_K == "version") {
+      nversion++
+      if (nversion > 1) err("duplicate top-level version:")
+      else if (unquote(KV_V) != "1") err("version must be 1 (got: " KV_V ")")
+      section = ""
+    } else if (KV_K == "gates") {
+      if (KV_V != "") err("gates: must be followed by an indented list")
+      section = "gates"
+    } else if (KV_K == "options") {
+      if (KV_V != "") err("options: must be followed by indented keys")
+      section = "options"
+    } else {
+      err("unknown top-level key: " KV_K)
+    }
+    next
+  }
+
+  if (ind == 2) {
+    if (section == "gates") {
+      if (substr(body, 1, 2) != "- ") { err("gate list items must start with \"- \""); next }
+      flushgate()
+      gate_open = 1
+      gatekv(trim(substr(body, 3)))
+      next
+    }
+    if (section == "options") {
+      if (!splitkv(body)) { err("expected \"key: value\" inside options:"); next }
+      if (!checkvalue(KV_K, KV_V)) next
+      if (KV_K == "baseRef" || KV_K == "skipInPrimaryCheckout" || KV_K == "maxLogTailBytes")
+        printf "OPT\t%s\t%s\n", KV_K, unquote(KV_V)
+      else
+        err("unknown options key: " KV_K)
+      next
+    }
+    err("indented line outside of gates: / options:")
+    next
+  }
+
+  if (ind == 4 && section == "gates") {
+    if (!gate_open) { err("gate field outside of a list item"); next }
+    gatekv(body)
+    next
+  }
+
+  err("unexpected indentation (" ind " spaces)")
+}
+END {
+  flushgate()
+  if (nversion == 0) printf "ERR\tmissing top-level \"version: 1\"\n"
+  if (ngates == 0) printf "ERR\tno gates are defined\n"
+}
+'
+
+PARSED="$WORKDIR/parsed.tsv"
+awk "$AWK_PARSER" "$CONFIG" > "$PARSED" || die_config "failed to read $CONFIG"
+
+if grep -q "^ERR$TAB" "$PARSED"; then
+  echo "verify-run: invalid config: $CONFIG" >&2
+  sed -n "s/^ERR$TAB/  - /p" "$PARSED" >&2
+  exit "$EXIT_CONFIG"
+fi
+
+GATE_IDS=()
+GATE_TOS=()
+GATE_CMDS=()
+OPT_BASE_REF=""
+OPT_SKIP_PRIMARY="true"
+OPT_MAX_TAIL="$DEFAULT_MAX_LOG_TAIL_BYTES"
+
+while IFS="$TAB" read -r kind a b rest; do
+  case "$kind" in
+    GATE)
+      GATE_IDS+=("$a")
+      GATE_TOS+=("$b")
+      GATE_CMDS+=("$rest")
+      ;;
+    OPT)
+      case "$a" in
+        baseRef) OPT_BASE_REF=$b;;
+        skipInPrimaryCheckout) OPT_SKIP_PRIMARY=$b;;
+        maxLogTailBytes) OPT_MAX_TAIL=$b;;
+      esac
+      ;;
+  esac
+done < "$PARSED"
+
+case "$OPT_SKIP_PRIMARY" in
+  true|false) ;;
+  *) die_config "options.skipInPrimaryCheckout must be true or false (got: $OPT_SKIP_PRIMARY)";;
+esac
+case "$OPT_MAX_TAIL" in
+  ''|*[!0-9]*) die_config "options.maxLogTailBytes must be an integer (got: $OPT_MAX_TAIL)";;
+esac
+if [ "$OPT_MAX_TAIL" -gt "$MAX_LOG_TAIL_BYTES_LIMIT" ]; then
+  die_config "options.maxLogTailBytes must be 0..$MAX_LOG_TAIL_BYTES_LIMIT (got: $OPT_MAX_TAIL)"
+fi
+
+GATE_ID_RE='^[a-z0-9][a-z0-9-]{0,31}$'
+SEEN_IDS="$WORKDIR/seen-ids"
+: > "$SEEN_IDS"
+gate_count=${#GATE_IDS[@]}
+i=0
+while [ "$i" -lt "$gate_count" ]; do
+  vid=${GATE_IDS[$i]}
+  case "$vid" in
+    work-evidence|scope) die_config "gate id is reserved: $vid";;
+  esac
+  [[ $vid =~ $GATE_ID_RE ]] || die_config "invalid gate id: $vid (must match $GATE_ID_RE)"
+  if grep -Fxq "$vid" "$SEEN_IDS"; then die_config "duplicate gate id: $vid"; fi
+  printf '%s\n' "$vid" >> "$SEEN_IDS"
+
+  vto=${GATE_TOS[$i]}
+  if [ "$vto" = "-" ]; then vto=$DEFAULT_TIMEOUT_SEC; fi
+  case "$vto" in
+    ''|*[!0-9]*) die_config "timeoutSec must be an integer (gate $vid, got: $vto)";;
+  esac
+  if [ "$vto" -lt 1 ] || [ "$vto" -gt "$MAX_TIMEOUT_SEC" ]; then
+    die_config "timeoutSec must be 1..$MAX_TIMEOUT_SEC (gate $vid, got: $vto)"
+  fi
+  GATE_TOS[$i]=$vto
+  i=$((i + 1))
+done
+
+SELECTED="$WORKDIR/selected-ids"
+: > "$SELECTED"
+if [ -n "$GATES_OPT" ]; then
+  printf '%s\n' "$GATES_OPT" | tr ',' '\n' | sed 's/^ *//; s/ *$//' | grep -v '^$' > "$SELECTED"
+  [ -s "$SELECTED" ] || die_config "--gates selects no gate"
+  # An unknown id here would silently run nothing and report `passed`.
+  while read -r want; do
+    grep -Fxq "$want" "$SEEN_IDS" || die_config "--gates refers to an unknown gate id: $want"
+  done < "$SELECTED"
+fi
+
+# --- git context --------------------------------------------------------------
+git_in() { git -C "$CWD" "$@"; }
+
+git_in rev-parse --git-dir >/dev/null 2>&1 || die_config "not a git repository: $CWD"
+
+BASE_REF=$BASE_REF_OPT
+[ -n "$BASE_REF" ] || BASE_REF=$OPT_BASE_REF
+if [ -z "$BASE_REF" ]; then
+  BASE_REF=$(git_in symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || BASE_REF=""
+fi
+[ -n "$BASE_REF" ] || die_config "cannot determine baseRef: set options.baseRef or pass --base-ref (refs/remotes/origin/HEAD is unset)"
+git_in rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1 \
+  || die_config "baseRef does not resolve to a commit: $BASE_REF"
+
+# --- work-evidence ------------------------------------------------------------
+if [ "$SKIP_WORK_EVIDENCE" -eq 1 ]; then
+  echo "GATE work-evidence SKIP reason=flag"
+else
+  merge_base=$(git_in merge-base "$BASE_REF" HEAD 2>/dev/null) \
+    || die_config "cannot compute merge-base($BASE_REF, HEAD)"
+  commits=$(git_in rev-list --count "$merge_base..HEAD" 2>/dev/null) \
+    || die_config "cannot count commits since $BASE_REF"
+  git_in status --porcelain > "$WORKDIR/status.txt" 2>/dev/null \
+    || die_config "git status failed in $CWD"
+  uncommitted=$(wc -l < "$WORKDIR/status.txt" | tr -d ' ')
+  if [ "$commits" -gt 0 ] || [ "$uncommitted" -gt 0 ]; then
+    echo "GATE work-evidence PASS commits=$commits uncommitted=$uncommitted"
+  else
+    echo "GATE work-evidence FAIL commits=$commits uncommitted=$uncommitted"
+    echo "RESULT not_started"
+    exit "$EXIT_NOT_STARTED"
+  fi
+fi
+
+# A linked worktree has its own git dir under <common>/worktrees/<name>; the
+# primary checkout is the one where they are the same path. Both sides are
+# resolved with `pwd -P`: on macOS $TMPDIR lives under the /var -> /private/var
+# symlink, and comparing a logical path against a physical one makes every
+# checkout look linked (i.e. silently disables the primary-checkout guard).
+resolve_dir() { ( cd "$CWD" && cd "$1" 2>/dev/null && pwd -P ); }
+git_dir=$(git_in rev-parse --git-dir 2>/dev/null) || die_config "cannot resolve the git directory of $CWD"
+common_git_dir=$(git_in rev-parse --git-common-dir 2>/dev/null) || die_config "cannot resolve the common git directory of $CWD"
+abs_git_dir=$(resolve_dir "$git_dir")
+abs_common_git_dir=$(resolve_dir "$common_git_dir")
+is_primary=0
+if [ -n "$abs_git_dir" ] && [ "$abs_git_dir" = "$abs_common_git_dir" ]; then
+  is_primary=1
+fi
+
+# --- gate execution -----------------------------------------------------------
+emit_log_tail() {
+  el_id=$1
+  el_status=$2
+  el_log=$3
+  [ "$OPT_MAX_TAIL" -gt 0 ] || return 0
+  [ -s "$el_log" ] || return 0
+  echo "--- gate $el_id ($el_status): last $OPT_MAX_TAIL bytes ---" >&2
+  tail -c "$OPT_MAX_TAIL" "$el_log" >&2
+  echo "--- end gate $el_id ---" >&2
+}
+
+any_failed=0
+gates_ran=0
+
+run_gate() {
+  rg_id=$1
+  rg_cmd=$2
+  rg_to=$3
+  rg_log="$WORKDIR/gate-$rg_id.log"
+  rg_mark="$WORKDIR/gate-$rg_id.timedout"
+  rm -f "$rg_mark"
+  rg_start=$(date +%s)
+
+  # `set -m` puts the gate in its own process group so the watchdog can kill the
+  # whole tree. Without it, `npm run x` dies but the node/sleep children it forked
+  # survive the timeout (measured: 2 orphans left behind).
+  set -m
+  ( cd "$CWD" && exec /bin/sh -c "$rg_cmd" ) > "$rg_log" 2>&1 &
+  rg_pid=$!
+  set +m
+
+  # `kill -TERM -N` signals whatever process group has id N. If job control could
+  # not be enabled, the gate stays in this shell's group and N is just a pid —
+  # then the group with that id belongs to some unrelated process tree, and
+  # signalling it blindly would kill a bystander. So confirm the gate really is
+  # its own group leader before using the group form.
+  rg_pgid=$(ps -o pgid= -p "$rg_pid" 2>/dev/null | tr -d ' ')
+  if [ "$rg_pgid" = "$rg_pid" ]; then rg_target="-$rg_pid"; else rg_target="$rg_pid"; fi
+
+  ( sleep "$rg_to"
+    : > "$rg_mark"
+    kill -s TERM -- "$rg_target" 2>/dev/null
+    sleep "$KILL_GRACE_SEC"
+    kill -s KILL -- "$rg_target" 2>/dev/null
+  ) >/dev/null 2>&1 &
+  rg_wpid=$!
+
+  # 2>/dev/null suppresses the shell job-control "Terminated" notice.
+  wait "$rg_pid" 2>/dev/null
+  rg_code=$?
+  kill -TERM "$rg_wpid" 2>/dev/null
+  wait "$rg_wpid" 2>/dev/null
+
+  rg_dur=$(( $(date +%s) - rg_start ))
+  gates_ran=$((gates_ran + 1))
+
+  if [ -f "$rg_mark" ]; then
+    echo "GATE $rg_id TIMEOUT exit=124 duration=${rg_dur}s"
+    any_failed=1
+    emit_log_tail "$rg_id" "TIMEOUT after ${rg_to}s" "$rg_log"
+  elif [ "$rg_code" -eq 0 ]; then
+    echo "GATE $rg_id PASS exit=0 duration=${rg_dur}s"
+  else
+    echo "GATE $rg_id FAIL exit=$rg_code duration=${rg_dur}s"
+    any_failed=1
+    emit_log_tail "$rg_id" "FAIL exit=$rg_code" "$rg_log"
+  fi
+}
+
+i=0
+while [ "$i" -lt "$gate_count" ]; do
+  cur_id=${GATE_IDS[$i]}
+  cur_to=${GATE_TOS[$i]}
+  cur_cmd=${GATE_CMDS[$i]}
+  i=$((i + 1))
+
+  if [ -s "$SELECTED" ] && ! grep -Fxq "$cur_id" "$SELECTED"; then
+    continue
+  fi
+  if [ "$is_primary" -eq 1 ] && [ "$OPT_SKIP_PRIMARY" = "true" ]; then
+    echo "GATE $cur_id SKIP reason=primary-checkout"
+    continue
+  fi
+  # Every gate runs even after one fails, so a single run reports every finding.
+  run_gate "$cur_id" "$cur_cmd" "$cur_to"
+done
+
+if [ "$gates_ran" -eq 0 ]; then
+  echo "RESULT skipped"
+  exit "$EXIT_SKIPPED"
+fi
+if [ "$any_failed" -ne 0 ]; then
+  echo "RESULT failed"
+  exit "$EXIT_FAILED"
+fi
+echo "RESULT passed"
+exit "$EXIT_PASSED"

--- a/.claude/skills/cmate-verify/SKILL.md
+++ b/.claude/skills/cmate-verify/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: cmate-verify
+description: リポジトリの検証ゲート（lint / typecheck / test / build 等）を .commandmate/verify.yaml に宣言し、worktree の cwd で逐次実行して exit code で合否を判定する。verify.yaml が無いリポジトリでは CI 定義から起案する。作業完了を主張する前の検証や、並列ワーカーの完了判定に使う。
+allowed-tools: Bash(.claude/skills/cmate-verify/scripts/*), Bash(.agents/skills/cmate-verify/scripts/*), Bash(git worktree list), Read, Write, Glob, Grep
+---
+
+# cmate-verify
+
+「このリポジトリで何が通れば合格か」を `.commandmate/verify.yaml` に宣言し、
+**実 exit code で** 判定するランナー。CommandMate の検証ゲート機能（Phase 1 以降）の
+設定形式 v1 を、製品実装より先に実地検証するための先行 Skill である。
+
+正準仕様は CommandMate リポジトリの [`docs/design/verification-config.md`](../../../docs/design/verification-config.md)。
+Phase 1 の製品ローダは同じ仕様を一般的な YAML パーサで実装するので、この Skill で書いた
+verify.yaml はそのまま引き継げる。
+
+> **なぜ exit code か**: `cmd | grep ...` は `$?` を grep に渡して非ゼロ終了を隠す。vitest は
+> 全テスト緑でも Unhandled Rejection で exit 1 を出しうるので、出力を grep した要約は
+> それを PASS と報告してしまう。ゲートは必ず `sh -c "$cmd" > log 2>&1` で走らせ `$?` を直接読む。
+
+## 構成
+
+```
+cmate-verify/
+├── SKILL.md
+└── scripts/
+    ├── verify-run.sh        # ゲート実行ランナー（bash 3.2 互換）
+    └── tests/
+        ├── run-tests.sh     # fixture ベーステスト（bash + git だけで動く）
+        └── fixtures/*.yaml
+```
+
+`scripts/tests/run-tests.sh` は vitest に依存しない。Node の無い導入先でも
+`bash scripts/tests/run-tests.sh` だけで検証できる（CommandMate 本体では
+`tests/unit/skills/cmate-verify/` の薄いラッパが `npm run test:unit` から同じ suite を回す）。
+
+## 手順 1: init（`.commandmate/verify.yaml` が無い場合）
+
+**コードを書かず、リポジトリをスキャンしてゲートを起案し、ユーザーの確認を得てから書き出す。**
+検出優先順位は次のとおり。上位が見つかったら下位は補助として扱う。
+
+1. **`.github/workflows/*.yml` の CI ジョブ** — そのリポジトリにおける「何が通れば合格か」の
+   既存の定義。`run:` の各ステップが第一候補。
+2. **`package.json` の `scripts`** — `lint` / `test` / `test:unit` / `typecheck` / `build` 系。
+3. **`Makefile` のターゲット** — `make lint` / `make test` 等。
+4. **言語マニフェスト** — `Cargo.toml`（`cargo clippy` / `cargo test`）、`pyproject.toml`
+   （`ruff` / `pytest` / `mypy`）、`go.mod`（`go vet` / `go test ./...`）等。
+
+起案時の注意:
+
+- 実行時間の長いゲートには `timeoutSec` を明示する（既定は 600 秒）。
+- ゲートの並び順がそのまま実行順になる。速いゲートを先に置くと失敗が早く読める
+  （途中で失敗しても残りは実行されるので、順序は打ち切りではなく可読性のための選択）。
+- **デプロイ・publish・リリース・外形変更を伴うコマンドはゲートにしない。** ゲートは
+  何度でも安全に再実行できるものに限る。
+- 起案結果は「どこから拾ったか」（CI ジョブ名 / npm script 名）とセットで提示し、
+  **ユーザーの確認を得てから** `.commandmate/verify.yaml` を書き出す。
+
+書き出したら、その場で 1 回実行して `RESULT passed` になることまで確認する。
+
+## 手順 2: run（verify.yaml がある場合）
+
+```bash
+.claude/skills/cmate-verify/scripts/verify-run.sh --cwd <worktree-path>
+```
+
+主なオプション:
+
+| オプション | 意味 |
+|---|---|
+| `--config <path>` | 既定は `<cwd>/.commandmate/verify.yaml` |
+| `--cwd <path>` | ゲートを実行する worktree。既定はカレントディレクトリ |
+| `--base-ref <ref>` | work-evidence の基準。`options.baseRef` より優先 |
+| `--gates id1,id2` | 一部のゲートだけ実行する。存在しない id は設定エラー |
+| `--skip-work-evidence` | 未着手ガードを飛ばす |
+
+出力は stdout に 1 ゲート 1 行、最終行が判定:
+
+```
+GATE work-evidence PASS commits=3 uncommitted=2
+GATE lint PASS exit=0 duration=12s
+GATE unit FAIL exit=1 duration=45s
+RESULT failed
+```
+
+失敗ゲートのログ末尾は **stderr** に出る（stdout をパース可能に保つため）。
+
+| RESULT | exit code | 意味 |
+|---|---|---|
+| `passed` | 0 | 実行した全ゲートが PASS |
+| — | 2 | 設定エラー（verify.yaml 不正 / ファイル無し / git でない cwd 等） |
+| `failed` | 20 | 1 つ以上のゲートが FAIL または TIMEOUT |
+| `not_started` | 21 | work-evidence が「作業の痕跡ゼロ」と判定（コマンド系ゲートは走らない） |
+| `skipped` | 22 | 実行したコマンド系ゲートが 0 件（メイン checkout での skip） |
+
+**`skipped` を `passed` と読まないこと。** 何も検証していない状態であり、緑ではない。
+
+## verify.yaml の書き方
+
+```yaml
+# .commandmate/verify.yaml — v1
+version: 1
+gates:
+  - id: lint
+    command: "npm run lint"
+    timeoutSec: 600
+  - id: typecheck
+    command: "npx tsc --noEmit"
+  - id: unit
+    command: "npm run test:unit"
+    timeoutSec: 1800
+options:
+  baseRef: origin/develop
+  skipInPrimaryCheckout: true
+  maxLogTailBytes: 8192
+```
+
+このランナーは awk / sed で読むため、**YAML のサブセットしか受け付けない**:
+
+- インデントは 2 スペース固定（タブは不可）
+- 値は 1 行スカラーのみ。アンカー / エイリアス（`&` `*`）・複数行文字列（`|` `>`）・
+  フロースタイル（`[...]` `{...}`）は拒否する
+- 行内コメントは無し。`#` で始まる行のみコメント
+- `key:` の**最初のコロン**で分割するので、値の中のコロンはそのまま書ける
+
+**制約に反する verify.yaml は「best-effort で解釈」せず exit 2 で拒否する。**
+黙って一部を読み飛ばすと「設定したつもりのゲートが走っていないのに passed」になるため。
+Phase 1 の製品ローダは一般的な YAML パーサを使うが、この形式で書いておけば両方で読める。
+
+各フィールドの型・既定値・範囲は `docs/design/verification-config.md` の仕様表が正準。
+
+## 組み込みゲート work-evidence
+
+コマンド系ゲートより先に、**そもそも作業が行われたか**を判定する。
+
+- PASS 条件: `merge-base(baseRef, HEAD)..HEAD` のコミット数 > 0 **または**
+  `git status --porcelain` が非空
+- 両方 0 なら `RESULT not_started` (exit 21)。コマンド系ゲートは 1 つも実行しない
+
+未起動のセッションを「全ゲート PASS」と誤報告しないためのガードである
+（変更ゼロのリポジトリでは lint も typecheck も当然通る）。
+
+## メイン checkout での skip
+
+`options.skipInPrimaryCheckout`（既定 `true`）が有効なとき、**プライマリ checkout では
+コマンド系ゲートを実行しない**。プライマリ checkout は稼働中サーバの cwd になっている
+ことがあり、その足元で build / test を回すと動いている画面を壊す。判定は
+`git rev-parse --git-dir` と `--git-common-dir` が同じ実パスを指すかで行う。
+
+検証は linked worktree で回すこと。
+
+## テスト
+
+```bash
+bash .claude/skills/cmate-verify/scripts/tests/run-tests.sh
+# ... ok - / not ok - の行が並び、最後に
+# tests: 123 passed, 0 failed
+```
+
+fixture は `scripts/tests/fixtures/*.yaml`。カバーしているのは
+全 PASS / 1 ゲート FAIL / timeout / work-evidence の not_started / 設定ファイル無し
+の 5 ケースに加えて、対になる反証ケース（同じ設定が linked worktree では実行される、
+`--skip-work-evidence` を付ければ同じ clean repo でも実行される）と、18 種の設定エラー、
+アサーションヘルパ自身の自己検査。
+
+判定が空振りしていないことは変異注入で確認してある（`set -m` の除去 → orphan 検出が赤 /
+失敗時の打ち切り → 継続実行の assert が赤 / work-evidence の OR を AND に → 33 件赤 /
+全 skip を passed と報告 → skip 判定が赤 / プライマリ判定の無効化 → 6 件赤）。
+`MIN_ASSERTIONS` はケースが黙って落ちたときに 0 failed で緑にならないための下限である。

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/all-pass.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/all-pass.yaml
@@ -1,0 +1,11 @@
+# Every gate passes. skipInPrimaryCheckout is false because the test sandboxes
+# are created with `git init` and are therefore primary checkouts.
+version: 1
+gates:
+  - id: first
+    command: echo first-ok
+  - id: second
+    command: "true"
+    timeoutSec: 30
+options:
+  skipInPrimaryCheckout: false

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-anchor.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-anchor.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+    command: &lint echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-block-scalar.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-block-scalar.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: |
+      echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-duplicate-id.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-duplicate-id.yaml
@@ -1,0 +1,6 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+  - id: a
+    command: echo hi again

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-flow.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-flow.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+    command: [echo, hi]

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-gate-key.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-gate-key.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+    retries: 3

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-indent.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-indent.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+     command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-invalid-id.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-invalid-id.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: Lint_Gate
+    command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-missing-command.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-missing-command.yaml
@@ -1,0 +1,3 @@
+version: 1
+gates:
+  - id: a

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-missing-id.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-missing-id.yaml
@@ -1,0 +1,3 @@
+version: 1
+gates:
+  - command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-no-gates.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-no-gates.yaml
@@ -1,0 +1,3 @@
+version: 1
+options:
+  baseRef: origin/main

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-no-version.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-no-version.yaml
@@ -1,0 +1,3 @@
+gates:
+  - id: a
+    command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-option-key.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-option-key.yaml
@@ -1,0 +1,6 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+options:
+  parallel: true

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-option-value.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-option-value.yaml
@@ -1,0 +1,6 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+options:
+  skipInPrimaryCheckout: maybe

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-reserved-id.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-reserved-id.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: work-evidence
+    command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-tab.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-tab.yaml
@@ -1,0 +1,4 @@
+version: 1
+gates:
+  - id: a
+	command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-range.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-range.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+    timeoutSec: 99999

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-type.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-timeout-type.yaml
@@ -1,0 +1,5 @@
+version: 1
+gates:
+  - id: a
+    command: echo hi
+    timeoutSec: ten

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-version.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/bad-version.yaml
@@ -1,0 +1,4 @@
+version: 2
+gates:
+  - id: a
+    command: echo hi

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/default-options.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/default-options.yaml
@@ -1,0 +1,5 @@
+# No options: block at all, so every default applies (skipInPrimaryCheckout=true).
+version: 1
+gates:
+  - id: sidefx
+    command: touch "$CMATE_VERIFY_TEST_MARKER"

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/one-fail.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/one-fail.yaml
@@ -1,0 +1,13 @@
+# The middle gate prints a green-looking summary and exits non-zero: the exact
+# shape that a grep-based verdict would call PASS. `after` proves that the run
+# continues past a failure so one invocation reports every finding.
+version: 1
+gates:
+  - id: ok
+    command: echo fine
+  - id: broken
+    command: echo "Tests 100 passed"; exit 3
+  - id: after
+    command: echo ran-after-failure
+options:
+  skipInPrimaryCheckout: false

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/parsing.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/parsing.yaml
@@ -1,0 +1,14 @@
+# Comments, blank lines, quoted and unquoted scalars, and values that contain
+# a colon and a hash.
+
+version: 1
+
+gates:
+  # only the first colon separates key from value
+  - id: quoted
+    command: "echo hash:# and colon"
+  - id: unquoted
+    command: sh -c "echo a:b"
+options:
+  skipInPrimaryCheckout: false
+  maxLogTailBytes: 4096

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/side-effect.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/side-effect.yaml
@@ -1,0 +1,7 @@
+# Single observable gate: the marker file is the evidence that gates really ran.
+version: 1
+gates:
+  - id: sidefx
+    command: touch "$CMATE_VERIFY_TEST_MARKER"
+options:
+  skipInPrimaryCheckout: false

--- a/.claude/skills/cmate-verify/scripts/tests/fixtures/timeout.yaml
+++ b/.claude/skills/cmate-verify/scripts/tests/fixtures/timeout.yaml
@@ -1,0 +1,13 @@
+# `slow` outlives its timeout. It backgrounds a child that carries a per-run
+# token in its argv before blocking, so killing only the direct child would
+# leave that token visible in `ps`: the orphan probe in run-tests.sh is what
+# makes the process-group kill testable. The marker would only appear at +4144s.
+version: 1
+gates:
+  - id: slow
+    command: sh -c "sleep 4143; : cmate-verify-orphan-probe $CMATE_VERIFY_TEST_MARKER" & sleep 4144; touch "$CMATE_VERIFY_TEST_MARKER"
+    timeoutSec: 1
+  - id: after
+    command: echo ran-after-timeout
+options:
+  skipInPrimaryCheckout: false

--- a/.claude/skills/cmate-verify/scripts/tests/run-tests.sh
+++ b/.claude/skills/cmate-verify/scripts/tests/run-tests.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# cmate-verify — fixture-based test suite for verify-run.sh.
+#
+# Self-contained on purpose: the skill is distributed to repositories that have
+# no vitest (and no Node), so the suite must run with nothing but bash + git.
+# `tests/unit/skills/cmate-verify/verify-run.test.ts` is a thin wrapper that runs
+# this file so the same assertions also gate `npm run test:unit`.
+#
+# Output is TAP-ish (`ok - ...` / `not ok - ...`) plus a final
+# `# tests: N passed, M failed`. Exit 0 only when M is 0 and enough assertions ran.
+#
+# bash 3.2 compatible: no `declare -A`, no `mapfile`, no `${var,,}`.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+RUNNER="$SCRIPT_DIR/../verify-run.sh"
+FIXTURES="$SCRIPT_DIR/fixtures"
+BASE_BRANCH="cmate-verify-base"
+
+# Floor on the assertion count. A suite that silently stops running cases would
+# otherwise exit 0 with "0 failed" — the same empty-glob trap the orchestrate-monitor
+# syntax test guards against.
+MIN_ASSERTIONS=100
+
+[ -f "$RUNNER" ] || { echo "run-tests: runner not found: $RUNNER" >&2; exit 2; }
+[ -d "$FIXTURES" ] || { echo "run-tests: fixtures not found: $FIXTURES" >&2; exit 2; }
+
+TMPBASE=${TMPDIR:-/tmp}
+TMPBASE=${TMPBASE%/}
+SANDBOX=$(mktemp -d "$TMPBASE/cmate-verify-tests.XXXXXX") || exit 2
+trap 'rm -rf "$SANDBOX"' EXIT
+
+TOTAL_PASS=0
+TOTAL_FAIL=0
+RUN_SEQ=0
+RC=0
+OUT=""
+ERR=""
+
+ok() { TOTAL_PASS=$((TOTAL_PASS + 1)); echo "ok - $1"; }
+notok() { TOTAL_FAIL=$((TOTAL_FAIL + 1)); echo "not ok - $1"; }
+
+assert_eq() { # name expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else notok "$1 (expected [$2], got [$3])"; fi
+}
+# -e is mandatory: a needle that starts with "--" (e.g. "--cwd is not a directory")
+# is otherwise parsed by grep as an option and silently never matches.
+assert_has() { # name file needle
+  if grep -Fq -e "$3" "$2"; then ok "$1"; else notok "$1 (not found in $2: $3)"; fi
+}
+assert_lacks() { # name file needle
+  if grep -Fq -e "$3" "$2"; then notok "$1 (unexpectedly found in $2: $3)"; else ok "$1"; fi
+}
+assert_file_present() { # name path
+  if [ -e "$2" ]; then ok "$1"; else notok "$1 (missing: $2)"; fi
+}
+assert_file_absent() { # name path
+  if [ -e "$2" ]; then notok "$1 (unexpectedly exists: $2)"; else ok "$1"; fi
+}
+assert_le() { # name actual limit
+  if [ "$2" -le "$3" ]; then ok "$1"; else notok "$1 ($2 > $3)"; fi
+}
+
+count_procs() { # pattern -> number of live processes whose argv contains it
+  ps -A -o args= 2>/dev/null | grep -F -e "$1" | grep -v grep | wc -l | tr -d ' '
+}
+
+# Polls instead of sleeping a fixed time: it removes the kill/probe race without
+# weakening the assertion, because a surviving orphan lives far longer than the
+# poll window.
+wait_for_no_procs() { # pattern seconds -> final count
+  wp_left=$2
+  while [ "$wp_left" -gt 0 ]; do
+    wp_n=$(count_procs "$1")
+    [ "$wp_n" -eq 0 ] && break
+    sleep 1
+    wp_left=$((wp_left - 1))
+  done
+  count_procs "$1"
+}
+
+run_verify() { # sets RC / OUT / ERR
+  RUN_SEQ=$((RUN_SEQ + 1))
+  OUT="$SANDBOX/out.$RUN_SEQ"
+  ERR="$SANDBOX/err.$RUN_SEQ"
+  bash "$RUNNER" "$@" > "$OUT" 2> "$ERR"
+  RC=$?
+}
+
+# new_repo <name> — a primary checkout whose HEAD equals $BASE_BRANCH.
+new_repo() {
+  nr_dir="$SANDBOX/$1"
+  mkdir -p "$nr_dir"
+  git init -q --template= "$nr_dir" >/dev/null 2>&1
+  git -C "$nr_dir" config user.email "test@example.invalid"
+  git -C "$nr_dir" config user.name "cmate-verify test"
+  git -C "$nr_dir" config commit.gpgsign false
+  git -C "$nr_dir" commit -q --allow-empty -m base
+  git -C "$nr_dir" branch -f "$BASE_BRANCH"
+  echo "$nr_dir"
+}
+
+new_marker() {
+  RUN_SEQ=$((RUN_SEQ + 1))
+  echo "$SANDBOX/marker.$RUN_SEQ"
+}
+
+echo "# cmate-verify fixture suite"
+
+# --- 0. harness self-check ----------------------------------------------------
+# Every assertion below is only worth its green if a wrong expectation is really
+# recorded as a failure. Each probe runs in a subshell so its counter mutations
+# do not leak into the real totals.
+probe=$(TOTAL_FAIL=0; assert_eq p a b >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_eq counts a mismatch as a failure" "1" "$probe"
+probe=$(TOTAL_PASS=0; assert_eq p a a >/dev/null; echo "$TOTAL_PASS")
+assert_eq "harness: assert_eq counts a match as a pass" "1" "$probe"
+echo "needle" > "$SANDBOX/probe.txt"
+probe=$(TOTAL_FAIL=0; assert_has p "$SANDBOX/probe.txt" "absent-string" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_has counts a missing needle as a failure" "1" "$probe"
+probe=$(TOTAL_FAIL=0; assert_lacks p "$SANDBOX/probe.txt" "needle" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_lacks counts a present needle as a failure" "1" "$probe"
+probe=$(TOTAL_FAIL=0; assert_file_absent p "$SANDBOX/probe.txt" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_file_absent counts an existing file as a failure" "1" "$probe"
+probe=$(TOTAL_FAIL=0; assert_file_present p "$SANDBOX/no-such-file" >/dev/null; echo "$TOTAL_FAIL")
+assert_eq "harness: assert_file_present counts a missing file as a failure" "1" "$probe"
+
+# --- 1. every gate passes -----------------------------------------------------
+repo=$(new_repo worked)
+git -C "$repo" commit -q --allow-empty -m work
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "all-pass: exit code is 0" "0" "$RC"
+assert_has "all-pass: work-evidence counts the commit" "$OUT" "GATE work-evidence PASS commits=1 uncommitted=0"
+assert_has "all-pass: first gate passes" "$OUT" "GATE first PASS exit=0 duration="
+assert_has "all-pass: second gate passes" "$OUT" "GATE second PASS exit=0 duration="
+assert_has "all-pass: verdict is passed" "$OUT" "RESULT passed"
+
+# --- 2. one gate fails, the rest still run ------------------------------------
+run_verify --config "$FIXTURES/one-fail.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "one-fail: exit code is 20" "20" "$RC"
+assert_has "one-fail: gate before the failure passes" "$OUT" "GATE ok PASS exit=0 duration="
+assert_has "one-fail: green-looking output with exit 3 is a FAIL" "$OUT" "GATE broken FAIL exit=3 duration="
+assert_has "one-fail: execution continues past the failure" "$OUT" "GATE after PASS exit=0 duration="
+assert_has "one-fail: verdict is failed" "$OUT" "RESULT failed"
+assert_has "one-fail: the failing gate output is reported on stderr" "$ERR" "Tests 100 passed"
+assert_lacks "one-fail: stdout stays parseable (no log tail)" "$OUT" "Tests 100 passed"
+
+# --- 3. timeout ---------------------------------------------------------------
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+export CMATE_VERIFY_TEST_MARKER
+started=$(date +%s)
+run_verify --config "$FIXTURES/timeout.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+elapsed=$(( $(date +%s) - started ))
+assert_eq "timeout: exit code is 20" "20" "$RC"
+assert_has "timeout: the slow gate is reported as TIMEOUT" "$OUT" "GATE slow TIMEOUT exit=124 duration="
+assert_has "timeout: execution continues past the timeout" "$OUT" "GATE after PASS exit=0 duration="
+assert_has "timeout: verdict is failed" "$OUT" "RESULT failed"
+# The gate would touch the marker at +4144s; the elapsed bound proves we did not
+# wait it out rather than killing it.
+assert_file_absent "timeout: the killed gate never reached its side effect" "$marker"
+assert_le "timeout: the run ends well before the gate would have finished" "$elapsed" "15"
+# The gate backgrounded a child carrying this run's marker path in its argv.
+# Killing only the direct child would leave it running for over an hour, so a
+# zero count here is what proves the whole process group was killed. The probe
+# is scoped to this run's marker so an orphan leaked by an earlier run cannot
+# fail (or mask) this one.
+orphans=$(wait_for_no_procs "cmate-verify-orphan-probe $marker" 5)
+assert_eq "timeout: no orphan survives the kill" "0" "$orphans"
+
+# --- 4. work-evidence -> not_started ------------------------------------------
+clean=$(new_repo clean)
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/side-effect.yaml" --cwd "$clean" --base-ref "$BASE_BRANCH"
+assert_eq "not_started: exit code is 21" "21" "$RC"
+assert_has "not_started: work-evidence reports zero work" "$OUT" "GATE work-evidence FAIL commits=0 uncommitted=0"
+assert_has "not_started: verdict is not_started" "$OUT" "RESULT not_started"
+assert_lacks "not_started: no command gate is reported" "$OUT" "GATE sidefx"
+assert_file_absent "not_started: no command gate is executed" "$marker"
+
+# --- 5. missing config file ---------------------------------------------------
+run_verify --config "$SANDBOX/there-is-no-such-file.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "missing-config: exit code is 2" "2" "$RC"
+assert_has "missing-config: the path is named on stderr" "$ERR" "config file not found"
+assert_lacks "missing-config: no verdict is emitted" "$OUT" "RESULT"
+
+# --- 6. work-evidence also passes on uncommitted changes ----------------------
+echo scratch > "$clean/untracked.txt"
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/side-effect.yaml" --cwd "$clean" --base-ref "$BASE_BRANCH"
+assert_eq "uncommitted: exit code is 0" "0" "$RC"
+assert_has "uncommitted: work-evidence passes on a dirty tree alone" "$OUT" "GATE work-evidence PASS commits=0 uncommitted=1"
+assert_file_present "uncommitted: the command gate ran" "$marker"
+rm -f "$clean/untracked.txt"
+
+# --- 7. --skip-work-evidence bypasses the not_started guard -------------------
+# Pairs with case 4: same repo, same config, only the flag differs. Without this
+# the not_started assertions could be passing for the wrong reason.
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/side-effect.yaml" --cwd "$clean" --base-ref "$BASE_BRANCH" --skip-work-evidence
+assert_eq "skip-work-evidence: exit code is 0" "0" "$RC"
+assert_has "skip-work-evidence: the gate is reported as skipped" "$OUT" "GATE work-evidence SKIP reason=flag"
+assert_has "skip-work-evidence: verdict is passed" "$OUT" "RESULT passed"
+assert_file_present "skip-work-evidence: the command gate ran" "$marker"
+
+# --- 8. primary checkout is skipped by default --------------------------------
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/default-options.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "primary-checkout: exit code is 22" "22" "$RC"
+assert_has "primary-checkout: the gate is skipped" "$OUT" "GATE sidefx SKIP reason=primary-checkout"
+assert_has "primary-checkout: verdict is skipped, not passed" "$OUT" "RESULT skipped"
+assert_lacks "primary-checkout: an all-skipped run is never reported as passed" "$OUT" "RESULT passed"
+assert_file_absent "primary-checkout: no command runs in the primary checkout" "$marker"
+
+# --- 9. the same config runs in a linked worktree ------------------------------
+# Pairs with case 8: identical fixture, identical defaults, only the checkout kind
+# differs — so case 8 cannot be green because of a broken config.
+linked="$SANDBOX/linked"
+git -C "$repo" worktree add -q "$linked" -b cmate-verify-linked >/dev/null 2>&1
+marker=$(new_marker)
+CMATE_VERIFY_TEST_MARKER="$marker"
+run_verify --config "$FIXTURES/default-options.yaml" --cwd "$linked" --base-ref "$BASE_BRANCH"
+assert_eq "linked-worktree: exit code is 0" "0" "$RC"
+assert_has "linked-worktree: the gate is not skipped" "$OUT" "GATE sidefx PASS exit=0 duration="
+assert_has "linked-worktree: verdict is passed" "$OUT" "RESULT passed"
+assert_file_present "linked-worktree: the command gate ran" "$marker"
+
+# --- 10. --gates selection ----------------------------------------------------
+run_verify --config "$FIXTURES/one-fail.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH" --gates ok,after
+assert_eq "gates-subset: exit code is 0" "0" "$RC"
+assert_has "gates-subset: a selected gate runs" "$OUT" "GATE ok PASS exit=0 duration="
+assert_lacks "gates-subset: an unselected gate does not run" "$OUT" "GATE broken"
+assert_has "gates-subset: verdict is passed" "$OUT" "RESULT passed"
+
+run_verify --config "$FIXTURES/one-fail.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH" --gates ok,nosuch
+assert_eq "gates-unknown: a typo is a config error, not a silent pass" "2" "$RC"
+assert_has "gates-unknown: the unknown id is named" "$ERR" "unknown gate id: nosuch"
+assert_lacks "gates-unknown: no verdict is emitted" "$OUT" "RESULT"
+
+# --- 11. parsing of comments, quotes and embedded colons ----------------------
+run_verify --config "$FIXTURES/parsing.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH"
+assert_eq "parsing: exit code is 0" "0" "$RC"
+assert_has "parsing: a quoted command keeps its hash and colon" "$OUT" "GATE quoted PASS exit=0 duration="
+assert_has "parsing: an unquoted command keeps its embedded quotes" "$OUT" "GATE unquoted PASS exit=0 duration="
+assert_has "parsing: verdict is passed" "$OUT" "RESULT passed"
+
+# --- 12. git context errors ---------------------------------------------------
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo"
+assert_eq "base-ref: an unresolvable default is a config error" "2" "$RC"
+assert_has "base-ref: the fix is spelled out" "$ERR" "cannot determine baseRef"
+
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo" --base-ref no/such/ref
+assert_eq "base-ref: an unknown ref is a config error" "2" "$RC"
+assert_has "base-ref: the bad ref is named" "$ERR" "baseRef does not resolve to a commit"
+
+mkdir -p "$SANDBOX/not-a-repo"
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$SANDBOX/not-a-repo" --base-ref "$BASE_BRANCH"
+assert_eq "non-git cwd: exit code is 2" "2" "$RC"
+assert_has "non-git cwd: the path is named" "$ERR" "not a git repository"
+
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$SANDBOX/no-such-directory" --base-ref "$BASE_BRANCH"
+assert_eq "missing cwd: exit code is 2" "2" "$RC"
+assert_has "missing cwd: the path is named" "$ERR" "--cwd is not a directory"
+
+run_verify --config "$FIXTURES/all-pass.yaml" --cwd "$repo" --base-ref "$BASE_BRANCH" --bogus
+assert_eq "unknown argument: exit code is 2" "2" "$RC"
+
+# --- 13. rejected configs -----------------------------------------------------
+# Every one of these must be a config error (exit 2) AND must not emit a verdict:
+# a malformed config that reported `passed` would be the worst possible failure.
+assert_rejected() { # fixture expected-message
+  run_verify --config "$FIXTURES/$1" --cwd "$repo" --base-ref "$BASE_BRANCH"
+  assert_eq "reject $1: exit code is 2" "2" "$RC"
+  assert_has "reject $1: explains why" "$ERR" "$2"
+  assert_lacks "reject $1: emits no verdict" "$OUT" "RESULT"
+}
+
+assert_rejected bad-version.yaml "version must be 1"
+assert_rejected bad-no-version.yaml "missing top-level"
+assert_rejected bad-duplicate-id.yaml "duplicate gate id: a"
+assert_rejected bad-reserved-id.yaml "gate id is reserved: work-evidence"
+assert_rejected bad-invalid-id.yaml "invalid gate id: Lint_Gate"
+assert_rejected bad-timeout-range.yaml "timeoutSec must be 1..7200"
+assert_rejected bad-timeout-type.yaml "timeoutSec must be an integer"
+assert_rejected bad-missing-command.yaml "gate is missing command:"
+assert_rejected bad-missing-id.yaml "gate is missing id:"
+assert_rejected bad-gate-key.yaml "unknown gate key: retries"
+assert_rejected bad-option-key.yaml "unknown options key: parallel"
+assert_rejected bad-option-value.yaml "skipInPrimaryCheckout must be true or false"
+assert_rejected bad-flow.yaml "flow-style values are not supported"
+assert_rejected bad-anchor.yaml "anchors/aliases are not supported"
+assert_rejected bad-block-scalar.yaml "block scalars are not supported"
+assert_rejected bad-indent.yaml "indentation must be a multiple of 2 spaces"
+assert_rejected bad-tab.yaml "tab characters are not allowed"
+assert_rejected bad-no-gates.yaml "no gates are defined"
+
+# --- summary ------------------------------------------------------------------
+total=$((TOTAL_PASS + TOTAL_FAIL))
+echo "# tests: $TOTAL_PASS passed, $TOTAL_FAIL failed"
+if [ "$total" -lt "$MIN_ASSERTIONS" ]; then
+  echo "not ok - suite ran only $total assertions (expected at least $MIN_ASSERTIONS)"
+  exit 1
+fi
+[ "$TOTAL_FAIL" -eq 0 ] || exit 1
+exit 0

--- a/.claude/skills/cmate-verify/scripts/verify-run.sh
+++ b/.claude/skills/cmate-verify/scripts/verify-run.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# cmate-verify / verify-run — run the gates declared in .commandmate/verify.yaml
+# and judge each one by its REAL exit code.
+#
+# Usage:
+#   verify-run.sh [--config <path>] [--cwd <worktree-path>] [--base-ref <ref>]
+#                 [--gates id1,id2] [--skip-work-evidence]
+#
+# stdout is machine-readable, one line per gate plus a final verdict:
+#   GATE work-evidence PASS commits=3 uncommitted=2
+#   GATE lint PASS exit=0 duration=12s
+#   GATE unit FAIL exit=1 duration=45s
+#   RESULT failed
+# Failing output tails and diagnostics go to stderr so stdout stays parseable.
+#
+# Exit code: passed=0 / config error=2 / failed=20 / not_started=21 / skipped=22.
+#
+# Never decide pass/fail by grepping a command's output: `cmd | grep ...` hands $?
+# to grep and hides a non-zero exit — vitest can print "Tests 100 passed" and still
+# exit 1 on an Unhandled Rejection. Each gate is run as `sh -c "$cmd" > log 2>&1`
+# and `$?` is read directly (same discipline as orchestrate-monitor/quality-gate.sh).
+#
+# bash 3.2 compatible on purpose (macOS ships /bin/bash 3.2.57): no `declare -A`,
+# no `mapfile`/`readarray`, no `${var,,}`. macOS also has no timeout(1), so the
+# per-gate timeout is a watchdog subshell over a job-controlled process group.
+set -u
+
+TAB=$(printf '\t')
+
+EXIT_PASSED=0
+EXIT_CONFIG=2
+EXIT_FAILED=20
+EXIT_NOT_STARTED=21
+EXIT_SKIPPED=22
+
+DEFAULT_TIMEOUT_SEC=600
+MAX_TIMEOUT_SEC=7200
+DEFAULT_MAX_LOG_TAIL_BYTES=8192
+MAX_LOG_TAIL_BYTES_LIMIT=1048576
+# Grace period between SIGTERM and SIGKILL for a timed-out gate.
+KILL_GRACE_SEC=5
+
+CONFIG=""
+CWD=""
+BASE_REF_OPT=""
+GATES_OPT=""
+SKIP_WORK_EVIDENCE=0
+
+usage() {
+  sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die_config() {
+  echo "verify-run: $1" >&2
+  exit "$EXIT_CONFIG"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --config) shift; CONFIG=${1:-}; [ -n "$CONFIG" ] || die_config "--config requires a path";;
+    --cwd) shift; CWD=${1:-}; [ -n "$CWD" ] || die_config "--cwd requires a path";;
+    --base-ref) shift; BASE_REF_OPT=${1:-}; [ -n "$BASE_REF_OPT" ] || die_config "--base-ref requires a ref";;
+    --gates) shift; GATES_OPT=${1:-}; [ -n "$GATES_OPT" ] || die_config "--gates requires a comma-separated list";;
+    --skip-work-evidence) SKIP_WORK_EVIDENCE=1;;
+    -h|--help) usage; exit 0;;
+    *) die_config "unknown argument: $1";;
+  esac
+  shift
+done
+
+if [ -z "$CWD" ]; then CWD=$PWD; fi
+[ -d "$CWD" ] || die_config "--cwd is not a directory: $CWD"
+CWD=$(cd "$CWD" && pwd)
+
+if [ -z "$CONFIG" ]; then CONFIG="$CWD/.commandmate/verify.yaml"; fi
+[ -f "$CONFIG" ] || die_config "config file not found: $CONFIG"
+
+TMPBASE=${TMPDIR:-/tmp}
+TMPBASE=${TMPBASE%/}
+WORKDIR=$(mktemp -d "$TMPBASE/cmate-verify.XXXXXX") || die_config "cannot create a temporary directory under $TMPBASE"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- YAML subset parser -------------------------------------------------------
+# Emits one TSV record per parsed item; the free-form field (a gate command) is
+# always last so `read -r kind a b rest` cannot split it. Anything the bash subset
+# forbids becomes an ERR record instead of a best-effort guess.
+AWK_PARSER='
+function err(msg) { printf "ERR\tline %d: %s\n", NR, msg }
+function trim(s) { sub(/^[ ]+/, "", s); sub(/[ ]+$/, "", s); return s }
+function unquote(s,   q) {
+  if (length(s) >= 2) {
+    q = substr(s, 1, 1)
+    if ((q == "\"" || q == SQ) && substr(s, length(s), 1) == q)
+      return substr(s, 2, length(s) - 2)
+  }
+  return s
+}
+function splitkv(s) {
+  KV_I = index(s, ":")
+  if (KV_I == 0) return 0
+  KV_K = trim(substr(s, 1, KV_I - 1))
+  KV_V = trim(substr(s, KV_I + 1))
+  if (KV_K !~ /^[A-Za-z][A-Za-z0-9]*$/) return 0
+  return 1
+}
+function checkvalue(key, v,   c) {
+  if (v == "") { err(key ": has an empty value"); return 0 }
+  c = substr(v, 1, 1)
+  if (c == "&" || c == "*") { err(key ": YAML anchors/aliases are not supported"); return 0 }
+  if (c == "[" || c == "{") { err(key ": flow-style values are not supported"); return 0 }
+  if (v ~ /^[|>][-+0-9]*$/) { err(key ": block scalars are not supported"); return 0 }
+  return 1
+}
+function gatekv(s) {
+  if (!splitkv(s)) { err("expected \"key: value\" inside a gate"); return }
+  if (!checkvalue(KV_K, KV_V)) return
+  if (KV_K == "id") {
+    if (gid != "") { err("duplicate id: in one gate"); return }
+    gid = unquote(KV_V)
+  } else if (KV_K == "command") {
+    if (gcmd != "") { err("duplicate command: in one gate"); return }
+    gcmd = unquote(KV_V)
+  } else if (KV_K == "timeoutSec") {
+    if (gto != "") { err("duplicate timeoutSec: in one gate"); return }
+    gto = unquote(KV_V)
+  } else {
+    err("unknown gate key: " KV_K)
+  }
+}
+function flushgate() {
+  if (!gate_open) return
+  if (gid == "") err("gate is missing id:")
+  if (gcmd == "") err("gate is missing command:")
+  if (gid != "" && gcmd != "") {
+    printf "GATE\t%s\t%s\t%s\n", gid, (gto == "" ? "-" : gto), gcmd
+    ngates++
+  }
+  gid = ""; gcmd = ""; gto = ""; gate_open = 0
+}
+BEGIN { SQ = sprintf("%c", 39); section = ""; gate_open = 0; ngates = 0; nversion = 0 }
+{
+  line = $0
+  sub(/\r$/, "", line)
+  if (index(line, "\t") > 0) { err("tab characters are not allowed"); next }
+  if (line ~ /^[ ]*$/) next
+  if (line ~ /^[ ]*#/) next
+  match(line, /^ */)
+  ind = RLENGTH
+  if (ind % 2 != 0) { err("indentation must be a multiple of 2 spaces"); next }
+  body = substr(line, ind + 1)
+
+  if (ind == 0) {
+    flushgate()
+    if (!splitkv(body)) { err("expected \"key: value\" at the top level"); next }
+    if (KV_K == "version") {
+      nversion++
+      if (nversion > 1) err("duplicate top-level version:")
+      else if (unquote(KV_V) != "1") err("version must be 1 (got: " KV_V ")")
+      section = ""
+    } else if (KV_K == "gates") {
+      if (KV_V != "") err("gates: must be followed by an indented list")
+      section = "gates"
+    } else if (KV_K == "options") {
+      if (KV_V != "") err("options: must be followed by indented keys")
+      section = "options"
+    } else {
+      err("unknown top-level key: " KV_K)
+    }
+    next
+  }
+
+  if (ind == 2) {
+    if (section == "gates") {
+      if (substr(body, 1, 2) != "- ") { err("gate list items must start with \"- \""); next }
+      flushgate()
+      gate_open = 1
+      gatekv(trim(substr(body, 3)))
+      next
+    }
+    if (section == "options") {
+      if (!splitkv(body)) { err("expected \"key: value\" inside options:"); next }
+      if (!checkvalue(KV_K, KV_V)) next
+      if (KV_K == "baseRef" || KV_K == "skipInPrimaryCheckout" || KV_K == "maxLogTailBytes")
+        printf "OPT\t%s\t%s\n", KV_K, unquote(KV_V)
+      else
+        err("unknown options key: " KV_K)
+      next
+    }
+    err("indented line outside of gates: / options:")
+    next
+  }
+
+  if (ind == 4 && section == "gates") {
+    if (!gate_open) { err("gate field outside of a list item"); next }
+    gatekv(body)
+    next
+  }
+
+  err("unexpected indentation (" ind " spaces)")
+}
+END {
+  flushgate()
+  if (nversion == 0) printf "ERR\tmissing top-level \"version: 1\"\n"
+  if (ngates == 0) printf "ERR\tno gates are defined\n"
+}
+'
+
+PARSED="$WORKDIR/parsed.tsv"
+awk "$AWK_PARSER" "$CONFIG" > "$PARSED" || die_config "failed to read $CONFIG"
+
+if grep -q "^ERR$TAB" "$PARSED"; then
+  echo "verify-run: invalid config: $CONFIG" >&2
+  sed -n "s/^ERR$TAB/  - /p" "$PARSED" >&2
+  exit "$EXIT_CONFIG"
+fi
+
+GATE_IDS=()
+GATE_TOS=()
+GATE_CMDS=()
+OPT_BASE_REF=""
+OPT_SKIP_PRIMARY="true"
+OPT_MAX_TAIL="$DEFAULT_MAX_LOG_TAIL_BYTES"
+
+while IFS="$TAB" read -r kind a b rest; do
+  case "$kind" in
+    GATE)
+      GATE_IDS+=("$a")
+      GATE_TOS+=("$b")
+      GATE_CMDS+=("$rest")
+      ;;
+    OPT)
+      case "$a" in
+        baseRef) OPT_BASE_REF=$b;;
+        skipInPrimaryCheckout) OPT_SKIP_PRIMARY=$b;;
+        maxLogTailBytes) OPT_MAX_TAIL=$b;;
+      esac
+      ;;
+  esac
+done < "$PARSED"
+
+case "$OPT_SKIP_PRIMARY" in
+  true|false) ;;
+  *) die_config "options.skipInPrimaryCheckout must be true or false (got: $OPT_SKIP_PRIMARY)";;
+esac
+case "$OPT_MAX_TAIL" in
+  ''|*[!0-9]*) die_config "options.maxLogTailBytes must be an integer (got: $OPT_MAX_TAIL)";;
+esac
+if [ "$OPT_MAX_TAIL" -gt "$MAX_LOG_TAIL_BYTES_LIMIT" ]; then
+  die_config "options.maxLogTailBytes must be 0..$MAX_LOG_TAIL_BYTES_LIMIT (got: $OPT_MAX_TAIL)"
+fi
+
+GATE_ID_RE='^[a-z0-9][a-z0-9-]{0,31}$'
+SEEN_IDS="$WORKDIR/seen-ids"
+: > "$SEEN_IDS"
+gate_count=${#GATE_IDS[@]}
+i=0
+while [ "$i" -lt "$gate_count" ]; do
+  vid=${GATE_IDS[$i]}
+  case "$vid" in
+    work-evidence|scope) die_config "gate id is reserved: $vid";;
+  esac
+  [[ $vid =~ $GATE_ID_RE ]] || die_config "invalid gate id: $vid (must match $GATE_ID_RE)"
+  if grep -Fxq "$vid" "$SEEN_IDS"; then die_config "duplicate gate id: $vid"; fi
+  printf '%s\n' "$vid" >> "$SEEN_IDS"
+
+  vto=${GATE_TOS[$i]}
+  if [ "$vto" = "-" ]; then vto=$DEFAULT_TIMEOUT_SEC; fi
+  case "$vto" in
+    ''|*[!0-9]*) die_config "timeoutSec must be an integer (gate $vid, got: $vto)";;
+  esac
+  if [ "$vto" -lt 1 ] || [ "$vto" -gt "$MAX_TIMEOUT_SEC" ]; then
+    die_config "timeoutSec must be 1..$MAX_TIMEOUT_SEC (gate $vid, got: $vto)"
+  fi
+  GATE_TOS[$i]=$vto
+  i=$((i + 1))
+done
+
+SELECTED="$WORKDIR/selected-ids"
+: > "$SELECTED"
+if [ -n "$GATES_OPT" ]; then
+  printf '%s\n' "$GATES_OPT" | tr ',' '\n' | sed 's/^ *//; s/ *$//' | grep -v '^$' > "$SELECTED"
+  [ -s "$SELECTED" ] || die_config "--gates selects no gate"
+  # An unknown id here would silently run nothing and report `passed`.
+  while read -r want; do
+    grep -Fxq "$want" "$SEEN_IDS" || die_config "--gates refers to an unknown gate id: $want"
+  done < "$SELECTED"
+fi
+
+# --- git context --------------------------------------------------------------
+git_in() { git -C "$CWD" "$@"; }
+
+git_in rev-parse --git-dir >/dev/null 2>&1 || die_config "not a git repository: $CWD"
+
+BASE_REF=$BASE_REF_OPT
+[ -n "$BASE_REF" ] || BASE_REF=$OPT_BASE_REF
+if [ -z "$BASE_REF" ]; then
+  BASE_REF=$(git_in symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || BASE_REF=""
+fi
+[ -n "$BASE_REF" ] || die_config "cannot determine baseRef: set options.baseRef or pass --base-ref (refs/remotes/origin/HEAD is unset)"
+git_in rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1 \
+  || die_config "baseRef does not resolve to a commit: $BASE_REF"
+
+# --- work-evidence ------------------------------------------------------------
+if [ "$SKIP_WORK_EVIDENCE" -eq 1 ]; then
+  echo "GATE work-evidence SKIP reason=flag"
+else
+  merge_base=$(git_in merge-base "$BASE_REF" HEAD 2>/dev/null) \
+    || die_config "cannot compute merge-base($BASE_REF, HEAD)"
+  commits=$(git_in rev-list --count "$merge_base..HEAD" 2>/dev/null) \
+    || die_config "cannot count commits since $BASE_REF"
+  git_in status --porcelain > "$WORKDIR/status.txt" 2>/dev/null \
+    || die_config "git status failed in $CWD"
+  uncommitted=$(wc -l < "$WORKDIR/status.txt" | tr -d ' ')
+  if [ "$commits" -gt 0 ] || [ "$uncommitted" -gt 0 ]; then
+    echo "GATE work-evidence PASS commits=$commits uncommitted=$uncommitted"
+  else
+    echo "GATE work-evidence FAIL commits=$commits uncommitted=$uncommitted"
+    echo "RESULT not_started"
+    exit "$EXIT_NOT_STARTED"
+  fi
+fi
+
+# A linked worktree has its own git dir under <common>/worktrees/<name>; the
+# primary checkout is the one where they are the same path. Both sides are
+# resolved with `pwd -P`: on macOS $TMPDIR lives under the /var -> /private/var
+# symlink, and comparing a logical path against a physical one makes every
+# checkout look linked (i.e. silently disables the primary-checkout guard).
+resolve_dir() { ( cd "$CWD" && cd "$1" 2>/dev/null && pwd -P ); }
+git_dir=$(git_in rev-parse --git-dir 2>/dev/null) || die_config "cannot resolve the git directory of $CWD"
+common_git_dir=$(git_in rev-parse --git-common-dir 2>/dev/null) || die_config "cannot resolve the common git directory of $CWD"
+abs_git_dir=$(resolve_dir "$git_dir")
+abs_common_git_dir=$(resolve_dir "$common_git_dir")
+is_primary=0
+if [ -n "$abs_git_dir" ] && [ "$abs_git_dir" = "$abs_common_git_dir" ]; then
+  is_primary=1
+fi
+
+# --- gate execution -----------------------------------------------------------
+emit_log_tail() {
+  el_id=$1
+  el_status=$2
+  el_log=$3
+  [ "$OPT_MAX_TAIL" -gt 0 ] || return 0
+  [ -s "$el_log" ] || return 0
+  echo "--- gate $el_id ($el_status): last $OPT_MAX_TAIL bytes ---" >&2
+  tail -c "$OPT_MAX_TAIL" "$el_log" >&2
+  echo "--- end gate $el_id ---" >&2
+}
+
+any_failed=0
+gates_ran=0
+
+run_gate() {
+  rg_id=$1
+  rg_cmd=$2
+  rg_to=$3
+  rg_log="$WORKDIR/gate-$rg_id.log"
+  rg_mark="$WORKDIR/gate-$rg_id.timedout"
+  rm -f "$rg_mark"
+  rg_start=$(date +%s)
+
+  # `set -m` puts the gate in its own process group so the watchdog can kill the
+  # whole tree. Without it, `npm run x` dies but the node/sleep children it forked
+  # survive the timeout (measured: 2 orphans left behind).
+  set -m
+  ( cd "$CWD" && exec /bin/sh -c "$rg_cmd" ) > "$rg_log" 2>&1 &
+  rg_pid=$!
+  set +m
+
+  # `kill -TERM -N` signals whatever process group has id N. If job control could
+  # not be enabled, the gate stays in this shell's group and N is just a pid —
+  # then the group with that id belongs to some unrelated process tree, and
+  # signalling it blindly would kill a bystander. So confirm the gate really is
+  # its own group leader before using the group form.
+  rg_pgid=$(ps -o pgid= -p "$rg_pid" 2>/dev/null | tr -d ' ')
+  if [ "$rg_pgid" = "$rg_pid" ]; then rg_target="-$rg_pid"; else rg_target="$rg_pid"; fi
+
+  ( sleep "$rg_to"
+    : > "$rg_mark"
+    kill -s TERM -- "$rg_target" 2>/dev/null
+    sleep "$KILL_GRACE_SEC"
+    kill -s KILL -- "$rg_target" 2>/dev/null
+  ) >/dev/null 2>&1 &
+  rg_wpid=$!
+
+  # 2>/dev/null suppresses the shell job-control "Terminated" notice.
+  wait "$rg_pid" 2>/dev/null
+  rg_code=$?
+  kill -TERM "$rg_wpid" 2>/dev/null
+  wait "$rg_wpid" 2>/dev/null
+
+  rg_dur=$(( $(date +%s) - rg_start ))
+  gates_ran=$((gates_ran + 1))
+
+  if [ -f "$rg_mark" ]; then
+    echo "GATE $rg_id TIMEOUT exit=124 duration=${rg_dur}s"
+    any_failed=1
+    emit_log_tail "$rg_id" "TIMEOUT after ${rg_to}s" "$rg_log"
+  elif [ "$rg_code" -eq 0 ]; then
+    echo "GATE $rg_id PASS exit=0 duration=${rg_dur}s"
+  else
+    echo "GATE $rg_id FAIL exit=$rg_code duration=${rg_dur}s"
+    any_failed=1
+    emit_log_tail "$rg_id" "FAIL exit=$rg_code" "$rg_log"
+  fi
+}
+
+i=0
+while [ "$i" -lt "$gate_count" ]; do
+  cur_id=${GATE_IDS[$i]}
+  cur_to=${GATE_TOS[$i]}
+  cur_cmd=${GATE_CMDS[$i]}
+  i=$((i + 1))
+
+  if [ -s "$SELECTED" ] && ! grep -Fxq "$cur_id" "$SELECTED"; then
+    continue
+  fi
+  if [ "$is_primary" -eq 1 ] && [ "$OPT_SKIP_PRIMARY" = "true" ]; then
+    echo "GATE $cur_id SKIP reason=primary-checkout"
+    continue
+  fi
+  # Every gate runs even after one fails, so a single run reports every finding.
+  run_gate "$cur_id" "$cur_cmd" "$cur_to"
+done
+
+if [ "$gates_ran" -eq 0 ]; then
+  echo "RESULT skipped"
+  exit "$EXIT_SKIPPED"
+fi
+if [ "$any_failed" -ne 0 ]; then
+  echo "RESULT failed"
+  exit "$EXIT_FAILED"
+fi
+echo "RESULT passed"
+exit "$EXIT_PASSED"

--- a/.commandmate/verify.yaml
+++ b/.commandmate/verify.yaml
@@ -1,0 +1,23 @@
+# .commandmate/verify.yaml — v1
+# 仕様: docs/design/verification-config.md
+# ランナー: .claude/skills/cmate-verify/scripts/verify-run.sh
+#
+# ゲートは CI（.github/workflows/ci-pr.yml）の lint / type-check / test-unit ジョブと
+# 同じコマンドを宣言している。build は稼働サーバの足元で走らせると配信中の成果物を
+# 壊すため、skipInPrimaryCheckout が守る linked worktree でのみ意味を持つ。
+version: 1
+gates:
+  - id: lint
+    command: "npm run lint"
+    timeoutSec: 900
+  - id: typecheck
+    command: "npx tsc --noEmit"
+    timeoutSec: 900
+  - id: unit
+    command: "npm run test:unit"
+    timeoutSec: 3600
+options:
+  baseRef: origin/develop
+  skipInPrimaryCheckout: true
+  # 8192 では vitest の失敗サマリが途中で切れ、2 件の失敗のうち 1 件しか読めなかった。
+  maxLogTailBytes: 32768

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,11 @@ logs/
 # CommandMate 実行時データ（ユーザーがチャットに添付した画像の保存先）。
 # src/app/api/worktrees/[id]/send/route.ts が imagePath の許可パスとして参照する。
 # アプリが書き込み続けるランタイム生成物のためコミットしない（dev-reports/ と同扱い）。
-/.commandmate/
+# verify.yaml だけは検証ゲートの宣言（設定であって生成物ではない）なので追跡する。
+# ディレクトリごと除外すると git がその中を走査せず ! 行が効かないため、
+# 除外は /.commandmate/*（中身単位）で書く必要がある。
+/.commandmate/*
+!/.commandmate/verify.yaml
 
 # 直下の .md は既知のドキュメントのみ追跡する。
 # 検証用スナップショットは *-snapshot.md / snapshot-*.md / codex-tab-final.md のように

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **検証ゲート Skill `cmate-verify` と `.commandmate/verify.yaml` v1 仕様を追加** (#1540): 検証ゲートの設定形式を製品実装（Phase 1）より先に実地検証するための先行 Skill。`docs/design/verification-config.md` を正準仕様とし、`.claude/skills/cmate-verify/` と `.agents/skills/cmate-verify/` へ byte-identical に配置（Claude は前者、Codex / Antigravity は後者しか読まない）。ランナーは bash 3.2 互換で、ゲートを定義順に逐次実行し**失敗しても残りを実行して全結果を報告**、判定は必ず実 exit code で行う（出力の grep は `$?` を隠す）。macOS に `timeout(1)` が無い前提で、job control による**プロセスグループ単位**の timeout kill を実装（直接の子だけを kill すると孫が生き残る／signal 送出前に pgid が pid と一致することを確認して無関係なプロセスグループを巻き込まない）。組み込みゲート `work-evidence` が「作業の痕跡ゼロ」を `not_started` として弾き、`skipInPrimaryCheckout` がメイン checkout でのコマンド実行を止める（全 skip は `passed` ではなく `skipped`）。fixture ベースの自己完結テスト 123 アサーション（vitest 非依存）＋ vitest ラッパで CI からも実行。
+
 ## [0.16.0] - 2026-07-29
 
 > **Highlight**: **Skill 配布 MVP を「入れられる」から「運用できる」へ引き上げたリリース。** 導入先 Agent の対応状況を manifest の申告だけでなく CommandMate 側の実測で裏付ける互換 matrix（#1246）、どの worktree に何が入っていて導入時のままかを横断確認する監査 dashboard と receipt からの reindex（#1248、DB migration v48）、Skill 導入を review 可能な commit / draft PR に載せる専用 git workflow（#1247）を追加した。あわせて、uninstall した Skill を再 install すると **exit 0 で「Installed」と報告しながら 1 バイトも書かれない** journal replay の欠陥（#1552）を修正し、対になる uninstall 経路の同型欠陥も同時に塞いだ。

--- a/docs/design/verification-config.md
+++ b/docs/design/verification-config.md
@@ -1,0 +1,235 @@
+# 仕様: `.commandmate/verify.yaml` v1（検証ゲート設定）
+
+- **Issue**: [#1540](https://github.com/Kewton/CommandMate/issues/1540)（親 [#1539](https://github.com/Kewton/CommandMate/issues/1539) / Phase 0）
+- **ステータス**: Accepted
+- **対象 version**: `1`
+- **参照実装**: `.claude/skills/cmate-verify/scripts/verify-run.sh`（= `.agents/skills/cmate-verify/...`、byte-identical）
+- **テスト**: `.claude/skills/cmate-verify/scripts/tests/`（fixture ベース）＋ `tests/unit/skills/cmate-verify/`（vitest ラッパ）
+
+本書は `.commandmate/verify.yaml` の **正準仕様**である。Phase 0 の Skill（`cmate-verify`）は
+bash + awk で、Phase 1 以降の製品ローダは一般的な YAML パーサでこの仕様を実装する。
+**同じ verify.yaml が両方で読めること**が本仕様の目的であり、Skill 期に書かれた設定は
+製品化後もそのまま使える。
+
+---
+
+## 1. 全体像
+
+```yaml
+# .commandmate/verify.yaml — v1
+version: 1
+gates:
+  - id: lint              # 必須。^[a-z0-9][a-z0-9-]{0,31}$ で一意。予約ID: work-evidence, scope
+    command: "npm run lint"   # 必須。worktree の cwd で shell 実行される
+    timeoutSec: 600       # 省略時 600。範囲 1..7200
+  - id: typecheck
+    command: "npx tsc --noEmit"
+  - id: unit
+    command: "npm run test:unit"
+    timeoutSec: 1800
+options:
+  baseRef: origin/develop      # work-evidence / scope 判定の基準。省略時はリポジトリのデフォルトブランチの origin
+  skipInPrimaryCheckout: true  # 省略時 true。メイン checkout（稼働サーバの cwd になり得る場所）ではコマンド系ゲートを skip
+  maxLogTailBytes: 8192        # 省略時 8192
+```
+
+---
+
+## 2. フィールド仕様
+
+### 2.1 トップレベル
+
+| キー | 型 | 必須 | 既定 | 制約 |
+|---|---|---|---|---|
+| `version` | integer | ✅ | — | `1` のみ。他の値・欠落は設定エラー |
+| `gates` | list | ✅ | — | 1 件以上。0 件は設定エラー |
+| `options` | map | — | 全既定値 | 未知キーは設定エラー |
+
+未知のトップレベルキーは設定エラー。v1 は閉じた集合として扱う。
+
+### 2.2 `gates[]`
+
+| キー | 型 | 必須 | 既定 | 制約 |
+|---|---|---|---|---|
+| `id` | string | ✅ | — | `^[a-z0-9][a-z0-9-]{0,31}$`。設定内で一意。予約 ID（`work-evidence` / `scope`）は使用不可 |
+| `command` | string | ✅ | — | 非空。`--cwd` を作業ディレクトリとして POSIX sh (`/bin/sh -c`) で実行される |
+| `timeoutSec` | integer | — | `600` | `1..7200` |
+
+`command` は **POSIX sh** で実行される。bash 固有構文（`[[ ]]` / 配列 / `function` キーワード）は
+使わないこと。必要なら `bash -c "..."` と明示的に書く。
+
+### 2.3 `options`
+
+| キー | 型 | 既定 | 意味 |
+|---|---|---|---|
+| `baseRef` | string | `refs/remotes/origin/HEAD` の指す先 | `work-evidence` の比較基準。解決できない場合は設定エラー（`--base-ref` で明示する） |
+| `skipInPrimaryCheckout` | boolean | `true` | プライマリ checkout ではコマンド系ゲートを skip する |
+| `maxLogTailBytes` | integer | `8192` | 失敗ゲートのログを stderr に出す際の末尾バイト数。`0..1048576`。`0` で抑止 |
+
+---
+
+## 3. 実行モデル
+
+### 3.1 順序
+
+1. 設定の読み込みと検証。**1 つでも違反があれば `RESULT` を出さずに exit 2**
+   （不正な設定が `passed` を出すのが最悪の失敗モードのため、best-effort 解釈はしない）。
+2. 組み込みゲート `work-evidence`（`--skip-work-evidence` 指定時は SKIP）。
+3. `skipInPrimaryCheckout` によるプライマリ checkout 判定。
+4. `gates` を **定義順に逐次実行**。
+
+### 3.2 途中で失敗しても止まらない
+
+**あるゲートが失敗しても残りのゲートは実行し、全結果を報告する。** 1 回の実行で全指摘を
+回収できることを優先する。定義順は打ち切りの制御ではなく、読みやすさのための並びである。
+
+### 3.3 判定
+
+| 条件 | RESULT | exit code |
+|---|---|---|
+| 実行したコマンド系ゲートが全て PASS | `passed` | 0 |
+| 設定エラー（不正な verify.yaml / ファイル無し / git でない cwd / 未知の `--gates` id 等） | （出力しない） | 2 |
+| 1 つ以上が FAIL または TIMEOUT | `failed` | 20 |
+| `work-evidence` が FAIL | `not_started` | 21 |
+| 実行したコマンド系ゲートが 0 件 | `skipped` | 22 |
+
+Issue #1540 本文は「1 つでも failed/timeout/error → `failed`」としている。参照実装が持つ
+ゲート状態は `PASS` / `FAIL` / `TIMEOUT` / `SKIP` の 4 つで、本文の *error* は独立した状態を
+持たない（ランナーがゲートを起動できない事象は、ゲートの非ゼロ exit code か設定エラー
+（exit 2）のいずれかとして必ず観測される）。判定への寄与は本文どおり「FAIL と TIMEOUT は
+`failed`」である。
+
+`skipped` (22) も本文には無い。本文の 3 値だけでは「`skipInPrimaryCheckout` により
+コマンドを 1 つも実行しなかった実行」を表現できず、`passed` と報告すれば
+**何も検証していない実行が緑になる**（本仕様が最も避けたい偽の緑）。`failed` も
+`not_started` も事実と異なるため、専用の値を追加した。**`skipped` を `passed` と
+同一視しないこと。**
+
+### 3.4 出力フォーマット
+
+stdout は 1 ゲート 1 行、最終行が判定。**stdout は機械可読を保ち、ログ末尾や診断は stderr に出す。**
+
+```
+GATE work-evidence PASS commits=3 uncommitted=2
+GATE lint PASS exit=0 duration=12s
+GATE unit FAIL exit=1 duration=45s
+RESULT failed
+```
+
+| 行 | 形式 |
+|---|---|
+| コマンド系ゲート | `GATE <id> PASS\|FAIL exit=<code> duration=<n>s` |
+| タイムアウト | `GATE <id> TIMEOUT exit=124 duration=<n>s` |
+| skip | `GATE <id> SKIP reason=primary-checkout\|flag` |
+| work-evidence | `GATE work-evidence PASS\|FAIL commits=<n> uncommitted=<n>` |
+| 判定 | `RESULT passed\|failed\|not_started\|skipped` |
+
+`--gates` で選択されなかったゲートは行を出さない（その実行の対象外であるため）。
+
+### 3.5 exit code は絶対にパイプで失わない
+
+各ゲートは `sh -c "$cmd" > "$log" 2>&1` の形で実行し、`$?` を直接読む。
+**出力を grep して合否を決めない。** `cmd | grep ...` は `$?` を grep のものにすり替え、
+vitest が「全テスト緑」と表示しながら Unhandled Rejection で exit 1 する状況を
+PASS と誤報告する（`.claude/skills/orchestrate-monitor/scripts/quality-gate.sh` と同じ規律）。
+
+### 3.6 タイムアウト
+
+macOS には `timeout(1)` が無い前提で実装する。参照実装は、ゲートを job control 有効
+（`set -m`）でバックグラウンド起動して独立したプロセスグループに置き、監視サブシェルが
+`timeoutSec` 経過後に **プロセスグループごと** SIGTERM → 猶予後 SIGKILL する。
+
+プロセスグループ単位であることは必須である。直接の子だけを kill する実装では、
+ゲートが起動した孫プロセス（`npm run` 配下の node 等）が生き残る（実測: 孤児 2 件）。
+
+ただし **プロセスグループ ID を確認してから** signal を送ること。`kill -TERM -N` は
+「ID が N のプロセスグループ」に signal を送るので、job control を有効化できず子が
+独立したグループに入らなかった場合、N は単なる pid であり、たまたま同じ ID を持つ
+**無関係なプロセスツリー**を巻き込む。参照実装は `ps -o pgid= -p <pid>` が pid と
+一致することを確認してからグループ形式を使い、一致しなければ pid のみに送る。
+
+---
+
+## 4. 組み込みゲート `work-evidence`
+
+コマンド系ゲートより先に実行される、**そもそも作業が行われたか**の判定。
+
+- PASS 条件: `merge-base(baseRef, HEAD)` から HEAD までのコミット数 > 0、
+  **または** `git status --porcelain` の出力が非空
+- 両方 0 → 実行全体を `not_started`（exit 21）とし、**コマンド系ゲートは 1 つも実行しない**
+
+変更が 1 バイトも無いリポジトリでは lint も typecheck も当然通るので、このガードが無いと
+「未起動のセッション」が「全ゲート PASS」として報告される。`--skip-work-evidence` で
+明示的に無効化できる（その場合 `GATE work-evidence SKIP reason=flag` を出す）。
+
+予約 ID `scope` は、スコープ逸脱・未達検証の組み込みゲート用に確保してあり、v1 では未実装。
+ユーザー定義ゲートの ID としては使用できない。
+
+---
+
+## 5. プライマリ checkout での skip
+
+`options.skipInPrimaryCheckout`（既定 `true`）が有効なとき、プライマリ checkout では
+コマンド系ゲートを実行せず `RESULT skipped`（exit 22）とする。
+
+プライマリ checkout は稼働中の開発サーバの cwd になっていることがあり、その足元で
+build / test を回すと配信中のビルド成果物を壊す。判定は `git rev-parse --git-dir` と
+`--git-common-dir` が同じディレクトリを指すか（linked worktree は前者が
+`<common>/worktrees/<name>` になる）で行う。
+
+両者は `pwd -P` で **実パスに正規化してから**比較する。macOS の `$TMPDIR` は
+`/var -> /private/var` シンボリックリンク配下にあり、論理パスと実パスを比較すると
+どの checkout も linked と判定され、このガードが黙って無効化される。
+
+---
+
+## 6. bash サブセット制約
+
+Phase 0 の `verify-run.sh` は awk / sed でパースするため、YAML のサブセットのみを受け付ける。
+
+| 規則 | 内容 |
+|---|---|
+| インデント | 2 スペース固定。タブは拒否。2 の倍数でない字下げは拒否 |
+| 値 | 1 行スカラーのみ |
+| アンカー / エイリアス | `&` `*` で始まる値は拒否 |
+| 複数行文字列 | `|` `>`（`|-` 等の修飾つきを含む）は拒否 |
+| フロースタイル | `[...]` `{...}` で始まる値は拒否 |
+| コメント | 行頭（インデント可）の `#` のみ。行内コメントは値の一部として扱う |
+| クォート | 値全体が `"..."` または `'...'` で囲まれていれば外側のクォートのみ除去 |
+| キーと値の分割 | 行内の**最初のコロン**で分割。値の中のコロンはそのまま書ける |
+
+**制約に反する verify.yaml は best-effort で解釈せず設定エラー（exit 2）として拒否する。**
+一部を黙って読み飛ばすと「設定したつもりのゲートが走っていないのに `passed`」になる。
+
+Phase 1 の製品ローダは一般的な YAML パーサを使うため上記より広い入力を受け付けうるが、
+**この形式で書いておけば両方で読める**。製品ローダ側は、上記サブセットを満たす文書を
+本仕様と同じ意味に解釈しなければならない。
+
+---
+
+## 7. CLI（Phase 0 参照実装）
+
+```
+verify-run.sh [--config <path>] [--cwd <worktree-path>] [--base-ref <ref>]
+              [--gates id1,id2] [--skip-work-evidence]
+```
+
+| オプション | 既定 | 意味 |
+|---|---|---|
+| `--config` | `<cwd>/.commandmate/verify.yaml` | 設定ファイル |
+| `--cwd` | カレントディレクトリ | ゲートを実行する worktree。git リポジトリでなければ設定エラー |
+| `--base-ref` | `options.baseRef` → `origin/HEAD` | `options.baseRef` より優先 |
+| `--gates` | 全ゲート | 実行するゲートの絞り込み（カンマ区切り）。**存在しない id は設定エラー**（黙って 0 件実行→`passed` を防ぐ） |
+| `--skip-work-evidence` | 無効 | `work-evidence` を SKIP する |
+
+---
+
+## 8. Phase 1 実装時の申し送り
+
+- `version` は fail closed。`2` 以上・欠落・型不一致はすべて拒否し、best-effort parse はしない。
+- 未知キー（トップレベル / gate / options）は拒否する。v1 は閉じた集合。
+- 実行順・「失敗しても継続」・判定表（§3.3）・出力フォーマット（§3.4）は互換性の対象。
+  RESULT 値と exit code は API とみなす。
+- `work-evidence` / `scope` の予約は維持する。`scope` を実装するときは本書の §4 を更新する。
+- タイムアウトはプロセスグループ単位で kill する（§3.6）。Node で実装する場合は
+  `child_process.spawn(..., { detached: true })` ＋ `process.kill(-pid, ...)` が対応物。

--- a/tests/unit/skills/cmate-verify/dual-placement.test.ts
+++ b/tests/unit/skills/cmate-verify/dual-placement.test.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The skill must exist byte-identically under both roots (Issue #1540).
+ *
+ * The official install path is `.agents/skills` (what Codex / Antigravity read),
+ * but Claude only reads `.claude/skills` — a skill placed in one root alone is
+ * invisible to the other agent, and `commandmate skill install` has shipped the
+ * same dual placement since #1460. Editing one copy and forgetting the other is
+ * the failure this test exists to catch.
+ */
+const CLAUDE_ROOT = path.join(process.cwd(), '.claude/skills/cmate-verify');
+const AGENTS_ROOT = path.join(process.cwd(), '.agents/skills/cmate-verify');
+
+function listFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push(path.relative(root, full));
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+describe('cmate-verify is placed byte-identically in both skill roots', () => {
+  it('both roots hold the same non-empty file list', () => {
+    const claudeFiles = listFiles(CLAUDE_ROOT);
+    const agentsFiles = listFiles(AGENTS_ROOT);
+    // Comparing two empty trees would pass trivially.
+    expect(claudeFiles.length).toBeGreaterThanOrEqual(20);
+    expect(agentsFiles).toEqual(claudeFiles);
+    expect(claudeFiles).toContain('SKILL.md');
+    expect(claudeFiles).toContain(path.join('scripts', 'verify-run.sh'));
+    expect(claudeFiles).toContain(path.join('scripts', 'tests', 'run-tests.sh'));
+  });
+
+  it('every file has identical bytes in both roots', () => {
+    for (const rel of listFiles(CLAUDE_ROOT)) {
+      const claude = readFileSync(path.join(CLAUDE_ROOT, rel));
+      const agents = readFileSync(path.join(AGENTS_ROOT, rel));
+      expect(agents.equals(claude), `differs between skill roots: ${rel}`).toBe(true);
+    }
+  });
+
+  it('diff -r reports no difference', () => {
+    // The acceptance criterion is spelled as `diff -r`; run the real thing so the
+    // check cannot drift from what a reviewer would type.
+    execFileSync('diff', ['-r', CLAUDE_ROOT, AGENTS_ROOT], { encoding: 'utf8' });
+  });
+
+  it('keeps the scripts executable in both roots', () => {
+    for (const rel of listFiles(CLAUDE_ROOT).filter((f) => f.endsWith('.sh'))) {
+      for (const root of [CLAUDE_ROOT, AGENTS_ROOT]) {
+        const mode = statSync(path.join(root, rel)).mode;
+        expect(mode & 0o111, `not executable: ${path.join(root, rel)}`).not.toBe(0);
+      }
+    }
+  });
+});

--- a/tests/unit/skills/cmate-verify/syntax.test.ts
+++ b/tests/unit/skills/cmate-verify/syntax.test.ts
@@ -1,0 +1,75 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOTS = [
+  path.join(process.cwd(), '.claude/skills/cmate-verify/scripts'),
+  path.join(process.cwd(), '.agents/skills/cmate-verify/scripts'),
+];
+
+function shellScripts(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.sh')) out.push(full);
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+const scripts = ROOTS.flatMap(shellScripts);
+
+/**
+ * bash 3.2 is what macOS ships (/bin/bash 3.2.57), so the skill cannot use the
+ * bash 4 builtins. Prose mentioning them is stripped first: a guard that counts
+ * matches inside its own explanatory comments false-positives on the very file
+ * documenting the rule.
+ */
+const BASH4_ONLY: Array<{ name: string; re: RegExp }> = [
+  { name: 'declare -A (associative array)', re: /\bdeclare\s+-A\b/ },
+  { name: 'local -A (associative array)', re: /\blocal\s+-A\b/ },
+  { name: 'mapfile', re: /\bmapfile\b/ },
+  { name: 'readarray', re: /\breadarray\b/ },
+  { name: '${var,,} / ${var^^} case conversion', re: /\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)/ },
+];
+
+function stripComments(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+}
+
+describe('cmate-verify shell scripts', () => {
+  it('finds the scripts to check in both roots', () => {
+    // Guard against an empty glob silently passing the whole suite.
+    expect(scripts.length).toBe(4);
+  });
+
+  it.each(scripts)('passes bash -n: %s', (file) => {
+    // Throws (non-zero exit) if the script has a syntax error.
+    execFileSync('bash', ['-n', file], { encoding: 'utf8' });
+  });
+
+  it.each(scripts)('uses no bash 4 only construct: %s', (file) => {
+    const code = stripComments(readFileSync(file, 'utf8'));
+    // Non-vacuity: the stripped source must still be the script, not an empty string.
+    expect(code).toContain('set -u');
+    for (const { name, re } of BASH4_ONLY) {
+      expect(re.test(code), `${path.basename(file)} uses ${name}`).toBe(false);
+    }
+  });
+
+  it('detects a bash 4 only construct when one is present', () => {
+    // Proves the matchers above are not vacuously green.
+    const injected = stripComments('set -u\ndeclare -A seen\nfoo=${bar,,}\n');
+    expect(BASH4_ONLY.filter(({ re }) => re.test(injected)).map(({ name }) => name)).toEqual([
+      'declare -A (associative array)',
+      '${var,,} / ${var^^} case conversion',
+    ]);
+  });
+});

--- a/tests/unit/skills/cmate-verify/verify-run.test.ts
+++ b/tests/unit/skills/cmate-verify/verify-run.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Thin wrapper around the skill's own fixture suite (Issue #1540).
+ *
+ * The assertions live in bash because the skill is distributed to repositories
+ * that have no vitest — `bash scripts/tests/run-tests.sh` must stand alone there.
+ * This file exists so the same suite also gates `npm run test:unit` / CI, and so
+ * a suite that silently stops running cases cannot report "0 failed" as green.
+ */
+const SUITE = path.join(
+  process.cwd(),
+  '.claude/skills/cmate-verify/scripts/tests/run-tests.sh',
+);
+
+// Includes a 1s gate timeout plus sandbox git repos; generous so a slow CI runner
+// does not turn this into a flake.
+const TIMEOUT_MS = 180_000;
+
+describe('cmate-verify fixture suite', () => {
+  it(
+    'runs green with every case reporting',
+    () => {
+      const result = spawnSync('bash', [SUITE], { encoding: 'utf8' });
+      const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+      const summary = output.match(/^# tests: (\d+) passed, (\d+) failed$/m);
+      expect(summary, `no summary line in suite output:\n${output}`).not.toBeNull();
+
+      const passed = Number(summary![1]);
+      const failed = Number(summary![2]);
+
+      expect(output.split('\n').filter((l) => l.startsWith('not ok')).join('\n')).toBe('');
+      expect(failed).toBe(0);
+      // Floor mirrors MIN_ASSERTIONS in run-tests.sh: a truncated run must not
+      // pass just because it never reached the failing case.
+      expect(passed).toBeGreaterThanOrEqual(100);
+      expect(result.status).toBe(0);
+    },
+    TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## 概要

Issue #1540（親 #1539 / Phase 0）。検証ゲートの設定形式 `.commandmate/verify.yaml` v1 を、製品実装（Phase 1）の前に実地検証するための先行 Skill。
設定形式は `docs/design/verification-config.md` を**正準仕様**として文書化し、Phase 1-1（#1541）のローダは同じ仕様を実装する。

## 変更内容

- `docs/design/verification-config.md`: v1 正準仕様
- `.claude/skills/cmate-verify/` と `.agents/skills/cmate-verify/` へ byte-identical 配置（`dual-placement.test.ts` で無差分を固定）
- `verify-run.sh`: bash 3.2 互換ランナー。ゲートを定義順に逐次実行し**失敗しても残りを実行して全結果を報告**、判定は必ず実 exit code（出力の grep は `$?` を隠す）
- macOS に `timeout(1)` が無い前提で、job control による**プロセスグループ単位**の timeout kill（直接の子だけ kill すると孫が生き残る。signal 送出前に pgid が pid と一致することを確認し、無関係なプロセスグループを巻き込まない）
- 組み込みゲート `work-evidence` が「作業の痕跡ゼロ」を `not_started` として弾き、`skipInPrimaryCheckout` がメイン checkout でのコマンド実行を止める（全 skip は `passed` ではなく `skipped`）
- fixture ベースの自己完結テスト **123 アサーション**（vitest 非依存）＋ vitest ラッパで CI からも実行

## `.gitignore` の変更について

`.commandmate/verify.yaml` を追跡するために除外規則を書き換えた:

```
-/.commandmate/
+/.commandmate/*
+!/.commandmate/verify.yaml
```

ディレクトリごと除外すると **git がその中を走査しないため `!` 行が効かない**。中身単位（`/.commandmate/*`）で除外する必要がある。ランタイム生成物（`attachments/` 等）は従来どおり除外されたまま。

## 検証

worktree `commandmate-issue-1540` で exit code を直接測定:

| ゲート | 結果 |
|--------|------|
| `npm run lint` | PASS (exit 0) |
| `npx tsc --noEmit` | PASS (exit 0) |
| `npm run test:unit` | PASS (exit 0) |
| `npm run build` | PASS (exit 0) |
| `scripts/tests/run-tests.sh` | 123 passed / 0 failed |

**dogfood**（受入条件）: worktree 上で `verify-run.sh` を実行し `RESULT passed`（exit 0）:

```
GATE work-evidence PASS commits=1 uncommitted=0
GATE lint PASS exit=0 duration=4s
GATE typecheck PASS exit=0 duration=2s
GATE unit PASS exit=0 duration=25s
RESULT passed
```

## スコープ外

製品コード（`src/`）への変更は一切なし（Phase 1 以降）

Refs #1540