### PR TITLE
chore(config): .commandmate/tasks/*.yaml を Git 追跡対象にし追跡ポリシーを可視化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,11 +71,21 @@ logs/
 # CommandMate 実行時データ（ユーザーがチャットに添付した画像の保存先）。
 # src/app/api/worktrees/[id]/send/route.ts が imagePath の許可パスとして参照する。
 # アプリが書き込み続けるランタイム生成物のためコミットしない（dev-reports/ と同扱い）。
-# verify.yaml だけは検証ゲートの宣言（設定であって生成物ではない）なので追跡する。
-# ディレクトリごと除外すると git がその中を走査せず ! 行が効かないため、
-# 除外は /.commandmate/*（中身単位）で書く必要がある。
+#
+# 例外は「設定」であって「生成物」でないファイルだけ。追跡ポリシーの解説と
+# 手元での確認方法は docs/design/commandmate-directory-tracking.md を参照。
+#
+# 【重要】サブディレクトリの中身を追跡したいときは ! を 1 行足すだけでは効かない。
+# git は除外されたディレクトリの中を走査しないため、まずディレクトリ自体を
+# 除外解除してから中身を絞り込む 2 段構えが要る（下の tasks/ がその形）。
+# 規則を変更したら scripts/check-commandmate-tracking.sh で確認すること。
 /.commandmate/*
 !/.commandmate/verify.yaml
+# 実行契約（Issue #1545 / Phase 2-1）。「誰がどんな制約で作業させたか」の記録なので
+# レビュー可能な形で追跡する。.yaml 以外（ログ等の副産物）は除外したままにする。
+!/.commandmate/tasks/
+/.commandmate/tasks/*
+!/.commandmate/tasks/*.yaml
 
 # 直下の .md は既知のドキュメントのみ追跡する。
 # 検証用スナップショットは *-snapshot.md / snapshot-*.md / codex-tab-final.md のように

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Added
+- **`.commandmate/tasks/*.yaml`（実行契約）を Git 追跡対象にし、追跡ポリシーを可視化** (#1545 の前提整備): `.commandmate/` はランタイムデータ置き場のため全体を除外しているが、その中の**設定**（`verify.yaml`・実行契約）はチームで共有すべきものなので追跡する必要がある。Phase 2-1 が契約を `.commandmate/tasks/<name>.yaml` に置く設計のため、着手前に規則を整えた。**負パターンを 1 行足すだけでは効かない** — git は除外されたディレクトリの中を走査しないので、ディレクトリを除外解除 → 中身を再除外 → 拡張子で許可、の 2 段構えが要る（#1540 で verify.yaml が踏んだ罠と同型）。利用者が状態を知る手段として `scripts/check-commandmate-tracking.sh`（`npm run check:tracking`）を追加し、追跡されるべきファイルと隣に置かれうる無視されるべきファイルの両方を一覧で報告する。規則を壊すと正しい書き方のヒントつきで exit 1 で落ちる。CI ガード `tests/unit/config/commandmate-tracking.test.ts` と設計文書 `docs/design/commandmate-directory-tracking.md` も追加した。判定には **`git check-ignore --no-index`** を使う — 既定では index が参照され、**すでに追跡済みのファイルはルールに関係なく「無視されない」と報告される**ため、`verify.yaml` の例外行を削除する変異を注入してもテストが緑のままだった（空振り緑）。`--no-index` 追加後は当該変異を含む 3 種の変異注入すべてでテストが実際に赤くなることを確認済み。
+
 
 - **検証ゲート Skill `cmate-verify` と `.commandmate/verify.yaml` v1 仕様を追加** (#1540): 検証ゲートの設定形式を製品実装（Phase 1）より先に実地検証するための先行 Skill。`docs/design/verification-config.md` を正準仕様とし、`.claude/skills/cmate-verify/` と `.agents/skills/cmate-verify/` へ byte-identical に配置（Claude は前者、Codex / Antigravity は後者しか読まない）。ランナーは bash 3.2 互換で、ゲートを定義順に逐次実行し**失敗しても残りを実行して全結果を報告**、判定は必ず実 exit code で行う（出力の grep は `$?` を隠す）。macOS に `timeout(1)` が無い前提で、job control による**プロセスグループ単位**の timeout kill を実装（直接の子だけを kill すると孫が生き残る／signal 送出前に pgid が pid と一致することを確認して無関係なプロセスグループを巻き込まない）。組み込みゲート `work-evidence` が「作業の痕跡ゼロ」を `not_started` として弾き、`skipInPrimaryCheckout` がメイン checkout でのコマンド実行を止める（全 skip は `passed` ではなく `skipped`）。fixture ベースの自己完結テスト 123 アサーション（vitest 非依存）＋ vitest ラッパで CI からも実行。
 
@@ -21,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **デモ動画収録スキル `demo-video` の基盤を追加** (#1553): 隔離デモ環境（使い捨て seed repo・専用ポート・$HOME 配下 DB・自前プロセスグループ）、キャプチャ済み ANSI カセットを tmux pane へ再生してサーバの status-detector／response poller／UI を実物のまま駆動する偽エージェント（LLM のみ差し替え・モックゼロ）、@playwright/test をライブラリとして使う scene 単位 webm 録画の 3 点。`.claude/skills` と `.agents/skills` へ byte-identical 配置。
 
-### Added
 
 - **`demo-video` に絵コンテ・日英テロップ・ffmpeg 合成・30 秒尺検証ゲートを追加** (#1554): `demo-video.sh` 一発で `demo-30s.ja.mp4` / `demo-30s.en.mp4` が出る。文言の編集点は `storyboard/default.yaml` だけで、シーンの尺もテロップの in/out も合成の切り貼りもそこから機械算出する（手書きタイムコードは無い）。ロケールはフル録画方式で、UI ごと切り替えて 2 回撮り、遷移ごとに `<html lang>` を実測して不一致ならテイクを失敗させる（「UI 言語がテロップ言語と一致」を目視でなく機械で担保）。テロップは HTML→透過 PNG→ffmpeg overlay で焼き込み（drawtext の日本語 fontfile／エスケープ問題を回避し意匠を CSS 1 箇所に集約、文字列は `textContent` 注入なので絵コンテがマークアップを注入できない）。尺は `ffprobe` 実測が 30.0±0.5s を外れたら **exit 1**。承認シーン用にカセットへ実キャプチャ由来の承認プロンプトを追加し、`{{TASK}}` 置換（承認後も元の指示を echo し続ける）と `Scene.prepare`（API 待ちを録画開始前に行う）を導入した。生成物はリポジトリ外に出しコミットしない（配布は Release アセット）。
 

--- a/docs/design/commandmate-directory-tracking.md
+++ b/docs/design/commandmate-directory-tracking.md
@@ -1,0 +1,122 @@
+# `.commandmate/` の追跡ポリシー
+
+- **関連 Issue**: [#1540](https://github.com/Kewton/CommandMate/issues/1540)（verify.yaml）／[#1545](https://github.com/Kewton/CommandMate/issues/1545)（実行契約）
+- **確認コマンド**: `./scripts/check-commandmate-tracking.sh`
+- **CI ガード**: `tests/unit/config/commandmate-tracking.test.ts`
+
+---
+
+## 1. 方針
+
+`.commandmate/` には **2 種類のものが混在**する。
+
+| 種類 | 例 | Git 追跡 | 理由 |
+|---|---|:---:|---|
+| **設定**（人が書く宣言） | `verify.yaml`、`tasks/*.yaml` | ✅ **する** | チーム全員・全 worktree で同じ判定基準／同じ契約を共有する必要がある。レビュー対象でもある |
+| **ランタイムデータ**（アプリが書く） | `attachments/`、キャッシュ類 | ❌ しない | アプリが動くたびに増え続ける生成物。`dev-reports/` と同じ扱い |
+
+したがって `.gitignore` は **「全部除外 → 設定だけを例外にする」** という許可リスト方式で書く。
+新しい設定ファイルを `.commandmate/` に追加するときは、この文書と `.gitignore` の両方を更新すること。
+
+---
+
+## 2. 現在の規則
+
+```gitignore
+/.commandmate/*
+!/.commandmate/verify.yaml
+!/.commandmate/tasks/
+/.commandmate/tasks/*
+!/.commandmate/tasks/*.yaml
+```
+
+読み方:
+
+1. `/.commandmate/*` — 配下をすべて除外（既定は「追跡しない」）
+2. `!/.commandmate/verify.yaml` — 検証ゲートの宣言だけ例外
+3. `!/.commandmate/tasks/` — **`tasks` ディレクトリ自体**の除外を解除
+4. `/.commandmate/tasks/*` — その中身は改めて全部除外
+5. `!/.commandmate/tasks/*.yaml` — 契約ファイル（`.yaml`）だけ例外
+
+---
+
+## 3. 落とし穴：`!` を 1 行足すだけでは効かない
+
+**サブディレクトリの中身を追跡したい場合、負パターン 1 行では追跡されない。**
+
+```gitignore
+# ❌ これは効かない
+/.commandmate/*
+!/.commandmate/verify.yaml
+!/.commandmate/tasks/*.yaml
+```
+
+理由は git の仕様で、
+
+> **除外されたディレクトリの中を git は走査しない。**
+
+`/.commandmate/*` が `tasks/` ディレクトリ自体を除外するため、git は `tasks/` を開かず、
+中のファイルに対する `!` パターンは**評価される機会がない**。
+
+そのため上記 §2 の 3〜5 のように、**ディレクトリを除外解除 → 中身を再除外 → 拡張子で許可**
+という 2 段構えが必要になる。
+
+この落とし穴は #1540（verify.yaml の追跡）で一度踏んでおり、`.gitignore` 内にも注意書きがある。
+
+---
+
+## 4. 確認方法
+
+### 手元で確認する
+
+```bash
+./scripts/check-commandmate-tracking.sh
+```
+
+```
+commandmate config tracking (.gitignore):
+  ok   .commandmate/verify.yaml               tracked (verification gates #1540)
+  ok   .commandmate/tasks/build.yaml          tracked (execution contract #1545)
+  ok   .commandmate/attachments/a.png         ignored (chat attachment (runtime))
+  ok   .commandmate/tasks/scratch.log         ignored (log beside a contract)
+  ...
+OK: all check-commandmate-tracking.sh expectations hold.
+```
+
+終了コードは 0（全期待どおり）／1（1 件以上違反）／2（git リポジトリでない）。
+規則を壊した場合は、正しい書き方のヒントを出して落ちる。
+
+### 単一ファイルを調べる
+
+```bash
+git check-ignore -v --no-index .commandmate/tasks/mytask.yaml
+```
+
+判定は**終了コード**で読むこと（`0` = 無視される、`1` = 追跡できる）。
+
+### 判定を誤りやすい点（2 つ）
+
+1. **`-v` の出力有無で判断しない。**
+   `-v` は否定パターンにマッチした場合も行を表示するため、「出力があった＝無視される」と
+   読むと**追跡できるファイルを無視と誤判定**する。
+
+2. **`--no-index` を省略しない。**
+   `git check-ignore` は既定で index を参照し、**すでに追跡済みのファイルはルールに関係なく
+   「無視されない」と報告する**。`verify.yaml` のようにコミット済みのファイルを既定のまま
+   調べると、`!` 行を削除しても「追跡できる」と出てしまい、規則の破壊を検出できない。
+
+   > この 2 点目は実際にこのリポジトリのテストで空振り（vacuous green）を生んだ。
+   > `!/.commandmate/verify.yaml` を削除する変異を注入してもテストが緑のままだったため発覚し、
+   > `--no-index` を付けて修正した。
+
+---
+
+## 5. 新しい設定ファイルを追加するとき
+
+1. `.gitignore` に例外を追加する（サブディレクトリなら §3 の 2 段構え）
+2. `scripts/check-commandmate-tracking.sh` の `expect` 行に**追跡されるべき例と、
+   隣に置かれうる無視されるべき例の両方**を追加する
+3. `tests/unit/config/commandmate-tracking.test.ts` の一覧にも同じ 2 例を追加する
+4. **変異注入で確認する** — 追加した例外行を消してテストが実際に赤くなること。
+   規則を書いただけでは「たまたま通っている」と区別できない
+5. 本書の §1 の表を更新する

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prepublishOnly": "npm run build:all",
     "start": "NODE_ENV=production node dist/server/server.js",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "check:tracking": "./scripts/check-commandmate-tracking.sh",
     "test": "NODE_ENV=test vitest",
     "test:ui": "NODE_ENV=test vitest --ui",
     "test:coverage": "NODE_ENV=test vitest --coverage",

--- a/scripts/check-commandmate-tracking.sh
+++ b/scripts/check-commandmate-tracking.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-commandmate-tracking — report which .commandmate/ paths git will track.
+#
+# `.commandmate/` holds runtime data (chat attachments, caches) and is excluded
+# wholesale. A few files in it are *configuration* rather than output and must be
+# committed so the whole team shares them:
+#
+#   .commandmate/verify.yaml       verification gates  (Issue #1540)
+#   .commandmate/tasks/*.yaml      execution contracts (Issue #1545)
+#
+# A config file that is silently ignored looks identical to one that is tracked
+# until someone clones the repo and finds it missing, so this script makes the
+# answer visible on demand. Run it after editing .gitignore.
+#
+# Usage: scripts/check-commandmate-tracking.sh
+# Exit:  0 = every expectation holds, 1 = at least one is wrong, 2 = not a repo.
+#
+# bash 3.2 compatible (macOS ships 3.2.57): no associative arrays, no mapfile.
+set -u
+
+cd "$(dirname "$0")/.." || exit 2
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "check-commandmate-tracking: not a git repository" >&2
+  exit 2
+}
+
+# `git check-ignore` evaluates a pathname against the ignore rules and does NOT
+# require the file to exist, so this script never touches the working tree.
+#
+# --no-index is required, not optional. By default check-ignore consults the
+# index, and an already-tracked file is reported as "not ignored" no matter what
+# the rules say — which would make every check on a committed file (verify.yaml)
+# pass unconditionally and hide a broken rule. We want the verdict of the rules
+# alone, which is what decides whether a *new* clone or a *new* file is kept.
+#
+# Judge by EXIT CODE, never by whether `-v` printed something: with -v git also
+# prints the matching *negation* line for paths that are NOT ignored, so
+# "produced output" reads a tracked file as ignored.
+#   exit 0 -> ignored
+#   exit 1 -> tracked
+is_ignored() { git check-ignore -q --no-index "$1"; }
+
+fail=0
+
+# expect <tracked|ignored> <path> <why>
+expect() {
+  want=$1; target=$2; why=$3
+  if is_ignored "$target"; then got=ignored; else got=tracked; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-38s %s (%s)\n' "$target" "$got" "$why"
+  else
+    printf '  FAIL %-38s want=%s got=%s (%s)\n' "$target" "$want" "$got" "$why"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "commandmate config tracking (.gitignore):"
+
+# Configuration — must be committed and shared.
+expect tracked '.commandmate/verify.yaml'        'verification gates #1540'
+expect tracked '.commandmate/tasks/build.yaml'   'execution contract #1545'
+expect tracked '.commandmate/tasks/any-name.yaml' 'contract, arbitrary name'
+
+# Runtime output and stray files — must stay out of the repository.
+expect ignored '.commandmate/attachments/a.png'  'chat attachment (runtime)'
+expect ignored '.commandmate/tasks/scratch.log'  'log beside a contract'
+expect ignored '.commandmate/tasks/notes.md'     'non-yaml beside a contract'
+expect ignored '.commandmate/cache.json'         'unknown runtime file'
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "OK: all ${0##*/} expectations hold."
+  exit 0
+fi
+echo "FAILED: $fail expectation(s) wrong."
+echo
+echo "Hint: to track files under a new subdirectory of .commandmate/, one '!' line"
+echo "is not enough — git does not descend into an excluded directory, so the"
+echo "negation never gets evaluated. Un-exclude the directory first, then narrow:"
+echo
+echo "    !/.commandmate/<dir>/"
+echo "    /.commandmate/<dir>/*"
+echo "    !/.commandmate/<dir>/*.yaml"
+exit 1

--- a/tests/unit/config/commandmate-tracking.test.ts
+++ b/tests/unit/config/commandmate-tracking.test.ts
@@ -1,0 +1,91 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `.commandmate/` is excluded wholesale because the app writes runtime data into
+ * it (chat attachments, caches). A few files in it are *configuration* and must
+ * be committed so the team shares them:
+ *
+ *   .commandmate/verify.yaml    verification gates  (#1540)
+ *   .commandmate/tasks/*.yaml   execution contracts (#1545)
+ *
+ * A config file that is silently ignored is indistinguishable from a tracked one
+ * until somebody clones the repo and finds it missing, so the rule is pinned here.
+ *
+ * The subtlety worth protecting: adding a single `!` line for a file inside a new
+ * subdirectory does NOT work, because git never descends into an excluded
+ * directory and so never evaluates the negation. The directory has to be
+ * un-excluded first, then its contents narrowed.
+ */
+
+const REPO_ROOT = process.cwd();
+const CHECKER = path.join(REPO_ROOT, 'scripts/check-commandmate-tracking.sh');
+
+/**
+ * True when git would ignore `target`.
+ *
+ * Judged by exit code (0 = ignored, 1 = tracked), never by whether `-v` printed
+ * something: with `-v` git also prints the matching *negation* line for paths
+ * that are not ignored, so "produced output" misreads a tracked file as ignored.
+ *
+ * `--no-index` is load-bearing. Without it check-ignore consults the index and
+ * calls any already-tracked file "not ignored" regardless of the rules, so the
+ * assertions on committed files (verify.yaml) would pass even with their `!`
+ * line deleted — a vacuous green. Verified by mutation: dropping the negation
+ * leaves this suite passing without the flag, and fails it with the flag.
+ *
+ * `git check-ignore` evaluates a pathname against the rules and does not require
+ * the file to exist, so these assertions never touch the working tree.
+ */
+function isIgnored(target: string): boolean {
+  const result = spawnSync('git', ['check-ignore', '-q', '--no-index', target], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(
+      `git check-ignore failed for ${target}: status=${result.status} ${result.stderr}`,
+    );
+  }
+  return result.status === 0;
+}
+
+describe('.commandmate/ tracking policy', () => {
+  // Configuration: committed and shared.
+  it.each([
+    ['.commandmate/verify.yaml', 'verification gates (#1540)'],
+    ['.commandmate/tasks/build.yaml', 'execution contract (#1545)'],
+    ['.commandmate/tasks/any-name.yaml', 'contract under an arbitrary name'],
+  ])('tracks %s — %s', (target) => {
+    expect(isIgnored(target)).toBe(false);
+  });
+
+  // Runtime output: must stay out of the repository.
+  it.each([
+    ['.commandmate/attachments/a.png', 'chat attachment written by the app'],
+    ['.commandmate/cache.json', 'unknown runtime file'],
+    ['.commandmate/tasks/scratch.log', 'log dropped beside a contract'],
+    ['.commandmate/tasks/notes.md', 'non-yaml dropped beside a contract'],
+  ])('ignores %s — %s', (target) => {
+    expect(isIgnored(target)).toBe(true);
+  });
+});
+
+describe('scripts/check-commandmate-tracking.sh', () => {
+  it('passes bash -n (bash 3.2 syntax gate)', () => {
+    execFileSync('bash', ['-n', CHECKER], { encoding: 'utf8' });
+  });
+
+  it('reports OK on the current .gitignore', () => {
+    // The script is what a developer runs by hand; if it and the rules above ever
+    // disagree, one of them is wrong and CI should say so rather than let the
+    // human-facing tool drift away from the pinned policy.
+    const result = spawnSync('bash', [CHECKER], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    expect(result.stdout + result.stderr).toContain('OK:');
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要

Phase 2-1（#1545）の**着手前提の整備**。実行契約 `.commandmate/tasks/<name>.yaml` を Git 追跡対象にし、追跡状態を利用者が確認できる手段を用意する。

`.commandmate/` はランタイムデータ置き場（チャット添付画像・キャッシュ）として全体が除外されているため、そのままでは契約ファイルが Git に入らない。契約は「誰がどんな制約で作業させたか」の記録でレビュー対象なので、`verify.yaml` と同じく追跡する必要がある。

## 変更内容

| ファイル | 内容 |
|---|---|
| `.gitignore` | `.commandmate/tasks/*.yaml` を追跡する 2 段構え規則 |
| `scripts/check-commandmate-tracking.sh` | 追跡状態の確認コマンド（`npm run check:tracking`） |
| `tests/unit/config/commandmate-tracking.test.ts` | CI ガード（9 tests） |
| `docs/design/commandmate-directory-tracking.md` | 追跡ポリシーと落とし穴の解説 |
| `CHANGELOG.md` | エントリ追加＋既存の重複見出し統合 |

## 負パターン 1 行では効かない

```gitignore
# ❌ 効かない
/.commandmate/*
!/.commandmate/tasks/*.yaml
```

git は**除外されたディレクトリの中を走査しない**ため、`tasks/` が除外されている状態では中のファイルに対する `!` が評価される機会がない。以下の 2 段構えが必要:

```gitignore
/.commandmate/*
!/.commandmate/verify.yaml
!/.commandmate/tasks/          # ① ディレクトリ自体を除外解除
/.commandmate/tasks/*          # ② 中身を再除外
!/.commandmate/tasks/*.yaml    # ③ .yaml だけ許可
```

#1540 の verify.yaml が踏んだ罠と同型。

## 利用者が状態を知る手段

```console
$ npm run check:tracking
commandmate config tracking (.gitignore):
  ok   .commandmate/verify.yaml               tracked (verification gates #1540)
  ok   .commandmate/tasks/build.yaml          tracked (execution contract #1545)
  ok   .commandmate/tasks/any-name.yaml       tracked (contract, arbitrary name)
  ok   .commandmate/attachments/a.png         ignored (chat attachment (runtime))
  ok   .commandmate/tasks/scratch.log         ignored (log beside a contract)
  ok   .commandmate/tasks/notes.md            ignored (non-yaml beside a contract)
  ok   .commandmate/cache.json                ignored (unknown runtime file)

OK: all check-commandmate-tracking.sh expectations hold.
```

規則を壊すと、正しい書き方のヒントつきで exit 1 で落ちる。`git check-ignore` はファイルの実在を要求しないため、**作業ツリーを一切変更しない**（bash 3.2 互換）。

## `--no-index` は必須 — 空振り緑を修正した

判定には `git check-ignore --no-index` を使っている。**既定では index が参照され、すでに追跡済みのファイルはルールに関係なく「無視されない」と報告される**ためである。

初版のテストはこれを踏み、`!/.commandmate/verify.yaml` を削除する変異を注入しても**緑のままだった**（verify.yaml はコミット済みのため常に「追跡できる」と報告されていた）。

`--no-index` 追加後、3 種の変異注入すべてでテストが実際に赤くなることを確認:

| 変異 | 結果 |
|---|---|
| `!/.commandmate/verify.yaml` 削除 | **2 failed** |
| tasks の 2 段構えを 1 行に戻す | **3 failed** |
| `*.yaml` 絞り込みを削除（ログまで追跡される） | **3 failed** |

この罠はスクリプト・テスト・設計文書の 3 箇所にコメントとして残した。

> あわせて `-v` の出力有無で判定しないことも明記している（`-v` は否定パターンにマッチした場合も行を表示するため、追跡できるファイルを「無視」と誤読する）。

## あわせて修正: CHANGELOG の重複見出し

`## [Unreleased]` 配下に `### Added` が 3 つ重複していた（#1540〜#1554 のコンフリクト解消時に生じたもの）。1 つに統合し、既存 7 件のエントリがすべて残っていることを develop との件数比較で確認済み。

## 検証

worktree で exit code を直接測定:

| ゲート | 結果 |
|--------|------|
| `npm run lint` | PASS (exit 0) |
| `npx tsc --noEmit` | PASS (exit 0) |
| `npm run test:unit` | PASS (exit 0) |
| `npm run build` | PASS (exit 0) |
| `npm run check:tracking` | PASS (exit 0) |

Refs #1545