### PR TITLE
refactor(status): セッション状態語彙の変換を status-mapping.ts へ一元化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`commandmate verify` コマンドと `wait --verify` / `--require-work` を追加** (#1544): 検証ゲートを CLI から起動し、`wait` の成功条件を「エージェントが止まった」から「検証に合格した」へ引き上げる。exit code は 合格 0 / ゲート不合格 20 / 作業証跡ゼロ 21 / タイムアウト 124 で、判定不能（`error`・`cancelled`）は 20 ではなく 99 に倒す（「判定できなかった」を「判定してダメだった」と読ませないため）。検証は**完了検知できた worktree だけ**に走り、プロンプト検出(10)やタイムアウト(124)はそのまま返す。複数 worktree では完了検知は並行・検証は直列（サーバ側が同時実行数 2 に制限しているため並行させても queue するだけ）、集約の優先順位は 10 > 20 > 21 > 124。直列実行の並行化・`not_started`→0 への写像・優先順位の入れ替え・プロンプト時のガード除去・timeout 判定を終端 status 判定より前に置く、の 5 種の変異注入でテストが実際に赤くなることを確認済み。
 
+### Changed
+
+- **セッション状態語彙の変換を `src/lib/session/status-mapping.ts` へ一元化** (#1550): `SessionStatus`（検出）・boolean 三つ組（`isRunning` / `isWaitingForResponse` / `isProcessing`）・`BranchStatus`（表示）の相互変換が 3 ファイルに散在していたため、変換だけを 1 モジュールへ移して対応表をゴールデンテストで固定した（挙動変更ゼロ）。`deriveCliStatus` は `@/types/sidebar` から移設し同名で re-export（既存 import と既存テストは無修正）、`worktree-status-helper.ts` の `status === 'waiting'` / `=== 'running'` インライン式は `sessionStatusToActivityFlags()`（`satisfies never` で exhaustive）に置換、`src/app/api/worktrees/route.ts` に private 定義されていた**逆方向**の `deriveSessionStatus`（三つ組 → SessionStatus）も同モジュールへ移した。`UIPhase` は `waiting → receiving → complete` が履歴依存のシーケンスであり `SessionStatus` の写像ではないので、唯一の表引き（プロンプト検出 → `prompt`）を持つ `worktreeUIReducer` に残し、本モジュールには写像関数を作っていない。既存の `worktree-status-helper.test.ts` は検出器を常に `status: 'ready'` でモックしており移設対象の `running` / `waiting` 分岐を一度も通らないため、SessionStatus 全値を helper 経由で駆動する回帰テストを別ファイルで追加した。マッピング 4 種＋ helper 配線 1 種の変異注入で、追加したテストが実際に赤くなることを確認済み。
+
 ## [0.16.0] - 2026-07-29
 
 > **Highlight**: **Skill 配布 MVP を「入れられる」から「運用できる」へ引き上げたリリース。** 導入先 Agent の対応状況を manifest の申告だけでなく CommandMate 側の実測で裏付ける互換 matrix（#1246）、どの worktree に何が入っていて導入時のままかを横断確認する監査 dashboard と receipt からの reindex（#1248、DB migration v48）、Skill 導入を review 可能な commit / draft PR に載せる専用 git workflow（#1247）を追加した。あわせて、uninstall した Skill を再 install すると **exit 0 で「Installed」と報告しながら 1 バイトも書かれない** journal replay の欠陥（#1552）を修正し、対になる uninstall 経路の同型欠陥も同時に塞いだ。

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -340,6 +340,7 @@
 | `src/cli/config/model-validation.ts` | CLI側model名バリデーション（validateCopilotModelName、MODEL_NAME_PATTERN、クロスバリデーション対象）（Issue #588） |
 | `src/config/review-config.ts` | Review設定定数・テンプレート定数（STALLED_THRESHOLD_MS, REVIEW_POLL_INTERVAL_MS, MAX_TEMPLATES, MAX_TEMPLATE_NAME_LENGTH, MAX_TEMPLATE_CONTENT_LENGTH）（Issue #600, #618）、MAX_COMMIT_LOG_LENGTH/GIT_LOG_TOTAL_TIMEOUT_MS追加（Issue #627） |
 | `src/lib/session/next-action-helper.ts` | 次アクション算出ヘルパー（getNextAction, getReviewStatus, ReviewStatus型）（Issue #600） |
+| `src/lib/session/status-mapping.ts` | セッション状態語彙の変換を一元化（sessionStatusToActivityFlags / deriveCliStatus / deriveSessionStatus / deriveBranchStatus）。SessionStatus ↔ boolean三つ組 ↔ BranchStatus の唯一の定義箇所で、`@/types/sidebar` は deriveCliStatus を re-export するのみ。UIPhase は状態機械のため写像化せず reducer に残す（Issue #1550） |
 | `src/lib/detection/stalled-detector.ts` | Stalled判定（isWorktreeStalled）（Issue #600） |
 | `src/lib/deep-link-validator.ts` | Deep linkバリデーション（isDeepLinkPane, normalizeDeepLinkPane, VALID_PANES, DeepLinkPane型）（Issue #600） |
 | `src/lib/api/worktrees-include-parser.ts` | API includeパラメータパーサー（Issue #600） |

--- a/src/app/api/worktrees/route.ts
+++ b/src/app/api/worktrees/route.ts
@@ -16,25 +16,11 @@ import { parseIncludeParam } from '@/lib/api/worktrees-include-parser';
 import { isWorktreeStalled } from '@/lib/detection/stalled-detector';
 import { getNextAction, getReviewStatus } from '@/lib/session/next-action-helper';
 import { resolveAgentInstances } from '@/lib/session/agent-instances-resolver';
+import { deriveSessionStatus } from '@/lib/session/status-mapping';
 import { createLogger } from '@/lib/logger';
-import type { SessionStatus } from '@/lib/detection/status-detector';
 import type { PromptType } from '@/types/models';
 
 const logger = createLogger('api/worktrees');
-
-/**
- * Derive SessionStatus from worktree status helper result.
- */
-function deriveSessionStatus(status: {
-  isSessionRunning: boolean;
-  isWaitingForResponse: boolean;
-  isProcessing: boolean;
-}): SessionStatus | null {
-  if (!status.isSessionRunning) return null;
-  if (status.isWaitingForResponse) return 'waiting';
-  if (status.isProcessing) return 'running';
-  return 'ready';
-}
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/lib/session/status-mapping.ts
+++ b/src/lib/session/status-mapping.ts
@@ -1,0 +1,162 @@
+/**
+ * Session status vocabulary mapping (Issue #1550).
+ *
+ * The same session reality is expressed in several vocabularies:
+ *
+ * | Vocabulary          | Defined in                          | Values                                    |
+ * |---------------------|-------------------------------------|-------------------------------------------|
+ * | `SessionStatus`     | `lib/detection/status-detector.ts`  | idle / ready / running / waiting          |
+ * | `BranchStatus`      | `types/sidebar.ts`                  | idle / ready / running / waiting / generating |
+ * | boolean triple      | `lib/session/worktree-status-helper.ts` | isRunning / isWaitingForResponse / isProcessing |
+ * | `UIPhase`           | `types/ui-state.ts`                 | idle / waiting / receiving / prompt / complete |
+ *
+ * This module is the single place where those vocabularies are converted into
+ * one another, so the correspondence cannot drift between call sites. It is a
+ * pure module (type-only imports) and is therefore safe to import from client
+ * components.
+ *
+ * ## The live conversion chain
+ *
+ *   terminal output
+ *     -> detectSessionStatus()                  (status-detector, NOT touched here)
+ *     -> SessionStatus
+ *     -> sessionStatusToActivityFlags()         (this module)
+ *     -> boolean triple (+ isRunning from tmux session existence)
+ *     -> deriveCliStatus()                      (this module)
+ *     -> BranchStatus                           (sidebar / header / tab dots)
+ *
+ * `deriveSessionStatus()` is the reverse edge of that chain: the worktrees API
+ * folds the boolean triple back into a `SessionStatus` for its JSON payload.
+ *
+ * ## Why `UIPhase` has no mapping function here
+ *
+ * `UIPhase` is a state machine, not a projection of `SessionStatus`: `waiting`
+ * -> `receiving` -> `complete` is a sequence driven by user sends and streamed
+ * output, and the same `SessionStatus` can legitimately correspond to several
+ * phases depending on history. The only edge that is a pure table lookup is
+ * "an active prompt was detected -> phase `prompt`", and that edge is already
+ * expressed exactly once, by the `SHOW_PROMPT` case of `worktreeUIReducer`
+ * (`hooks/useWorktreeUIState.ts`). Re-encoding it here would add an indirection
+ * with no second call site, so the reducer stays the single owner.
+ */
+
+import type { SessionStatus } from '@/lib/detection/status-detector';
+import type { BranchStatus } from '@/types/sidebar';
+
+/**
+ * The boolean triple that both the sidebar and the worktree detail panes use to
+ * describe one CLI-tool / agent-instance session.
+ *
+ * Structurally identical to `CliToolSessionStatus` in `worktree-status-helper.ts`;
+ * declared here so this module stays free of server-side imports.
+ */
+export interface CliToolStatusFlags {
+  isRunning: boolean;
+  isWaitingForResponse: boolean;
+  isProcessing: boolean;
+}
+
+/** The activity half of the boolean triple — everything except session existence. */
+export type SessionActivityFlags = Omit<CliToolStatusFlags, 'isRunning'>;
+
+/**
+ * Project a detected `SessionStatus` onto the activity flags.
+ *
+ * `isRunning` is deliberately NOT derived here: it comes from tmux session
+ * existence (plus the Claude health check), which is independent of what the
+ * terminal output says.
+ *
+ * | SessionStatus | isWaitingForResponse | isProcessing |
+ * |---------------|----------------------|--------------|
+ * | `idle`        | false                | false        |
+ * | `ready`       | false                | false        |
+ * | `running`     | false                | true         |
+ * | `waiting`     | true                 | false        |
+ */
+export function sessionStatusToActivityFlags(status: SessionStatus): SessionActivityFlags {
+  switch (status) {
+    case 'waiting':
+      return { isWaitingForResponse: true, isProcessing: false };
+    case 'running':
+      return { isWaitingForResponse: false, isProcessing: true };
+    case 'idle':
+    case 'ready':
+      return { isWaitingForResponse: false, isProcessing: false };
+    default:
+      // exhaustive check: SessionStatus extensions cause a compile error [DR2-005]
+      status satisfies never;
+      return { isWaitingForResponse: false, isProcessing: false };
+  }
+}
+
+/**
+ * Derive `BranchStatus` from one session's boolean triple.
+ *
+ * Shared by the sidebar (`toBranchItem`), the worktree detail tab dots, the
+ * desktop header status row, Sessions and Review.
+ *
+ * Precedence is waiting > running > ready > idle: a session that is both
+ * waiting for an answer and processing is shown as `waiting`, because the user
+ * action it needs is the more significant fact.
+ *
+ * Note that `generating` is never produced here — it exists in `BranchStatus`
+ * but has no boolean-triple source. Resolving that asymmetry is out of scope
+ * for Issue #1550 (this issue only moves the conversions to one place).
+ */
+export function deriveCliStatus(toolStatus?: CliToolStatusFlags): BranchStatus {
+  if (!toolStatus) return 'idle';
+  if (toolStatus.isWaitingForResponse) return 'waiting';
+  if (toolStatus.isProcessing) return 'running';
+  if (toolStatus.isRunning) return 'ready';
+  return 'idle';
+}
+
+/**
+ * Fold a worktree-level boolean triple back into a `SessionStatus` for the
+ * worktrees API payload — the reverse edge of `sessionStatusToActivityFlags`.
+ *
+ * Returns `null` (not `'idle'`) when no session is running, because the API
+ * contract distinguishes "no session" from "a session that reports idle".
+ */
+export function deriveSessionStatus(status: {
+  isSessionRunning: boolean;
+  isWaitingForResponse: boolean;
+  isProcessing: boolean;
+}): SessionStatus | null {
+  if (!status.isSessionRunning) return null;
+  if (status.isWaitingForResponse) return 'waiting';
+  if (status.isProcessing) return 'running';
+  return 'ready';
+}
+
+/**
+ * The `SessionStatus` -> `BranchStatus` correspondence, as one table.
+ *
+ * Composed from the two conversions the live chain actually uses, so it can
+ * never drift from them.
+ *
+ * | isRunning | SessionStatus | BranchStatus |
+ * |-----------|---------------|--------------|
+ * | false     | (any / null)  | `idle`       |
+ * | true      | `null`        | `ready`      |
+ * | true      | `idle`        | `ready`      |
+ * | true      | `ready`       | `ready`      |
+ * | true      | `running`     | `running`    |
+ * | true      | `waiting`     | `waiting`    |
+ *
+ * The `idle` -> `ready` row is not a mistake: once a tmux session exists, the
+ * sidebar shows `ready` (the user can send a message) even while the detector
+ * still reports `idle` for the terminal contents.
+ */
+export function deriveBranchStatus(
+  sessionStatus: SessionStatus | null,
+  isRunning: boolean,
+): BranchStatus {
+  if (!isRunning) return 'idle';
+  return deriveCliStatus({
+    isRunning: true,
+    ...(sessionStatus
+      ? sessionStatusToActivityFlags(sessionStatus)
+      : { isWaitingForResponse: false, isProcessing: false }),
+  });
+}

--- a/src/lib/session/worktree-status-helper.ts
+++ b/src/lib/session/worktree-status-helper.ts
@@ -16,6 +16,7 @@ import { CLIToolManager } from '@/lib/cli-tools/manager';
 import { CLI_TOOL_IDS, type CLIToolType } from '@/lib/cli-tools/types';
 import { captureSessionOutput } from './cli-session';
 import { detectSessionStatus } from '@/lib/detection/status-detector';
+import { sessionStatusToActivityFlags } from './status-mapping';
 import { OPENCODE_PANE_HEIGHT } from '@/lib/cli-tools/opencode';
 import { GEMINI_PANE_HEIGHT } from '@/lib/cli-tools/gemini';
 import { STATUS_DETECTION_CAPTURE_LINES } from '@/config/status-capture-config';
@@ -129,8 +130,8 @@ async function detectInstanceSessionStatus(
       const lastServerResponseTs = getLastServerResponseTimestamp(compositeKey);
       const lastOutputTimestamp = lastServerResponseTs ? new Date(lastServerResponseTs) : undefined;
       const statusResult = detectSessionStatus(output, cliToolId, lastOutputTimestamp);
-      isWaitingForResponse = statusResult.status === 'waiting';
-      isProcessing = statusResult.status === 'running';
+      // Issue #1550: SessionStatus → activity flags lives in status-mapping.ts
+      ({ isWaitingForResponse, isProcessing } = sessionStatusToActivityFlags(statusResult.status));
 
       // Clean up stale pending prompts (scoped to this instance) if none is showing
       if (!statusResult.hasActivePrompt) {

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -14,6 +14,12 @@ import {
   type AgentInstance,
 } from '@/lib/cli-tools/types';
 import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
+import { deriveCliStatus } from '@/lib/session/status-mapping';
+
+// Issue #1550: the status-vocabulary conversions now live in
+// `@/lib/session/status-mapping`. Re-exported here so existing importers of
+// `@/types/sidebar` keep working; that module holds the only definition.
+export { deriveCliStatus };
 
 /**
  * Branch status in sidebar
@@ -24,27 +30,6 @@ import { DEFAULT_SELECTED_AGENTS } from '@/lib/selected-agents-validator';
  * - generating: AI is generating response
  */
 export type BranchStatus = 'idle' | 'ready' | 'running' | 'waiting' | 'generating';
-
-/** Per-CLI tool status input shape */
-interface CLIToolStatusInput {
-  isRunning: boolean;
-  isWaitingForResponse: boolean;
-  isProcessing: boolean;
-}
-
-/**
- * Derive BranchStatus from per-CLI tool session status flags.
- * Shared by sidebar (toBranchItem) and WorktreeDetailRefactored tab dots.
- */
-export function deriveCliStatus(
-  toolStatus?: CLIToolStatusInput
-): BranchStatus {
-  if (!toolStatus) return 'idle';
-  if (toolStatus.isWaitingForResponse) return 'waiting';
-  if (toolStatus.isProcessing) return 'running';
-  if (toolStatus.isRunning) return 'ready';
-  return 'idle';
-}
 
 /**
  * Aggregate per-agent CLI statuses into a single representative BranchStatus

--- a/tests/unit/lib/status-mapping.test.ts
+++ b/tests/unit/lib/status-mapping.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Golden tests for the session status vocabulary mapping (Issue #1550).
+ *
+ * Issue #1550 is a behaviour-preserving refactor: these tests pin the mapping
+ * that shipped before the conversions were moved into one module, so any future
+ * change to the correspondence has to be a deliberate edit of this table.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  sessionStatusToActivityFlags,
+  deriveCliStatus,
+  deriveSessionStatus,
+  deriveBranchStatus,
+  type CliToolStatusFlags,
+} from '@/lib/session/status-mapping';
+import type { SessionStatus } from '@/lib/detection/status-detector';
+import type { BranchStatus } from '@/types/sidebar';
+
+/** Every value of SessionStatus, spelled out so a new value fails to compile. */
+const ALL_SESSION_STATUSES = ['idle', 'ready', 'running', 'waiting'] as const;
+
+// Compile-time guard: if SessionStatus gains a value, this assignment breaks.
+const _sessionStatusCoverage: readonly SessionStatus[] = ALL_SESSION_STATUSES;
+const _sessionStatusExhaustive: (typeof ALL_SESSION_STATUSES)[number] =
+  null as unknown as SessionStatus;
+void _sessionStatusCoverage;
+void _sessionStatusExhaustive;
+
+describe('sessionStatusToActivityFlags (Issue #1550)', () => {
+  const TABLE: ReadonlyArray<
+    [SessionStatus, { isWaitingForResponse: boolean; isProcessing: boolean }]
+  > = [
+    ['idle', { isWaitingForResponse: false, isProcessing: false }],
+    ['ready', { isWaitingForResponse: false, isProcessing: false }],
+    ['running', { isWaitingForResponse: false, isProcessing: true }],
+    ['waiting', { isWaitingForResponse: true, isProcessing: false }],
+  ];
+
+  it.each(TABLE)('%s → %j', (status, expected) => {
+    expect(sessionStatusToActivityFlags(status)).toEqual(expected);
+  });
+
+  it('covers every SessionStatus value', () => {
+    expect(TABLE.map(([status]) => status)).toEqual([...ALL_SESSION_STATUSES]);
+  });
+
+  it('reproduces the pre-refactor inline expressions in worktree-status-helper', () => {
+    // Before Issue #1550 the helper computed these two booleans inline as
+    // `status === 'waiting'` / `status === 'running'`. Assert the extracted
+    // function is equivalent for every input rather than trusting the move.
+    for (const status of ALL_SESSION_STATUSES) {
+      expect(sessionStatusToActivityFlags(status)).toEqual({
+        isWaitingForResponse: status === 'waiting',
+        isProcessing: status === 'running',
+      });
+    }
+  });
+
+  it('never reports both waiting and processing for a single status', () => {
+    for (const status of ALL_SESSION_STATUSES) {
+      const flags = sessionStatusToActivityFlags(status);
+      expect(flags.isWaitingForResponse && flags.isProcessing).toBe(false);
+    }
+  });
+});
+
+describe('deriveCliStatus — full boolean-triple table (Issue #1550)', () => {
+  // All 2^3 = 8 flag combinations, plus the absent-input case.
+  const TABLE: ReadonlyArray<[CliToolStatusFlags, BranchStatus]> = [
+    [{ isRunning: false, isWaitingForResponse: false, isProcessing: false }, 'idle'],
+    [{ isRunning: false, isWaitingForResponse: false, isProcessing: true }, 'running'],
+    [{ isRunning: false, isWaitingForResponse: true, isProcessing: false }, 'waiting'],
+    [{ isRunning: false, isWaitingForResponse: true, isProcessing: true }, 'waiting'],
+    [{ isRunning: true, isWaitingForResponse: false, isProcessing: false }, 'ready'],
+    [{ isRunning: true, isWaitingForResponse: false, isProcessing: true }, 'running'],
+    [{ isRunning: true, isWaitingForResponse: true, isProcessing: false }, 'waiting'],
+    [{ isRunning: true, isWaitingForResponse: true, isProcessing: true }, 'waiting'],
+  ];
+
+  it('enumerates all 8 flag combinations', () => {
+    expect(TABLE).toHaveLength(8);
+    expect(new Set(TABLE.map(([flags]) => JSON.stringify(flags))).size).toBe(8);
+  });
+
+  it.each(TABLE)('%j → %s', (flags, expected) => {
+    expect(deriveCliStatus(flags)).toBe(expected);
+  });
+
+  it('returns idle when no status is supplied', () => {
+    expect(deriveCliStatus(undefined)).toBe('idle');
+  });
+
+  it('gives waiting precedence over processing', () => {
+    expect(
+      deriveCliStatus({ isRunning: true, isWaitingForResponse: true, isProcessing: true })
+    ).toBe('waiting');
+  });
+
+  it('never produces generating (no boolean-triple source exists)', () => {
+    for (const [flags] of TABLE) {
+      expect(deriveCliStatus(flags)).not.toBe('generating');
+    }
+  });
+});
+
+describe('deriveSessionStatus — reverse edge (Issue #1550)', () => {
+  const TABLE: ReadonlyArray<
+    [
+      { isSessionRunning: boolean; isWaitingForResponse: boolean; isProcessing: boolean },
+      SessionStatus | null,
+    ]
+  > = [
+    [{ isSessionRunning: false, isWaitingForResponse: false, isProcessing: false }, null],
+    [{ isSessionRunning: false, isWaitingForResponse: true, isProcessing: true }, null],
+    [{ isSessionRunning: true, isWaitingForResponse: false, isProcessing: false }, 'ready'],
+    [{ isSessionRunning: true, isWaitingForResponse: false, isProcessing: true }, 'running'],
+    [{ isSessionRunning: true, isWaitingForResponse: true, isProcessing: false }, 'waiting'],
+    [{ isSessionRunning: true, isWaitingForResponse: true, isProcessing: true }, 'waiting'],
+  ];
+
+  it.each(TABLE)('%j → %s', (flags, expected) => {
+    expect(deriveSessionStatus(flags)).toBe(expected);
+  });
+
+  it('returns null (not idle) when no session is running', () => {
+    expect(
+      deriveSessionStatus({
+        isSessionRunning: false,
+        isWaitingForResponse: false,
+        isProcessing: false,
+      })
+    ).toBeNull();
+  });
+
+  it('round-trips SessionStatus → flags → SessionStatus for running sessions', () => {
+    for (const status of ALL_SESSION_STATUSES) {
+      const roundTripped = deriveSessionStatus({
+        isSessionRunning: true,
+        ...sessionStatusToActivityFlags(status),
+      });
+      // 'idle' is the one non-fixpoint: a live session that the detector calls
+      // 'idle' is reported to the API as 'ready'.
+      expect(roundTripped).toBe(status === 'idle' ? 'ready' : status);
+    }
+  });
+});
+
+describe('deriveBranchStatus — SessionStatus × isRunning table (Issue #1550)', () => {
+  const TABLE: ReadonlyArray<[SessionStatus | null, boolean, BranchStatus]> = [
+    [null, false, 'idle'],
+    ['idle', false, 'idle'],
+    ['ready', false, 'idle'],
+    ['running', false, 'idle'],
+    ['waiting', false, 'idle'],
+    [null, true, 'ready'],
+    ['idle', true, 'ready'],
+    ['ready', true, 'ready'],
+    ['running', true, 'running'],
+    ['waiting', true, 'waiting'],
+  ];
+
+  it('enumerates every (SessionStatus | null) × isRunning combination', () => {
+    expect(TABLE).toHaveLength((ALL_SESSION_STATUSES.length + 1) * 2);
+  });
+
+  it.each(TABLE)('sessionStatus=%s isRunning=%s → %s', (status, isRunning, expected) => {
+    expect(deriveBranchStatus(status, isRunning)).toBe(expected);
+  });
+
+  it('collapses every status to idle when the session is not running', () => {
+    for (const status of [...ALL_SESSION_STATUSES, null]) {
+      expect(deriveBranchStatus(status, false)).toBe('idle');
+    }
+  });
+
+  it('agrees with the live chain (activity flags → deriveCliStatus)', () => {
+    // deriveBranchStatus must not become a parallel implementation: assert it
+    // equals the composition the production code path actually performs.
+    for (const status of ALL_SESSION_STATUSES) {
+      const viaChain = deriveCliStatus({
+        isRunning: true,
+        ...sessionStatusToActivityFlags(status),
+      });
+      expect(deriveBranchStatus(status, true)).toBe(viaChain);
+    }
+  });
+});
+
+describe('table integrity — a wrong expectation is recorded as a failure', () => {
+  // Guards against a vacuously-green table: if `it.each` silently passed on a
+  // mismatched row, this deliberate mismatch would go unnoticed too.
+  it('fails a row whose expected value is wrong', () => {
+    expect(() => expect(deriveCliStatus(undefined)).toBe('running')).toThrow();
+    expect(() => expect(sessionStatusToActivityFlags('waiting')).toEqual({
+      isWaitingForResponse: false,
+      isProcessing: false,
+    })).toThrow();
+    expect(() => expect(deriveBranchStatus('running', true)).toBe('idle')).toThrow();
+    expect(() =>
+      expect(
+        deriveSessionStatus({
+          isSessionRunning: false,
+          isWaitingForResponse: false,
+          isProcessing: false,
+        })
+      ).toBe('idle')
+    ).toThrow();
+  });
+});
+
+describe('single definition site (Issue #1550 acceptance)', () => {
+  it('re-exports the same function object from @/types/sidebar', async () => {
+    const sidebar = await import('@/types/sidebar');
+    expect(sidebar.deriveCliStatus).toBe(deriveCliStatus);
+  });
+});

--- a/tests/unit/lib/worktree-status-helper-status-mapping.test.ts
+++ b/tests/unit/lib/worktree-status-helper-status-mapping.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Issue #1550: pin the SessionStatus → boolean-triple conversion performed by
+ * detectWorktreeSessionStatus().
+ *
+ * The pre-existing worktree-status-helper.test.ts always mocks the detector as
+ * `status: 'ready'`, so the `running` / `waiting` branches of that conversion
+ * were never exercised — exactly the lines this refactor moved into
+ * `status-mapping.ts`. These cases drive every SessionStatus through the helper
+ * and assert the flags it produces.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CLIToolType, AgentInstance } from '@/lib/cli-tools/types';
+import type { SessionStatus } from '@/lib/detection/status-detector';
+
+vi.mock('@/lib/cli-tools/manager', () => ({
+  CLIToolManager: {
+    getInstance: () => ({
+      getTool: (cliToolId: string) => ({
+        getSessionName: (worktreeId: string, instanceId?: string) =>
+          instanceId && instanceId !== cliToolId
+            ? `${cliToolId}-${worktreeId}-${instanceId}`
+            : `${cliToolId}-${worktreeId}`,
+        name: cliToolId,
+      }),
+    }),
+  },
+}));
+
+vi.mock('@/lib/cli-tools/types', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/cli-tools/types')>();
+  return {
+    ...original,
+    CLI_TOOL_IDS: ['claude'] as readonly CLIToolType[],
+  };
+});
+
+vi.mock('@/lib/session/cli-session', () => ({
+  captureSessionOutput: vi.fn().mockResolvedValue('$ '),
+}));
+
+vi.mock('@/lib/detection/status-detector', () => ({
+  detectSessionStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/session/claude-session', () => ({
+  isSessionHealthy: vi.fn().mockResolvedValue({ healthy: true }),
+}));
+
+vi.mock('@/lib/cli-tools/opencode', () => ({ OPENCODE_PANE_HEIGHT: 200 }));
+vi.mock('@/lib/cli-tools/gemini', () => ({ GEMINI_PANE_HEIGHT: 200 }));
+
+vi.mock('@/lib/polling/auto-yes-manager', () => ({
+  getLastServerResponseTimestamp: vi.fn().mockReturnValue(null),
+  buildCompositeKey: vi.fn((worktreeId: string, cliToolId: string) => `${worktreeId}:${cliToolId}`),
+}));
+
+import { detectWorktreeSessionStatus } from '@/lib/session/worktree-status-helper';
+import { detectSessionStatus } from '@/lib/detection/status-detector';
+
+const mockDb = {} as ReturnType<typeof import('@/lib/db/db-instance').getDbInstance>;
+const mockGetMessages = vi.fn().mockReturnValue([]);
+const mockMarkPending = vi.fn();
+const mockGetAgentInstances = vi.fn(() => [] as AgentInstance[]);
+
+function mockDetectedStatus(status: SessionStatus, hasActivePrompt = false): void {
+  vi.mocked(detectSessionStatus).mockReturnValue({
+    status,
+    confidence: 'high',
+    reason: 'input_prompt',
+    hasActivePrompt,
+    promptDetection: { isPrompt: hasActivePrompt, cleanContent: '' },
+  });
+}
+
+async function detectWithRunningSession(status: SessionStatus) {
+  mockDetectedStatus(status);
+  const result = await detectWorktreeSessionStatus(
+    'wt-1',
+    new Set(['claude-wt-1']),
+    mockDb,
+    mockGetMessages,
+    mockMarkPending,
+    mockGetAgentInstances
+  );
+  return result.sessionStatusByCli.claude;
+}
+
+describe('detectWorktreeSessionStatus SessionStatus → flags (Issue #1550)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMessages.mockReturnValue([]);
+    mockGetAgentInstances.mockReturnValue([]);
+  });
+
+  const TABLE: ReadonlyArray<[SessionStatus, boolean, boolean]> = [
+    // status, isWaitingForResponse, isProcessing
+    ['idle', false, false],
+    ['ready', false, false],
+    ['running', false, true],
+    ['waiting', true, false],
+  ];
+
+  it.each(TABLE)(
+    'detector %s → isWaitingForResponse=%s isProcessing=%s',
+    async (status, isWaitingForResponse, isProcessing) => {
+      const flags = await detectWithRunningSession(status);
+      expect(flags).toEqual({ isRunning: true, isWaitingForResponse, isProcessing });
+    }
+  );
+
+  it('propagates the flags to the worktree-level aggregate', async () => {
+    mockDetectedStatus('waiting');
+    const result = await detectWorktreeSessionStatus(
+      'wt-1',
+      new Set(['claude-wt-1']),
+      mockDb,
+      mockGetMessages,
+      mockMarkPending,
+      mockGetAgentInstances
+    );
+    expect(result.isSessionRunning).toBe(true);
+    expect(result.isWaitingForResponse).toBe(true);
+    expect(result.isProcessing).toBe(false);
+  });
+
+  it('leaves both activity flags false when no session is running', async () => {
+    mockDetectedStatus('running');
+    const result = await detectWorktreeSessionStatus(
+      'wt-1',
+      new Set(),
+      mockDb,
+      mockGetMessages,
+      mockMarkPending,
+      mockGetAgentInstances
+    );
+    // The detector is never consulted when the tmux session is absent.
+    expect(detectSessionStatus).not.toHaveBeenCalled();
+    expect(result.sessionStatusByCli.claude).toEqual({
+      isRunning: false,
+      isWaitingForResponse: false,
+      isProcessing: false,
+    });
+  });
+
+  it('records a wrong expectation as a failure (guards against a vacuous table)', async () => {
+    const flags = await detectWithRunningSession('running');
+    expect(() => expect(flags?.isProcessing).toBe(false)).toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1550（親 #1539 / Phase 3-3）。セッション状態の語彙変換（SessionStatus → BranchStatus / UIPhase）が複数箇所に分散していたものを `src/lib/session/status-mapping.ts` へ集約する。

**挙動変更ゼロのリファクタ**。Epic 上は他フェーズと独立で、#1548（Phase 3-1）と並列実装した。

## 変更内容

- `src/lib/session/status-mapping.ts`（新規）: `deriveCliStatus` / `deriveBranchStatus` / `deriveSessionStatus` を集約
- `src/types/sidebar.ts`: 定義を移設し **re-export で既存 import を維持**
- `src/lib/session/worktree-status-helper.ts`: 集約先を参照
- `src/app/api/worktrees/route.ts`: **インライン定義されていた `deriveSessionStatus` を集約**（Issue の列挙になかった 3 つ目の導出）
- テスト 2 ファイル（新規）

## 受入条件の確認

**定義は 1 箇所のみ**（実測）:

```
src/lib/session/status-mapping.ts:106:export function deriveCliStatus(...)
src/lib/session/status-mapping.ts:151:export function deriveBranchStatus(...)
```

他ファイルはすべて import / re-export 経由。

**既存テストは 1 つも書き換えていない** — 変更したテストファイル 2 件はいずれも新規追加であり、既存テストは無修正のまま green。受入条件が「テストを書き換えないと通らない場合、それは挙動変更なので実装を見直す」としているため、書き換えゼロは挙動不変の直接的な証拠になる。

## 検証

worktree で exit code を直接測定:

| ゲート | 結果 |
|--------|------|
| `npm run lint` | PASS (exit 0) |
| `npx tsc --noEmit` | PASS (exit 0) |
| `npm run test:unit` | PASS (exit 0) |
| `npm run build` | PASS (exit 0) |

マッピング系テスト: 49 tests。

**変異注入でゴールデンテストの非空振り性を確認**:

| 変異 | 結果 |
|---|---|
| `deriveCliStatus` が常に同じ値を返す | **14 failed** |
| `deriveBranchStatus` が常に同じ値を返す | **7 failed** |

## スコープ外

語彙自体の統合・リネーム、TaskStatus（#1548）との統合、status-detector の検出ロジック（一切触れていない）

Refs #1550