### PR TITLE
docs: --stop-pattern の照合対象と限界をヘルプ・ガイドに明記 (#1682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`--stop-pattern` の照合対象と限界をヘルプ・ガイドに明記** (#1682): `--stop-pattern` はターミナル出力のデルタへの正規表現照合であり、エージェントが実行するコマンドの抑止には使えない（ビルドログに `rm -rf` 等の文字列が表示されただけでも発火して Auto-Yes が停止する実害が #1678 で発生）。`auto-yes` / `send` の `--help`、`commandmate docs agent-operations`、`docs/user-guide/cli-operations-guide.md` に「ターミナル出力への照合。コマンド抑止には実行契約の `autoYes.denyPatterns` を使う」旨を追記した。あわせて同ガイドに「worker 稼働中の worktree で監督側が検証・ビルドをしない（生成物ディレクトリ共有で双方のビルドが破損する）」の注意項を追加した
+
 ## [0.20.0] - 2026-08-04
 
 > **Highlight**: worktree ID を「一度採番したら動かない値」に作り替えたリリース。ブランチ由来だった ID をディレクトリ由来へ変え（#1644）、既存行も migration v54 で一括で振り直し、旧 ID は alias として API・ページ・CLI の 3 面で解決し続ける（#1645）。この移行中に**同一 git リポジトリを 2 つの scan root として登録していると sync のたびに ID が 8 hex ずつ伸び、稼働中セッションが UI から消える**回帰（#1659）を本番で踏んだため、churn を塞ぎ（migration v55 で伸びた ID を圧縮）、原因となる構成に気付ける警告（#1662）と、リポジトリを**非破壊で走査対象から外す** GUI（#1658）を追加した。あわせて Auto-Yes が Claude in Chrome の許可ダイアログに応答しない問題（#1676）など、実運用で踏んだ不具合を 12 件修正している。

--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -137,7 +137,7 @@ commandmate send <worktree-id> "<message>" --auto-yes --stop-pattern "FAILED"
 | `--register` | `--instance` で指定したセッションをroster（エージェントインスタンス一覧）に登録 | - |
 | `--auto-yes` | 送信前にAuto-Yesを有効化 | - |
 | `--duration <d>` | Auto-Yesの有効期間（1h, 3h, 8h） | 1h |
-| `--stop-pattern <p>` | Auto-Yes停止条件（正規表現） | - |
+| `--stop-pattern <p>` | Auto-Yes停止条件（正規表現、ターミナル出力への照合。[auto-yes の注意](#--stop-pattern-はターミナル出力への照合コマンドの抑止には使えない)参照） | - |
 
 > `--instance` の詳細（ID規約・rosterとの関係）は [マルチセッション（1エージェント複数セッション）](#マルチセッション1エージェント複数セッション) を参照してください。
 
@@ -665,6 +665,17 @@ commandmate auto-yes <worktree-id> --enable --instance codex-2  # 追加イン�
 | `--instance <id>` | **対象の推奨指定方法**。対象インスタンスID。他インスタンスと独立してAuto-Yesを制御 |
 | `--agent <id>` | roster に無いインスタンス向けの補助（`--instance` 単独で足りる場合は不要） |
 
+### `--stop-pattern` はターミナル出力への照合（コマンドの抑止には使えない）
+
+`--stop-pattern` はエージェントが実行する**コマンドを監視するものではなく**、ターミナル出力の
+新規部分（デルタ）への正規表現照合です。コマンドの実行そのものを止めることはできず、逆に
+ビルドログ等の出力にパターン文字列が**表示されただけ**でも発火します（例: `rm -rf` を指定すると、
+npm スクリプトがクリーンアップで `rm -rf dist` をログに出しただけで Auto-Yes が停止します）。
+
+「危険なコマンドに対する自動応答を抑止したい」場合は、実行契約の `autoYes.denyPatterns`
+（[docs/design/task-contract.md](../design/task-contract.md)）を使ってください。こちらは
+確認プロンプトの**質問文・選択肢**に照合し、マッチしたら自動応答せず人間へエスカレートします。
+
 ---
 
 ## commandmate instances
@@ -1125,6 +1136,17 @@ commandmate wait "$WT2" --instance codex --timeout 1800
 commandmate capture "$WT1" --json
 commandmate capture "$WT2" --instance codex --json
 ```
+
+### エージェント稼働中の worktree でビルドしない（生成物ディレクトリの共有破損）
+
+エージェント（worker）が作業中の worktree で、監督側が検証やビルド
+（`npm run build` / `npm run preview` 等）を実行しないでください。双方が同じ生成物
+ディレクトリ（`.next` / `dist` 等）に書き込むため、**両方のビルドが破損**します。
+
+- 検証・ビルドは `commandmate wait` で worker の完了を確認してから実行する
+- 稼働中にどうしても必要な場合は、別の worktree / 別ディレクトリに checkout して行う
+- `commandmate verify` のゲートは worktree の作業ディレクトリで走るため、worker 稼働中の
+  実行も同じ競合を起こします。完了後（`wait --verify` の裁定後）に実行してください
 
 ---
 

--- a/src/cli/commands/auto-yes.ts
+++ b/src/cli/commands/auto-yes.ts
@@ -21,7 +21,7 @@ export function createAutoYesCommand(): Command {
     .option('--enable', 'Enable auto-yes')
     .option('--disable', 'Disable auto-yes')
     .option('--duration <duration>', `Duration (${ALLOWED_DURATIONS.join(', ')})`)
-    .option('--stop-pattern <pattern>', 'Stop pattern (regex, max 500 chars)')
+    .option('--stop-pattern <pattern>', 'Stop pattern (regex, max 500 chars). Matched against terminal output; cannot block commands (build logs mentioning the pattern also trigger it). To suppress auto-responses per command, use the task contract\'s autoYes.denyPatterns')
     .option('--instance <id>', INSTANCE_OPTION_DESCRIPTION)
     .option('--agent <agent>', AGENT_OPTION_DESCRIPTION)
     .option('--token <token>', TOKEN_WARNING)

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -176,7 +176,7 @@ export function createSendCommand(): Command {
     .option('--model <model>', 'Specify AI model for Copilot or Antigravity agent')
     .option('--auto-yes', 'Enable auto-yes before sending')
     .option('--duration <duration>', `Auto-yes duration (${ALLOWED_DURATIONS.join(', ')})`)
-    .option('--stop-pattern <pattern>', 'Auto-yes stop pattern (regex)')
+    .option('--stop-pattern <pattern>', 'Auto-yes stop pattern (regex). Matched against terminal output; cannot block commands (use the task contract\'s autoYes.denyPatterns for that)')
     .option('--contract <path>', 'Execution contract path relative to the worktree root (e.g. .commandmate/tasks/my-task.yaml). Records a task and sends the contract preamble plus its goal.')
     .option('--token <token>', TOKEN_WARNING)
     .action(async (worktreeId: string, message: string | undefined, options: SendOptions) => {

--- a/src/cli/docs/agent-operations.ts
+++ b/src/cli/docs/agent-operations.ts
@@ -52,7 +52,8 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
     --register             Register the --instance session into the agent-instance roster
     --auto-yes             Enable auto-yes before sending
     --duration <d>         Auto-yes duration: 1h, 3h, 8h (default: 1h)
-    --stop-pattern <p>     Auto-yes stop condition (regex)
+    --stop-pattern <p>     Auto-yes stop condition (regex; matches terminal output,
+                           cannot block commands -- see auto-yes below)
 
   Finding worktree IDs:
     WT=$(commandmate ls --branch feature/101 --quiet)
@@ -178,6 +179,12 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
   commandmate auto-yes <id> --enable --stop-pattern "error"
   commandmate auto-yes <id> --disable                   # Disable
   commandmate auto-yes <id> --enable --instance codex-2 # Scoped to one instance
+
+  --stop-pattern matches new terminal output, not the commands an agent runs.
+  It cannot block a command; a build log that merely prints the pattern
+  (e.g. "rm -rf" in an npm script) also triggers it and stops auto-yes.
+  To suppress auto-responses for risky prompts, use the task contract's
+  autoYes.denyPatterns instead (docs/design/task-contract.md).
 
 ### commandmate instances <worktree-id> [action] [args]
   Discover and manage a worktree's agent-instance roster (1 agent, multiple sessions).


### PR DESCRIPTION
## 概要

--stop-pattern がターミナル出力への照合であり、コマンド抑止には契約の autoYes.denyPatterns を使うことをヘルプ・CLI 埋め込みドキュメント・cli-operations-guide に明記。worker 稼働中 worktree での監督側ビルド禁止の注意も追加。

出典: #1678（実運用フィードバック）/ 対象Issue: #1682
※ base=develop のため自動クローズされません。マージ後に手動クローズします。

## 検証
- `commandmate wait --verify` exit 0（work-evidence / scope / lint / typecheck / unit 全 PASS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114KJux74MhrqQZ416fbkAi