### PR TITLE
fix: respond の yes/no を multiple_choice の選択肢番号へ意味解決する (#1681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GUI の worktree 同期ボタンと同じ `POST /api/repositories/sync` を呼ぶ薄いサブコマンド。`git worktree add` で作成した worktree を GUI を開かずに `commandmate ls` へ反映でき、worktree 作成 → dispatch が CLI だけで完結する（#1678 A-1）
   - `--json` で同期結果（worktreeCount / repositoryCount / repositories / deletedCount / cleanupWarnings）を API レスポンス相当のまま出力
   - サーバー未起動時は既存コマンドと同じ接続エラー（exit 1）。リポジトリ未設定の 400 はサーバーの文言（WORKTREE_REPOS / CM_ROOT_DIR の案内）を素通しして exit 2
+- **CLI: `respond <worktree-id> --default`** — 検出中プロンプトの default 選択肢（❯ ハイライト位置）を明示的に選択する（#1681）
 
 ### Changed
 
 - **`--stop-pattern` の照合対象と限界をヘルプ・ガイドに明記** (#1682): `--stop-pattern` はターミナル出力のデルタへの正規表現照合であり、エージェントが実行するコマンドの抑止には使えない（ビルドログに `rm -rf` 等の文字列が表示されただけでも発火して Auto-Yes が停止する実害が #1678 で発生）。`auto-yes` / `send` の `--help`、`commandmate docs agent-operations`、`docs/user-guide/cli-operations-guide.md` に「ターミナル出力への照合。コマンド抑止には実行契約の `autoYes.denyPatterns` を使う」旨を追記した。あわせて同ガイドに「worker 稼働中の worktree で監督側が検証・ビルドをしない（生成物ディレクトリ共有で双方のビルドが破損する）」の注意項を追加した
 - **verify / wait --verify: 不合格ゲートの logTail 表示に行数上限** (#1683): stderr への logTail 表示を末尾 40 行までにし、超過分は `... (+N more lines; run \`commandmate verify show <run-id>\` for the full log)` の 1 行に畳む。保存側（`options.maxLogTailBytes`、最大 1MB）は従来どおりで、`--json` / `verify show` は全文を返す
+
+### Fixed
+
+- **CLI**: `respond` の `yes` / `no` を multiple_choice プロンプトの選択肢ラベルへ意味解決してから送信するように修正（#1681）。従来は非数値回答をテキスト+Enter で送るだけで、カーソルナビ型メニュー（claude / antigravity）では文字入力が無視され Enter が default 選択肢の選択に化けていた（3 択への `respond no` が default の "Yes" を選ぶ = 否認のつもりが承認）。肯定候補が複数ある場合は最小番号（= 最小権限）を選択し、解決不能な場合は何も送信せず `unresolvable_answer` でエラー終了する。あわせて default 選択肢を明示的に選ぶ `respond --default` と、解決結果（選択した番号・ラベル）の stdout 出力（監査用）を追加
 
 ## [0.20.0] - 2026-08-04
 

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -278,6 +278,7 @@
 | `src/app/login/page.tsx` | ログイン画面（Issue #331: トークン認証フォーム、Rate limit/ロックアウト表示、認証無効時は / へリダイレクト。Issue #383: ngrok 経由モバイルアクセス用 QR コードログイン）。ログインページ |
 | `src/lib/session-key-sender.ts` | Claudeセッションキー送信ロジック（Issue #479） |
 | `src/lib/prompt-answer-input.ts` | プロンプト応答入力ロジック（getAnswerInput）（Issue #479） |
+| `src/lib/prompt-answer-semantic.ts` | yes/no の意味解決（Issue #1681）。multiple_choice のラベルを肯定/否定選択肢番号へ解決（resolvePromptAnswer）、--default 解決、解決不能時は PromptAnswerResolutionError で送信拒否 |
 | `src/lib/slash-command-format.ts` | スラッシュコマンドトリガ表記（getSlashCommandTrigger）。Issue #790で Codex skill（`source==='codex-skill'`）は Codex CLI 公式構文 `$NAME`、その他（Claude/Copilot/Gemini）は `/NAME` を返す。Issue #1306: resolveCommandDescription(command, t) が descriptionKey（組み込み）と description（ユーザー定義 frontmatter）の両方を解決 |
 | `src/lib/skill-events.ts` | Skill install → slash-command palette の疎結合ブリッジ（#1477）。`SKILL_INSTALLED_EVENT='skill:installed'` と `dispatchSkillInstalled(worktreeId)`（SSR で no-op）。`SkillInstallPanel` の install 成功時に dispatch し、`useSlashCommands` が worktreeId 一致時のみ refetch。`useSlashCommands` の fetch は `{cache:'no-store'}` で常に fresh |
 | `src/lib/link-utils.ts` | リンク種別判定・相対パス解決・hrefサニタイズ（Issue #505） |

--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -336,19 +336,35 @@ Completed: localllm-test-main
 ### 使用方法
 
 ```bash
-commandmate respond <worktree-id> "yes"          # Yes/No
+commandmate respond <worktree-id> "yes"          # Yes/No（複数選択では肯定選択肢へ意味解決）
 commandmate respond <worktree-id> "2"            # 複数選択（番号）
 commandmate respond <worktree-id> "text"         # テキスト入力
+commandmate respond <worktree-id> --default      # default 選択肢を明示的に選ぶ
 commandmate respond <worktree-id> "yes" --instance codex          # プライマリインスタンス指定
 commandmate respond <worktree-id> "yes" --instance codex-2        # 追加インスタンス宛て
 ```
+
+### yes / no の意味解決（Issue #1681）
+
+複数選択（multiple_choice）プロンプトへの `yes` / `no`（`y` / `n`）は、選択肢ラベルを正規化して
+肯定（`Yes...`）/ 否定（`No...`・`Deny`）の**選択肢番号に解決してから**送信します。カーソルナビ型
+メニュー（claude / antigravity）ではテキスト入力が無視され Enter が default 選択肢の選択に
+化けるため（`respond no` が承認になる事故）、テキスト+Enter では送りません。
+
+- 肯定候補が複数ある場合（例: `1. Yes` / `2. Yes, allow all edits...`）は**最も番号の小さい選択肢**
+  （= 最小権限）を選びます
+- 解決できない場合（yes/no 系ラベルが無い・チェックボックス型・選択肢を読めない）は**何も送信せず**
+  exit 99（`unresolvable_answer`）で失敗します。番号で応答してください
+- 解決結果は監査のため stdout に出力されます: `Resolved "no" to option 3: No, and tell Claude ...`
+- `--default` は default 選択肢（❯ ハイライト位置）を明示的に選びます（`<answer>` と排他）
 
 ### 終了コード
 
 | コード | 意味 |
 |:------:|------|
 | 0 | 応答成功 |
-| 99 | プロンプトが既に消えている（`prompt_no_longer_active`）|
+| 2 | 引数エラー（`<answer>` と `--default` の同時指定・両方欠落 等）|
+| 99 | プロンプトが既に消えている（`prompt_no_longer_active`）/ yes・no を選択肢に解決できない（`unresolvable_answer`）|
 
 ---
 

--- a/src/app/api/worktrees/[id]/prompt-response/route.ts
+++ b/src/app/api/worktrees/[id]/prompt-response/route.ts
@@ -13,6 +13,7 @@ import { captureSessionOutputFresh } from '@/lib/session/cli-session';
 import { detectPrompt, type PromptDetectionResult } from '@/lib/detection/prompt-detector';
 import { stripAnsi, stripBoxDrawing, buildDetectPromptOptions } from '@/lib/detection/cli-patterns';
 import { sendPromptAnswer } from '@/lib/prompt-answer-sender';
+import { resolvePromptAnswer, PromptAnswerResolutionError, type AnswerResolution } from '@/lib/prompt-answer-semantic';
 import { isValidWorktreeId } from '@/lib/security/path-validator';
 import type { PromptType, SubmitMode } from '@/types/models';
 import { isValidSubmitMode } from '@/types/models';
@@ -25,7 +26,9 @@ import { canonicalWorktreeId } from '@/lib/git/git-route-worktree';
 const logger = createLogger('api/prompt-response');
 
 interface PromptResponseRequest {
-  answer: string;
+  answer?: string;
+  /** Issue #1681: explicitly select the prompt's default option (`respond --default`). */
+  useDefault?: boolean;
   cliTool?: string;
   /** Issue #868: target a specific agent instance (defaults to the primary). */
   instanceId?: string;
@@ -53,15 +56,22 @@ export async function POST(
 
     const body: PromptResponseRequest = await req.json();
     const { answer, cliTool: cliToolParam, instanceId: instanceParam, promptType: bodyPromptType, defaultOptionNumber: bodyDefaultOptionNumber, submitMode: bodySubmitMode } = body;
+    const useDefault = body.useDefault === true;
 
     // Issue #616: Allowlist validation for submitMode
     const validSubmitMode: SubmitMode | undefined =
       isValidSubmitMode(bodySubmitMode) ? bodySubmitMode : undefined;
 
-    // Validation
-    if (!answer) {
+    // Validation (Issue #1681: exactly one of answer / useDefault)
+    if (!answer && !useDefault) {
       return NextResponse.json(
         { error: 'answer is required' },
+        { status: 400 }
+      );
+    }
+    if (answer && useDefault) {
+      return NextResponse.json(
+        { error: 'answer and useDefault are mutually exclusive' },
         { status: 400 }
       );
     }
@@ -129,12 +139,36 @@ export async function POST(
         return NextResponse.json({
           success: false,
           reason: 'prompt_no_longer_active',
-          answer,
+          answer: answer ?? '',
         });
       }
     } catch {
       // If capture fails, proceed with caution - don't block manual responses
       logger.warn('failed-to-verify-prompt');
+    }
+
+    // Issue #1681: resolve semantic yes/no answers (and --default) to a concrete
+    // option number BEFORE sending. On cursor-navigated menus a raw "no" + Enter
+    // degrades into selecting the highlighted default option, so unresolvable
+    // answers are refused without sending anything.
+    let resolution: AnswerResolution;
+    try {
+      resolution = resolvePromptAnswer({
+        answer,
+        useDefault,
+        promptData: promptCheck?.promptData,
+        fallbackPromptType: bodyPromptType,
+      });
+    } catch (error: unknown) {
+      if (error instanceof PromptAnswerResolutionError) {
+        return NextResponse.json({
+          success: false,
+          reason: 'unresolvable_answer',
+          message: error.message,
+          answer: answer ?? '',
+        });
+      }
+      throw error;
     }
 
     // Send answer to tmux
@@ -143,7 +177,7 @@ export async function POST(
     try {
       await sendPromptAnswer({
         sessionName,
-        answer,
+        answer: resolution.input,
         cliToolId,
         promptData: promptCheck?.promptData,
         fallbackPromptType: bodyPromptType,
@@ -177,7 +211,9 @@ export async function POST(
 
     return NextResponse.json({
       success: true,
-      answer,
+      answer: resolution.input,
+      // Issue #1681: audit trail — which option a semantic/default answer selected.
+      ...(resolution.resolved ? { resolved: resolution.resolved } : {}),
     });
   } catch (error: unknown) {
     logger.error('failed-to-respond-to-prompt:', { error: error instanceof Error ? error.message : String(error) });

--- a/src/cli/commands/respond.ts
+++ b/src/cli/commands/respond.ts
@@ -20,11 +20,12 @@ export function createRespondCommand(): Command {
   cmd
     .description("Respond to an agent's prompt (yes/no, number, or text)")
     .argument('<worktree-id>', 'Worktree ID')
-    .argument('<answer>', 'Response answer (yes, no, number, or free text)')
+    .argument('[answer]', 'Response answer (yes, no, number, or free text)')
+    .option('--default', "Select the prompt's default option (mutually exclusive with <answer>)")
     .option('--instance <id>', INSTANCE_OPTION_DESCRIPTION)
     .option('--agent <agent>', AGENT_OPTION_DESCRIPTION)
     .option('--token <token>', TOKEN_WARNING)
-    .action(async (worktreeId: string, answer: string, options: RespondOptions) => {
+    .action(async (worktreeId: string, answer: string | undefined, options: RespondOptions) => {
       try {
         // [SEC4-04] Validate worktree ID
         if (!isValidWorktreeId(worktreeId)) {
@@ -44,9 +45,14 @@ export function createRespondCommand(): Command {
           process.exit(ExitCode.CONFIG_ERROR);
         }
 
-        // Validate answer is not empty
-        if (!answer.trim()) {
-          console.error('Error: Answer cannot be empty.');
+        // Issue #1681: exactly one of <answer> / --default
+        const useDefault = options.default === true;
+        if (useDefault && answer !== undefined) {
+          console.error('Error: <answer> and --default are mutually exclusive.');
+          process.exit(ExitCode.CONFIG_ERROR);
+        }
+        if (!useDefault && (answer === undefined || !answer.trim())) {
+          console.error('Error: Answer cannot be empty. Provide an answer or --default.');
           process.exit(ExitCode.CONFIG_ERROR);
         }
 
@@ -61,7 +67,7 @@ export function createRespondCommand(): Command {
           : options.agent;
 
         // [DR2-06] Use prompt-response API with cliTool (not cliToolId)
-        const body: Record<string, unknown> = { answer };
+        const body: Record<string, unknown> = useDefault ? { useDefault: true } : { answer };
         if (agent) {
           body.cliTool = agent;
         }
@@ -78,8 +84,25 @@ export function createRespondCommand(): Command {
         if (result && !result.success) {
           // [DR2-06] Check reason for failure
           const reason = result.reason || 'unknown';
-          console.error(`Warning: Response may not have been applied. Reason: ${reason}`);
+          if (reason === 'unresolvable_answer') {
+            // Issue #1681: nothing was sent to the terminal.
+            console.error(`Error: Answer was not sent. Reason: ${reason}${result.message ? ` (${result.message})` : ''}`);
+          } else {
+            console.error(`Warning: Response may not have been applied. Reason: ${reason}`);
+          }
           process.exit(ExitCode.UNEXPECTED_ERROR);
+        }
+
+        // Issue #1681: audit trail — print which option was actually selected.
+        const resolved = result?.resolved;
+        if (resolved) {
+          if (resolved.via === 'semantic') {
+            console.log(`Resolved "${answer}" to option ${resolved.optionNumber}: ${resolved.optionLabel}`);
+          } else if (resolved.optionNumber !== undefined) {
+            console.log(`Selected default option ${resolved.optionNumber}: ${resolved.optionLabel}`);
+          } else {
+            console.log(`Selected default answer: ${resolved.optionLabel}`);
+          }
         }
 
         console.error('Response sent.');

--- a/src/cli/types/api-responses.ts
+++ b/src/cli/types/api-responses.ts
@@ -119,7 +119,15 @@ export interface PromptData {
 export interface PromptResponseResult {
   success: boolean;
   answer: string;
-  reason?: string; // e.g. 'prompt_no_longer_active'
+  reason?: string; // e.g. 'prompt_no_longer_active', 'unresolvable_answer'
+  /** Issue #1681: detail accompanying reason 'unresolvable_answer' */
+  message?: string;
+  /** Issue #1681: how a semantic yes/no or --default answer was resolved */
+  resolved?: {
+    via: 'semantic' | 'default';
+    optionNumber?: number;
+    optionLabel: string;
+  };
 }
 
 /** wait exit 10 CLI extended output type */

--- a/src/cli/types/index.ts
+++ b/src/cli/types/index.ts
@@ -341,6 +341,8 @@ export interface RespondOptions {
   token?: string;
   /** Issue #868: agent instance ID or alias (defaults to the agent's primary instance) */
   instance?: string;
+  /** Issue #1681: select the prompt's default option instead of passing an answer */
+  default?: boolean;
 }
 
 /** capture command options [Issue #518] */

--- a/src/lib/prompt-answer-semantic.ts
+++ b/src/lib/prompt-answer-semantic.ts
@@ -1,0 +1,186 @@
+/**
+ * Semantic yes/no answer resolution for detected prompts (Issue #1681).
+ *
+ * `respond <wt> yes|no` used to send the raw text + Enter. Cursor-navigated
+ * multiple-choice menus (claude / antigravity) ignore typed characters, so the
+ * Enter selected the highlighted default option — `respond no` on a
+ * "1. Yes / 2. Yes, allow all / 3. No" menu approved instead of denying.
+ *
+ * This module resolves a semantic yes/no answer (or an explicit "pick the
+ * default" request) to a concrete option number BEFORE anything is sent, and
+ * refuses with {@link PromptAnswerResolutionError} when no option label can be
+ * matched, so the caller sends nothing at all instead of a stray Enter.
+ */
+
+import type { MultipleChoiceOption, PromptData, PromptType } from '@/types/models';
+
+/** Checkbox-style multi-select options have no yes/no semantics. */
+const CHECKBOX_OPTION_PATTERN = /^\[[ x]\] /;
+
+/** Labels that mean "approve" (e.g. "Yes", "Yes, allow all edits ..."). */
+const AFFIRMATIVE_LABEL_PATTERN = /^yes\b/i;
+
+/** Labels that mean "reject" (e.g. "No", "No, and tell Claude ...", "Deny"). */
+const NEGATIVE_LABEL_PATTERNS = [/^no\b/i, /\bdeny\b/i];
+
+export type SemanticAnswer = 'yes' | 'no';
+
+/**
+ * Raised when an answer cannot be resolved to a concrete option. Messages are
+ * fixed strings (no user input) per SEC-003 and are safe to return to clients.
+ */
+export class PromptAnswerResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PromptAnswerResolutionError';
+  }
+}
+
+/**
+ * Parse an answer as a semantic yes/no token. Only exact tokens qualify —
+ * free text like "yes please" is NOT semantic and passes through unchanged.
+ */
+export function parseSemanticAnswer(answer: string): SemanticAnswer | null {
+  const normalized = answer.trim().toLowerCase();
+  if (normalized === 'yes' || normalized === 'y') return 'yes';
+  if (normalized === 'no' || normalized === 'n') return 'no';
+  return null;
+}
+
+/** How the concrete input was derived from the request. */
+export interface ResolvedAnswerInfo {
+  via: 'semantic' | 'default';
+  /** Selected option number (absent for yes_no default resolution). */
+  optionNumber?: number;
+  /** Selected option label ('yes'/'no' for yes_no default resolution). */
+  optionLabel: string;
+}
+
+export interface AnswerResolution {
+  /** The input to actually send to the terminal. */
+  input: string;
+  /** Present only when semantic or default resolution occurred. */
+  resolved?: ResolvedAnswerInfo;
+}
+
+function isNegativeLabel(label: string): boolean {
+  return NEGATIVE_LABEL_PATTERNS.some(p => p.test(label));
+}
+
+function isAffirmativeLabel(label: string): boolean {
+  // A label matching a negative pattern never counts as affirmative
+  // (guards against future pattern overlap).
+  return AFFIRMATIVE_LABEL_PATTERN.test(label) && !isNegativeLabel(label);
+}
+
+function resolveSemanticOption(
+  options: MultipleChoiceOption[],
+  semantic: SemanticAnswer,
+): MultipleChoiceOption {
+  if (options.some(o => CHECKBOX_OPTION_PATTERN.test(o.label))) {
+    throw new PromptAnswerResolutionError(
+      'Multi-select (checkbox) prompts cannot be answered with yes/no. Answer with an option number.'
+    );
+  }
+
+  const matcher = semantic === 'yes' ? isAffirmativeLabel : isNegativeLabel;
+  const matches = options.filter(o => matcher(o.label));
+  if (matches.length === 0) {
+    throw new PromptAnswerResolutionError(
+      `No option label matches "${semantic}". Answer with an option number.`
+    );
+  }
+
+  // Multiple matches (e.g. "1. Yes" / "2. Yes, allow all edits ..."): pick the
+  // lowest-numbered one — in Claude-style permission menus that is the plain,
+  // narrowest-scope choice.
+  return matches.reduce((a, b) => (a.number <= b.number ? a : b));
+}
+
+function resolveDefaultOption(options: MultipleChoiceOption[]): MultipleChoiceOption {
+  // Mirrors prompt-answer-sender: when no option carries the ❯ indicator the
+  // cursor rests on option 1.
+  const def = options.find(o => o.isDefault)
+    ?? options.find(o => o.number === 1)
+    ?? options[0];
+  if (!def) {
+    throw new PromptAnswerResolutionError('The prompt has no options to select a default from.');
+  }
+  return def;
+}
+
+export interface ResolvePromptAnswerParams {
+  /** Raw answer from the request (absent when useDefault is set). */
+  answer?: string;
+  /** Explicit "select the default option" request (`respond --default`). */
+  useDefault?: boolean;
+  /** Fresh server-side prompt detection result (authoritative when present). */
+  promptData?: PromptData;
+  /** Client-claimed prompt type, used only when fresh detection is unavailable. */
+  fallbackPromptType?: PromptType;
+}
+
+/**
+ * Resolve the request to the concrete terminal input.
+ *
+ * - `useDefault`: resolves to the default option (multiple_choice) or the
+ *   default answer (yes_no). Requires detected promptData.
+ * - semantic yes/no on a detected multiple_choice prompt: resolves the option
+ *   number by label; unresolvable labels raise instead of degrading to Enter.
+ * - semantic yes/no when detection failed but the client claims
+ *   multiple_choice: raises (option labels are unknown).
+ * - everything else (numbers, free text, yes/no on yes_no prompts) passes
+ *   through unchanged.
+ *
+ * @throws PromptAnswerResolutionError when the answer must not be sent.
+ */
+export function resolvePromptAnswer(params: ResolvePromptAnswerParams): AnswerResolution {
+  const { answer, useDefault, promptData, fallbackPromptType } = params;
+
+  if (useDefault) {
+    if (promptData?.type === 'multiple_choice') {
+      const opt = resolveDefaultOption(promptData.options);
+      return {
+        input: String(opt.number),
+        resolved: { via: 'default', optionNumber: opt.number, optionLabel: opt.label },
+      };
+    }
+    if (promptData?.type === 'yes_no') {
+      if (promptData.defaultOption) {
+        return {
+          input: promptData.defaultOption,
+          resolved: { via: 'default', optionLabel: promptData.defaultOption },
+        };
+      }
+      throw new PromptAnswerResolutionError('The yes/no prompt declares no default option.');
+    }
+    throw new PromptAnswerResolutionError(
+      'Cannot select the default option: no active prompt was detected.'
+    );
+  }
+
+  const rawAnswer = answer ?? '';
+  const semantic = parseSemanticAnswer(rawAnswer);
+  if (semantic === null) {
+    return { input: rawAnswer };
+  }
+
+  if (promptData?.type === 'multiple_choice') {
+    const opt = resolveSemanticOption(promptData.options, semantic);
+    return {
+      input: String(opt.number),
+      resolved: { via: 'semantic', optionNumber: opt.number, optionLabel: opt.label },
+    };
+  }
+
+  // Fresh detection did not yield a multiple-choice prompt. If the client
+  // claims one, the option labels are unknown — refuse rather than let the
+  // text degrade into a bare Enter that picks the default.
+  if (!promptData && fallbackPromptType === 'multiple_choice') {
+    throw new PromptAnswerResolutionError(
+      'Cannot resolve yes/no: the prompt is multiple choice but its options could not be read.'
+    );
+  }
+
+  return { input: rawAnswer };
+}

--- a/tests/unit/api/prompt-response-verification.test.ts
+++ b/tests/unit/api/prompt-response-verification.test.ts
@@ -771,3 +771,207 @@ describe('POST /api/worktrees/:id/prompt-response - Multi-select (checkbox) prom
     expect(sentKeys).toEqual(['Space', 'Down', 'Down', 'Enter']);
   });
 });
+
+describe('POST /api/worktrees/:id/prompt-response - Semantic yes/no resolution (Issue #1681)', () => {
+  let db: Database.Database;
+
+  const claudePermissionPromptData = {
+    type: 'multiple_choice' as const,
+    question: 'Do you want to make this edit?',
+    options: [
+      { number: 1, label: 'Yes', isDefault: true },
+      { number: 2, label: 'Yes, allow all edits during this session (shift+tab)', isDefault: false },
+      { number: 3, label: 'No, and tell Claude what to do differently (esc)', isDefault: false },
+    ],
+    status: 'pending' as const,
+  };
+
+  function createBodyRequest(worktreeId: string, body: Record<string, unknown>): NextRequest {
+    return new Request(`http://localhost:3000/api/worktrees/${worktreeId}/prompt-response`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest;
+  }
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    runMigrations(db);
+
+    const { setMockDb } = await import('@/lib/db/db-instance');
+    setMockDb(db);
+
+    const worktree: Worktree = {
+      id: 'test-wt',
+      name: 'Test Worktree',
+      path: '/path/to/test',
+      repositoryPath: '/path/to/repo',
+      repositoryName: 'TestRepo',
+      cliToolId: 'claude',
+    };
+    upsertWorktree(db, worktree);
+
+    vi.clearAllMocks();
+
+    // Reset mocks that earlier describe blocks may have set to reject/false
+    const { sendKeys, sendSpecialKeys } = await import('@/lib/tmux/tmux');
+    vi.mocked(sendKeys).mockResolvedValue(undefined);
+    vi.mocked(sendSpecialKeys).mockResolvedValue(undefined);
+    mockIsRunning.mockResolvedValue(true);
+  });
+
+  it('resolves "no" to the negative option on the Claude 3-choice menu (no Enter degradation)', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { detectPrompt } = await import('@/lib/detection/prompt-detector');
+    const { sendSpecialKeys, sendKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockResolvedValue('permission menu');
+    vi.mocked(detectPrompt).mockReturnValue({
+      isPrompt: true,
+      promptData: claudePermissionPromptData,
+      cleanContent: 'permission menu',
+    });
+
+    const request = createBodyRequest('test-wt', { answer: 'no' });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.answer).toBe('3');
+    expect(data.resolved).toEqual({
+      via: 'semantic',
+      optionNumber: 3,
+      optionLabel: 'No, and tell Claude what to do differently (esc)',
+    });
+    // offset = 3 - 1 = 2 -> cursor navigation to the "No" option, not a bare Enter
+    expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test-wt', ['Down', 'Down', 'Enter']);
+    expect(sendKeys).not.toHaveBeenCalled();
+  });
+
+  it('resolves "yes" to the plain affirmative option (option 1)', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { detectPrompt } = await import('@/lib/detection/prompt-detector');
+    const { sendSpecialKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockResolvedValue('permission menu');
+    vi.mocked(detectPrompt).mockReturnValue({
+      isPrompt: true,
+      promptData: claudePermissionPromptData,
+      cleanContent: 'permission menu',
+    });
+
+    const request = createBodyRequest('test-wt', { answer: 'yes' });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.answer).toBe('1');
+    expect(data.resolved?.optionNumber).toBe(1);
+    expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test-wt', ['Enter']);
+  });
+
+  it('refuses unresolvable yes/no and sends NOTHING', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { detectPrompt } = await import('@/lib/detection/prompt-detector');
+    const { sendSpecialKeys, sendKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockResolvedValue('model picker');
+    vi.mocked(detectPrompt).mockReturnValue({
+      isPrompt: true,
+      promptData: {
+        type: 'multiple_choice',
+        question: 'Select model:',
+        options: [
+          { number: 1, label: 'Default (recommended)', isDefault: true },
+          { number: 2, label: 'Opus', isDefault: false },
+        ],
+        status: 'pending',
+      },
+      cleanContent: 'model picker',
+    });
+
+    const request = createBodyRequest('test-wt', { answer: 'yes' });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(false);
+    expect(data.reason).toBe('unresolvable_answer');
+    expect(sendKeys).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).not.toHaveBeenCalled();
+  });
+
+  it('refuses yes/no when capture failed but the client claims multiple_choice', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { sendSpecialKeys, sendKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockRejectedValue(new Error('tmux capture failed'));
+
+    const request = createBodyRequest('test-wt', { answer: 'yes', promptType: 'multiple_choice' });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(false);
+    expect(data.reason).toBe('unresolvable_answer');
+    expect(sendKeys).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).not.toHaveBeenCalled();
+  });
+
+  it('keeps text+Enter for yes/no when capture failed and nothing claims multiple_choice', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { sendKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockRejectedValue(new Error('tmux capture failed'));
+
+    const request = createBodyRequest('test-wt', { answer: 'yes' });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(sendKeys).toHaveBeenCalledWith('claude-test-wt', 'yes', false);
+  });
+
+  it('selects the default option with useDefault', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { detectPrompt } = await import('@/lib/detection/prompt-detector');
+    const { sendSpecialKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockResolvedValue('permission menu');
+    vi.mocked(detectPrompt).mockReturnValue({
+      isPrompt: true,
+      promptData: claudePermissionPromptData,
+      cleanContent: 'permission menu',
+    });
+
+    const request = createBodyRequest('test-wt', { useDefault: true });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.answer).toBe('1');
+    expect(data.resolved).toEqual({ via: 'default', optionNumber: 1, optionLabel: 'Yes' });
+    expect(sendSpecialKeys).toHaveBeenCalledWith('claude-test-wt', ['Enter']);
+  });
+
+  it('refuses useDefault when no prompt was detected (capture failed)', async () => {
+    const { captureSessionOutputFresh } = await import('@/lib/session/cli-session');
+    const { sendSpecialKeys, sendKeys } = await import('@/lib/tmux/tmux');
+
+    vi.mocked(captureSessionOutputFresh).mockRejectedValue(new Error('tmux capture failed'));
+
+    const request = createBodyRequest('test-wt', { useDefault: true });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+    const data = await response.json();
+
+    expect(data.success).toBe(false);
+    expect(data.reason).toBe('unresolvable_answer');
+    expect(sendKeys).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when both answer and useDefault are provided', async () => {
+    const request = createBodyRequest('test-wt', { answer: 'yes', useDefault: true });
+    const response = await promptResponse(request, { params: Promise.resolve({ id: 'test-wt' }) });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/unit/cli/commands/respond.test.ts
+++ b/tests/unit/cli/commands/respond.test.ts
@@ -83,3 +83,98 @@ describe('respond command action', () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 });
+
+describe('respond command semantic resolution (Issue #1681)', () => {
+  it('prints the resolved option to stdout for audit', async () => {
+    mockFetchResponse({
+      success: true,
+      answer: '3',
+      resolved: {
+        via: 'semantic',
+        optionNumber: 3,
+        optionLabel: 'No, and tell Claude what to do differently (esc)',
+      },
+    }, 200);
+    const { createRespondCommand } = await import('../../../../src/cli/commands/respond');
+    const cmd = createRespondCommand();
+    await cmd.parseAsync(['node', 'respond', 'wt1', 'no']);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      'Resolved "no" to option 3: No, and tell Claude what to do differently (esc)'
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith('Response sent.');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('exits non-zero when the answer is unresolvable', async () => {
+    mockFetchResponse({
+      success: false,
+      answer: 'yes',
+      reason: 'unresolvable_answer',
+      message: 'No option label matches "yes". Answer with an option number.',
+    }, 200);
+    const { createRespondCommand } = await import('../../../../src/cli/commands/respond');
+    const cmd = createRespondCommand();
+    await cmd.parseAsync(['node', 'respond', 'wt1', 'yes']);
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('unresolvable_answer')
+    );
+    expect(mockExit).toHaveBeenCalledWith(99);
+  });
+
+  it('sends useDefault with --default and prints the selected option', async () => {
+    mockFetchResponse({
+      success: true,
+      answer: '1',
+      resolved: { via: 'default', optionNumber: 1, optionLabel: 'Yes' },
+    }, 200);
+    const { createRespondCommand } = await import('../../../../src/cli/commands/respond');
+    const cmd = createRespondCommand();
+    await cmd.parseAsync(['node', 'respond', 'wt1', '--default']);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/worktrees/wt1/prompt-response'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ useDefault: true }),
+      })
+    );
+    expect(mockConsoleLog).toHaveBeenCalledWith('Selected default option 1: Yes');
+  });
+
+  it('prints the default answer for yes_no default resolution (no option number)', async () => {
+    mockFetchResponse({
+      success: true,
+      answer: 'yes',
+      resolved: { via: 'default', optionLabel: 'yes' },
+    }, 200);
+    const { createRespondCommand } = await import('../../../../src/cli/commands/respond');
+    const cmd = createRespondCommand();
+    await cmd.parseAsync(['node', 'respond', 'wt1', '--default']);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith('Selected default answer: yes');
+  });
+
+  it('rejects <answer> combined with --default', async () => {
+    // process.exit is mocked (no-op), so the action continues past validation;
+    // mock fetch to keep the continuation off the network.
+    mockFetchResponse({ success: true, answer: '' }, 200);
+    const { createRespondCommand } = await import('../../../../src/cli/commands/respond');
+    const cmd = createRespondCommand();
+    await cmd.parseAsync(['node', 'respond', 'wt1', 'yes', '--default']);
+
+    expect(mockConsoleError).toHaveBeenCalledWith('Error: <answer> and --default are mutually exclusive.');
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('rejects a missing answer without --default', async () => {
+    mockFetchResponse({ success: true, answer: '' }, 200);
+    const { createRespondCommand } = await import('../../../../src/cli/commands/respond');
+    const cmd = createRespondCommand();
+    await cmd.parseAsync(['node', 'respond', 'wt1']);
+
+    expect(mockConsoleError).toHaveBeenCalledWith('Error: Answer cannot be empty. Provide an answer or --default.');
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+});

--- a/tests/unit/lib/prompt-answer-semantic.test.ts
+++ b/tests/unit/lib/prompt-answer-semantic.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for semantic yes/no answer resolution (Issue #1681).
+ *
+ * `respond <wt> yes|no` must resolve to a concrete option number on
+ * multiple_choice prompts instead of degrading into text + Enter (which
+ * selects the highlighted default on cursor-navigated menus).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSemanticAnswer,
+  resolvePromptAnswer,
+  PromptAnswerResolutionError,
+} from '@/lib/prompt-answer-semantic';
+import type { PromptData } from '@/types/models';
+
+/** Claude Code 3-choice permission menu (the Issue #1681 repro). */
+const claudePermissionPrompt: PromptData = {
+  type: 'multiple_choice',
+  question: 'Do you want to make this edit?',
+  options: [
+    { number: 1, label: 'Yes', isDefault: true },
+    { number: 2, label: 'Yes, allow all edits during this session (shift+tab)', isDefault: false },
+    { number: 3, label: "No, and tell Claude what to do differently (esc)", isDefault: false },
+  ],
+  status: 'pending',
+};
+
+/** Antigravity 4-choice permission menu (no isDefault flags). */
+const agyPermissionPrompt: PromptData = {
+  type: 'multiple_choice',
+  question: 'Do you want to proceed?',
+  options: [
+    { number: 1, label: 'Yes' },
+    { number: 2, label: "Yes, and always allow in this conversation for commands that start with 'git status'" },
+    { number: 3, label: "Yes, and always allow for commands that start with 'git status' (Persist to settings.json)" },
+    { number: 4, label: 'No' },
+  ],
+  status: 'pending',
+};
+
+describe('parseSemanticAnswer', () => {
+  it.each([
+    ['yes', 'yes'],
+    ['y', 'yes'],
+    ['Yes', 'yes'],
+    ['YES', 'yes'],
+    [' yes ', 'yes'],
+    ['no', 'no'],
+    ['n', 'no'],
+    ['No', 'no'],
+    ['N', 'no'],
+  ])('parses %j as %j', (input, expected) => {
+    expect(parseSemanticAnswer(input)).toBe(expected);
+  });
+
+  it.each(['2', 'maybe', '', 'yes please', 'no way', 'none'])(
+    'returns null for non-semantic input %j',
+    (input) => {
+      expect(parseSemanticAnswer(input)).toBeNull();
+    }
+  );
+});
+
+describe('resolvePromptAnswer — semantic yes/no on multiple_choice', () => {
+  it('resolves "no" to the negative option on the Claude 3-choice menu (not the default "Yes")', () => {
+    const result = resolvePromptAnswer({ answer: 'no', promptData: claudePermissionPrompt });
+    expect(result.input).toBe('3');
+    expect(result.resolved).toEqual({
+      via: 'semantic',
+      optionNumber: 3,
+      optionLabel: "No, and tell Claude what to do differently (esc)",
+    });
+  });
+
+  it('resolves "yes" to the lowest-numbered affirmative option (narrowest scope)', () => {
+    const result = resolvePromptAnswer({ answer: 'yes', promptData: claudePermissionPrompt });
+    expect(result.input).toBe('1');
+    expect(result.resolved?.optionNumber).toBe(1);
+    expect(result.resolved?.optionLabel).toBe('Yes');
+  });
+
+  it('resolves "no" to option 4 on the Antigravity menu', () => {
+    const result = resolvePromptAnswer({ answer: 'no', promptData: agyPermissionPrompt });
+    expect(result.input).toBe('4');
+    expect(result.resolved?.optionLabel).toBe('No');
+  });
+
+  it('keeps yes/no semantics on a 2-choice menu', () => {
+    const twoChoice: PromptData = {
+      type: 'multiple_choice',
+      question: 'Proceed?',
+      options: [
+        { number: 1, label: 'Yes', isDefault: true },
+        { number: 2, label: 'No', isDefault: false },
+      ],
+      status: 'pending',
+    };
+    expect(resolvePromptAnswer({ answer: 'yes', promptData: twoChoice }).input).toBe('1');
+    expect(resolvePromptAnswer({ answer: 'no', promptData: twoChoice }).input).toBe('2');
+  });
+
+  it('resolves "no" via the deny pattern when no label starts with "no"', () => {
+    const allowDeny: PromptData = {
+      type: 'multiple_choice',
+      question: 'Permission?',
+      options: [
+        { number: 1, label: 'Allow', isDefault: true },
+        { number: 2, label: 'Deny', isDefault: false },
+      ],
+      status: 'pending',
+    };
+    expect(resolvePromptAnswer({ answer: 'no', promptData: allowDeny }).input).toBe('2');
+  });
+
+  it('accepts single-letter aliases y/n', () => {
+    expect(resolvePromptAnswer({ answer: 'n', promptData: claudePermissionPrompt }).input).toBe('3');
+    expect(resolvePromptAnswer({ answer: 'Y', promptData: claudePermissionPrompt }).input).toBe('1');
+  });
+
+  it('throws when no option label matches the semantic answer', () => {
+    const modelPicker: PromptData = {
+      type: 'multiple_choice',
+      question: 'Select model:',
+      options: [
+        { number: 1, label: 'Default (recommended)', isDefault: true },
+        { number: 2, label: 'Opus', isDefault: false },
+        { number: 3, label: 'Haiku', isDefault: false },
+      ],
+      status: 'pending',
+    };
+    expect(() => resolvePromptAnswer({ answer: 'yes', promptData: modelPicker }))
+      .toThrow(PromptAnswerResolutionError);
+  });
+
+  it('throws for multi-select (checkbox) prompts', () => {
+    const multiSelect: PromptData = {
+      type: 'multiple_choice',
+      question: 'Select tools:',
+      options: [
+        { number: 1, label: '[ ] Yes tool', isDefault: true },
+        { number: 2, label: '[ ] No tool', isDefault: false },
+      ],
+      status: 'pending',
+    };
+    expect(() => resolvePromptAnswer({ answer: 'yes', promptData: multiSelect }))
+      .toThrow(PromptAnswerResolutionError);
+  });
+
+  it('throws when detection failed but the client claims multiple_choice (labels unknown)', () => {
+    expect(() => resolvePromptAnswer({
+      answer: 'no',
+      promptData: undefined,
+      fallbackPromptType: 'multiple_choice',
+    })).toThrow(PromptAnswerResolutionError);
+  });
+
+  it('never classifies a negative label as affirmative', () => {
+    const trickPrompt: PromptData = {
+      type: 'multiple_choice',
+      question: 'Proceed?',
+      options: [
+        { number: 1, label: 'No, deny everything', isDefault: true },
+        { number: 2, label: 'Yes', isDefault: false },
+      ],
+      status: 'pending',
+    };
+    expect(resolvePromptAnswer({ answer: 'yes', promptData: trickPrompt }).input).toBe('2');
+    expect(resolvePromptAnswer({ answer: 'no', promptData: trickPrompt }).input).toBe('1');
+  });
+});
+
+describe('resolvePromptAnswer — passthrough cases', () => {
+  it('passes numeric answers through unchanged', () => {
+    const result = resolvePromptAnswer({ answer: '2', promptData: claudePermissionPrompt });
+    expect(result).toEqual({ input: '2' });
+  });
+
+  it('passes free text through unchanged on multiple_choice', () => {
+    const result = resolvePromptAnswer({ answer: 'use tabs instead', promptData: claudePermissionPrompt });
+    expect(result).toEqual({ input: 'use tabs instead' });
+  });
+
+  it('passes yes/no through unchanged on yes_no prompts (text input works there)', () => {
+    const yesNo: PromptData = {
+      type: 'yes_no',
+      question: 'Continue?',
+      options: ['yes', 'no'],
+      status: 'pending',
+    };
+    expect(resolvePromptAnswer({ answer: 'yes', promptData: yesNo })).toEqual({ input: 'yes' });
+    expect(resolvePromptAnswer({ answer: 'no', promptData: yesNo })).toEqual({ input: 'no' });
+  });
+
+  it('passes yes/no through unchanged when nothing indicates multiple_choice', () => {
+    expect(resolvePromptAnswer({ answer: 'yes', promptData: undefined })).toEqual({ input: 'yes' });
+  });
+
+  it('trusts fresh yes_no detection over a stale multiple_choice fallback claim', () => {
+    const yesNo: PromptData = {
+      type: 'yes_no',
+      question: 'Continue?',
+      options: ['yes', 'no'],
+      status: 'pending',
+    };
+    expect(resolvePromptAnswer({
+      answer: 'yes',
+      promptData: yesNo,
+      fallbackPromptType: 'multiple_choice',
+    })).toEqual({ input: 'yes' });
+  });
+});
+
+describe('resolvePromptAnswer — useDefault (--default)', () => {
+  it('selects the isDefault option on multiple_choice', () => {
+    const prompt: PromptData = {
+      type: 'multiple_choice',
+      question: 'Choose:',
+      options: [
+        { number: 1, label: 'A', isDefault: false },
+        { number: 2, label: 'B', isDefault: true },
+      ],
+      status: 'pending',
+    };
+    const result = resolvePromptAnswer({ useDefault: true, promptData: prompt });
+    expect(result.input).toBe('2');
+    expect(result.resolved).toEqual({ via: 'default', optionNumber: 2, optionLabel: 'B' });
+  });
+
+  it('falls back to option 1 when no option carries isDefault (cursor rests on 1)', () => {
+    const result = resolvePromptAnswer({ useDefault: true, promptData: agyPermissionPrompt });
+    expect(result.input).toBe('1');
+    expect(result.resolved?.optionLabel).toBe('Yes');
+  });
+
+  it('uses defaultOption for yes_no prompts', () => {
+    const yesNo: PromptData = {
+      type: 'yes_no',
+      question: 'Continue?',
+      options: ['yes', 'no'],
+      defaultOption: 'no',
+      status: 'pending',
+    };
+    const result = resolvePromptAnswer({ useDefault: true, promptData: yesNo });
+    expect(result.input).toBe('no');
+    expect(result.resolved).toEqual({ via: 'default', optionLabel: 'no' });
+  });
+
+  it('throws for yes_no prompts without a declared default', () => {
+    const yesNo: PromptData = {
+      type: 'yes_no',
+      question: 'Continue?',
+      options: ['yes', 'no'],
+      status: 'pending',
+    };
+    expect(() => resolvePromptAnswer({ useDefault: true, promptData: yesNo }))
+      .toThrow(PromptAnswerResolutionError);
+  });
+
+  it('throws when no prompt was detected', () => {
+    expect(() => resolvePromptAnswer({ useDefault: true, promptData: undefined }))
+      .toThrow(PromptAnswerResolutionError);
+  });
+});


### PR DESCRIPTION
## 概要

respond の非数値回答（yes/no）をラベル正規化で肯定/否定の選択肢番号に解決してから送信。解決不能な multiple_choice へはエラー（exit 非0）で何も送信しない。--default で既定選択肢の明示選択を追加。従来の「Enter がハイライト中の default を選ぶ」誤承認経路を廃止。

出典: #1678（実運用フィードバック）/ 対象Issue: #1681
※ base=develop のため自動クローズされません。マージ後に手動クローズします。

## 検証
- `commandmate wait --verify` exit 0（work-evidence / scope / lint / typecheck / unit 全 PASS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114KJux74MhrqQZ416fbkAi