### PR TITLE
docs: 判定の可観測性（discoverability 原則）を明文化し判定点を棚卸しする (#1686)

### DIFF
--- a/.claude/commands/multi-stage-design-review.md
+++ b/.claude/commands/multi-stage-design-review.md
@@ -50,7 +50,7 @@ description: "設計書の4段階レビュー（通常→整合性→影響分�
 
 | Stage | レビュー種別 | フォーカス | 目的 |
 |-------|------------|----------|------|
-| 1 | 通常レビュー | 設計原則 | SOLID/KISS/YAGNI/DRY準拠確認 |
+| 1 | 通常レビュー | 設計原則 | SOLID/KISS/YAGNI/DRY準拠確認＋発見可能性（discoverability） |
 | 2 | 整合性レビュー | 整合性 | 設計書と実装の整合性確認 |
 | 3 | 影響分析レビュー | 影響範囲 | 変更の波及効果分析 |
 | 4 | セキュリティレビュー | セキュリティ | OWASP Top 10準拠確認 |
@@ -85,10 +85,18 @@ mkdir -p dev-reports/issue/{issue_number}/multi-stage-design-review
 
 ### Stage 1: 通常レビュー（設計原則）
 
+**Stage 1 の必須観点**（focus_area: 設計原則）:
+
+- SOLID / KISS / YAGNI / DRY 準拠
+- **発見可能性（discoverability）**: この機能・この判定結果を、運用者はどの層で・どのコマンドで知るか？
+  サーバーログにしか出ない判定・抑止・自動アクションはないか？（判定は理由コードつきで
+  `capture --json` / `wait` / `task show` 等の運用者が読む層に露出すること。
+  詳細: [docs/design/discoverability-principle.md](../../docs/design/discoverability-principle.md)）
+
 #### 1-1. レビュー実行
 
 ```
-Use architecture-review-agent (model: opus) to review Issue #{issue_number} with focus on 設計原則.
+Use architecture-review-agent (model: opus) to review Issue #{issue_number} with focus on 設計原則 and 発見可能性（discoverability: この機能・判定結果を運用者はどの層・どのコマンドで知るか。ログにしか出ない判定はないか）.
 
 Context file: dev-reports/issue/{issue_number}/multi-stage-design-review/stage1-review-context.json
 Output file: dev-reports/issue/{issue_number}/multi-stage-design-review/stage1-review-result.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **設計原則文書: 判定の可観測性（discoverability 原則）を明文化** (#1686): 「サーバー側が下した判定・抑止・自動アクションは、理由コードつきで運用者が読む層（`capture --json` / `wait` / `task show`）に露出する」を `docs/design/discoverability-principle.md` として明文化し、既存判定点の棚卸し（露出済み: #1682〜#1685・skills#47 / 未露出の対応候補: stop-pattern のマッチ内容、プロンプト dedup スキップ）を記録した。あわせて cli-operations-guide.md に無人実行の推奨契約テンプレートを掲載し、誤用されやすいフラグ（`wait --on-prompt` / `send --auto-yes`）の `--help` にクロスリファレンスを追記、設計レビュー（/multi-stage-design-review Stage 1）の観点に discoverability を追加した
+
 - **verify / wait --verify: scope 不合格の logTail 末尾に定型ガイダンスを付与** (#1683): 違反 path 一覧の直後に「意図した差分なら契約の `scope.allow`（＝Issue の対象ファイル）へ path を追加し `send --contract` で送り直す（scope は送信時スナップショットで裁定）／`deny:` に一致する path は差し戻す」旨のガイダンスを追加。列挙漏れ起因の scope 不合格（#1678 B-2）を worker / 監督側が出力だけで自己解決できるようにする
 - **CLI: `commandmate sync` — サーバーの worktree 再スキャンを CLI から実行** (#1680)
   - GUI の worktree 同期ボタンと同じ `POST /api/repositories/sync` を呼ぶ薄いサブコマンド。`git worktree add` で作成した worktree を GUI を開かずに `commandmate ls` へ反映でき、worktree 作成 → dispatch が CLI だけで完結する（#1678 A-1）

--- a/docs/design/discoverability-principle.md
+++ b/docs/design/discoverability-principle.md
@@ -1,0 +1,92 @@
+# 設計原則: 判定の可観測性（discoverability 原則）
+
+- **Issue**: [#1686](https://github.com/Kewton/CommandMate/issues/1686)（出典 [#1678](https://github.com/Kewton/CommandMate/issues/1678) の実運用フィードバック検証）
+- **ステータス**: Accepted
+- **棚卸し基準日**: 2026-08-04（コード実測。関数名・ファイルパスで参照する — 行番号は腐るため書かない）
+
+## 原則
+
+> **サーバー側が下した判定・抑止・自動アクションは、理由コードつきで、運用者が実際に読む層
+> （`capture --json` / `wait` の stdout / `task show` / `verify` の GATE・RESULT 行）に露出する。**
+
+サーバーログ・DB・契約 schema にしか存在しない判定は「存在しない」のと同じに扱われる。
+#1678 の実運用フィードバック 11 件中 4 件（A-2 / A-4 / A-5 / B-5）は、機能・情報は既に存在するのに
+運用者が到達できなかったケースだった。運用者は表層のアフォーダンスで「存在しない」と判断し、
+回避策の自作や誤った一般化に進む。本書はその構造への恒久対策である。
+
+## 層の定義
+
+| 層 | 具体例 | 性質 |
+|---|---|---|
+| **運用者が読む層**（表層） | `capture --json` / `wait` の stdout / `task show` / `verify` の GATE・RESULT 行 / `--help` / docs の冒頭サンプル / skill の report | 運用者・監督スクリプト・skill が実際に参照する。ここに無い情報は運用上「存在しない」 |
+| **実行時の深い層** | サーバーログ（`logger.*`）/ DB / 契約 schema の 3 層目 / gate logTail の全文 | デバッグ・監査には残るが、運用判断のループには入らない |
+
+## 構造問題の 4 機構（#1678 実例）
+
+| 実例 | 機構 |
+|---|---|
+| A-2: allow-listed モードに到達できず safe の穴と誤認 | **冒頭サンプルの既定路線化** — docs 冒頭サンプルがコピペされる運用になる。抑止事実がサーバーログにしか出なかった |
+| A-5: `--stop-pattern` をコマンド抑止に誤用 | **アフォーダンス勾配** — `--help` に見える引数が手前にあり、正しい道具（契約 `autoYes.denyPatterns`）は YAML の 3 層目 |
+| A-4: `wait` exit 10 の stdout ペイロードを見落とし | **exit code 分岐によるペイロード破棄** — 監督定石が「exit code 分岐 → capture で取り直す」で stdout の JSON が捨てられる |
+| B-5: GATE 行が report に届かない | **層の吸収** — ラッパ（dispatch runner）が exit code と要約だけを転記し、中間 stdout の情報が報告層で消える |
+
+## 実装規約
+
+新しい判定・抑止・自動アクションを実装するとき、および既存のものをレビューするときは以下に従う。
+
+1. **理由コードを持たせて運用者層へ出す**: 判定の結果だけでなく「なぜそうなったか」を
+   機械可読な理由フィールド（例: `autoYes.lastSuppression.reason`、`stopReason`）として
+   `capture --json` / `wait` / `task show` のいずれかに露出する。サーバーログのみの判定を作らない。
+2. **exit code に載せた情報は、同じ情報を機械可読な stdout（JSON）でも必ず出す**:
+   上位層（skill / 監督スクリプト）は CLI の stdout を吸収して report を作る。exit code は分岐にしか
+   使えないため、ペイロードを伴わない exit code は情報を運びきれない。
+   `wait` exit 10 の `WaitPromptOutput`（`src/cli/types/api-responses.ts`）は準拠例。
+   仕様上ペイロードが空になるケース（selection_list 型の `options: []` 等）は、空である理由を
+   判別できるフィールド（`type` / `question` に載せた `sessionStatusReason` 等）を必ず載せる。
+3. **`--help` のクロスリファレンス規約**: 誤用されやすいフラグの help 文には
+   「この用途ならこちら」を 1 行添える（例: `--stop-pattern` → 契約の `autoYes.denyPatterns`）。
+   正しい道具が別の層（契約 YAML 等）にある場合ほど必須。
+4. **docs の冒頭サンプル＝コピペされる運用**: 各設計書・ガイドの最初のサンプルは推奨運用を示す。
+   「最小の例」を冒頭に置くと、それが既定路線になる（A-2 の機構）。
+5. **CLI の JSON 出力は安定インターフェース**: `capture --json` / `verify --json` /
+   `wait` exit 10 の JSON 構造は、上位層が転写する前提の公開インターフェースとして扱う。
+   正準の型は `src/cli/types/api-responses.ts`、運用者向け仕様は
+   [cli-operations-guide.md](../user-guide/cli-operations-guide.md) に記載する。
+   変更は追加的（additive）に行い、既存フィールドの削除・意味変更は互換性破壊として扱う。
+
+## 判定点の棚卸し（2026-08-04 実測）
+
+### 露出済み
+
+| 判定点 | 露出層 | 対応 |
+|---|---|---|
+| Auto-Yes ポリシー抑止（`suppressedBy`） | `capture --json` の `autoYes.lastSuppression`（reason / mode / promptType / pattern / at） | #1684 / PR #1691 で対応済み |
+| Auto-Yes 自動応答の事実と回答内容 | `capture --prompts [--json]` の監査証跡（question / options / answer / `answeredBy`） | #1685 / PR #1692 で対応済み |
+| verify の scope 違反 path | 不合格ゲートの logTail に違反 path 一覧（最大 100 件）＋復旧ガイダンス | #1683 / PR #1688 で対応済み |
+| `--stop-pattern` の照合対象と限界 | `auto-yes` / `send` の `--help`、`commandmate docs agent-operations`、cli-operations-guide.md | #1682 / PR #1687 で対応済み |
+| `wait` のプロンプト検出ペイロード | exit 10 と同時に `WaitPromptOutput` JSON を stdout へ出力（`src/cli/commands/wait.ts`）。selection_list 型は `type: selection_list` ＋ `question` に `sessionStatusReason` を載せ、`options: []` が仕様であることを判別可能 | 準拠済み（実装規約 2 の準拠例） |
+| verify の GATE 行の report 転記 | commandmate-skills 側 dispatch report にゲート結果を転記 | commandmate-skills#47 / skills PR #48 で対応済み |
+| stop-pattern 発火の事実 | `capture --json` の `autoYes.stopReason`（`stop_pattern_matched`。`src/lib/session/current-output-builder.ts` が露出） | 露出済み（ただしマッチ内容は未露出 — 下表参照） |
+
+### 未露出（対応候補）
+
+実装対応は #1686 の範囲外。新規 Issue の起票はオーケストレーターが判断する。
+
+| 判定点 | 現状（実測） | 対応候補 |
+|---|---|---|
+| stop-pattern 発火時に**何にマッチしたか** | `checkStopCondition`（`src/lib/auto-yes-state.ts`）はマッチ判定後 `disableAutoYes(..., 'stop_pattern_matched')` を呼ぶだけで、マッチした文字列・行を保存しない。サーバーログ `stop-condition-matched` も compositeKey のみ。運用者は `stopReason` から発火の事実は知れるが、誤爆（ビルドログがパターンを含んだ等）の切り分けができない | マッチ文字列（前後の行を含む短い抜粋）を auto-yes 状態に保存し、`capture --json` の `autoYes` に `stopMatchedText` として露出する |
+| プロンプト dedup スキップ | `src/lib/polling/response-checker.ts` の `isDuplicatePrompt` 分岐が `logger.info('duplicate-prompt-skipped', ...)` を出すのみ。`capture --json` に露出なし。「プロンプトが出たはずなのに保存されていない」とき、dedup が原因か検出漏れかを運用者が判別できない | スキップ回数・最終スキップ時刻をセッション状態に記録し `capture --json` へ露出する（同型: response 側 dedup `isDuplicateResponse`（Issue #1268）はログすら出さない） |
+
+## 開発プロセスへの組み込み
+
+- 設計レビュー（`/multi-stage-design-review` Stage 1）のレビュー観点に**発見可能性（discoverability）**を追加済み:
+  「この機能・この判定結果を、運用者はどの層で・どのコマンドで知るか？ ログにしか出ない判定はないか？」
+  （[.claude/commands/multi-stage-design-review.md](../../.claude/commands/multi-stage-design-review.md)）
+- 本原則は CLAUDE.md には書かない（CLAUDE.md はモジュール詳細・原則本文を持たない方針）。
+
+## 関連
+
+- [#1678](https://github.com/Kewton/CommandMate/issues/1678)（出典）/ #1682 / #1683 / #1684 / #1685 / commandmate-skills#47
+- [task-contract.md](./task-contract.md) — 冒頭レシピは無人実行推奨（allow-listed ＋ denyPatterns）を併記済み（#1684）
+- [cli-operations-guide.md](../user-guide/cli-operations-guide.md) — 無人実行の推奨契約テンプレート
+- #1676 — 検出層の沈黙（「判定すら行われない」ケース）は本書の範囲外。運用者から見た症状は同型だが、機構が異なる

--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -563,6 +563,50 @@ autoYes:
 ポリシーが自動応答を抑止した事実は `commandmate capture --json` の
 `autoYes.lastSuppression` に出ます（[capture の JSON フィールド](#json出力の主要フィールド)参照）。
 
+### 無人実行の推奨契約テンプレート（Issue #1686）
+
+無人でワーカーを走らせる契約はこのテンプレートから始めてください。
+「目的・変更許可スコープ・合格条件・Auto-Yes ポリシー」が一式そろっており、
+`send --contract` → `wait --verify` → `capture --json` / `capture --prompts` の
+パイプラインでそのまま裁定・観測できます。
+
+```yaml
+# .commandmate/tasks/issue-123.yaml — 無人実行の推奨契約テンプレート
+version: 1
+title: "Issue #123: <一行サマリ>"
+goal: |
+  https://github.com/<org>/<repo>/issues/123 を実装する。
+  受入条件: Issue の受入条件チェックリストをすべて満たすこと。
+  作業完了後は commit すること。
+scope:
+  allow:                              # Issue の対象ファイルを列挙（列挙漏れは scope ゲートで不合格になる）
+    - "src/**"
+    - "tests/**"
+    - "docs/**"
+    - "CHANGELOG.md"
+  deny: []
+verify:
+  gates: [lint, typecheck, unit]      # verify.yaml のゲート id。省略時: 全ゲート
+autoYes:
+  mode: allow-listed                  # safe は yes_no 型のみ。無人実行は allow-listed（上記参照）
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: ['rm -rf', 'git push.*--force', 'sudo ']
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true
+```
+
+```bash
+commandmate send <worktree-id> --contract .commandmate/tasks/issue-123.yaml
+commandmate wait <worktree-id> --verify          # 合格 0 / 不合格 20 / 作業証跡ゼロ 21
+commandmate capture <worktree-id> --json         # autoYes.lastSuppression で抑止を観測
+commandmate capture <worktree-id> --prompts      # auto-yes が解決したプロンプトの監査証跡
+```
+
+フィールドの正準仕様は [docs/design/task-contract.md](../design/task-contract.md)、
+判定の可観測性の設計原則は
+[docs/design/discoverability-principle.md](../design/discoverability-principle.md) を参照してください。
+
 ### 一覧・詳細
 
 ```bash

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -174,7 +174,7 @@ export function createSendCommand(): Command {
     .option('--agent <agent>', AGENT_OPTION_DESCRIPTION)
     .option('--register', 'Register the --instance session into the agent-instance roster (needs --agent unless the instance id is itself a CLI tool id)')
     .option('--model <model>', 'Specify AI model for Copilot or Antigravity agent')
-    .option('--auto-yes', 'Enable auto-yes before sending')
+    .option('--auto-yes', 'Enable auto-yes before sending (session-wide, no policy guard; for unattended runs prefer --contract with an autoYes policy)')
     .option('--duration <duration>', `Auto-yes duration (${ALLOWED_DURATIONS.join(', ')})`)
     .option('--stop-pattern <pattern>', 'Auto-yes stop pattern (regex). Matched against terminal output; cannot block commands (use the task contract\'s autoYes.denyPatterns for that)')
     .option('--contract <path>', 'Execution contract path relative to the worktree root (e.g. .commandmate/tasks/my-task.yaml). Records a task and sends the contract preamble plus its goal.')

--- a/src/cli/commands/wait.ts
+++ b/src/cli/commands/wait.ts
@@ -317,7 +317,7 @@ export function createWaitCommand(): Command {
     .description('Wait for agent completion (1 worktree per CLI instance recommended)')
     .argument('<worktree-ids...>', 'Worktree ID(s) to wait on')
     .option('--timeout <seconds>', 'Maximum wait time in seconds', parseInt)
-    .option('--on-prompt <mode>', 'Prompt handling: agent (default) or human')
+    .option('--on-prompt <mode>', 'Prompt handling: agent (default) exits 10 with a prompt JSON payload on stdout (read it before re-capturing); human keeps waiting for a human reply')
     .option('--stall-timeout <seconds>', 'Maximum time without output change', parseInt)
     .option('--instance <id>', WAIT_INSTANCE_OPTION_DESCRIPTION)
     .option('--verify', 'After completion, run every verification gate; exit 20 when a gate fails, 21 when there is nothing to verify')

--- a/src/cli/docs/agent-operations.ts
+++ b/src/cli/docs/agent-operations.ts
@@ -60,7 +60,9 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
     --agent <id>           Ad-hoc CLI tool for an instance the roster does not know:
                            claude (default), codex, gemini, vibe-local, opencode, copilot, antigravity
     --register             Register the --instance session into the agent-instance roster
-    --auto-yes             Enable auto-yes before sending
+    --auto-yes             Enable auto-yes before sending (session-wide, no policy
+                           guard -- for unattended runs prefer --contract with an
+                           autoYes policy: mode / denyPatterns)
     --duration <d>         Auto-yes duration: 1h, 3h, 8h (default: 1h)
     --stop-pattern <p>     Auto-yes stop condition (regex; matches terminal output,
                            cannot block commands -- see auto-yes below)
@@ -101,6 +103,9 @@ These commands enable coding agents (Claude Code, Codex, etc.) to orchestrate ot
 
   Prompt JSON output (exit 10):
     {"worktreeId":"...","cliToolId":"claude","type":"yes_no","question":"...","options":["yes","no"],"status":"pending"}
+    The payload IS the prompt -- read it from stdout before falling back to
+    capture. For type "selection_list", options is empty by design and the
+    question field carries the reason.
 
   --verify turns "the agent stopped" into "the work passes the repository's own
   checks". Verification only runs when completion was detected: a prompt (10) or


### PR DESCRIPTION
## 概要

#1678 で 11 件中 4 件が「機能・情報は存在するのに運用者が到達できなかった」構造への恒久対策。

- docs/design/discoverability-principle.md を新設: 可観測性原則の明文化＋判定点の棚卸し（露出済み: #1682/#1683/#1684/#1685/skills#47、未露出候補: stop-pattern マッチ内容・プロンプト dedup スキップ）
- /multi-stage-design-review のチェック観点に discoverability を追加
- wait --on-prompt / send --auto-yes の help にクロスリファレンス追記
- cli-operations-guide に無人実行の推奨契約テンプレートを掲載

出典: #1678 / 対象Issue: #1686（base=develop のため手動クローズします）

## 検証
- `commandmate wait --verify` exit 0（work-evidence / scope / lint / typecheck / unit 全 PASS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114KJux74MhrqQZ416fbkAi