### PR TITLE
docs(sync-map): #1728 を commandmate-skills へ移植済みとして記録する

### DIFF
--- a/.claude/skills/sync-map.json
+++ b/.claude/skills/sync-map.json
@@ -227,7 +227,7 @@
           "path": "SKILL.md",
           "policy": "port-required",
           "sha256": "53d8a9da5082c1c11f33970afbe601e19343d8103ea1855255b9181e74a4da9d",
-          "note": "counterpart は独立に書き起こされた文書で、共有行は 17 行しかない（2026-08-01 実測、CommandMate 423 行 / skills 380 行）。コピーではなく「同じ scripts を説明した別の文書」なので、移植するのは prose ではなく挙動の記述（フラグ・exit code・判定順序・警告文言）である。 【未移植 #1728】CommandMate 側だけを変更した。hooks-git.sh: worktree id の突合に `slug(basename(path))`（deriveWorktreeId / #1621）を第1候補として追加（ブランチ由来の旧2規則は残置）、診断行に ERROR/WARN のレベル語を付与。monitor.sh: シグナル報告 trap・正常終端以外の EXIT 報告・`--heartbeat`（既定10）を追加。SKILL.md: 上記の挙動記述（突合順の表・レベル語・生存報告）を追記。skills/cmate-orchestrate-monitor への移植は本 Issue のスコープ外で、オーケストレーターが完了報告に記載する。"
+          "note": "counterpart は独立に書き起こされた文書で、共有行は 17 行しかない（2026-08-01 実測、CommandMate 423 行 / skills 380 行）。コピーではなく「同じ scripts を説明した別の文書」なので、移植するのは prose ではなく挙動の記述（フラグ・exit code・判定順序・警告文言）である。 #1728 で両側に反映済み（skills 0.7.0 / commandmate-skills#110、2026-08-07）。hooks-git.sh: worktree id の突合に `slug(basename(path))`（deriveWorktreeId / #1621）を第1候補として追加（ブランチ由来の旧2規則は残置）、診断行に ERROR/WARN のレベル語を付与。monitor.sh: シグナル報告 trap・正常終端以外の EXIT 報告・`--heartbeat`（既定10）を追加。SKILL.md: 上記の挙動記述（突合順の表・レベル語・生存報告）を追記。"
         },
         {
           "path": "scripts/classify-state.sh",
@@ -238,7 +238,7 @@
           "path": "scripts/hooks-git.sh",
           "policy": "port-required",
           "sha256": "096e9c12f3aff269fdebaa2a217958f9c20895884ab8c629358080584549dff4",
-          "note": "#1614 で同期済み（skills 0.4.0）。この pin が実際に赤くなって移植を強制した最初の事例である: #1614 の編集で hooks-git.sh と monitor.sh の 2 件が sync-map.test.ts で red になり、counterpart へ移植してから update した。 【未移植 #1728】CommandMate 側だけを変更した。hooks-git.sh: worktree id の突合に `slug(basename(path))`（deriveWorktreeId / #1621）を第1候補として追加（ブランチ由来の旧2規則は残置）、診断行に ERROR/WARN のレベル語を付与。monitor.sh: シグナル報告 trap・正常終端以外の EXIT 報告・`--heartbeat`（既定10）を追加。SKILL.md: 上記の挙動記述（突合順の表・レベル語・生存報告）を追記。skills/cmate-orchestrate-monitor への移植は本 Issue のスコープ外で、オーケストレーターが完了報告に記載する。"
+          "note": "#1614 で同期済み（skills 0.4.0）。この pin が実際に赤くなって移植を強制した最初の事例である: #1614 の編集で hooks-git.sh と monitor.sh の 2 件が sync-map.test.ts で red になり、counterpart へ移植してから update した。 #1728 で両側に反映済み（skills 0.7.0 / commandmate-skills#110、2026-08-07）。hooks-git.sh: worktree id の突合に `slug(basename(path))`（deriveWorktreeId / #1621）を第1候補として追加（ブランチ由来の旧2規則は残置）、診断行に ERROR/WARN のレベル語を付与。monitor.sh: シグナル報告 trap・正常終端以外の EXIT 報告・`--heartbeat`（既定10）を追加。SKILL.md: 上記の挙動記述（突合順の表・レベル語・生存報告）を追記。"
         },
         {
           "path": "scripts/hooks-task.sh",
@@ -255,7 +255,7 @@
           "path": "scripts/monitor.sh",
           "policy": "port-required",
           "sha256": "7cab647dd08890bde450565c2a59c24e1d9f8d740dc72ba8b44a7bd78a18b031",
-          "note": "#1613 で同期済み。それ以前は skills 側だけが FALLBACK MODE 警告を出していた（コード差分 13 行）。 【未移植 #1728】CommandMate 側だけを変更した。hooks-git.sh: worktree id の突合に `slug(basename(path))`（deriveWorktreeId / #1621）を第1候補として追加（ブランチ由来の旧2規則は残置）、診断行に ERROR/WARN のレベル語を付与。monitor.sh: シグナル報告 trap・正常終端以外の EXIT 報告・`--heartbeat`（既定10）を追加。SKILL.md: 上記の挙動記述（突合順の表・レベル語・生存報告）を追記。skills/cmate-orchestrate-monitor への移植は本 Issue のスコープ外で、オーケストレーターが完了報告に記載する。"
+          "note": "#1613 で同期済み。それ以前は skills 側だけが FALLBACK MODE 警告を出していた（コード差分 13 行）。 #1728 で両側に反映済み（skills 0.7.0 / commandmate-skills#110、2026-08-07）。hooks-git.sh: worktree id の突合に `slug(basename(path))`（deriveWorktreeId / #1621）を第1候補として追加（ブランチ由来の旧2規則は残置）、診断行に ERROR/WARN のレベル語を付与。monitor.sh: シグナル報告 trap・正常終端以外の EXIT 報告・`--heartbeat`（既定10）を追加。SKILL.md: 上記の挙動記述（突合順の表・レベル語・生存報告）を追記。"
         },
         {
           "path": "scripts/quality-gate.sh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 正常終端（全 COMPLETE / `--max-polls` 到達）**以外**の全終了で `monitor: ERROR exiting on poll round <r> with <d>/<n> worker(s) complete` を出す。EXIT trap にぶら下げてあるので個別に trap していない死に方でも出る。引数検証で落ちる経路は trap 設置前なので従来どおり
   - `--heartbeat N`（既定 10、`0` で無効）で `monitor: alive (poll=N, complete=d/total)` を定期出力する。既定の運用ストリーム（介入・終局判定）は byte 単位で従来どおり
   - **再現条件は未特定**。144 はパイプライン（`monitor.sh … | grep …`）の `$?` ＝ grep の終了コードでもありうるため、`monitor.sh` 自身が signal 16 で死んだとは断定していない。次に起きたときに原因がログへ残るようにした修正である
+  - **上記 2 件は公開版 skill `cmate-orchestrate-monitor` にも移植済み**（[commandmate-skills#110](https://github.com/Kewton/commandmate-skills/pull/110)、skills 0.7.0）。`sync-map.json` の `port-required` エントリ 3 件は両側反映済みとして記録してある
 
 - **detection: claude のタスクパネルが直上のプロンプトを飲み、worker が無言で timeout する問題を修正** (#1708)
   - タスクパネルはペイン最下部に固定描画されるため、実運用の 200x1000 ペインではダイアログが上部・パネルが約 880 行下に来る。空行が潰されるとパネルが Pass 2 の走査窓に入り、ヘッダ `N tasks (X done, …)` と折り畳み行 `… +N completed` が**それぞれ独立に**選択肢として拾われて本物の選択肢を弾いていた（実キャプチャの 1 行削除実験で確認。片方だけ直しても未検出のまま）。パネルを**ブロックごと** skip する


### PR DESCRIPTION
## 概要

[commandmate-skills#110](https://github.com/Kewton/commandmate-skills/pull/110)（skills **0.7.0**）がマージされ、公開版 skill `cmate-orchestrate-monitor` にも #1728 の 2 件が反映された。`sync-map.json` の記録を実態に合わせる。

## 背景

#1728 は CommandMate 側（`.claude/skills/orchestrate-monitor/`）だけを直した状態でマージされており、`sync-map.json` の `port-required` エントリ 3 件に `【未移植 #1728】` が付いていた。

**この状態でリリースすると、同じ skill が 2 つのリポジトリで機能的に食い違ったまま公開される。** 移植を先に片付けた。

## 変更点

`sync-map.json` の 3 エントリ（`SKILL.md` / `scripts/hooks-git.sh` / `scripts/monitor.sh`）の `note` から `【未移植 #1728】` ブロックを除去し、移植先 PR と skills バージョンを含む「両側反映済み」の記録へ置き換える。CHANGELOG の #1728 ブロックにも移植先へのリンクを 1 行追加。

**注記のみの変更。** `sha256` pin は CommandMate 側の実ファイルを対象とするため影響しない。

## 移植先で確認したこと

| 項目 | 結果 |
|---|---|
| `slug(basename(path))` を第 1 候補に追加 | `hooks-git.sh:179`、旧 2 規則は残置 |
| 診断行の ERROR / WARN レベル語 | 9 箇所 |
| `monitor.sh` シグナル trap | HUP/INT/QUIT/PIPE/TERM ＋ 非正常 EXIT 報告 |
| `--heartbeat` | 既定 10 秒 |
| version bump | 0.6.1 → **0.7.0**（公開済み version は immutable） |
| `catalog/` | 未変更（release 生成物） |

移植先の 10 ゲートすべて exit 0。`origin/main` の最新を取り込んだ状態で再実行しても monitor-fixtures / validate / bash-syntax すべて exit 0。

## 検証

```
npx vitest run tests/unit/skills/sync-map.test.ts
→ exit 0 / Test Files 1 passed / Tests 50 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kvv7Ktzv5GejXDBoDv8WZ