### PR TITLE
test(cli-tools): manager.test.ts の child_process をモックし実プロセス起動を排除する (#1752)

### DIFF
--- a/.commandmate/tasks/issue-1752.yaml
+++ b/.commandmate/tasks/issue-1752.yaml
@@ -1,0 +1,85 @@
+version: 1
+title: "Issue #1752: manager.test.ts が実プロセスを起動し内側タイムアウトが vitest 既定を超える"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1752 を修正する。
+
+  ## 事象
+  `tests/unit/cli-tools/manager.test.ts` が CI で断続的にタイムアウトで落ちる。
+  アサーション不一致ではなくタイムアウトである。リリース v0.22.0 のコミット d24901c4 で、
+  同一コミット・同一ジョブが pull_request run では success、push run では failure に割れた
+  （run 31151127023 / 31151080694）。実装の欠陥ではなくテスト設計が実行環境の負荷に耐えていない。
+
+  ## 根本原因（Issue 本文の主張。**鵜呑みにせず自分でコードを読んで裏取りすること**）
+  内側（被テストコード）のタイムアウト予算が、外側（vitest）のテストタイムアウトを構造的に超えている。
+
+  - `getAllToolsInfo()` は 7 ツールの `isInstalled()` を `Promise.all` で並列実行する
+    （`src/lib/cli-tools/manager.ts` 付近）。各実装は実プロセスを起動する。
+  - `BaseCLITool.isInstalled()` は `execAsync('which <cmd>')`（`/bin/sh -c` 経由）、timeout 5000ms。
+  - `CopilotTool.isInstalled()` は `execFile('gh', ['--version'])` → `execFile('gh', ['copilot','--help'])`
+    の **2 段直列**で、最悪 5000 + 5000 = 10,000ms。
+  - `vitest.config.ts` に `testTimeout` の明示設定が無く既定 5000ms が効くため、
+    **copilot の内側タイムアウトは一度も観測されえない**（必ずテスト側が先に死ぬ）。
+  - GitHub Actions ランナーには `gh` がプリインストールされているので stage 1 は必ず成功し、
+    stage 2 が必ず実行される。
+  - `child_process` は一切モックされていない（当該テストファイルの import に `vi.mock` が無い）。
+
+  主張とコードが食い違ったら**実測を正とし**、食い違いの内容を報告に明記すること。
+
+  ## 対応方針
+  `child_process` をモックする。リポジトリ内に前例が複数ある。
+
+    tests/unit/cli/utils/browser.test.ts
+    tests/unit/cli/utils/npm-runner.test.ts
+    tests/unit/cli/utils/npx-runner.test.ts
+    tests/unit/cli/utils/preflight.test.ts
+    tests/unit/cli/utils/process-inspector.test.ts
+
+  `testTimeout` を広げるだけの対処は採らない。遅さの原因（実プロセス起動）が残るため。
+  **`vitest.config.ts` の全体既定は変更しない**（他 816 ファイルの挙動が変わるため、Issue の
+  スコープ外と本文が明示している）。
+
+  ## 受入条件（すべて満たすこと）
+  - [ ] `tests/unit/cli-tools/manager.test.ts` が実プロセスを起動しない
+        （`vi.mock('child_process')` で `exec` / `execFile` を差し替える）
+  - [ ] `installed` の真偽値を **true / false の両方**検証する。`expect(typeof info.installed).toBe('boolean')`
+        のような中身を検査しない assertion をやめる
+  - [ ] copilot の 2 段チェックについて、**stage 1 失敗で stage 2 が呼ばれない**ことと、
+        **stage 1 成功 → stage 2 失敗で `false`** になることを、個別のテストで固定する
+  - [ ] **変異注入で非空振りを証明する**。例:
+        (a) `getAllToolsInfo()` の `Promise.all` を直列に変える
+        (b) copilot の stage 2 を削る
+        のそれぞれで、対応するテストが**赤になること**を実測し、赤になったテスト名と出力を報告に含める。
+        **変異は必ず元に戻し、`git status` がクリーンであることを確認すること。**
+  - [ ] 該当ファイル単体の実行時間が **1 秒未満**であること。
+        `npx vitest run tests/unit/cli-tools/manager.test.ts > /tmp/m.log 2>&1; echo $?` で実測し、
+        実測値（tests 件数と duration）を報告に含める
+  - [ ] `npm run lint` / `npx tsc --noEmit` / `npm run test:unit` がすべて exit 0
+
+  ## 実装の変更について
+  `src/lib/cli-tools/manager.ts` / `base.ts` / `copilot.ts` は **変更しない**。
+  テスト側で閉じるべき欠陥である。scope.allow もそれを反映している。
+  もし実装変更が不可避だと判断した場合は、**変更せずに理由を報告して停止すること**
+  （scope ゲートで不合格になるので勝手に広げても通らない）。
+
+  ## 作業ルール（厳守）
+  - **exit code は必ず `cmd > log 2>&1; echo $?` で実測する。** `grep` に pipe すると
+    `Errors 1 error` 行と exit code が消えて偽 PASS になる。全テストが緑でも
+    Unhandled Rejection で exit 1 になることがある。
+  - CI 差を再現するときは `CI=true` を付ける（`fileParallelism` の既定が変わる）。
+  - **成果物は単一の commit にまとめること。** commit message は
+    `test(cli-tools): manager.test.ts の child_process をモックし実プロセス起動を排除する (#1752)` の形。
+  - **PR は作らない。** PR 作成はオーケストレーターが行う。
+  - `dev-reports/` 配下には成果物を残さない（scope 外）。
+  - `.commandmate/` 配下を変更しない。
+  - 完了したら最後に `IMPL_COMPLETED` と出力する。
+scope:
+  allow:
+    - "tests/unit/cli-tools/**"
+    - "CHANGELOG.md"
+  deny: []
+verify:
+  gates: [lint, typecheck, unit]
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true
+  requireCommit: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **test: `tests/unit/cli-tools/manager.test.ts` が CI で断続的にタイムアウトで落ちる問題を修正** (#1752)
+  - このファイルは `child_process` をモックしておらず、`getToolInfo` / `getAllToolsInfo` / `getInstalledTools` を呼ぶたびに 7 ツール分の**実プロセス**を起動していた。`BaseCLITool.isInstalled()` は `which <cmd>`（timeout 5000ms）、`CopilotTool.isInstalled()` は `gh --version` → `gh copilot --help` の **2 段直列**（最悪 5000 + 5000 = 10,000ms）。一方 `vitest.config.ts` は `testTimeout` 未設定＝既定 5000ms なので、**内側の予算が外側を構造的に超えており**、copilot の内側タイムアウトは一度も観測されえない。GitHub Actions ランナーには `gh` がプリインストールされているため stage 1 は必ず成功し、stage 2 が必ず実行される。v0.22.0 の同一コミット・同一ジョブが pull_request run では success、push run では failure に割れた（run 31151127023 / 31151080694）のはこのため（アサーション不一致ではなくタイムアウト）
+  - `vi.mock('child_process')` で `exec` / `execFile` を差し替えて実プロセス起動を排除した。**`testTimeout` を広げる対処は採っていない**（遅さの原因が残るうえ、全体既定の変更は他 816 ファイルに波及する）
+  - あわせて空振りの assertion を潰した。以前は `expect(typeof info.installed).toBe('boolean')` しか見ておらず、**true でも false でも緑**になっていた。`installed` を true / false の両方で固定し、copilot の 2 段チェックは「stage 1 失敗で stage 2 を呼ばない」「stage 1 成功 → stage 2 失敗で false」を個別のテストとして分離した
+  - `stopPollers` の委譲先である `@/lib/polling/response-poller` もモックした（この責務は `manager-stop-pollers.test.ts` が持つ）。依存グラフの import だけで 500ms 以上かかっていたため
+  - **変異注入で非空振りを証明済み**（2026-08-08）: (a) `getAllToolsInfo()` の `Promise.all` を直列 for ループへ変えると `should issue every probe before any of them resolves (checks run concurrently)` が赤（発行済み probe が `['which claude']` の 1 本だけになる）、(b) `CopilotTool.isInstalled()` の stage 2 を削ると 3 件が赤（copilot の 2 段テスト 2 件と `getInstalledTools` の `copilot` 混入）。変異はいずれも元に戻し、`src/` の diff が空であることを確認済み
+  - **実測**: 23 tests / `Duration 357ms`（tests 7ms）、`CI=true` でも 364ms。修正前は 17 tests / 1.28s（tests 216ms、実プロセス起動あり）。なお開発機では 6 ツールすべてと `gh copilot` が実際にインストールされているが、テストは `installed: false` を期待して緑になる — 実バイナリを参照していないことの実測的な裏付け
+
 ## [0.22.1] - 2026-08-07
 
 > **Highlight**: Skill 一覧が**古いバージョンをインストール済みとして表示し、そこからの更新が必ず失敗する**問題を修正する（#1753）。一覧 API は索引を、更新 API は receipt を真実として読んでおり、両者が食い違うと UI は旧版を出して更新導線を描き、押すと `SKILL_UPDATE_VERSION_NOT_ELIGIBLE` を返していた。エラー文言は利用者に「もう最新です」としか読めず、UI に索引を作り直す導線も無いため、**一度ずれると回復できない**状態だった。読み取り時の索引修復を「欠落行の復元」から「receipt と食い違う行の収束」まで広げ、コストは索引が既に持つ `receipt_sha256` との比較で抑えている（一致する行は parse も書き込みもしない）。**このリリースを適用すると、ずれている索引は一覧を開いた時点で自動的に直る。**

--- a/tests/unit/cli-tools/manager.test.ts
+++ b/tests/unit/cli-tools/manager.test.ts
@@ -1,16 +1,130 @@
 /**
  * Unit tests for CLIToolManager
+ *
+ * Issue #1752: このファイルは以前 child_process をモックしておらず、`getToolInfo` /
+ * `getAllToolsInfo` / `getInstalledTools` を呼ぶたびに 7 ツール分の実プロセスが起動していた。
+ * `BaseCLITool.isInstalled()` は `which <cmd>`（timeout 5000ms）、`CopilotTool.isInstalled()` は
+ * `gh --version` → `gh copilot --help` の 2 段直列（最悪 5000 + 5000 = 10,000ms）で、
+ * vitest 側は `testTimeout` 未設定＝既定 5000ms。つまり内側の予算が外側を構造的に超えており、
+ * 負荷の高い CI ランナーではアサーション不一致ではなく **タイムアウト** で落ちていた。
+ * exec / execFile をモックして実プロセスを排除し、あわせて `installed` を true / false の
+ * 両方で固定する（以前は `typeof info.installed === 'boolean'` しか見ておらず、
+ * どちらに転んでも緑になる assertion だった）。
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as childProcess from 'child_process';
+
+// 実プロセス起動の唯一の入口である exec / execFile を差し替える。
+// `BaseCLITool` と `claude-session.isClaudeInstalled()` は exec、`CopilotTool` は execFile を使う。
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    exec: vi.fn(),
+    execFile: vi.fn(),
+  };
+});
+
+// `stopPollers()` の委譲先。このファイルは stopPollers を検証しない
+// （それは manager-stop-pollers.test.ts の担当）のに、response-poller の依存グラフだけで
+// import に 500ms 以上かかるため切り離す。実行時間の短縮が目的で、被検証範囲は変わらない。
+vi.mock('@/lib/polling/response-poller', () => ({ stopPolling: vi.fn() }));
+
 import { CLIToolManager } from '@/lib/cli-tools/manager';
-import type { CLIToolType, ICLITool } from '@/lib/cli-tools/types';
+import type { CLIToolType } from '@/lib/cli-tools/types';
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+/** Map への登録順 = `getAllTools()` / `getAllToolsInfo()` の並び順 */
+const TOOL_ORDER: CLIToolType[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'vibe-local',
+  'opencode',
+  'copilot',
+  'antigravity',
+];
+
+/** 偽の `which` が見つけるコマンド集合 */
+let installedCommands: Set<string>;
+/** `gh --version`（stage 1）の成否 */
+let ghVersionOk: boolean;
+/** `gh copilot --help`（stage 2）の成否 */
+let ghCopilotOk: boolean;
+/** true の間コールバックを発火せず parked に積む（並列性を観測するため） */
+let holdCallbacks: boolean;
+
+/** 記録された `exec` のコマンド文字列 */
+let execCommands: string[];
+/** 記録された `execFile` の [file, ...args] */
+let execFileCalls: string[][];
+/** holdCallbacks 中に保留されたコールバック */
+let parked: Array<() => void>;
+
+function respond(ok: boolean, callback: ExecCallback | undefined): void {
+  if (!callback) return;
+  const fire = (): void => {
+    if (ok) {
+      callback(null, 'ok', '');
+    } else {
+      callback(new Error('Command failed'), '', 'not found');
+    }
+  };
+  if (holdCallbacks) {
+    parked.push(fire);
+  } else {
+    queueMicrotask(fire);
+  }
+}
+
+/** 保留中のコールバックを、連鎖して増えた分がなくなるまで発火する */
+async function releaseParked(): Promise<void> {
+  holdCallbacks = false;
+  while (parked.length > 0) {
+    const batch = parked.splice(0, parked.length);
+    for (const fire of batch) fire();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
 
 describe('CLIToolManager', () => {
   let manager: CLIToolManager;
 
   beforeEach(() => {
     manager = CLIToolManager.getInstance();
+
+    installedCommands = new Set<string>();
+    ghVersionOk = false;
+    ghCopilotOk = false;
+    holdCallbacks = false;
+    execCommands = [];
+    execFileCalls = [];
+    parked = [];
+
+    vi.mocked(childProcess.exec).mockImplementation(((
+      command: string,
+      _options: unknown,
+      callback?: unknown
+    ) => {
+      execCommands.push(command);
+      const target = command.replace(/^which\s+/, '');
+      respond(installedCommands.has(target), callback as ExecCallback | undefined);
+      return {} as childProcess.ChildProcess;
+    }) as unknown as typeof childProcess.exec);
+
+    vi.mocked(childProcess.execFile).mockImplementation(((
+      file: string,
+      args: string[],
+      _options: unknown,
+      callback?: unknown
+    ) => {
+      execFileCalls.push([file, ...args]);
+      const ok = args[0] === '--version' ? ghVersionOk : ghCopilotOk;
+      respond(ok, callback as ExecCallback | undefined);
+      return {} as childProcess.ChildProcess;
+    }) as unknown as typeof childProcess.execFile);
   });
 
   describe('Singleton pattern', () => {
@@ -76,104 +190,209 @@ describe('CLIToolManager', () => {
       const tool2 = manager.getTool('claude');
       expect(tool1).toBe(tool2);
     });
+
+    it('should throw for an unknown tool type', () => {
+      expect(() => manager.getTool('nope' as CLIToolType)).toThrow(
+        "CLI tool 'nope' not found"
+      );
+    });
   });
 
   describe('getAllTools', () => {
     it('should return all seven tools', () => {
       const tools = manager.getAllTools();
       expect(tools).toHaveLength(7);
-
-      const ids = tools.map(t => t.id);
-      expect(ids).toContain('claude');
-      expect(ids).toContain('codex');
-      expect(ids).toContain('gemini');
-      expect(ids).toContain('vibe-local');
-      expect(ids).toContain('opencode');
-      expect(ids).toContain('copilot');
-      expect(ids).toContain('antigravity');
+      expect(tools.map((t) => t.id)).toEqual(TOOL_ORDER);
     });
 
     it('should return tools in consistent order', () => {
       const tools1 = manager.getAllTools();
       const tools2 = manager.getAllTools();
 
-      expect(tools1[0].id).toBe(tools2[0].id);
-      expect(tools1[1].id).toBe(tools2[1].id);
-      expect(tools1[2].id).toBe(tools2[2].id);
-      expect(tools1[3].id).toBe(tools2[3].id);
+      expect(tools1.map((t) => t.id)).toEqual(tools2.map((t) => t.id));
     });
   });
 
   describe('getToolInfo', () => {
-    it('should return tool info with installation status', async () => {
+    it('should report installed = true when the command is on PATH', async () => {
+      installedCommands = new Set(['claude']);
+
       const info = await manager.getToolInfo('claude');
 
-      expect(info.id).toBe('claude');
-      expect(info.name).toBe('Claude Code');
-      expect(info.command).toBe('claude');
-      expect(typeof info.installed).toBe('boolean');
+      expect(info).toEqual({
+        id: 'claude',
+        name: 'Claude Code',
+        command: 'claude',
+        installed: true,
+      });
+      expect(execCommands).toEqual(['which claude']);
     });
 
-    it('should return correct info for all tools', async () => {
-      const claudeInfo = await manager.getToolInfo('claude');
+    it('should report installed = false when the command is missing from PATH', async () => {
+      installedCommands = new Set<string>();
+
+      const info = await manager.getToolInfo('claude');
+
+      expect(info).toEqual({
+        id: 'claude',
+        name: 'Claude Code',
+        command: 'claude',
+        installed: false,
+      });
+      expect(execCommands).toEqual(['which claude']);
+    });
+
+    it('should probe each tool with its own command', async () => {
+      installedCommands = new Set(['codex']);
+
       const codexInfo = await manager.getToolInfo('codex');
       const geminiInfo = await manager.getToolInfo('gemini');
+      const antigravityInfo = await manager.getToolInfo('antigravity');
 
-      expect(claudeInfo.id).toBe('claude');
-      expect(codexInfo.id).toBe('codex');
-      expect(geminiInfo.id).toBe('gemini');
+      expect(codexInfo.installed).toBe(true);
+      expect(geminiInfo.installed).toBe(false);
+      expect(antigravityInfo.installed).toBe(false);
+      expect(execCommands).toEqual(['which codex', 'which gemini', 'which agy']);
+    });
+  });
+
+  /**
+   * Issue #545 の 2 段チェックを manager 越しに固定する。
+   * stage 2 を落とすと「gh さえ入っていれば copilot 扱い」に退行するため、
+   * stage 1 単独成功で false になること／stage 1 失敗時に stage 2 を呼ばないことを個別に押さえる。
+   */
+  describe('getToolInfo (copilot の 2 段チェック)', () => {
+    it('should report installed = true only when both gh and the copilot extension answer', async () => {
+      ghVersionOk = true;
+      ghCopilotOk = true;
+
+      const info = await manager.getToolInfo('copilot');
+
+      expect(info.installed).toBe(true);
+      expect(execFileCalls).toEqual([
+        ['gh', '--version'],
+        ['gh', 'copilot', '--help'],
+      ]);
+    });
+
+    it('should report installed = false when gh answers but the copilot extension does not', async () => {
+      ghVersionOk = true;
+      ghCopilotOk = false;
+
+      const info = await manager.getToolInfo('copilot');
+
+      expect(info.installed).toBe(false);
+      expect(execFileCalls).toEqual([
+        ['gh', '--version'],
+        ['gh', 'copilot', '--help'],
+      ]);
+    });
+
+    it('should skip the copilot extension check entirely when gh itself is missing', async () => {
+      ghVersionOk = false;
+      ghCopilotOk = true; // stage 2 に到達したら true になってしまう設定
+
+      const info = await manager.getToolInfo('copilot');
+
+      expect(info.installed).toBe(false);
+      expect(execFileCalls).toEqual([['gh', '--version']]);
     });
   });
 
   describe('getAllToolsInfo', () => {
-    it('should return info for all tools', async () => {
+    it('should return per-tool installation status for all seven tools', async () => {
+      installedCommands = new Set(['claude', 'gemini', 'agy']);
+      ghVersionOk = true;
+      ghCopilotOk = true;
+
       const allInfo = await manager.getAllToolsInfo();
 
-      expect(allInfo).toHaveLength(7);
-
-      const ids = allInfo.map(info => info.id);
-      expect(ids).toContain('claude');
-      expect(ids).toContain('codex');
-      expect(ids).toContain('gemini');
-      expect(ids).toContain('vibe-local');
-      expect(ids).toContain('opencode');
-      expect(ids).toContain('copilot');
-      expect(ids).toContain('antigravity');
+      expect(allInfo).toEqual([
+        { id: 'claude', name: 'Claude Code', command: 'claude', installed: true },
+        { id: 'codex', name: 'Codex CLI', command: 'codex', installed: false },
+        { id: 'gemini', name: 'Gemini CLI', command: 'gemini', installed: true },
+        { id: 'vibe-local', name: 'Vibe Local', command: 'vibe-local', installed: false },
+        { id: 'opencode', name: 'OpenCode', command: 'opencode', installed: false },
+        { id: 'copilot', name: 'Copilot', command: 'gh', installed: true },
+        { id: 'antigravity', name: 'Antigravity CLI', command: 'agy', installed: true },
+      ]);
     });
 
-    it('should include installation status for each tool', async () => {
+    it('should report every tool as not installed when nothing is on PATH', async () => {
       const allInfo = await manager.getAllToolsInfo();
 
-      allInfo.forEach(info => {
-        expect(typeof info.installed).toBe('boolean');
-        expect(typeof info.name).toBe('string');
-        expect(typeof info.command).toBe('string');
-      });
+      expect(allInfo.map((info) => info.id)).toEqual(TOOL_ORDER);
+      expect(allInfo.map((info) => info.installed)).toEqual([
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+      ]);
+    });
+
+    it('should issue every probe before any of them resolves (checks run concurrently)', async () => {
+      installedCommands = new Set([
+        'claude',
+        'codex',
+        'gemini',
+        'vibe-local',
+        'opencode',
+        'agy',
+      ]);
+      ghVersionOk = true;
+      ghCopilotOk = true;
+      holdCallbacks = true;
+
+      const pending = manager.getAllToolsInfo();
+
+      // 直列化されていればこの時点で発行済みの probe は先頭 1 本だけになる。
+      // 7 ツール分がすべて in-flight であることが、Promise.all を使っている証拠。
+      expect(execCommands).toEqual([
+        'which claude',
+        'which codex',
+        'which gemini',
+        'which vibe-local',
+        'which opencode',
+        'which agy',
+      ]);
+      expect(execFileCalls).toEqual([['gh', '--version']]);
+
+      await releaseParked();
+
+      const allInfo = await pending;
+      expect(allInfo.map((info) => info.installed)).toEqual([
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+      ]);
     });
   });
 
   describe('getInstalledTools', () => {
-    it('should return only installed tools', async () => {
+    it('should return only the tools whose probe succeeded', async () => {
+      installedCommands = new Set(['claude', 'gemini', 'agy']);
+      ghVersionOk = true;
+      ghCopilotOk = false; // copilot は gh があっても拡張が無いので除外される
+
       const installed = await manager.getInstalledTools();
 
-      // All returned tools should have installed = true
+      expect(installed.map((info) => info.id)).toEqual(['claude', 'gemini', 'antigravity']);
       for (const info of installed) {
         expect(info.installed).toBe(true);
       }
     });
 
-    it('should return array of tool info', async () => {
+    it('should return an empty array when no tool is installed', async () => {
       const installed = await manager.getInstalledTools();
 
-      expect(Array.isArray(installed)).toBe(true);
-
-      if (installed.length > 0) {
-        const first = installed[0];
-        expect(first).toHaveProperty('id');
-        expect(first).toHaveProperty('name');
-        expect(first).toHaveProperty('command');
-        expect(first).toHaveProperty('installed');
-      }
+      expect(installed).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Refs #1752

## 何が壊れていたか

`tests/unit/cli-tools/manager.test.ts` が CI で断続的に**タイムアウト**で落ちていた。
アサーション不一致ではない。

```
FAIL tests/unit/cli-tools/manager.test.ts > CLIToolManager > getAllToolsInfo > should return info for all tools
Error: Test timed out in 5000ms.
```

同一コミット `d24901c4`（v0.22.0）で、同じワークフローの同じジョブが 2 つの run に割れた。

| run id | event | Unit Tests |
|---|---|---|
| 31151127023 | `pull_request` | success |
| 31151080694 | `push` | **failure** |

コードが同一で結果が割れる以上、実装の欠陥ではなく**テストの設計が実行環境の負荷に耐えていない**。

### 根本原因

**内側（被テストコード）のタイムアウト予算が、外側（vitest）のテストタイムアウトを構造的に超えている。**

`getAllToolsInfo()` は 7 ツールの `isInstalled()` を `Promise.all` で並列実行し、各実装が
**実プロセスを起動する**。

| 実装 | 起動 | タイムアウト |
|---|---|---|
| `BaseCLITool.isInstalled()` | `execAsync('which <cmd>')`（`/bin/sh -c` 経由） | 5000ms |
| `CopilotTool.isInstalled()` stage 1 | `execFile('gh', ['--version'])` | 5000ms |
| 〃 stage 2 | `execFile('gh', ['copilot', '--help'])` | 5000ms |

copilot だけが 2 段を**直列**に実行するので最悪 5000 + 5000 = **10,000ms**。
`vitest.config.ts` に `testTimeout` の明示設定が無く既定 **5000ms** が効くため、
**copilot の内側タイムアウトは一度も観測されえない**（必ずテスト側が先に死ぬ）。

GitHub Actions ランナーには `gh` がプリインストールされているため stage 1 は必ず成功し、
**stage 2 が必ず実行される**（`gh copilot` 拡張は入っていないので拡張解決の失敗まで待つ）。
「CI では早く失敗するから軽い」という想定は成り立たない。

`child_process` は一切モックされておらず、**単体テストが実プロセスを 20 回以上起動していた**。

## 何を変えたか

`vi.mock('child_process')` で `exec` / `execFile` を差し替え、実プロセス起動を排除した。
リポジトリ内の前例（`tests/unit/cli/utils/npm-runner.test.ts` 等）に揃えている。

**`testTimeout` を広げる対処は採っていない。** 遅さの原因（実プロセス起動）が残り、
負荷が上がれば再発するため。`vitest.config.ts` の全体既定も変更していない
（他 816 ファイルの挙動が変わるため、Issue がスコープ外と明示している）。

**実装は 1 行も変更していない。** `src/lib/cli-tools/manager.ts` / `base.ts` / `copilot.ts` は
そのままで、テスト側で閉じるべき欠陥である。変更は `tests/` と `CHANGELOG.md` だけ。

### 検査内容の強化

モック化により `installed` が**決定的**になったので、中身を検査しない
`expect(typeof info.installed).toBe('boolean')` をやめた。

- `installed` の **true / false 両方**を固定
- copilot の 2 段チェックを個別に固定
  - stage 1 成功 → stage 2 成功で `true`
  - stage 1 成功 → stage 2 失敗で `false`
  - **stage 1 失敗なら stage 2 は呼ばれない**
- `getAllToolsInfo()` が**全プローブを一斉に発行する**（＝ `Promise.all` の並列性）ことを固定

## 検証（すべて実測）

### ゲート実測（`commandmate wait --verify`, run 164）

| ゲート | 結果 | 実測 |
|---|---|---|
| work-evidence | PASS | commits=1, uncommitted=0 |
| scope | PASS | exit=0 |
| lint | PASS | exit=0, 5.0s |
| typecheck | PASS | exit=0, 2.4s |
| unit | PASS | exit=0, 392.9s |

### 該当ファイル単体の実行時間

```
$ npx vitest run tests/unit/cli-tools/manager.test.ts
 Test Files  1 passed (1)
      Tests  23 passed (23)
   Duration  401ms (transform 227ms, setup 54ms, import 267ms, tests 7ms, environment 0ms)
```

**401ms（うち tests 実行は 7ms）**。受入基準の「1 秒未満」を満たす。
修正前はローカルで 17 tests / 1.18s、CI ではタイムアウトしていた。

### 変異注入（非空振りの証明）

レビュー側で独立に再実行し、いずれも赤になることを確認した（変異は都度復元し、
`git status` がクリーンであることを確認済み）。

| 変異 | 結果 |
|---|---|
| `getAllToolsInfo()` の `Promise.all` を直列 `for await` に変える | **1 failed / 22 passed** — `should issue every probe before any of them resolves (checks run concurrently)` |
| `CopilotTool.isInstalled()` の stage 2 を削除する | **3 failed / 20 passed** — copilot の 2 段チェック 2 件と `getInstalledTools > should return only the tools whose probe succeeded` |

## なぜこれが効くか

`installed` の真偽値は**実行マシン依存でなくなった**（`which claude` の結果に左右されない）。
実プロセスを起動しないので、CI の負荷がどれだけ上がっても内側予算が外側予算を食い潰すことがない。

## 補足

`chore(orchestrate): #1752 の実行契約を配置する` は実行契約（`.commandmate/tasks/issue-1752.yaml`）
の配置コミット。`.gitignore` が `/.commandmate/tasks/*.yaml` を追跡対象としており、
リポジトリの既存の契約群と同じ扱い。検証ゲートの変更集合からは #1580 により除外される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9TmgDF4JauYCvAxB6aB69
