### PR TITLE
feat(slash-commands): カタログを claude docs へリコンサイルし未反映 3 件を反映する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **slash-commands: カタログを claude docs へリコンサイルし、未反映の 3 コマンドを追加** (#1767)
+  - `/agents` `/import` `/list-agents`（いずれも claude のみ）。`code.claude.com/docs/en/commands.md` の実行（2026-08-13）で 3 件とも実在する行であることを確認済み。カタログ総数 159 → 162、claude 可視数 97 → 100（codex 53 / opencode 10 / antigravity 13 は変化なし）
+  - **`/agents` と `/import` は claude 専用の説明キーを持つ**（Issue #1704 の tool-scoped key）。`/agents` は opencode の「利用可能なエージェントを一覧・管理」、`/import` は codex の「Claude Code から設定…を取り込み」という**別の意味の説明を共有していた**ため、そのままでは claude のパレットに他ツール向けの誤った説明が出る。`slashCommands.descriptions.{agents,import}` を tool 別オブジェクトへ分割し、既存ツールの文面は 1 文字も変えずにそれぞれのキーへ移した
+  - `/schedule`（#1488 のキュレーション判断）・`/ultraplan`（#1503 の幻コマンド）・`/pr-comments` `/vim`（上流で削除済み）・`/cost` `/stats`（`/usage` のエイリアス）は**従来どおり追加していない**
+
 ## [0.22.2] - 2026-08-09
 
 > **Highlight**: サーバーを 2 つ動かしている環境で、**`commandmate ls` などが `~/.commandmate/.env` を読まず既定ポート 3000 の別サーバーに繋いでいた**問題を修正する（#1743）。`.env` を読んでいたのは `status` だけだったため「どのサーバーに繋がっているか分からない」状態になり、`cmate-orchestrate` の dispatch は正しく作成・登録した worktree を「無い」と誤判定して run を 1 回無駄に消費していた。解決順を **シェルで export した `CM_PORT` > `~/.commandmate/.env` > 3000** に統一し、`ls` だけでなく `ApiClient` を使う全 subcommand が同じ経路で解決するようにした。**接続先ホストは `localhost` から `127.0.0.1` に変わる**（`status` が報告するアドレスと一致させるため）。あわせて、リリース PR の CI を断続的に落としていた `manager.test.ts` の実プロセス起動（1 ファイルで 20 回以上）を排除し、実行時間を 1.28s → **357ms**（うち tests 7ms）に短縮した（#1752）。

--- a/locales/en/worktree.json
+++ b/locales/en/worktree.json
@@ -131,7 +131,10 @@
       "connect": "Connect to language server",
       "exit": "Exit OpenCode TUI",
       "models": "Switch AI model",
-      "agents": "List and manage available agents",
+      "agents": {
+        "opencode": "List and manage available agents",
+        "claude": "Show a reminder to ask Claude to create or manage subagents, or to edit .claude/agents/ directly"
+      },
       "themes": "Change TUI theme",
       "editor": "Open editor for long messages",
       "advisor": "Enable or disable the advisor tool, which consults a second model for guidance at key moments during a task",
@@ -203,7 +206,10 @@
       "sandbox-add-read-dir": "Let sandbox read a directory: /sandbox-add-read-dir [absolute-path]",
       "experimental": "Toggle experimental features",
       "approve": "Approve one retry of a recent auto-review denial",
-      "import": "Import setup, this project, and recent chats from Claude Code",
+      "import": {
+        "codex": "Import setup, this project, and recent chats from Claude Code",
+        "claude": "Bring configuration from OpenAI Codex or Google Gemini CLI into Claude Code, including instruction files, MCP servers, commands, subagents, and skills"
+      },
       "archive": "Archive this session and exit",
       "delete": "Permanently delete this session and exit",
       "app": "Continue this session in the Desktop app",
@@ -217,7 +223,8 @@
       "rollout": "Print the rollout file path",
       "ps": "List background terminals",
       "personality": "Choose a communication style for Codex",
-      "test-approval": "Test approval request"
+      "test-approval": "Test approval request",
+      "list-agents": "List the subagents and other Claude Code sessions Claude can message, with the name to use for each"
     }
   },
   "session": {

--- a/locales/ja/worktree.json
+++ b/locales/ja/worktree.json
@@ -131,7 +131,10 @@
       "connect": "言語サーバーに接続",
       "exit": "OpenCode TUI を終了",
       "models": "AI モデルを切り替え",
-      "agents": "利用可能なエージェントを一覧・管理",
+      "agents": {
+        "opencode": "利用可能なエージェントを一覧・管理",
+        "claude": "サブエージェントの作成・管理を Claude に依頼するか .claude/agents/ を直接編集するよう促す案内を表示"
+      },
       "themes": "TUI のテーマを変更",
       "editor": "長文メッセージ用のエディタを開く",
       "advisor": "アドバイザーツールの有効・無効を切り替え（要所で第 2 のモデルに助言を求める）",
@@ -203,7 +206,10 @@
       "sandbox-add-read-dir": "サンドボックスに読み取り可能なディレクトリを追加: /sandbox-add-read-dir [絶対パス]",
       "experimental": "実験的機能を切り替え",
       "approve": "直近の自動レビュー拒否に対する再試行を 1 回承認",
-      "import": "Claude Code から設定・プロジェクト・最近のチャットを取り込み",
+      "import": {
+        "codex": "Claude Code から設定・プロジェクト・最近のチャットを取り込み",
+        "claude": "OpenAI Codex / Google Gemini CLI の設定（指示ファイル・MCP サーバー・コマンド・サブエージェント・スキル）を Claude Code に取り込み"
+      },
       "archive": "このセッションをアーカイブして終了",
       "delete": "このセッションを完全に削除して終了",
       "app": "このセッションをデスクトップアプリで継続",
@@ -217,7 +223,8 @@
       "rollout": "rollout ファイルのパスを表示",
       "ps": "バックグラウンドのターミナル一覧を表示",
       "personality": "Codex の応答スタイルを選択",
-      "test-approval": "承認リクエストのテスト"
+      "test-approval": "承認リクエストのテスト",
+      "list-agents": "Claude がメッセージを送れるサブエージェントと他の Claude Code セッションを宛先名つきで一覧表示"
     }
   },
   "session": {

--- a/src/config/slash-commands-catalog.json
+++ b/src/config/slash-commands-catalog.json
@@ -476,7 +476,7 @@
     },
     {
       "name": "agents",
-      "descriptionKey": "slashCommands.descriptions.agents",
+      "descriptionKey": "slashCommands.descriptions.agents.opencode",
       "category": "standard-config",
       "cliTools": [
         "opencode"
@@ -1396,7 +1396,7 @@
     },
     {
       "name": "import",
-      "descriptionKey": "slashCommands.descriptions.import",
+      "descriptionKey": "slashCommands.descriptions.import.codex",
       "category": "standard-util",
       "cliTools": [
         "codex"
@@ -1620,6 +1620,36 @@
       "category": "standard-util",
       "cliTools": [
         "codex"
+      ],
+      "isStandard": true,
+      "source": "standard"
+    },
+    {
+      "name": "agents",
+      "descriptionKey": "slashCommands.descriptions.agents.claude",
+      "category": "standard-util",
+      "cliTools": [
+        "claude"
+      ],
+      "isStandard": true,
+      "source": "standard"
+    },
+    {
+      "name": "import",
+      "descriptionKey": "slashCommands.descriptions.import.claude",
+      "category": "standard-util",
+      "cliTools": [
+        "claude"
+      ],
+      "isStandard": true,
+      "source": "standard"
+    },
+    {
+      "name": "list-agents",
+      "descriptionKey": "slashCommands.descriptions.list-agents",
+      "category": "standard-util",
+      "cliTools": [
+        "claude"
       ],
       "isStandard": true,
       "source": "standard"

--- a/tests/unit/lib/slash-command-description-override.test.ts
+++ b/tests/unit/lib/slash-command-description-override.test.ts
@@ -15,6 +15,8 @@
  * @vitest-environment node
  */
 
+import fs from 'fs';
+import path from 'path';
 import { describe, it, expect } from 'vitest';
 import { reconcileCatalog, toolDescriptionKeyFor } from '@/lib/slash-command-reconcile/engine';
 import {
@@ -126,9 +128,10 @@ describe('descriptionKey override, engine → dictionary → renderer', () => {
 
 describe('the bundled catalog carries descriptionKey through verbatim', () => {
   // The override only works if standard-commands.ts passes the authored key
-  // along instead of re-deriving it from the name. Asserting that over today's
-  // catalog proves nothing — no entry overrides yet, so the two forms coincide
-  // for all 159 of them. The property has to be checked on an entry that does.
+  // along instead of re-deriving it from the name. Until Issue #1767 no shipped
+  // entry overrode anything, so this had to be checked on a synthetic entry;
+  // /agents and /import now override for real (see the shipped-override test
+  // below), and this stays as the minimal statement of the property.
   it('does not re-derive the key from the command name', () => {
     const overridden = toStandardCommand({
       name: 'btw',
@@ -148,7 +151,41 @@ describe('the bundled catalog carries descriptionKey through verbatim', () => {
     );
   });
 
-  it('resolves an overridden key through the renderer even though no entry uses one yet', () => {
+  // Issue #1767: the first shipped overrides. /agents and /import each exist on
+  // claude and on another tool with genuinely different meanings, so both names
+  // became per-tool objects in the dictionary. Resolution here goes through
+  // lookupNestedValue — path traversal, the way next-intl resolves a dotted key —
+  // rather than the flattened map the other guards use, because a dictionary that
+  // stored "agents.claude" as one literal key would satisfy a flat lookup and
+  // still render the raw key in the palette.
+  it('resolves every shipped tool-scoped override against the real dictionaries', () => {
+    const overridden = (catalogJson as SlashCommandsCatalog).commands.filter(
+      (entry) => (entry.descriptionKey ?? '').split('.').length > 3
+    );
+    expect(overridden.map((e) => e.descriptionKey)).toEqual([
+      'slashCommands.descriptions.agents.opencode',
+      'slashCommands.descriptions.import.codex',
+      'slashCommands.descriptions.agents.claude',
+      'slashCommands.descriptions.import.claude',
+    ]);
+
+    for (const locale of ['en', 'ja'] as const) {
+      const dict = JSON.parse(
+        fs.readFileSync(path.resolve(__dirname, `../../../locales/${locale}/worktree.json`), 'utf8')
+      );
+      for (const entry of overridden) {
+        const text = resolveCommandDescription(asSlashCommand(entry), (key) =>
+          lookupNestedValue(dict, key) ?? key
+        );
+        expect(text, `${locale} cannot resolve ${entry.descriptionKey}`).not.toBe(
+          entry.descriptionKey
+        );
+        expect(text.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('resolves a synthetic overridden key through the renderer', () => {
     const overridden = asSlashCommand({
       name: 'btw',
       descriptionKey: toolDescriptionKeyFor('btw', 'codex'),

--- a/tests/unit/lib/standard-commands.test.ts
+++ b/tests/unit/lib/standard-commands.test.ts
@@ -91,8 +91,11 @@ describe('STANDARD_COMMANDS', () => {
   // refresh against claude docs / codex 0.146.0 added 104 real commands.
   // 56 -> 159. The bans below are what actually protects the set; this number
   // only pins that a refresh was reviewed rather than applied blind.
-  it('should have 159 standard commands', () => {
-    expect(STANDARD_COMMANDS.length).toBe(159);
+  // Issue #1767: +3 claude built-ins the weekly drift check surfaced — /agents,
+  // /import, /list-agents, all real rows on code.claude.com/docs/en/commands.md.
+  // 159 -> 162.
+  it('should have 162 standard commands', () => {
+    expect(STANDARD_COMMANDS.length).toBe(162);
   });
 
   it('should have all required properties for each command', () => {
@@ -324,15 +327,23 @@ describe('STANDARD_COMMANDS', () => {
   });
 
   // Issue #1503: these 6 entries did not exist on claude 2.1.218 / codex 0.144.6
-  // and were purged; the "(removed)" claude /agents stub went too, leaving only
-  // the opencode /agents. None of them may reappear in the catalog.
+  // and were purged. None of them may reappear in the catalog.
+  //
+  // Issue #1767 narrows the /agents half exactly the way v0.21.2 narrowed /vim.
+  // The old assertion was "claude ships no /agents at all", which was right while
+  // the claude docs row was a bare "(removed)" stub. It no longer is: the row on
+  // code.claude.com/docs/en/commands.md (fetched 2026-08-13) reads "As of
+  // v2.1.198, running `/agents` prints a reminder to ask Claude to create or
+  // manage subagents…" — a real command with a real description. So claude gets
+  // an entry, and what is pinned instead is that the two entries stay separate
+  // and never share a description key (Issue #1704 tool-scoped keys).
   it('does not carry the Issue #1503 phantom commands', () => {
     for (const name of ['cost', 'lazy', 'todos', 'pr-comments', 'approvals', 'undo']) {
       expect(STANDARD_COMMANDS.some((c) => c.name === name), `/${name} must be gone`).toBe(false);
     }
     const agentsEntries = STANDARD_COMMANDS.filter((c) => c.name === 'agents');
-    expect(agentsEntries.length).toBe(1);
-    expect(agentsEntries[0].cliTools).toEqual(['opencode']);
+    expect(agentsEntries.map((c) => c.cliTools?.join(',')).sort()).toEqual(['claude', 'opencode']);
+    expect(new Set(agentsEntries.map((c) => c.descriptionKey)).size).toBe(2);
   });
 
   // Issue #689: New Claude commands with explicit cliTools: ['claude'] (DR1-001)
@@ -381,28 +392,35 @@ describe('STANDARD_COMMANDS', () => {
   // Issue #1503: -5 Claude-visible phantoms (cost/lazy/todos/pr-comments + the
   // "(removed)" /agents stub) → 24.
   // v0.21.2: reconciled against the claude commands doc → 97.
-  it('should have 97 commands available for Claude', () => {
+  // Issue #1767: +3 (/agents, /import, /list-agents) → 100.
+  it('should have 100 commands available for Claude', () => {
     const claudeCommands = STANDARD_COMMANDS.filter(
       (cmd) => !cmd.cliTools || cmd.cliTools.includes('claude')
     );
-    expect(claudeCommands.length).toBe(97);
+    expect(claudeCommands.length).toBe(100);
   });
 
   // Issue #689: agent (Codex) vs agents (OpenCode) differentiation (DR1-002)
   // Issue #1306: distinct keys are not enough — two keys can hold identical
   // text (see /model and /models), so assert the resolved text differs too.
-  it('agent (Codex) and agents (OpenCode) should have distinct descriptions', () => {
-    const agent = STANDARD_COMMANDS.find((c) => c.name === 'agent');
-    const agents = STANDARD_COMMANDS.find((c) => c.name === 'agents');
-    expect(agent).toBeDefined();
-    expect(agents).toBeDefined();
-    expect(agent?.descriptionKey).not.toBe(agents?.descriptionKey);
+  // Issue #1767: claude's /agents joined the pair meaning a third thing, so
+  // `descriptions.agents` is now a per-tool object rather than one string.
+  // Each entry is therefore resolved through its own key (a flat `dict.agents`
+  // lookup would silently read undefined here), and all three must differ.
+  it('agent (Codex), agents (OpenCode) and agents (Claude) have distinct descriptions', () => {
+    type CliTool = NonNullable<SlashCommand['cliTools']>[number];
+    const pick = (name: string, tool: CliTool): SlashCommand => {
+      const cmd = STANDARD_COMMANDS.find((c) => c.name === name && c.cliTools?.includes(tool));
+      expect(cmd, `/${name} must be ${tool}-visible`).toBeDefined();
+      return cmd as SlashCommand;
+    };
+    const entries = [pick('agent', 'codex'), pick('agents', 'opencode'), pick('agents', 'claude')];
+    expect(new Set(entries.map((c) => c.descriptionKey)).size).toBe(entries.length);
 
     for (const locale of LOCALES) {
-      const dict = loadDescriptions(locale);
-      expect(dict.agent).toBeTruthy();
-      expect(dict.agents).toBeTruthy();
-      expect(dict.agent).not.toBe(dict.agents);
+      const texts = entries.map((cmd) => descriptionFor(cmd, locale));
+      texts.forEach((text) => expect(text).toBeTruthy());
+      expect(new Set(texts).size).toBe(entries.length);
     }
   });
 


### PR DESCRIPTION
## 概要

Issue #1767（catalog-drift 自動起票）の未反映 3 件を反映する。

- `[claude] /agents` / `[claude] /import` / `[claude] /list-agents` を追加
- `/agents` と `/import` は **description-conflict** でもあったため、tool 固有の description キーへ分離した

## description-conflict の解消方法

両コマンドは既存エントリ（`/agents` は opencode、`/import` は codex）と description を共有しており、
claude の実ソースは別のことを言っていた。#1704 で導入済みの per-entry `descriptionKey` 機構を使い、
共有文字列を **tool 別オブジェクトへ分割**した。

| キー | 分割前 | 分割後 |
|---|---|---|
| `descriptions.agents` | `"List and manage available agents"`（共有） | `{opencode: <同一文字列>, claude: <新規>}` |
| `descriptions.import` | `"Import setup, this project, ..."`（共有） | `{codex: <同一文字列>, claude: <新規>}` |

**既存ツールの表示文字列はバイト単位で不変**（opencode の `/agents`、codex の `/import`）。
共有 description を上書きしていないため、無関係なツールの表示は変わらない。

## 自動追加しなかった 6 件（現状が正しい）

過去の人間の判断を尊重し、動かしていない。

- `[excluded]` `/schedule`（#1488 のキュレーション判断）/ `/ultraplan`（#1503 が幻コマンドとして排除）
- `[removed-row]` `[claude] /pr-comments` `[claude] /vim`（`/vim` は codex 版のみ存続。claude 版は追加せず）
- `[alias-row]` `/cost` `/stats`（`/usage` のエイリアス）

既知の警告 1 件（`antigravity provider not implemented yet` / #1489 Phase 2）は対象外。

## 検証

`commandmate wait --verify` の実 exit code で裁定（exit 0）。

```
GATE work-evidence PASS (commits=1, uncommitted=0)
GATE scope         PASS (exit=0)
GATE lint          PASS (exit=0, 4.2s)
GATE typecheck     PASS (exit=0, 1.9s)
GATE unit          PASS (exit=0, 380.5s)
RESULT passed
```

### 空振り緑の反証（変異注入）

新規テストが実際にガードとして効くことを確認済み。claude `/agents` の `descriptionKey` を
共有キー（`.agents.opencode`）へ戻す変異を注入したところ、**2 ファイル 5 テストが赤**になった。
復旧後に 70/70 緑を再確認。

- `tests/unit/lib/slash-command-description-override.test.ts` — engine → 辞書 → カタログ → レンダラの全経路
- `tests/unit/lib/standard-commands.test.ts`

Refs #1767