### PR TITLE
fix(proxy): External Appsへの転送時に末尾スラッシュとクエリ文字列を保持する (#1802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix(proxy): 上流転送で末尾スラッシュとクエリ文字列を保持する** (#1802)
+  - **External Apps のプロキシがルート画面（`/proxy/<app>/`）だけ 200 で、配下（`/proxy/<app>/try/`,
+    `/proxy/<app>/assets/`）が 404 になっていた。** Next.js static export のようにディレクトリ URL に
+    末尾 `/` を要求する上流では、`/try/` と `/try` は**別の URL**であり、上流は後者を 404 にする
+  - **原因は `src/app/proxy/[...path]/route.ts` の `'/proxy/' + pathSegments.join('/')`。**
+    Next.js の catch-all params は「区切り文字を落とした percent-decode 済みの配列」なので、
+    配列から join で URL を再構築する方式では**構造的に 3 つの情報が失われる**:
+    ①末尾スラッシュ ②クエリ文字列（`buildUpstreamUrl()` の JSDoc は "including query string" と
+    書いてあるのに呼び出し側が一度も search を渡していなかった）③percent-encode
+    （`%20` が素の空白、`%2F` が区切りの `/` に化ける）
+  - **修正は `new URL(request.url)` の `pathname` + `search` をそのまま連結して転送する形に変えた。**
+    `pathSegments` は `pathPrefix` の検索用途（DB の `pathPrefix` は decode 済みの素の文字列）にのみ残した
+  - **保存されるのはパスであり、クエリは route handler 到達前に Next.js が正規化する（実機計測）。**
+    エコー上流を立てて実サーバ経由で計測した結果は以下のとおり:
+    - パス: **バイト列がそのまま保存される** — `/try/` は `/try/`、`a%20b` / `a%2Fb` /
+      `%E6%97%A5%E6%9C%AC` / 素の `+` すべて無変換で上流へ届く
+    - クエリ: **バイト完全一致は達成できない** — `?q=a%20b&n=1` は `?q=a+b&n=1` に、
+      `?bare` は `?bare=` になる（`URLSearchParams` で再シリアライズした時の署名）。
+      `%2B` / `%26` / `%3D` / percent-encode 済みマルチバイト値は保存される。
+      これは App Router の route handler からは触れない層での正規化であり、
+      本 Issue のコード（`new URL()` も `fetch()` も無改変であることを node で切り分け済み）が
+      原因ではなく、本 Issue の範囲では解消できない。既知の制限として、
+      `?` 単独の空クエリも WHATWG URL の仕様上 `search` が空文字になるため落ちる（`/x?` → `/x`）
+  - **ログには query string を載せない（Issue #395 の方針）。** クエリにトークンが載りうるため、
+    転送用 path（`pathname + search`）とログ用 path（`pathname` のみ）を分離した。
+    `/proxy/` 単体での 400、WebSocket フォールバックの 426 は挙動を変えていない
+    （`next.config.js` の `skipTrailingSlashRedirect: true`（#671）と、
+    `src/lib/ws-server.ts` が `request.url` を生のまま渡す upgrade 経路には手を入れていない）
 - **fix(session): 並列開発で宙に浮いた 2 つの配線を繋いだ（`reasoningEffort` が永久に null／詳細ヘッダに指示待ち表現が無い）** (#1785, #1787, #1784)
   - **どちらも「実装されていなかった」のではなく「着地済みの実装同士が繋がれていなかった」。**
     Phase 2（#1784・保持層）と Phase 3（#1785・露出）、および #1787（waiting 視認性）が**同時並行で開発され、

--- a/src/app/proxy/[...path]/route.ts
+++ b/src/app/proxy/[...path]/route.ts
@@ -18,6 +18,43 @@ import type { ProxyLogEntry } from '@/lib/proxy/logger';
 export const dynamic = 'force-dynamic';
 
 /**
+ * Resolve the paths used for upstream forwarding and for logging.
+ *
+ * Issue #1802: Next.js catch-all params (`params.path`) are percent-decoded and
+ * carry neither the trailing slash nor the query string, so rebuilding the path
+ * with `pathSegments.join('/')` structurally drops all three. Read the pathname
+ * and search from `request.url` instead, and concatenate them verbatim.
+ *
+ * How much is preserved differs between the two halves (measured end-to-end
+ * against an echo upstream through a real CommandMate server):
+ *
+ * - **pathname**: preserved byte-for-byte. `/try/` stays `/try/`, and
+ *   `%20` / `%2F` / `%E6%97%A5%E6%9C%AC` / a literal `+` all survive unchanged.
+ * - **search**: NOT byte-for-byte. Next.js re-serializes the query string
+ *   before the route handler ever runs, so `?q=a%20b` arrives here as `?q=a+b`
+ *   and `?bare` arrives as `?bare=` (the signature of a URLSearchParams
+ *   round-trip). `%2B`, `%26`, `%3D` and percent-encoded multibyte values are
+ *   preserved. That normalization happens in a layer an App Router route
+ *   handler cannot reach; this function neither causes nor can undo it.
+ *   A bare `?` with no query also collapses (`/x?` -> `/x`) per the WHATWG URL
+ *   spec, since `search` is the empty string in that case.
+ *
+ * The forwarded path carries the query string; the logged path deliberately
+ * does not, because query strings may carry tokens and Issue #395 requires
+ * that such internals stay out of logs.
+ *
+ * @param request - The incoming request
+ * @returns The upstream path (pathname + search) and the log-safe path
+ */
+function resolveProxyPaths(request: Request): {
+  upstreamPath: string;
+  logPath: string;
+} {
+  const { pathname, search } = new URL(request.url);
+  return { upstreamPath: pathname + search, logPath: pathname };
+}
+
+/**
  * Handle proxy request for any HTTP method
  */
 async function handleProxy(
@@ -27,9 +64,13 @@ async function handleProxy(
   const startTime = Date.now();
   const method = request.method;
 
-  // Extract path prefix for app lookup; forward full path to upstream
+  // Extract path prefix for app lookup from the decoded segments; the DB stores
+  // pathPrefix as a plain decoded string, so segment[0] is the right key here.
   const [pathPrefix] = pathSegments;
-  const path = '/proxy/' + pathSegments.join('/');
+
+  // Issue #1802: forward the received pathname (trailing slash and percent-
+  // encoding intact) plus the search verbatim; log without the query string.
+  const { upstreamPath: path, logPath } = resolveProxyPaths(request);
 
   // Handle empty path prefix
   if (!pathPrefix) {
@@ -75,7 +116,7 @@ async function handleProxy(
         timestamp: Date.now(),
         pathPrefix,
         method,
-        path,
+        path: logPath,
         statusCode: response.status,
         responseTime: Date.now() - startTime,
         isWebSocket: true,
@@ -93,7 +134,7 @@ async function handleProxy(
       timestamp: Date.now(),
       pathPrefix,
       method,
-      path,
+      path: logPath,
       statusCode: response.status,
       responseTime: Date.now() - startTime,
       isWebSocket: false,
@@ -107,7 +148,7 @@ async function handleProxy(
 
     return response;
   } catch (error) {
-    logProxyError(pathPrefix, method, path, error as Error);
+    logProxyError(pathPrefix, method, logPath, error as Error);
 
     // Issue #395: Fixed-string error message; do not expose internal error details
     return NextResponse.json(

--- a/src/lib/proxy/handler.ts
+++ b/src/lib/proxy/handler.ts
@@ -75,7 +75,14 @@ export function filterHeaders(
  *
  * @param request - The incoming request
  * @param app - The external app configuration
- * @param path - The full request path including proxy prefix (e.g., /proxy/{pathPrefix}/page)
+ * @param path - The full request path including proxy prefix and query string
+ *   (e.g., /proxy/{pathPrefix}/page/?q=a+b). Issue #1802: the caller passes
+ *   pathname + search taken from the request URL, so the trailing slash and the
+ *   percent-encoded pathname bytes reach the upstream unchanged. The query
+ *   string is forwarded as the caller received it, which is not necessarily as
+ *   the client sent it - Next.js re-serializes the query before the route
+ *   handler runs (`?q=a%20b` -> `?q=a+b`, `?bare` -> `?bare=`). This function
+ *   itself never rewrites what it is given.
  * @returns The proxied response
  */
 export async function proxyHttp(

--- a/tests/unit/proxy/handler.test.ts
+++ b/tests/unit/proxy/handler.test.ts
@@ -191,6 +191,33 @@ describe('HTTP Proxy Handler', () => {
         expect.any(Object)
       );
     });
+
+    // Issue #1802: the path handed in by the route handler must reach fetch()
+    // unchanged - trailing slash kept, percent-encoding not re-encoded.
+    // This covers the proxyHttp -> fetch hop only. A client's ?q=a%20b never
+    // reaches this layer as %20: Next.js normalizes it to ?q=a+b before the
+    // route handler runs (see tests/unit/proxy/route.test.ts).
+    it('should forward a trailing slash and percent-encoded bytes to fetch unchanged', async () => {
+      const { proxyHttp } = await import('@/lib/proxy/handler');
+
+      const mockApp = createMockApp({
+        targetHost: '127.0.0.1',
+        targetPort: 60310,
+        pathPrefix: 'commandagent',
+      });
+      const request = new Request(
+        'http://localhost:3000/proxy/commandagent/try/?q=a%20b&n=1'
+      );
+
+      global.fetch = vi.fn().mockResolvedValue(new Response('OK'));
+
+      await proxyHttp(request, mockApp, '/proxy/commandagent/try/?q=a%20b&n=1');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:60310/proxy/commandagent/try/?q=a%20b&n=1',
+        expect.any(Object)
+      );
+    });
   });
 
   describe('proxyWebSocket', () => {

--- a/tests/unit/proxy/route.test.ts
+++ b/tests/unit/proxy/route.test.ts
@@ -215,3 +215,255 @@ describe('Proxy Route Handler - pathPrefix preservation', () => {
     );
   });
 });
+
+/**
+ * Issue #1802: The upstream path must be taken from the request URL, not
+ * rebuilt from `params.path`. Next.js catch-all params are percent-decoded and
+ * carry neither the trailing slash nor the query string, so every case below
+ * passes params in the shape Next.js would actually produce (decoded, no
+ * trailing slash, no search) while the request URL holds the raw form.
+ *
+ * SCOPE LIMIT - do not read these green tests as proof of end-to-end byte
+ * preservation of the query string. These tests build the `Request` themselves,
+ * so they exercise only the route handler layer and skip the normalization
+ * Next.js performs on `request.url` before the handler runs. That normalization
+ * is not reproducible in a unit test and cannot be undone from inside an App
+ * Router route handler. Measured end-to-end through a real CommandMate server
+ * against an echo upstream:
+ *
+ *   PATH - preserved byte-for-byte
+ *     /proxy/testapp/a%20b/              -> /proxy/testapp/a%20b/
+ *     /proxy/testapp/a%2Fb/              -> /proxy/testapp/a%2Fb/
+ *     /proxy/testapp/%E6%97%A5%E6%9C%AC/ -> /proxy/testapp/%E6%97%A5%E6%9C%AC/
+ *     /proxy/testapp/a+b/                -> /proxy/testapp/a+b/
+ *
+ *   QUERY - normalized by Next.js before the handler (URLSearchParams round-trip)
+ *     ?q=a%20b&n=1          -> ?q=a+b&n=1        (%20 becomes +)
+ *     ?bare                 -> ?bare=            (valueless key gains =)
+ *     ?q=a%2Bb              -> ?q=a%2Bb          (preserved)
+ *     ?q=a%26b              -> ?q=a%26b          (preserved)
+ *     ?sig=aGVsbG8%3D       -> ?sig=aGVsbG8%3D   (preserved)
+ *     ?q=%E6%97%A5%E6%9C%AC -> ?q=%E6%97%A5%E6%9C%AC (preserved)
+ *
+ * A bare `?` also collapses (`/x?` -> `/x`), since WHATWG `URL.search` is the
+ * empty string in that case. What these tests do prove is that the handler
+ * forwards whatever pathname and search it was handed, without rewriting them.
+ */
+describe('Proxy Route Handler - trailing slash and query string preservation (Issue #1802)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Run a proxy request and return the path handed to proxyHttp */
+  async function proxyAndGetPath(
+    url: string,
+    params: string[],
+    method: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET'
+  ) {
+    const mockApp = createMockApp();
+    const { proxyHttp, logProxyRequest } = await setupProxyMocks(mockApp);
+
+    const route = await import('@/app/proxy/[...path]/route');
+
+    const hasBody = method !== 'GET' && method !== 'HEAD';
+    const request = new Request(url, {
+      method,
+      ...(hasBody ? { body: 'payload' } : {}),
+    });
+    const response = await route[method](request, {
+      params: Promise.resolve({ path: params }),
+    });
+
+    const call = vi.mocked(proxyHttp).mock.calls[0];
+    return {
+      response,
+      mockApp,
+      request,
+      path: call?.[2],
+      logProxyRequest,
+      proxyHttp,
+    };
+  }
+
+  it('should preserve the trailing slash of a sub path', async () => {
+    const { path, response } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/try/',
+      ['testapp', 'try']
+    );
+
+    expect(path).toBe('/proxy/testapp/try/');
+    expect(response.status).toBe(200);
+  });
+
+  it('should forward a sub path without a trailing slash unchanged', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/try',
+      ['testapp', 'try']
+    );
+
+    expect(path).toBe('/proxy/testapp/try');
+  });
+
+  it('should preserve the trailing slash of the app root path', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/',
+      ['testapp']
+    );
+
+    expect(path).toBe('/proxy/testapp/');
+  });
+
+  it('should forward the app root path without a trailing slash unchanged', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp',
+      ['testapp']
+    );
+
+    expect(path).toBe('/proxy/testapp');
+  });
+
+  it('should append the received search string to the forwarded path without rewriting it', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/search?q=a%20b&n=1',
+      ['testapp', 'search']
+    );
+
+    // The handler concatenates the search it was given; it does not re-encode.
+    // Note that a real request would already have arrived as ?q=a+b - Next.js
+    // normalizes the query before this layer (see the SCOPE LIMIT note above),
+    // so this asserts only that the handler itself adds no further rewriting.
+    expect(path).toBe('/proxy/testapp/search?q=a%20b&n=1');
+    expect(path).not.toContain('+');
+    expect(path).not.toContain('a b');
+  });
+
+  it('should keep a trailing slash and the query string together', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/try/?q=a%20b&n=1',
+      ['testapp', 'try']
+    );
+
+    expect(path).toBe('/proxy/testapp/try/?q=a%20b&n=1');
+  });
+
+  it('should not decode percent-encoded path segments (%2F stays encoded)', async () => {
+    // Next.js would hand us the decoded segment 'a/b', which would rebuild into
+    // a structurally different path (/proxy/testapp/a/b).
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/a%2Fb/',
+      ['testapp', 'a/b']
+    );
+
+    expect(path).toBe('/proxy/testapp/a%2Fb/');
+  });
+
+  it('should preserve percent-encoded multibyte (Japanese) path segments', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/%E6%97%A5%E6%9C%AC%E8%AA%9E/',
+      ['testapp', '日本語']
+    );
+
+    expect(path).toBe('/proxy/testapp/%E6%97%A5%E6%9C%AC%E8%AA%9E/');
+  });
+
+  it('should preserve the trailing slash on a deep nested path', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/a/b/c/?x=1',
+      ['testapp', 'a', 'b', 'c']
+    );
+
+    expect(path).toBe('/proxy/testapp/a/b/c/?x=1');
+  });
+
+  it('should preserve the trailing slash and query string for HEAD requests', async () => {
+    const { path } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/assets/?v=1',
+      ['testapp', 'assets'],
+      'HEAD'
+    );
+
+    expect(path).toBe('/proxy/testapp/assets/?v=1');
+  });
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'] as const)(
+    'should preserve the trailing slash and query string for %s requests',
+    async (method) => {
+      const { path } = await proxyAndGetPath(
+        'http://localhost:3000/proxy/testapp/items/?page=2',
+        ['testapp', 'items'],
+        method
+      );
+
+      expect(path).toBe('/proxy/testapp/items/?page=2');
+    }
+  );
+
+  it('should log the path without the query string (Issue #395)', async () => {
+    const { logProxyRequest } = await proxyAndGetPath(
+      'http://localhost:3000/proxy/testapp/search?token=secret&q=a%20b',
+      ['testapp', 'search']
+    );
+
+    expect(logProxyRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/proxy/testapp/search',
+        pathPrefix: 'testapp',
+        method: 'GET',
+      })
+    );
+    const entry = vi.mocked(logProxyRequest).mock.calls[0][0];
+    expect(entry.path).not.toContain('token');
+  });
+
+  it('should still return 400 for an empty path prefix without proxying', async () => {
+    const mockApp = createMockApp();
+    const { proxyHttp } = await setupProxyMocks(mockApp);
+
+    const { GET } = await import('@/app/proxy/[...path]/route');
+
+    const request = new Request('http://localhost:3000/proxy/');
+    const response = await GET(request, {
+      params: Promise.resolve({ path: [] }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Path prefix is required',
+    });
+    expect(proxyHttp).not.toHaveBeenCalled();
+  });
+
+  it('should hand the same raw path to the WebSocket fallback and still return 426', async () => {
+    const mockApp = createMockApp({ websocketEnabled: true });
+    await setupProxyMocks(mockApp);
+
+    const { isWebSocketUpgrade, proxyWebSocket } = await import(
+      '@/lib/proxy/handler'
+    );
+    vi.mocked(isWebSocketUpgrade).mockReturnValue(true);
+    vi.mocked(proxyWebSocket).mockResolvedValue(
+      new Response('Upgrade Required', { status: 426 })
+    );
+
+    const { GET } = await import('@/app/proxy/[...path]/route');
+
+    const request = new Request('http://localhost:3000/proxy/testapp/ws/?v=1', {
+      headers: { upgrade: 'websocket' },
+    });
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ['testapp', 'ws'] }),
+    });
+
+    expect(response.status).toBe(426);
+    expect(proxyWebSocket).toHaveBeenCalledWith(
+      request,
+      mockApp,
+      '/proxy/testapp/ws/?v=1'
+    );
+  });
+});


### PR DESCRIPTION
## 概要

External Apps のプロキシが、受信URLの**末尾スラッシュ**と**クエリ文字列**を保持せずに上流へ転送していた問題を修正する。Next.js static export のようにディレクトリURLで末尾 `/` を必要とするアプリで、ルート画面は 200 なのに配下の画面が 404 になっていた。

Issue #1802

## 原因

`src/app/proxy/[...path]/route.ts` で catch-all params から URL を再構築していた。

```ts
const path = '/proxy/' + pathSegments.join('/');
```

Next.js の `params.path` は**区切り文字を落とした percent-decode 済みの配列**なので、この方式では ①末尾スラッシュ ②クエリ文字列 ③percent-encode の3つが構造的に失われる。

なお `next.config.js` の `skipTrailingSlashRedirect: true`（#671）は既に入っており、末尾 `/` は 308 で消えるのではなく **route handler まで到達したうえで上記 join で落ちていた**。

## 修正

上流へ渡す path を `new URL(request.url)` の `pathname` + `search` から構成する形に変更。`pathSegments` は `pathPrefix` の DB 検索専用に残した。

あわせて**ログ用 path と転送用 path を分離**した。クエリ文字列にはトークンが載りうるため、Issue #395 の「内部情報をログに出さない」方針に従いログには pathname のみを記録する。

`next.config.js` と `src/lib/ws-server.ts` の WebSocket upgrade 経路（`request.url` を生のまま扱う）には手を入れていない。

## 実機検証

エコー上流（受信した生URLをそのまま返す）と**実 CommandAgent**（`:60310`）を、隔離DB・別ポートの実サーバへ登録して計測した。

Issue の受入条件（実 CommandAgent）:

| Path | 修正前（稼働中 :3000） | 修正後 |
|---|---|---|
| `/proxy/commandagent/` | 200 | 200 |
| `/proxy/commandagent/try/` | **404** | **200** |
| `/proxy/commandagent/assets/` | **404** | **200** |
| `/proxy/commandagent/try` | 404 | 404（正） |
| `/proxy/commandagent/api/runs` | 200 | 200 |

深い階層 / HEAD / POST・PUT・PATCH・DELETE も末尾スラッシュ保持を実機確認済み。

## 既知の制限（本PRでは直せない層）

**クエリ文字列のバイト完全一致は達成できない。** 実測で `?q=a%20b` は上流に `?q=a+b`、`?bare` は `?bare=` として届く。

切り分け済みで、原因は本PRのコードではない:

- `new URL('...?q=a%20b').search` は `?q=a%20b` を返す（node 実測）
- `fetch()` も変えない（node から上流へ直接 fetch して受信URLを確認）
- 残るのは **Next.js が route handler へ渡す前に `request.url` を再構成している**こと。`%20`→`+` と `?bare`→`?bare=` はどちらも URLSearchParams 再シリアライズの署名

App Router の route handler からは触れない層のため、バイト完全一致が要件になる場合（HMAC署名つきURL等）は `server.ts` の HTTP レイヤで `/proxy/` を横取りする必要がある（WebSocket upgrade は既にその方式）。**別Issueとして起票する。**

パス側は `%20` / `%2F` / マルチバイト / 素の `+` すべてバイト保存されることを実機確認済み。クエリ側も `%2B` / `%26` / `%3D` / percent-encode 済みマルチバイトは保存される。

## テスト

`tests/unit/proxy/route.test.ts` に 13 件追加（両スラッシュ形態 × ルート/サブパス、深い階層、HEAD、非GET 4種、`%2F` 非デコード、日本語マルチバイト、ログにクエリを載せないこと、空 prefix の 400、WebSocket フォールバックの 426）。

**変異注入で非空振りを確認済み**: (a) `join` 方式へ戻すと 13 件が赤 / (b) `search` の連結を削ると 9 件が赤。

unit test は `Request` を自前で組み立てるため上記 Next.js 正規化を通らない。green を end-to-end のバイト保存と誤読しないよう、実測値の表を describe のコメントに残してある。

## 品質ゲート

`lint` / `tsc --noEmit` / `test:unit`（878 files, 16,180 tests）すべて exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7H3TFQswmbVKAJhAxG5yp
