### PR TITLE
fix(proxy): クエリ文字列を生バイトのまま上流へ転送する (#1804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix(proxy): クエリ文字列を生バイトのまま上流へ転送する** (#1804)
+  - **#1802 でクエリは転送されるようになったが、バイト完全一致ではなかった。**
+    `?q=a%20b&n=1` は上流に `?q=a+b&n=1` として、`?bare` は `?bare=` として届いていた。
+    `application/x-www-form-urlencoded` の意味論では `+` と `%20` は同じ空白にデコードされるため
+    大半のアプリでは実害が無いが、**クエリのバイト列に対して署名を検証する上流**
+    （HMAC 署名つき URL / presigned URL / OAuth 1.0a）では署名検証に失敗する
+  - **原因は Next.js が route handler に渡す前に `request.url` を再構成していること。**
+    `%20`→`+` と `?bare`→`?bare=` は `URLSearchParams` で再シリアライズした時の署名であり、
+    App Router の route handler の内側からは触れない層で起きる
+  - **修正は「Next.js を迂回する」のではなく「生 URL を一段手前で退避する」方式。**
+    `server.ts` の `requestHandler` は Next.js に渡す前に生の `req.url`（Node の request target）を
+    持っているので、これを `x-cm-raw-url` ヘッダへ退避し、
+    `src/app/proxy/[...path]/route.ts` が読み戻す。ヘッダが無い場合（`next dev` 単体・unit test）は
+    従来どおり `request.url` にフォールバックするため #1802 の挙動を維持する
+  - **`/proxy/*` を `server.ts` で横取りする案（起票時の方針）は採用しなかった。**
+    `/proxy/...` は現在 `src/middleware.ts` の認証と IP 制限を通っており、
+    `AUTH_EXCLUDED_PATHS` は完全一致判定なので除外されていない。Next.js を迂回すると
+    **External Apps から認証と IP 制限が丸ごと外れる**（Cloudflare Tunnel 配下では外部公開に直結）。
+    `next.config.js` の `headers()`（CSP 等）も失われる。この性質を
+    `tests/unit/proxy/proxy-auth-guard.test.ts` で固定した
+  - **偽装防止**: `server.ts` は `x-cm-raw-url` を**無条件に `delete` してから**
+    `/proxy/` の時だけ `set` する。クライアントが付けてきた値は経路を問わず必ず捨てられる。
+    内部用ヘッダなので `filterHeaders()` で剥がしており**上流へは転送されない**
+  - **`server.ts` 側は inline 4 行、import は 1 つも追加していない**（#1428 の再発防止）。
+    top-level に内部モジュールの静的 import を足すと `tsx server.ts` 下で Next の
+    AsyncLocalStorage bootstrap が壊れ、最初のリクエストでクラッシュする。
+    この故障は unit / integration / build / lint をすべてすり抜け E2E だけで落ちる
+  - **実機計測（隔離 DB・ポート 3805・エコー上流 3806、生 TCP でバイト単位送信）**:
+    `?q=a%20b&n=1` / `?bare` / `?q=a%2Bb` / `?q=a%26b` / `?sig=aGVsbG8%3D` /
+    `?q=%E6%97%A5%E6%9C%AC` / `?q=a+b` / `?empty=` / `?a=1&a=2` がすべてバイト一致で上流着。
+    #1802 のパス保存（`/try/` と `/try` の区別・`a%2Fb`・`a%20b`・多バイト・素の `+`・深い階層）と
+    HEAD / POST / PUT / PATCH / DELETE に回帰なし。認証有効時は未認証 `/proxy/...` が 307（/login）、
+    不正 Bearer が 401、正規 Cookie が 200 でクエリもバイト一致
+  - **既知の制限（実測により起票時の想定と乖離）**: `?` 単独（`/search/?`）は依然として落ちる。
+    ただし原因は `new URL()` ではなく **Node の `fetch()`（undici）**である。
+    生文字列を最初の `?` で分割する実装により `?` は `buildUpstreamUrl()` まで保持され、
+    `new URL(...).href` も `?` を保つが、undici は request target を `pathname + search` で組み立て、
+    present-but-empty なクエリでは `search` が `''` になるため送信時に落ちる
+    （`fetch('http://127.0.0.1:3806/a/?')` の上流受信が `/a/` であることを実測）。
+    解消には proxy の transport を `http.request` に置き換える必要があり、
+    undici の gzip 透過処理（`content-encoding` 剥がし）も自前で作り直すことになるため、
+    空クエリを表す区切り文字 1 バイトの代償としては割に合わないと判断した
 - **fix(proxy): 上流転送で末尾スラッシュとクエリ文字列を保持する** (#1802)
   - **External Apps のプロキシがルート画面（`/proxy/<app>/`）だけ 200 で、配下（`/proxy/<app>/try/`,
     `/proxy/<app>/assets/`）が 404 になっていた。** Next.js static export のようにディレクトリ URL に

--- a/server.ts
+++ b/server.ts
@@ -192,6 +192,30 @@ app.prepare().then(() => {
     const method = req.method ?? 'UNKNOWN';
     const url = req.url ?? '/';
 
+    // Issue #1804: hand the proxy route handler the RAW request target.
+    //
+    // Next.js re-serializes the query string before an App Router route handler
+    // sees `request.url` (`?q=a%20b` -> `?q=a+b`, `?bare` -> `?bare=`, a lone
+    // `?` collapses), which breaks upstreams that verify a signature over the
+    // query bytes. `req.url` here is the untouched request target, so stash it
+    // in a header; `src/app/proxy/[...path]/route.ts` reads it back.
+    //
+    // The unconditional `delete` comes FIRST and runs for every request, so a
+    // client-supplied `x-cm-raw-url` can never survive to be trusted; only the
+    // conditional set below can put a value there. Requests still go through
+    // Next (and therefore through middleware.ts's auth + IP restriction and
+    // next.config.js's security headers) - deliberately NOT intercepted here.
+    //
+    // Kept inline, with the header name written out literally: importing a
+    // helper or a constant module here adds a module graph to server.ts's
+    // eval-time graph, which perturbs Next's AsyncLocalStorage bootstrap under
+    // `tsx server.ts` and kills the first request that compiles middleware
+    // (#1428; the symptom is E2E-only). Do not refactor this into an import.
+    delete req.headers['x-cm-raw-url'];
+    if (url.startsWith('/proxy/')) {
+      req.headers['x-cm-raw-url'] = url;
+    }
+
     // Issue #1621/#1645: a URL naming a worktree by a retired ID gets a real
     // 308 here, before Next renders anything. The cheap prefix test keeps every
     // other route free of the dynamic import and the alias lookup.

--- a/src/app/proxy/[...path]/route.ts
+++ b/src/app/proxy/[...path]/route.ts
@@ -11,7 +11,7 @@ import { getDbInstance } from '@/lib/db/db-instance';
 import { getExternalAppCache } from '@/lib/external-apps/cache';
 import { proxyHttp, proxyWebSocket, isWebSocketUpgrade } from '@/lib/proxy/handler';
 import { logProxyRequest, logProxyError } from '@/lib/proxy/logger';
-import { PROXY_ERROR_MESSAGES } from '@/lib/proxy/config';
+import { PROXY_ERROR_MESSAGES, PROXY_RAW_URL_HEADER } from '@/lib/proxy/config';
 import type { ProxyLogEntry } from '@/lib/proxy/logger';
 
 // Force dynamic rendering
@@ -22,22 +22,43 @@ export const dynamic = 'force-dynamic';
  *
  * Issue #1802: Next.js catch-all params (`params.path`) are percent-decoded and
  * carry neither the trailing slash nor the query string, so rebuilding the path
- * with `pathSegments.join('/')` structurally drops all three. Read the pathname
- * and search from `request.url` instead, and concatenate them verbatim.
+ * with `pathSegments.join('/')` structurally drops all three. The path must come
+ * from the request URL instead.
  *
- * How much is preserved differs between the two halves (measured end-to-end
- * against an echo upstream through a real CommandMate server):
+ * Issue #1804: `request.url` is good enough for the pathname (preserved
+ * byte-for-byte) but NOT for the query string. Next.js re-serializes the query
+ * before an App Router route handler ever runs, so `?q=a%20b` arrives here as
+ * `?q=a+b` and `?bare` as `?bare=` - the signature of a URLSearchParams
+ * round-trip - which breaks any upstream that verifies a signature over the
+ * query bytes (HMAC-signed URLs, presigned URLs, OAuth 1.0a). That
+ * normalization happens in a layer this handler cannot reach.
  *
- * - **pathname**: preserved byte-for-byte. `/try/` stays `/try/`, and
- *   `%20` / `%2F` / `%E6%97%A5%E6%9C%AC` / a literal `+` all survive unchanged.
- * - **search**: NOT byte-for-byte. Next.js re-serializes the query string
- *   before the route handler ever runs, so `?q=a%20b` arrives here as `?q=a+b`
- *   and `?bare` arrives as `?bare=` (the signature of a URLSearchParams
- *   round-trip). `%2B`, `%26`, `%3D` and percent-encoded multibyte values are
- *   preserved. That normalization happens in a layer an App Router route
- *   handler cannot reach; this function neither causes nor can undo it.
- *   A bare `?` with no query also collapses (`/x?` -> `/x`) per the WHATWG URL
- *   spec, since `search` is the empty string in that case.
+ * So the raw request target is captured one layer earlier instead: `server.ts`
+ * copies the Node `IncomingMessage.req.url` - the untouched request target -
+ * into {@link PROXY_RAW_URL_HEADER} before handing the request to Next. When
+ * that header is present it is authoritative; the header is safe to trust
+ * because `server.ts` deletes it unconditionally on every request before
+ * setting it, so a client-supplied value never survives.
+ *
+ * The raw target is split on the FIRST `?` rather than parsed with `new URL()`:
+ * WHATWG parsing drops a bare trailing `?` (`/x?` -> `/x`, since `search` is
+ * the empty string in that case), and string splitting also guarantees the
+ * query bytes are passed through with no interpretation at all.
+ *
+ * KNOWN LIMIT (measured, Issue #1804): a bare trailing `?` still does not reach
+ * the upstream, but no longer because of anything in this file - it survives to
+ * `proxyHttp`, and Node's `fetch()` drops it when it serializes the URL back to
+ * a request target (undici uses `pathname + search`, and `search` is `''` for
+ * `http://x/a?` even though `href` keeps the `?`). Verified against an echo
+ * upstream: `fetch('http://127.0.0.1:PORT/a/?')` is received as `/a/`. Every
+ * other query form measured is byte-exact. Fixing this last case would mean
+ * replacing the proxy transport with `http.request`, which also gives up
+ * undici's transparent gzip handling - not worth it for a delimiter that
+ * denotes an empty query either way.
+ *
+ * Without the header (running under `next dev` with no custom server, or in a
+ * unit test that builds its own `Request`) this falls back to `request.url`,
+ * preserving the Issue #1802 behavior.
  *
  * The forwarded path carries the query string; the logged path deliberately
  * does not, because query strings may carry tokens and Issue #395 requires
@@ -50,6 +71,13 @@ function resolveProxyPaths(request: Request): {
   upstreamPath: string;
   logPath: string;
 } {
+  const rawUrl = request.headers.get(PROXY_RAW_URL_HEADER);
+  if (rawUrl) {
+    const queryStart = rawUrl.indexOf('?');
+    const pathname = queryStart === -1 ? rawUrl : rawUrl.slice(0, queryStart);
+    return { upstreamPath: rawUrl, logPath: pathname };
+  }
+
   const { pathname, search } = new URL(request.url);
   return { upstreamPath: pathname + search, logPath: pathname };
 }
@@ -68,8 +96,8 @@ async function handleProxy(
   // pathPrefix as a plain decoded string, so segment[0] is the right key here.
   const [pathPrefix] = pathSegments;
 
-  // Issue #1802: forward the received pathname (trailing slash and percent-
-  // encoding intact) plus the search verbatim; log without the query string.
+  // Issue #1802/#1804: forward the raw request target (trailing slash, percent-
+  // encoding and query bytes intact); log without the query string.
   const { upstreamPath: path, logPath } = resolveProxyPaths(request);
 
   // Handle empty path prefix

--- a/src/lib/proxy/config.ts
+++ b/src/lib/proxy/config.ts
@@ -46,6 +46,28 @@ export const SENSITIVE_REQUEST_HEADERS = [
 ] as const;
 
 /**
+ * Issue #1804: Internal header carrying the raw request target.
+ *
+ * Next.js re-serializes the query string before an App Router route handler
+ * ever runs (`?q=a%20b` -> `?q=a+b`, `?bare` -> `?bare=`, a lone `?` collapses),
+ * so `request.url` is not what the client sent. `server.ts` stashes the raw
+ * `req.url` from the Node `IncomingMessage` into this header before handing the
+ * request to Next, and the proxy route handler reads it back.
+ *
+ * `server.ts` deletes this header unconditionally on every request before
+ * setting it, so a client cannot forge it. It is CommandMate-internal and must
+ * never reach the upstream app - see {@link INTERNAL_REQUEST_HEADERS}.
+ */
+export const PROXY_RAW_URL_HEADER = 'x-cm-raw-url';
+
+/**
+ * Issue #1804: CommandMate-internal request headers that must not be forwarded
+ * to upstream. These are set by our own HTTP layer for our own consumption and
+ * carry no meaning outside the process.
+ */
+export const INTERNAL_REQUEST_HEADERS = [PROXY_RAW_URL_HEADER] as const;
+
+/**
  * HTTP headers that should be stripped from proxied responses.
  *
  * content-encoding / content-length are stripped because Node's fetch

--- a/src/lib/proxy/handler.ts
+++ b/src/lib/proxy/handler.ts
@@ -16,6 +16,7 @@ import {
   HOP_BY_HOP_RESPONSE_HEADERS,
   SENSITIVE_REQUEST_HEADERS,
   SENSITIVE_RESPONSE_HEADERS,
+  INTERNAL_REQUEST_HEADERS,
   PROXY_STATUS_CODES,
   PROXY_ERROR_MESSAGES,
 } from './config';
@@ -33,6 +34,14 @@ export function isWebSocketUpgrade(request: Request): boolean {
 
 /**
  * Build the upstream URL for the proxy request
+ *
+ * Issue #1804: `path` is the raw request target, so this concatenation is the
+ * last place the bytes are still exactly what the client sent. `fetch()` then
+ * re-parses this string as a WHATWG URL, which preserves everything measured
+ * against an echo upstream EXCEPT a bare trailing `?`: undici sends
+ * `pathname + search`, and `search` is `''` for `http://x/a?`. The URL returned
+ * here does keep the `?` (`new URL('http://x/a?').href` does too) - it is lost
+ * one layer further down.
  *
  * @param app - The external app configuration
  * @param path - The request path (including query string)
@@ -76,13 +85,13 @@ export function filterHeaders(
  * @param request - The incoming request
  * @param app - The external app configuration
  * @param path - The full request path including proxy prefix and query string
- *   (e.g., /proxy/{pathPrefix}/page/?q=a+b). Issue #1802: the caller passes
- *   pathname + search taken from the request URL, so the trailing slash and the
- *   percent-encoded pathname bytes reach the upstream unchanged. The query
- *   string is forwarded as the caller received it, which is not necessarily as
- *   the client sent it - Next.js re-serializes the query before the route
- *   handler runs (`?q=a%20b` -> `?q=a+b`, `?bare` -> `?bare=`). This function
- *   itself never rewrites what it is given.
+ *   (e.g., /proxy/{pathPrefix}/page/?q=a%20b). Issue #1802: the caller passes
+ *   pathname + search, so the trailing slash and the percent-encoded pathname
+ *   bytes reach the upstream unchanged. Issue #1804: the caller now sources
+ *   both halves from the raw request target that `server.ts` stashed in
+ *   `x-cm-raw-url`, so the query string is byte-identical to what the client
+ *   sent rather than a URLSearchParams round-trip of it. This function itself
+ *   never rewrites what it is given.
  * @returns The proxied response
  */
 export async function proxyHttp(
@@ -92,11 +101,14 @@ export async function proxyHttp(
 ): Promise<Response> {
   const upstreamUrl = buildUpstreamUrl(app, path);
 
-  // Strip hop-by-hop and sensitive headers from the request (Issue #395)
+  // Strip hop-by-hop and sensitive headers from the request (Issue #395), plus
+  // CommandMate-internal ones (Issue #1804: x-cm-raw-url is consumed by the
+  // route handler and has no meaning to the upstream app).
   const headers = filterHeaders(
     request.headers,
     HOP_BY_HOP_REQUEST_HEADERS,
     SENSITIVE_REQUEST_HEADERS,
+    INTERNAL_REQUEST_HEADERS,
   );
 
   try {

--- a/tests/unit/proxy/handler.test.ts
+++ b/tests/unit/proxy/handler.test.ts
@@ -335,6 +335,55 @@ describe('HTTP Proxy Handler', () => {
       // Root path is forwarded as-is
       expect(url).toBe('http://localhost:3001/');
     });
+
+    /**
+     * Issue #1804: the caller now passes the RAW request target, so this
+     * concatenation is the last point at which the bytes are still exactly what
+     * the client sent.
+     */
+    it.each([
+      '/proxy/testapp/search?q=a%20b&n=1',
+      '/proxy/testapp/search?bare',
+      '/proxy/testapp/search?q=a%2Bb',
+      '/proxy/testapp/search?sig=aGVsbG8%3D',
+      '/proxy/testapp/search?q=%E6%97%A5%E6%9C%AC',
+      '/proxy/testapp/a%2Fb/',
+      '/proxy/testapp/search/?',
+    ])('should concatenate the raw request target %s without rewriting it', async (path) => {
+      const { buildUpstreamUrl } = await import('@/lib/proxy/handler');
+
+      const mockApp = createMockApp({
+        targetHost: '127.0.0.1',
+        targetPort: 3806,
+      });
+
+      expect(buildUpstreamUrl(mockApp, path)).toBe(`http://127.0.0.1:3806${path}`);
+    });
+
+    /**
+     * Issue #1804 KNOWN LIMIT, pinned so it is not mistaken for a bug in the
+     * layers above. A bare trailing `?` survives resolveProxyPaths() and
+     * buildUpstreamUrl(), and even survives `new URL().href` - but Node's
+     * fetch() serializes the request target as `pathname + search`, and
+     * `search` is '' when the query is present-but-empty. Measured end-to-end:
+     * `/proxy/testapp/search/?` is received upstream as
+     * `/proxy/testapp/search/`.
+     */
+    it('should keep a bare ? in the built URL even though fetch() later drops it', async () => {
+      const { buildUpstreamUrl } = await import('@/lib/proxy/handler');
+
+      const mockApp = createMockApp({ targetHost: '127.0.0.1', targetPort: 3806 });
+      const built = buildUpstreamUrl(mockApp, '/proxy/testapp/search/?');
+
+      expect(built).toBe('http://127.0.0.1:3806/proxy/testapp/search/?');
+      expect(built.endsWith('?')).toBe(true);
+
+      // The layer that actually loses it:
+      const parsed = new URL(built);
+      expect(parsed.href).toBe('http://127.0.0.1:3806/proxy/testapp/search/?');
+      expect(parsed.search).toBe('');
+      expect(parsed.pathname + parsed.search).toBe('/proxy/testapp/search/');
+    });
   });
 
   // Issue #395: Security hardening tests
@@ -396,6 +445,71 @@ describe('HTTP Proxy Handler', () => {
 
       const calledHeaders = getForwardedRequestHeaders();
       expect(calledHeaders.has(headerName)).toBe(false);
+    });
+  });
+
+  /**
+   * Issue #1804: `x-cm-raw-url` is set by server.ts purely so the proxy route
+   * handler can recover the raw request target. It is CommandMate-internal and
+   * must not leak to the upstream app, which would otherwise see a header
+   * naming our own routing prefix.
+   */
+  describe('internal request header stripping (Issue #1804)', () => {
+    it('should strip x-cm-raw-url before forwarding to upstream', async () => {
+      const { proxyHttp } = await import('@/lib/proxy/handler');
+
+      const mockApp = createMockApp();
+      const request = new Request('http://localhost:3000/proxy/test/api', {
+        method: 'GET',
+        headers: {
+          'x-cm-raw-url': '/proxy/test/api/?q=a%20b',
+          'Accept': 'application/json',
+        },
+      });
+
+      global.fetch = vi.fn().mockResolvedValue(new Response('OK'));
+
+      await proxyHttp(request, mockApp, '/proxy/test/api/?q=a%20b');
+
+      const calledHeaders = getForwardedRequestHeaders();
+      expect(calledHeaders.has('x-cm-raw-url')).toBe(false);
+      // Unrelated headers still get through.
+      expect(calledHeaders.get('accept')).toBe('application/json');
+    });
+
+    it('should strip every header listed in INTERNAL_REQUEST_HEADERS', async () => {
+      const { proxyHttp } = await import('@/lib/proxy/handler');
+      const { INTERNAL_REQUEST_HEADERS } = await import('@/lib/proxy/config');
+
+      expect(INTERNAL_REQUEST_HEADERS.length).toBeGreaterThan(0);
+
+      const mockApp = createMockApp();
+      const request = new Request('http://localhost:3000/proxy/test/api', {
+        method: 'GET',
+        headers: Object.fromEntries(
+          INTERNAL_REQUEST_HEADERS.map((name) => [name, 'internal-value'])
+        ),
+      });
+
+      global.fetch = vi.fn().mockResolvedValue(new Response('OK'));
+
+      await proxyHttp(request, mockApp, '/proxy/test/api');
+
+      const calledHeaders = getForwardedRequestHeaders();
+      for (const header of INTERNAL_REQUEST_HEADERS) {
+        expect(calledHeaders.has(header)).toBe(false);
+      }
+    });
+
+    it('should name the raw-url header consistently across config exports', async () => {
+      const { PROXY_RAW_URL_HEADER, INTERNAL_REQUEST_HEADERS } = await import(
+        '@/lib/proxy/config'
+      );
+
+      // server.ts writes this literal inline (it must not import from src/),
+      // so the two spellings are pinned here.
+      expect(PROXY_RAW_URL_HEADER).toBe('x-cm-raw-url');
+      expect(INTERNAL_REQUEST_HEADERS).toContain(PROXY_RAW_URL_HEADER);
     });
   });
 

--- a/tests/unit/proxy/proxy-auth-guard.test.ts
+++ b/tests/unit/proxy/proxy-auth-guard.test.ts
@@ -1,0 +1,264 @@
+/**
+ * /proxy/* must keep going through Next.js middleware (Issue #1804)
+ *
+ * WHY THIS TEST EXISTS
+ *
+ * Issue #1804 was originally filed proposing that `server.ts` intercept
+ * `/proxy/` at the HTTP layer and never hand it to Next.js, so the raw request
+ * target would be available. That plan is unsafe and was rejected:
+ *
+ *   - `src/middleware.ts` is what enforces auth and IP restriction for
+ *     `/proxy/...`. `AUTH_EXCLUDED_PATHS` is matched with `Array.includes()`
+ *     (exact match, see middleware.ts's S002 note), so no `/proxy/...` URL is
+ *     excluded - every one of them is authenticated today.
+ *   - Bypassing Next.js therefore strips auth AND IP restriction from every
+ *     External App at once. Under a Cloudflare Tunnel that is direct public
+ *     exposure of whatever the upstream app serves.
+ *   - `next.config.js`'s `headers()` (CSP, X-Frame-Options, ...) would be lost
+ *     as well.
+ *
+ * The shipped fix keeps `/proxy/` flowing through Next.js and only copies the
+ * raw `req.url` into a header, so it does not touch auth at all. These tests
+ * pin the property that made that choice necessary: if someone later moves the
+ * proxy into `server.ts`, `/proxy/...` stops being authenticated and this file
+ * is what should stop them.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock next/server before importing middleware (same shape as
+// tests/integration/auth-middleware.test.ts)
+vi.mock('next/server', () => {
+  class MockNextResponse {
+    status: number;
+    headers: Map<string, string>;
+    private _redirect: string | null;
+
+    constructor(_body?: unknown, init?: { status?: number }) {
+      this.status = init?.status ?? 200;
+      this.headers = new Map();
+      this._redirect = null;
+    }
+
+    static next() {
+      const res = new MockNextResponse();
+      res.status = 200;
+      return res;
+    }
+
+    static json(_body: unknown, init?: { status?: number }) {
+      return new MockNextResponse(_body, init);
+    }
+
+    static redirect(url: URL | string) {
+      const res = new MockNextResponse();
+      res.status = 302;
+      res._redirect = typeof url === 'string' ? url : url.toString();
+      return res;
+    }
+
+    get redirectUrl() {
+      return this._redirect;
+    }
+  }
+
+  return { NextResponse: MockNextResponse };
+});
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withContext: vi.fn().mockReturnThis(),
+  },
+}));
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}));
+
+/** Build a NextRequest-ish object for the middleware under test */
+function createMockRequest(
+  pathname: string,
+  cookies: Record<string, string> = {},
+  headers: Record<string, string> = {}
+) {
+  return {
+    nextUrl: {
+      pathname,
+      clone: () => ({
+        pathname: '/login',
+        toString: () => 'http://localhost:3000/login',
+      }),
+    },
+    url: `http://localhost:3000${pathname}`,
+    cookies: {
+      get: (name: string) => {
+        const value = cookies[name];
+        return value !== undefined ? { name, value } : undefined;
+      },
+    },
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+  };
+}
+
+/** Every proxy URL shape this Issue touches, including the query-string cases */
+const PROXY_PATHS = [
+  '/proxy/testapp',
+  '/proxy/testapp/',
+  '/proxy/testapp/try/',
+  '/proxy/testapp/search',
+  '/proxy/testapp/a%2Fb/',
+  '/proxy/testapp/assets/main.js',
+];
+
+describe('/proxy/* authentication and IP restriction (Issue #1804 guard)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.CM_AUTH_TOKEN_HASH;
+    delete process.env.CM_AUTH_EXPIRE;
+    delete process.env.CM_ALLOWED_IPS;
+    delete process.env.CM_TRUST_PROXY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  /** Enable auth with a known token and return it */
+  async function enableAuth(): Promise<string> {
+    const { generateToken, hashToken } = await import('@/lib/security/auth');
+    const token = generateToken();
+    const hash = hashToken(token);
+    process.env.CM_AUTH_TOKEN_HASH = hash;
+    vi.resetModules();
+    process.env.CM_AUTH_TOKEN_HASH = hash;
+    return token;
+  }
+
+  it('should list no /proxy path in AUTH_EXCLUDED_PATHS', async () => {
+    const { AUTH_EXCLUDED_PATHS } = await import('@/config/auth-config');
+
+    for (const excluded of AUTH_EXCLUDED_PATHS) {
+      expect(excluded.startsWith('/proxy')).toBe(false);
+    }
+  });
+
+  it.each(PROXY_PATHS)(
+    'should redirect an unauthenticated browser request for %s to /login',
+    async (pathname) => {
+      await enableAuth();
+
+      const { middleware } = await import('@/middleware');
+      const res = await middleware(createMockRequest(pathname) as never);
+
+      expect(res.status).toBe(302);
+    }
+  );
+
+  it('should 401 an unauthenticated /proxy request that carries an Authorization header', async () => {
+    await enableAuth();
+
+    const { middleware } = await import('@/middleware');
+    const res = await middleware(
+      createMockRequest(
+        '/proxy/testapp/api',
+        {},
+        { authorization: 'Bearer wrong-token' }
+      ) as never
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should reject a /proxy request whose auth cookie is invalid', async () => {
+    await enableAuth();
+
+    const { middleware } = await import('@/middleware');
+    const res = await middleware(
+      createMockRequest('/proxy/testapp/', {
+        cm_auth_token: 'not-the-token',
+      }) as never
+    );
+
+    expect(res.status).toBe(302);
+  });
+
+  it('should let an authenticated /proxy request through', async () => {
+    const token = await enableAuth();
+
+    const { middleware } = await import('@/middleware');
+    const res = await middleware(
+      createMockRequest('/proxy/testapp/try/', { cm_auth_token: token }) as never
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it('should not let a forged x-cm-raw-url header change the authentication outcome', async () => {
+    await enableAuth();
+
+    const { middleware } = await import('@/middleware');
+    const res = await middleware(
+      createMockRequest(
+        '/proxy/testapp/',
+        {},
+        { 'x-cm-raw-url': '/login' }
+      ) as never
+    );
+
+    // The header is not part of routing or auth: still unauthenticated.
+    expect(res.status).toBe(302);
+  });
+
+  it.each(PROXY_PATHS)(
+    'should deny %s from a disallowed IP even before auth runs',
+    async (pathname) => {
+      process.env.CM_ALLOWED_IPS = '10.0.0.0/8';
+      vi.resetModules();
+      process.env.CM_ALLOWED_IPS = '10.0.0.0/8';
+
+      const { middleware } = await import('@/middleware');
+      const res = await middleware(
+        createMockRequest(pathname, {}, { 'x-real-ip': '203.0.113.9' }) as never
+      );
+
+      expect(res.status).toBe(403);
+    }
+  );
+
+  it('should allow a /proxy request from an allowed IP when auth is off', async () => {
+    process.env.CM_ALLOWED_IPS = '127.0.0.1/32';
+    vi.resetModules();
+    process.env.CM_ALLOWED_IPS = '127.0.0.1/32';
+
+    const { middleware } = await import('@/middleware');
+    const res = await middleware(
+      createMockRequest('/proxy/testapp/', {}, { 'x-real-ip': '127.0.0.1' }) as never
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it('should keep /proxy/ inside the middleware matcher', async () => {
+    const { config } = await import('@/middleware');
+
+    const matchers = config.matcher;
+    expect(matchers.length).toBeGreaterThan(0);
+
+    for (const pathname of PROXY_PATHS) {
+      const matched = matchers.some((pattern) =>
+        new RegExp(`^${pattern}$`).test(pathname)
+      );
+      expect(matched).toBe(true);
+    }
+  });
+});

--- a/tests/unit/proxy/route.test.ts
+++ b/tests/unit/proxy/route.test.ts
@@ -248,6 +248,13 @@ describe('Proxy Route Handler - pathPrefix preservation', () => {
  * A bare `?` also collapses (`/x?` -> `/x`), since WHATWG `URL.search` is the
  * empty string in that case. What these tests do prove is that the handler
  * forwards whatever pathname and search it was handed, without rewriting them.
+ *
+ * Issue #1804 later routed AROUND that normalization rather than undoing it:
+ * `server.ts` copies the raw `req.url` into `x-cm-raw-url` before Next sees the
+ * request, and the handler prefers it when present. This block deliberately
+ * sends no such header, so it now also pins the fallback path that `next dev`
+ * without the custom server takes. The #1804 block at the bottom of this file
+ * covers the header path.
  */
 describe('Proxy Route Handler - trailing slash and query string preservation (Issue #1802)', () => {
   beforeEach(() => {
@@ -464,6 +471,244 @@ describe('Proxy Route Handler - trailing slash and query string preservation (Is
       request,
       mockApp,
       '/proxy/testapp/ws/?v=1'
+    );
+  });
+});
+
+/**
+ * Issue #1804: byte-exact query forwarding via the raw request target.
+ *
+ * `request.url` reaches an App Router route handler only after Next.js has
+ * re-serialized the query string, so `?q=a%20b` becomes `?q=a+b` and `?bare`
+ * becomes `?bare=`. server.ts stashes the untouched `req.url` in `x-cm-raw-url`
+ * before handing the request to Next; these tests fix the handler's half of
+ * that contract by supplying the header directly.
+ *
+ * SCOPE LIMIT - as with the #1802 block above, these tests build their own
+ * `Request`, so they prove the handler prefers and forwards the raw target
+ * verbatim. They do NOT prove server.ts sets the header (see
+ * tests/unit/proxy/server-raw-url.test.ts) and they do not prove end-to-end
+ * byte preservation, which was measured against a live server and an echo
+ * upstream on port 3805.
+ */
+describe('Proxy Route Handler - raw request target forwarding (Issue #1804)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Run a proxy request whose `request.url` carries the Next.js-normalized form
+   * and whose `x-cm-raw-url` header carries the raw request target.
+   */
+  async function proxyWithRawUrl(
+    normalizedUrl: string,
+    params: string[],
+    rawUrl?: string,
+    method: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET'
+  ) {
+    const mockApp = createMockApp();
+    const { proxyHttp, logProxyRequest } = await setupProxyMocks(mockApp);
+
+    const route = await import('@/app/proxy/[...path]/route');
+
+    const hasBody = method !== 'GET' && method !== 'HEAD';
+    const request = new Request(normalizedUrl, {
+      method,
+      ...(rawUrl !== undefined ? { headers: { 'x-cm-raw-url': rawUrl } } : {}),
+      ...(hasBody ? { body: 'payload' } : {}),
+    });
+    const response = await route[method](request, {
+      params: Promise.resolve({ path: params }),
+    });
+
+    const call = vi.mocked(proxyHttp).mock.calls[0];
+    return { response, path: call?.[2], logProxyRequest, proxyHttp };
+  }
+
+  it('should forward %20 in the query verbatim instead of the normalized +', async () => {
+    const { path, response } = await proxyWithRawUrl(
+      // What Next.js hands the handler after its URLSearchParams round-trip...
+      'http://localhost:3000/proxy/testapp/search?q=a+b&n=1',
+      ['testapp', 'search'],
+      // ...and what the client actually sent.
+      '/proxy/testapp/search?q=a%20b&n=1'
+    );
+
+    expect(path).toBe('/proxy/testapp/search?q=a%20b&n=1');
+    expect(path).not.toContain('a+b');
+    expect(response.status).toBe(200);
+  });
+
+  it('should forward a valueless key without appending =', async () => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/search?bare=',
+      ['testapp', 'search'],
+      '/proxy/testapp/search?bare'
+    );
+
+    expect(path).toBe('/proxy/testapp/search?bare');
+    expect(path).not.toContain('bare=');
+  });
+
+  it('should preserve a bare ? with no query string', async () => {
+    // `new URL('http://x/proxy/testapp/search/?').search` is '' - the WHATWG
+    // parser drops the delimiter - so the raw target must be split on the first
+    // '?' as a string rather than parsed.
+    //
+    // KNOWN LIMIT: this is as far as the `?` gets. proxyHttp hands the built
+    // URL to fetch(), which serializes it as `pathname + search` and therefore
+    // drops it on the wire. Measured: `/proxy/testapp/search/?` arrives
+    // upstream as `/proxy/testapp/search/`. See the buildUpstreamUrl block in
+    // tests/unit/proxy/handler.test.ts.
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/search/',
+      ['testapp', 'search'],
+      '/proxy/testapp/search/?'
+    );
+
+    expect(path).toBe('/proxy/testapp/search/?');
+  });
+
+  it.each([
+    ['?q=a%2Bb', '/proxy/testapp/s?q=a%2Bb'],
+    ['?q=a%26b', '/proxy/testapp/s?q=a%26b'],
+    ['?sig=aGVsbG8%3D', '/proxy/testapp/s?sig=aGVsbG8%3D'],
+    ['?q=%E6%97%A5%E6%9C%AC', '/proxy/testapp/s?q=%E6%97%A5%E6%9C%AC'],
+    ['?q=a+b', '/proxy/testapp/s?q=a+b'],
+    ['?empty=', '/proxy/testapp/s?empty='],
+    ['?a=1&a=2', '/proxy/testapp/s?a=1&a=2'],
+  ])('should forward %s byte-for-byte', async (_label, rawUrl) => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/s',
+      ['testapp', 's'],
+      rawUrl
+    );
+
+    expect(path).toBe(rawUrl);
+  });
+
+  it('should keep the trailing slash and the raw query together', async () => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/try/?q=a+b',
+      ['testapp', 'try'],
+      '/proxy/testapp/try/?q=a%20b'
+    );
+
+    expect(path).toBe('/proxy/testapp/try/?q=a%20b');
+  });
+
+  it('should preserve percent-encoded path bytes carried by the raw target', async () => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/a%2Fb/%E6%97%A5%E6%9C%AC/',
+      ['testapp', 'a/b', '日本'],
+      '/proxy/testapp/a%2Fb/%E6%97%A5%E6%9C%AC/'
+    );
+
+    expect(path).toBe('/proxy/testapp/a%2Fb/%E6%97%A5%E6%9C%AC/');
+  });
+
+  it('should prefer the raw target over request.url when the two disagree', async () => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/normalized',
+      ['testapp', 'normalized'],
+      '/proxy/testapp/raw/'
+    );
+
+    expect(path).toBe('/proxy/testapp/raw/');
+  });
+
+  it('should fall back to request.url when the raw header is absent (next dev / unit test path)', async () => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/try/?q=a+b',
+      ['testapp', 'try']
+      // no x-cm-raw-url
+    );
+
+    expect(path).toBe('/proxy/testapp/try/?q=a+b');
+  });
+
+  it('should fall back to request.url when the raw header is an empty string', async () => {
+    const { path } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/try/',
+      ['testapp', 'try'],
+      ''
+    );
+
+    expect(path).toBe('/proxy/testapp/try/');
+  });
+
+  it.each(['HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'] as const)(
+    'should forward the raw query byte-for-byte for %s requests',
+    async (method) => {
+      const { path } = await proxyWithRawUrl(
+        'http://localhost:3000/proxy/testapp/items/?page=2&q=a+b',
+        ['testapp', 'items'],
+        '/proxy/testapp/items/?page=2&q=a%20b',
+        method
+      );
+
+      expect(path).toBe('/proxy/testapp/items/?page=2&q=a%20b');
+    }
+  );
+
+  it('should log the raw path without its query string (Issue #395)', async () => {
+    const { logProxyRequest } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/search?token=secret',
+      ['testapp', 'search'],
+      '/proxy/testapp/search?token=secret&sig=aGVsbG8%3D'
+    );
+
+    const entry = vi.mocked(logProxyRequest).mock.calls[0][0];
+    expect(entry.path).toBe('/proxy/testapp/search');
+    expect(entry.path).not.toContain('token');
+    expect(entry.path).not.toContain('sig');
+  });
+
+  it('should log a bare ? path without the delimiter', async () => {
+    const { logProxyRequest } = await proxyWithRawUrl(
+      'http://localhost:3000/proxy/testapp/search/',
+      ['testapp', 'search'],
+      '/proxy/testapp/search/?'
+    );
+
+    const entry = vi.mocked(logProxyRequest).mock.calls[0][0];
+    expect(entry.path).toBe('/proxy/testapp/search/');
+  });
+
+  it('should hand the raw target to the WebSocket fallback too', async () => {
+    const mockApp = createMockApp({ websocketEnabled: true });
+    await setupProxyMocks(mockApp);
+
+    const { isWebSocketUpgrade, proxyWebSocket } = await import(
+      '@/lib/proxy/handler'
+    );
+    vi.mocked(isWebSocketUpgrade).mockReturnValue(true);
+    vi.mocked(proxyWebSocket).mockResolvedValue(
+      new Response('Upgrade Required', { status: 426 })
+    );
+
+    const { GET } = await import('@/app/proxy/[...path]/route');
+
+    const request = new Request('http://localhost:3000/proxy/testapp/ws/?v=a+b', {
+      headers: {
+        upgrade: 'websocket',
+        'x-cm-raw-url': '/proxy/testapp/ws/?v=a%20b',
+      },
+    });
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ['testapp', 'ws'] }),
+    });
+
+    expect(response.status).toBe(426);
+    expect(proxyWebSocket).toHaveBeenCalledWith(
+      request,
+      mockApp,
+      '/proxy/testapp/ws/?v=a%20b'
     );
   });
 });

--- a/tests/unit/proxy/server-raw-url.test.ts
+++ b/tests/unit/proxy/server-raw-url.test.ts
@@ -1,0 +1,218 @@
+/**
+ * server.ts raw request target capture (Issue #1804)
+ *
+ * WHY THIS TEST IS SHAPED THIS WAY
+ *
+ * The fix has two halves. The route handler half is covered by
+ * tests/unit/proxy/route.test.ts, which can simply build a `Request`. The
+ * server half lives in `server.ts`'s `requestHandler`, and `server.ts` cannot
+ * be imported from a test: importing it boots Next, opens a port, runs DB
+ * migrations and registers signal handlers.
+ *
+ * It also must not be refactored into an importable helper. Adding a module
+ * graph to `server.ts`'s eval-time graph perturbs Next's AsyncLocalStorage
+ * bootstrap under `tsx server.ts`, and the first request that compiles
+ * middleware dies (#1428) - a failure mode that is invisible to unit,
+ * integration, build and lint, and only shows up in E2E or in production.
+ *
+ * So this test reads the shipped `server.ts` bytes, cuts out exactly the
+ * Issue #1804 block, and EXECUTES it against fake `req` objects. That keeps the
+ * assertions behavioral rather than a source-text pattern match: deleting the
+ * header stash, or deleting the unconditional `delete` that makes it
+ * unforgeable, both turn assertions here red (verified by mutation injection).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/** Statement that immediately precedes the Issue #1804 block in server.ts */
+const BLOCK_START_ANCHOR = "const url = req.url ?? '/';";
+/** Comment that immediately follows the Issue #1804 block in server.ts */
+const BLOCK_END_ANCHOR = '// Issue #1621/#1645: a URL naming a worktree';
+
+const SERVER_TS_PATH = path.resolve(process.cwd(), 'server.ts');
+
+/**
+ * Extract the Issue #1804 block from server.ts.
+ *
+ * If either anchor moves, this throws rather than silently extracting nothing -
+ * an empty block would make every assertion below vacuously fail, but with a
+ * confusing message.
+ */
+function extractRawUrlBlock(): string {
+  const source = readFileSync(SERVER_TS_PATH, 'utf8');
+
+  const startIndex = source.indexOf(BLOCK_START_ANCHOR);
+  if (startIndex === -1) {
+    throw new Error(
+      `server.ts no longer contains the anchor ${BLOCK_START_ANCHOR}; ` +
+        'update tests/unit/proxy/server-raw-url.test.ts to match.'
+    );
+  }
+
+  const endIndex = source.indexOf(BLOCK_END_ANCHOR, startIndex);
+  if (endIndex === -1) {
+    throw new Error(
+      `server.ts no longer contains the anchor ${BLOCK_END_ANCHOR}; ` +
+        'update tests/unit/proxy/server-raw-url.test.ts to match.'
+    );
+  }
+
+  return source.slice(startIndex + BLOCK_START_ANCHOR.length, endIndex);
+}
+
+/** Shape of the fake `req` the extracted block runs against */
+type FakeReq = { headers: Record<string, string | string[] | undefined> };
+
+/** The extracted block, compiled into a callable */
+type RawUrlBlock = (req: FakeReq, url: string) => void;
+
+/**
+ * Compile the extracted block into a callable `(req, url) => void`.
+ *
+ * The block is plain JavaScript (no type annotations, no imports) precisely
+ * because #1428 forbids server.ts from importing anything here.
+ */
+function compileRawUrlBlock(): RawUrlBlock {
+  return new Function('req', 'url', extractRawUrlBlock()) as RawUrlBlock;
+}
+
+/**
+ * Build a fake Node IncomingMessage-ish object. Node lower-cases every incoming
+ * header name, so a client sending `X-CM-Raw-URL` lands on `x-cm-raw-url` here;
+ * the fixtures below use the lower-cased form for that reason.
+ */
+function createReq(
+  headers: Record<string, string | string[] | undefined> = {}
+): FakeReq {
+  return { headers };
+}
+
+describe('server.ts raw request target capture (Issue #1804)', () => {
+  const run = compileRawUrlBlock();
+
+  describe('capture', () => {
+    it('should stash the raw request target for /proxy/ requests', () => {
+      const req = createReq();
+      run(req, '/proxy/testapp/search?q=a%20b&n=1');
+
+      expect(req.headers['x-cm-raw-url']).toBe(
+        '/proxy/testapp/search?q=a%20b&n=1'
+      );
+    });
+
+    it.each([
+      '/proxy/testapp/search?q=a%20b&n=1',
+      '/proxy/testapp/search?bare',
+      '/proxy/testapp/search/?',
+      '/proxy/testapp/search?q=a%2Bb',
+      '/proxy/testapp/search?q=a%26b',
+      '/proxy/testapp/search?sig=aGVsbG8%3D',
+      '/proxy/testapp/search?q=%E6%97%A5%E6%9C%AC',
+      '/proxy/testapp/search?q=a+b',
+      '/proxy/testapp/a%2Fb/%E6%97%A5%E6%9C%AC/',
+      '/proxy/testapp/try/',
+      '/proxy/testapp/try',
+      '/proxy/testapp',
+    ])('should stash %s byte-for-byte with no rewriting', (rawUrl) => {
+      const req = createReq();
+      run(req, rawUrl);
+
+      expect(req.headers['x-cm-raw-url']).toBe(rawUrl);
+    });
+  });
+
+  describe('forgery protection', () => {
+    it('should overwrite a client-supplied x-cm-raw-url on a /proxy/ request', () => {
+      const req = createReq({ 'x-cm-raw-url': '/proxy/testapp/EVIL/' });
+      run(req, '/proxy/testapp/real/?q=1');
+
+      expect(req.headers['x-cm-raw-url']).toBe('/proxy/testapp/real/?q=1');
+    });
+
+    it('should delete a client-supplied x-cm-raw-url on a non-proxy request', () => {
+      const req = createReq({ 'x-cm-raw-url': '/proxy/testapp/EVIL/' });
+      run(req, '/dashboard');
+
+      expect(req.headers['x-cm-raw-url']).toBeUndefined();
+    });
+
+    it.each([
+      '/',
+      '/api/worktrees',
+      '/login',
+      // Prefix look-alikes: the guard tests for '/proxy/', not '/proxy'.
+      '/proxyfoo/bar',
+      '/proxy',
+      '/notproxy/testapp/',
+      '/worktrees/abc',
+    ])(
+      'should leave no x-cm-raw-url behind for %s even when the client sends one',
+      (url) => {
+        const req = createReq({ 'x-cm-raw-url': '/proxy/testapp/EVIL/' });
+        run(req, url);
+
+        expect(req.headers['x-cm-raw-url']).toBeUndefined();
+      }
+    );
+
+    it('should delete an array-valued forged header (duplicate header lines)', () => {
+      const req = createReq({
+        'x-cm-raw-url': ['/proxy/a/EVIL/', '/proxy/b/EVIL/'],
+      });
+      run(req, '/dashboard');
+
+      expect(req.headers['x-cm-raw-url']).toBeUndefined();
+    });
+
+    it('should not leave the forged value reachable on a /proxy/ request', () => {
+      const req = createReq({
+        'x-cm-raw-url': ['/proxy/a/EVIL/', '/proxy/b/EVIL/'],
+      });
+      run(req, '/proxy/testapp/real');
+
+      expect(req.headers['x-cm-raw-url']).toBe('/proxy/testapp/real');
+      expect(Array.isArray(req.headers['x-cm-raw-url'])).toBe(false);
+    });
+  });
+
+  describe('non-interference', () => {
+    it('should not touch other headers', () => {
+      const req = createReq({
+        'x-real-ip': '127.0.0.1',
+        cookie: 'cm_auth_token=abc',
+      });
+      run(req, '/proxy/testapp/');
+
+      expect(req.headers['x-real-ip']).toBe('127.0.0.1');
+      expect(req.headers['cookie']).toBe('cm_auth_token=abc');
+    });
+  });
+
+  describe('source-level constraints', () => {
+    /**
+     * #1428: a top-level static import of an internal module in server.ts kills
+     * the first request that compiles middleware, and only E2E notices. The
+     * #1804 block must therefore stay inline and import-free.
+     */
+    it('should keep the Issue #1804 block free of imports', () => {
+      // The block's own comment explains WHY it must not import, so strip
+      // comments before looking for the thing they talk about.
+      const code = extractRawUrlBlock()
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('//'))
+        .join('\n');
+
+      expect(code).toContain("delete req.headers['x-cm-raw-url']");
+      expect(code).not.toMatch(/\bimport\b/);
+      expect(code).not.toMatch(/\brequire\s*\(/);
+    });
+
+    it('should not add a static import of the proxy config module to server.ts', () => {
+      const source = readFileSync(SERVER_TS_PATH, 'utf8');
+
+      expect(source).not.toMatch(/^import .*proxy\/config/m);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

External Apps のプロキシが、クエリ文字列を**バイト完全一致**で上流へ転送するようにする。

Issue #1804（#1802 の残件）

## 事象

#1802 でクエリは転送されるようになったが、バイトが変わっていた。

| 送信 | 修正前 |
|---|---|
| `?q=a%20b&n=1` | `?q=a+b&n=1` |
| `?bare` | `?bare=` |

form-urlencoded の意味論では `+` と `%20` はどちらも空白なので大半のアプリでは実害がないが、**クエリのバイト列に署名を検証する上流**（HMAC 署名つき URL / presigned URL / OAuth 1.0a）では署名検証に失敗する。

## 原因

**Next.js が route handler に渡す前に `request.url` を再構成している。** `%20`→`+` と `?bare`→`?bare=` は URLSearchParams で再シリアライズした時の署名で、App Router の route handler の内側からは触れない。

切り分け済み: `new URL().search` は `%20` を保つ / node から直接 `fetch()` しても上流受信は `%20` のまま → 残るのは Next.js。

## 修正方針

**Next.js を迂回するのではなく、生 URL を一段手前で退避する。**

`server.ts` の `requestHandler` は Next.js に渡す前に生の `req.url`（Node の request target）を持っている。これを `x-cm-raw-url` ヘッダへ退避し、route handler が読み戻す。生文字列は最初の `?` で分割して扱い、`new URL()` を通さない（クエリのバイト列を一切解釈しないため）。ヘッダが無い場合（`next dev` 単体・unit test）は `request.url` にフォールバックし #1802 の挙動を維持する。

### 起票時の「server.ts で /proxy/ を横取りする」案を採らなかった理由

`/proxy/...` は現在 **`src/middleware.ts` の認証と IP 制限を通っている**。`AUTH_EXCLUDED_PATHS` は完全一致判定（`middleware.ts:106`）なので除外されていない。

Next.js を迂回すると **External Apps から認証と IP 制限が丸ごと外れ**、Cloudflare Tunnel 配下では外部公開に直結する。`next.config.js` の `headers()`（CSP 等）も失われる。この性質を `tests/unit/proxy/proxy-auth-guard.test.ts` で固定した（将来同じ設計を試みた人がここで止まる）。

### #1428 対策

`server.ts` 側は **inline 4 行に留め、import を 1 つも追加していない**。top-level に内部モジュールの静的 import を足すと `tsx server.ts` 下で Next の AsyncLocalStorage bootstrap が壊れ、最初のリクエストでクラッシュする。この故障は **unit / integration / build / lint をすべてすり抜け E2E だけで落ちる**ため、理由をコードコメントに残し、「#1804 ブロックが import を含まないこと」「server.ts が proxy/config を静的 import しないこと」をテストで固定した。

## 実機検証

隔離 HOME / 別ポート / エコー上流（受信した生 URL と受信ヘッダを返す）で実測。**20 項目中 19 PASS**（残り1件は下記の既知の制限）。

| 送信 | 修正前 | 修正後 |
|---|---|---|
| `?q=a%20b&n=1` | `?q=a+b&n=1` | **`?q=a%20b&n=1`** |
| `?bare` | `?bare=` | **`?bare`** |
| `?q=a+b` / `?q=a%2Bb` / `?q=a%26b` / `?sig=aGVsbG8%3D` / 多バイト | 保存 | 保存 |

#1802 の保存項目（`/try/` と `/try` の区別、`/proxy/app/` と `/proxy/app`、`a%2Fb`、多バイトパス、深い階層、HEAD、非GET 4種）に回帰なし。

### セキュリティ

- 偽装 `x-cm-raw-url` は無視され実 URL が使われる（無条件 `delete` → 条件付き `set`）
- `x-cm-raw-url` は上流の受信ヘッダに現れない（`INTERNAL_REQUEST_HEADERS` 経由で `filterHeaders()` が剥がす）
- **認証が維持されていることを実測**: 認証情報なし → 307（/login）、不正 Bearer → 401、偽装ヘッダ＋認証なし → 307、正規 Bearer → 200 かつクエリはバイト一致
- `tsx server.ts` 起動後に実リクエストを送って 200 を確認（#1428 型のクラッシュは Ready 到達では検出できない）

## 既知の制限（本PRでは直さない）

**`?` 単独（`/search/?`）は依然として落ちる。** 原因は `new URL()` ではなく **Node の `fetch()`（undici）**。undici は request target を `pathname + search` で組み立てるため、present-but-empty なクエリでは `search` が `''` になり送信時に消える。

```
fetch('http://127.0.0.1:P/a/?')        -> 上流受信 /a/     ← 落ちる
http.request({path:'/a/?'})            -> 上流受信 /a/?    ← 保持
```

解消には proxy の transport を `http.request` へ置き換える必要があり、undici の gzip 透過処理（content-encoding 剥がし）も自前で作り直しになる。**空クエリを表す区切り文字 1 バイトの代償としては割に合わない**と判断した。この境界は両実装の JSDoc とテストに明記してある。

## テスト

- `tests/unit/proxy/server-raw-url.test.ts`（新規）— 退避ロジック。`server.ts` は import できないので shipped の `server.ts` から当該ブロックを切り出して実行し振る舞いを固定
- `tests/unit/proxy/proxy-auth-guard.test.ts`（新規）— `/proxy/*` が認証・IP 制限の対象であり続けることを固定
- `route.test.ts` / `handler.test.ts` — バイト保存・内部ヘッダ剥がし・定数と直書き literal のドリフト防止

**変異注入で非空振りを確認済み**: (a) ヘッダ退避を削除 → 15 件が赤（実機でも `?q=a+b&n=1` `?bare=` に退行することを確認）/ (b) 無条件 `delete` を削除 → 10 件が赤。

## 品質ゲート

`lint` / `tsc --noEmit` / `test:unit`（880 files, 16,260 tests）すべて exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7H3TFQswmbVKAJhAxG5yp
