### PR TITLE
docs(readme): hero・Key Features・ワークフロー節・比較表を Vibe Engineering 軸へ整合する（EN/JA）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **README（EN / JA）の hero・Key Features・ワークフロー節・比較表を Vibe Engineering 軸へ整合** (#1814): hero を `docs/design/public-messaging.md` の H1 ＋定義文に差し替え、Key Features 先頭に Task Contract / Verification Gates / Evidence & Metrics / Skills Catalog / 入力待ち通知の 5 行を追加し、Multi-Agent 行を 7 CLI（`CLI_TOOL_IDS` 実数）へ更新した。「Optional Workflow Layer」は `## Vibe Engineering workflow` へ昇格して "optional, not required" を削除し、公式 Catalog Skill と `send --contract` → `wait --verify` の最小コマンド列で説明する構成に変えた（`.claude/commands` 表はこのリポジトリ限定である旨を明記して 1 行リンクへ縮退）。競合 4 製品名の比較表は With / Without CommandMate 表に置換。ガード `tests/unit/docs/public-messaging.test.ts` の対象に両 README を追加した
+
 - **Mission / Vision を `docs/concept.md` / `docs/en/concept.md` に正本化し、公開面の文言表 `docs/design/public-messaging.md` を新設** (#1808): hero・定義文・4 カード・With / Without 表・デモのキャプションとテロップ・チュートリアル導入文・footer タグライン・禁止語リストを ja / en 両方で確定した。軸語 "Vibe Engineering" の一次情報（Simon Willison, 2025-10-07）を実際に確認し出典として記録。禁止語リストはガードテスト `tests/unit/docs/public-messaging.test.ts` の配列と一致していることを固定している
 
 ## [0.24.0] - 2026-08-16

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
   <img src="./docs/images/demo-desktop.gif" width="600" alt="CommandMate Desktop Demo" />
 </p>
 
-> **Orchestrate your agent CLIs, not your terminal tabs.**
+> **From vibe coding to Vibe Engineering.**
 
-CommandMate is a local control plane for agent CLIs.
+Vibe Engineering — the AI does the building; the system, not your expertise, guarantees the engineering.
 
 ```bash
 npx commandmate@latest
@@ -27,8 +27,8 @@ npx commandmate@latest
 
 ---
 
-CommandMate adds orchestration and visibility on top of your existing agent CLIs.
-It does not replace tmux, Git worktrees, or your terminal. It makes them easier to manage at scale.
+CommandMate adds the machinery — a contract before the work, verification gates after it, Skills that carry the method — on top of the agent CLIs you already use.
+It does not replace tmux, Git worktrees, your terminal, or your agent CLI. It puts a frame around them, so the work arrives verified instead of merely finished.
 
 <p align="center">
   <img src="./docs/images/demo-mobile.gif" width="300" alt="CommandMate Mobile Demo" />
@@ -44,8 +44,13 @@ If this is the kind of AI development workflow you want, [give the repo a star](
 
 | Feature | What it does | Why it matters |
 |---------|-------------|----------------|
+| **Task Contract** | Declare the goal, the changeable scope and the gates before the work starts, then `send --contract` hands them to the agent | The agent works to a written definition of done instead of guessing at one |
+| **Verification Gates** | Gates declared in `.commandmate/verify.yaml` run through `verify` / `wait --verify` and return exit `0` / `20` / `21` | "Done" is what a verification run returned, not what the agent said |
+| **Evidence & Metrics** | The built-in work-evidence and scope gates, plus `verify history`, `task show` and `report metrics` | Commits, gate logs and numbers are left behind for the next decision |
+| **Skills Catalog** | Install and update official Skills per worktree, from the web UI or `commandmate skill` | The method is installed for the agent to read, not kept in someone's head |
+| **Never miss a waiting agent** | A waiting agent shows up as a badge, a toast, the tab title, the PWA app badge and a push notification | You find out the moment an agent needs you, even away from the desk |
 | **Git Worktree Sessions** | One session per worktree, parallel execution | Multiple issues progress simultaneously without interference |
-| **Multi-Agent Support** | Choose Claude Code, Codex, Gemini, or local models per issue | Pick the right agent for each task |
+| **Multi-Agent Support** | Choose Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Antigravity or local models per worktree | Pick the right agent for each task |
 | **Auto Yes Mode** | Agent runs without stopping for confirmations | Optional unattended mode for trusted workflows — review the Security section before enabling |
 | **Web UI (Desktop & Mobile)** | Full session control from any browser | Monitor and steer from your desk or your phone |
 | **File Viewer & Markdown Editor** | Browse and edit worktree files in the browser | Review changes and update AI instructions without opening an IDE |
@@ -111,12 +116,16 @@ development machine or phone will already have.
 flowchart LR
     A["Browser / Phone"] -->|HTTP| B["CommandMate Server"]
     B --> C["Session Manager"]
+    G["Task Contract\n.commandmate/tasks/*.yaml"] --> C
     C -->|"spawn / attach"| D["tmux sessions\n(per worktree)"]
-    D --> E["Claude Code CLI"]
+    D --> E["Agent CLI"]
     C <-->|"read / write"| F[("Local DB\n& State")]
+    E --> H["Verification Gates\n.commandmate/verify.yaml"]
+    H -->|"exit 0 / 20 / 21"| B
 ```
 
 Each Git worktree gets its own tmux session, so multiple tasks run in parallel without interference.
+The contract goes in before the session starts; the gates run after it stops, and their exit code is the verdict.
 
 ---
 
@@ -405,55 +414,92 @@ npm start
 ---
 
 <details>
-<summary><strong>Comparison</strong></summary>
+<summary><strong>With / Without CommandMate</strong></summary>
 
-| Feature | CommandMate | Remote Control (Official) | Happy Coder | claude-squad | Omnara |
-|---------|:-----------:|:------------------------:|:-----------:|:------------:|:------:|
-| Auto Yes Mode | Yes | No | No | Yes (TUI only) | No |
-| Git Worktree Management | Yes | No | No | Yes (TUI only) | No |
-| Parallel Sessions | Yes | **No (1 only)** | Yes | Yes | No |
-| Mobile Web UI | Yes | Yes (claude.ai) | Yes | **No** | Yes |
-| File Viewer | Yes | No | No | No | No |
-| Markdown Editor | Yes | No | No | No | No |
-| Screenshot Instructions | Yes | No | No | Not possible | No |
-| Scheduled Execution | Yes | No | No | No | No |
-| Survives Laptop Close | Yes (daemon) | **No (terminal must stay open)** | Yes | Yes | Yes |
-| Token Authentication | Yes | N/A (Anthropic account) | N/A (app) | No | N/A (cloud) |
-| Free / OSS | Yes | Requires Pro/Max | Free + Paid | Yes | $20/mo |
-| Runs 100% Locally | Yes | Via Anthropic API | Server-routed | Yes | Cloud fallback |
+The comparison that matters is not against other products; it is against the way of working.
+
+| Dimension | Vibe coding | Vibe Engineering with CommandMate |
+|---|---|---|
+| What "done" means | The agent says it's done | A verification run says so — exit 0 / 20 / 21 |
+| Scope of change | Whatever the agent touched | Declared in the contract, enforced by the scope gate |
+| Method | In someone's head | Installed as Skills from the Catalog (`cmate-task-contract`, `cmate-verify`, …) |
+| Evidence | A chat transcript | Commits, gate logs, `verify history`, `report metrics` |
+| Parallel work | Terminal tabs | One worktree and one contract per task |
+| When it stops | You notice, eventually | Waiting is surfaced: badge, toast, tab title, push |
+| Which agent | Locked to one | Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Antigravity, local models |
 
 </details>
 
 ---
 
-## Optional Workflow Layer
+## Vibe Engineering workflow
 
 <a id="issue-driven-development"></a>
 
-If your team wants more structure, CommandMate can also help you standardize
-issue refinement, design review, planning, implementation, and acceptance checks.
-These workflows build on top of the same CLI sessions and worktrees. They are optional, not required.
-
-CommandMate is built for developers who spend less time editing files and more time defining issues, reviewing direction, and accepting outcomes from coding agents. The commands below turn that workflow into a repeatable process.
+We do not make the AI smarter. We make the software-engineering ability its user needed into a system.
+That system is three things you can hand to any agent: the method, as installed Skills; the contract,
+declared before the work; the gates, which decide afterwards whether the work is done.
 
 ```
-Define Issue → Refine with AI → Review Direction → Generate Plan → Agent Executes
+Requirement → Contract → Agent runs (any CLI, per worktree) → Verified result
 ```
 
-| Step | Command | What happens |
-|------|---------|-------------|
-| Refine the issue | `/issue-enhance` | AI asks clarifying questions and fills in missing details |
-| Review the issue | `/multi-stage-issue-review` | Multi-stage review (consistency, impact scope) with automated fixes |
-| Review the design | `/multi-stage-design-review` | 4-stage review (general → consistency → impact → security) |
-| Plan the work | `/work-plan` | Generates a task breakdown with dependencies |
-| Implement via TDD | `/tdd-impl` | Red-Green-Refactor cycle, automated |
-| Verify acceptance | `/acceptance-test` | Validates all acceptance criteria from the issue |
-| Create the PR | `/create-pr` | Auto-generates title, description, and labels |
-| Dev (full) | `/pm-auto-dev` | TDD implementation → acceptance test → refactoring → progress report |
-| Issue → Dev (full) | `/pm-auto-issue2dev` | Issue review → design review → work plan → TDD → acceptance test → refactoring → progress report |
-| Design → Dev (full) | `/pm-auto-design2dev` | Design review → work plan → TDD → acceptance test → refactoring → progress report |
+### 1. Install the method as Skills
 
-For details, see the [issues](https://github.com/Kewton/CommandMate/issues), [dev reports](./dev-reports/issue/), and [workflow examples](./docs/en/user-guide/workflow-examples.md) in the CommandMate repository.
+Skills come from the official Catalog
+([Kewton/commandmate-skills](https://github.com/Kewton/commandmate-skills)) and install into the
+worktree you choose — from the web UI (`/skills`, or the Skills pane of a worktree) or from the CLI.
+
+```bash
+commandmate skill list
+commandmate skill install cmate-task-contract --worktree <worktree-id> --version <version> --yes
+```
+
+| Skill | What it covers |
+|-------|----------------|
+| `cmate-issue-authoring` | Turns a feature description into a set of implementable issues |
+| `cmate-issue-refinement` | Refines a vague issue into an implementable specification, read-only |
+| `cmate-task-contract` | Drafts `.commandmate/tasks/<name>.yaml` from an issue: goal, scope, gates |
+| `cmate-verify` | Declares the gates in `.commandmate/verify.yaml` and runs them for a real exit code |
+| `cmate-verify-advisor` | Proposes gate improvements from the verification history |
+| `cmate-worker-development` | The six steps a worker follows: read, investigate, plan, implement, verify, evidence |
+| `cmate-acceptance-test` | Checks the issue's acceptance criteria and returns Go / Conditional Go / No-Go |
+| `cmate-orchestrate` | Plans several issues in parallel, dispatches them with contracts, judges by exit code |
+
+The Catalog also publishes `cmate-repository-analysis`, `cmate-orchestrate-monitor`,
+`cmate-worktree-setup` and `cmate-worktree-cleanup`. See the
+[Skills guide](./docs/user-guide/skills.md) for the support matrix, the install roots, and the
+rollback story.
+
+### 2. Declare the contract, then let the gates judge
+
+```bash
+# .commandmate/tasks/issue-123.yaml declares goal, scope.allow / scope.deny and the gates to run
+commandmate send <worktree-id> --contract .commandmate/tasks/issue-123.yaml
+commandmate wait <worktree-id> --verify
+```
+
+`--contract` supplies the message, so you do not pass one yourself. `wait --verify` runs the gates
+once the agent stops and returns the verdict as its exit code: **0** everything passed, **20** a gate
+failed, **21** the work-evidence gate found neither a commit nor an uncommitted change.
+
+The contract format is specified in [Task Contract](./docs/design/task-contract.md), the gate format
+in [Verification gates](./docs/design/verification-config.md) — both specifications are written in
+Japanese, but the YAML they specify is the same on either side.
+
+### Read next
+
+| Document | What it gives you |
+|----------|-------------------|
+| [Concept](./docs/en/concept.md) | The Vision, the Mission, and how each implementation item maps to a feature |
+| [Tutorial](./docs/en/user-guide/tutorial.md) | Fork a sample repository and run one task through contract and verification in about fifteen minutes |
+| [Product Highlights](./docs/en/features/product-highlights.md) | A feature-by-feature tour of the product |
+| [CLI Operations Guide](./docs/en/user-guide/cli-operations-guide.md) | Every agent-facing command, in depth |
+
+> **Developing CommandMate itself?** The `/work-plan`, `/pm-auto-dev` and other slash commands under
+> `.claude/commands` belong to **this repository only** — they are not installed into yours, and the
+> portable equivalents are the Catalog Skills above. See the
+> [Commands guide](./docs/en/user-guide/commands-guide.md).
 
 ---
 
@@ -462,9 +508,12 @@ For details, see the [issues](https://github.com/Kewton/CommandMate/issues), [de
 | Document | Description |
 |----------|-------------|
 | [CLI Setup Guide](./docs/en/user-guide/cli-setup-guide.md) | Installation and initial setup |
+| [Tutorial](./docs/en/user-guide/tutorial.md) | Fork a sample repository and go from contract to verified result in about fifteen minutes |
 | [Web App Guide](./docs/en/user-guide/webapp-guide.md) | Basic web app operations |
 | [Quick Start](./docs/en/user-guide/quick-start.md) | Using Claude Code commands |
-| [Concept](./docs/en/concept.md) | Vision, Mission, and how each implementation item maps to a feature |
+| [Concept](./docs/en/concept.md) | The canonical Vision, Mission and core principle, and how each implementation item maps to a feature |
+| [Product Highlights](./docs/en/features/product-highlights.md) | A feature-by-feature tour of the product |
+| [Skills Guide](./docs/user-guide/skills.md) | Installing official Catalog Skills into a worktree (Japanese) |
 | [Architecture](./docs/en/architecture.md) | System design |
 | [Deployment Guide](./docs/en/DEPLOYMENT.md) | Production environment setup |
 | [UI/UX Guide](./docs/en/UI_UX_GUIDE.md) | UI implementation details |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -15,9 +15,9 @@
   <img src="../images/demo-desktop.gif" width="600" alt="CommandMate デスクトップデモ" />
 </p>
 
-> **ターミナルをさばくな。エージェント CLI をオーケストレーションしよう。**
+> **vibe coding から、Vibe Engineering へ。**
 
-CommandMate は、エージェント CLI のローカルコントロールプレーンです。
+Vibe Engineering — 作るのは AI。エンジニアリングを保証するのは、あなたの専門知識ではなく仕組み。
 
 ```bash
 npx commandmate@latest
@@ -27,8 +27,8 @@ npx commandmate@latest
 
 ---
 
-CommandMate は、既存のエージェント CLI の上にオーケストレーションと可視性を追加します。
-tmux、Git worktree、ターミナルを置き換えません。大規模な管理を容易にします。
+CommandMate は、既に使っているエージェント CLI の上に**仕組み**を足します。作業の前に契約を、作業の後に検証ゲートを、方法論は Skill として。
+tmux も Git worktree もターミナルもエージェント CLI も置き換えません。それらに枠をかけ、成果物が「終わった」ではなく「検証済み」で返るようにします。
 
 <p align="center">
   <img src="../images/demo-mobile.gif" width="300" alt="CommandMate モバイルデモ" />
@@ -44,8 +44,13 @@ tmux、Git worktree、ターミナルを置き換えません。大規模な管�
 
 | 機能 | できること | なぜ重要か |
 |------|-----------|-----------|
+| **実行契約（Task Contract）** | 作業を始める前に goal・変更してよい scope・検証ゲートを宣言し、`send --contract` でエージェントへ渡す | エージェントは推測ではなく、書かれた完了定義に向かって働く |
+| **検証ゲート** | `.commandmate/verify.yaml` に宣言したゲートを `verify` / `wait --verify` で実行し、exit `0` / `20` / `21` を返す | 「完了」はエージェントの申告ではなく、検証ランが返した裁定になる |
+| **証跡とメトリクス** | 組み込みの work-evidence / scope ゲートに加え、`verify history`・`task show`・`report metrics` | commit・ゲートログ・数値が残り、次の判断の材料になる |
+| **Skills カタログ** | 公式 Catalog の Skill を worktree ごとに導入・更新（Web UI / `commandmate skill`） | 方法論は誰かの頭の中ではなく、エージェントが読む形で導入される |
+| **入力待ちを見逃さない** | 入力待ちがバッジ・トースト・タブタイトル・PWA の App Badge・push 通知で届く | エージェントがあなたを必要とした瞬間に、席を外していても気づける |
 | **Git Worktree セッション** | worktree ごとに独立したセッション、並列実行 | 複数の Issue が干渉なく同時に進む |
-| **マルチエージェント対応** | Issue ごとに Claude Code、Codex、Gemini、ローカルモデルを選択 | タスクに最適なエージェントを使い分け |
+| **マルチエージェント対応** | worktree ごとに Claude Code / Codex / Gemini CLI / Copilot / OpenCode / Antigravity / ローカルモデルを選択 | タスクに最適なエージェントを使い分け |
 | **Auto Yes モード** | 確認なしでエージェントが動き続ける | 信頼できるワークフロー向けのオプショナル自動実行モード |
 | **Web UI（デスクトップ & モバイル）** | あらゆるブラウザからセッションを操作 | デスクからでもスマホからでも監視・指示が可能 |
 | **ファイルビューワ & Markdown エディタ** | ブラウザからファイルの閲覧・編集 | IDE を開かずにコード確認や AI への指示更新 |
@@ -79,18 +84,47 @@ tmux、Git worktree、ターミナルを置き換えません。大規模な管�
 
 ---
 
+## アプリとしてインストール（PWA）
+
+CommandMate は Progressive Web App です。モバイルブラウザの**ホーム画面に追加**から全画面（standalone）で起動でき、外出先でエージェントを監視するのに向いています。Service Worker が静的アセットを事前キャッシュし、オフライン時はフォールバック画面を表示します。API レスポンス・ログイン画面・WebSocket 通信はキャッシュしません。
+
+> **インストールには HTTPS が必要です。** ブラウザが Service Worker を登録する（＝インストールを提示する）のは `https://` か `http://localhost` の場合だけです。LAN 上の平文 HTTP（例: `http://192.168.x.x:3000`）でアクセスしている間は、ブラウザ側の制約でインストールとオフライン対応が無効になります。有効にするにはトンネルか HTTPS のリバースプロキシを使ってください（上のセキュリティ節を参照）。PWA レイヤーなしでもアプリ本体は完全に利用できます。
+
+---
+
+## ブラウザ対応
+
+Web UI は Tailwind CSS 4 で構築しており、配色・テーマの層で `@property` と `color-mix()` を使うため、
+モダンブラウザを対象としています。最低対応バージョンは次のとおりです。
+
+| ブラウザ | 最低バージョン |
+|---------|--------------|
+| Safari (macOS / iOS) | 16.4+ |
+| Chrome / Edge | 111+ |
+| Firefox | 128+ |
+
+これより古いブラウザでも読み込めますが、配色と余白が劣化した状態で表示されます。
+CommandMate はローカルの開発者向けツールなので、現行の開発マシンやスマートフォンに
+入っているブラウザとこの範囲は一致します。
+
+---
+
 ## 仕組み
 
 ```mermaid
 flowchart LR
     A["ブラウザ / スマホ"] -->|HTTP| B["CommandMate Server"]
     B --> C["Session Manager"]
+    G["Task Contract\n.commandmate/tasks/*.yaml"] --> C
     C -->|"spawn / attach"| D["tmux sessions\n(worktree ごと)"]
-    D --> E["Claude Code CLI"]
+    D --> E["Agent CLI"]
     C <-->|"read / write"| F[("Local DB\n& State")]
+    E --> H["Verification Gates\n.commandmate/verify.yaml"]
+    H -->|"exit 0 / 20 / 21"| B
 ```
 
 Git worktree ごとに専用の tmux セッションが割り当てられるため、複数タスクを干渉なく並列実行できます。
+契約はセッションを起動する前に入り、ゲートはセッションが止まった後に走ります。その exit code が裁定です。
 
 ---
 
@@ -333,55 +367,91 @@ npm start
 ---
 
 <details>
-<summary><strong>競合比較</strong></summary>
+<summary><strong>With / Without CommandMate</strong></summary>
 
-| 機能 | CommandMate | Remote Control（公式） | Happy Coder | claude-squad | Omnara |
-|------|:-----------:|:---------------------:|:-----------:|:------------:|:------:|
-| Auto Yes モード | あり | なし | なし | あり（TUI のみ） | なし |
-| Git Worktree 管理 | あり | なし | なし | あり（TUI のみ） | なし |
-| 並列セッション | あり | **なし（1つのみ）** | あり | あり | なし |
-| モバイル Web UI | あり | あり（claude.ai） | あり | **なし** | あり |
-| ファイルビューワ | あり | なし | なし | なし | なし |
-| Markdown エディタ | あり | なし | なし | なし | なし |
-| スクリーンショット指示 | あり | なし | なし | 不可能 | なし |
-| スケジュール実行 | あり | なし | なし | なし | なし |
-| PC を閉じても継続 | あり（デーモン） | **なし（ターミナル必須）** | あり | あり | あり |
-| トークン認証 | あり | N/A（Anthropic アカウント） | N/A（アプリ） | なし | N/A（クラウド） |
-| 無料 / OSS | あり | Pro/Max 必須 | 無料+有料 | あり | $20/月 |
-| 完全ローカル実行 | あり | Anthropic API 経由 | サーバー経由 | あり | クラウドフォールバック |
+比べるべき相手は他の製品ではなく、**やり方**です。
+
+| 観点 | vibe coding（丸投げ） | Vibe Engineering with CommandMate |
+|---|---|---|
+| 「完了」の意味 | エージェントが「できた」と言ったとき | 検証ランがそう言ったとき — exit 0 / 20 / 21 |
+| 変更範囲 | エージェントが触った範囲すべて | 契約で宣言し、scope ゲートで強制する |
+| 方法論 | 誰かの頭の中 | Catalog から Skill として導入する（`cmate-task-contract` / `cmate-verify` ほか） |
+| 証跡 | チャットの履歴 | commit ・ ゲートログ ・ `verify history` ・ `report metrics` |
+| 並列作業 | ターミナルのタブ | タスクごとに worktree 1 つと契約 1 つ |
+| 止まったとき | そのうち気づく | 入力待ちが届く: バッジ ・ トースト ・ タブタイトル ・ 通知 |
+| 使えるエージェント | 1 つに固定 | Claude Code ・ Codex ・ Gemini CLI ・ Copilot ・ OpenCode ・ Antigravity ・ ローカルモデル |
 
 </details>
 
 ---
 
-## オプショナルワークフローレイヤー
+## Vibe Engineering ワークフロー
 
 <a id="issue-driven-development"></a>
 
-チームでより構造的な開発を行いたい場合、CommandMate は Issue の精査、設計レビュー、
-計画立案、実装、受け入れチェックの標準化もサポートします。
-これらのワークフローは同じ CLI セッションと worktree の上に構築されます。利用は任意です。
-
-CommandMate は、ファイルを直接編集する時間よりも、Issue を定義し、方向性を確認し、コーディングエージェントの成果を受け入れる時間の方が長い開発者のために作られています。以下のコマンドは、そのワークフローを再現可能なプロセスに変えます。
+AI を賢くするのではなく、AI を使う側に必要だったソフトウェアエンジニアリング能力を仕組み化する。
+その仕組みは、どのエージェントにも渡せる 3 つで構成されます。**方法論**は導入された Skill として、
+**契約**は作業の前に宣言するものとして、**ゲート**は作業の後に完了を裁定するものとして。
 
 ```
-Issue 定義 → AI で補強 → 方向性レビュー → 計画生成 → エージェントが実行
+要求 → 契約 → エージェントが実行（任意の CLI・worktree ごと） → 検証済みの成果物
 ```
 
-| ステップ | コマンド | 実行内容 |
-|---------|---------|---------|
-| Issue を補強 | `/issue-enhance` | AI が不足情報を質問し、Issue を補完 |
-| Issue レビュー | `/multi-stage-issue-review` | 多段階レビュー（整合性・影響範囲）と指摘の自動対応 |
-| 設計レビュー | `/multi-stage-design-review` | 4 段階レビュー（通常 → 整合性 → 影響分析 → セキュリティ） |
-| 作業計画 | `/work-plan` | タスク分割と依存関係を生成 |
-| TDD 実装 | `/tdd-impl` | Red-Green-Refactor サイクルを自動実行 |
-| 受入テスト | `/acceptance-test` | Issue の受入基準を検証 |
-| PR 作成 | `/create-pr` | タイトル・説明・ラベルを自動生成 |
-| 開発（一括） | `/pm-auto-dev` | TDD 実装 → 受入テスト → リファクタリング → 進捗レポート |
-| Issue → 実装（一括） | `/pm-auto-issue2dev` | Issue レビュー → 設計レビュー → 作業計画 → TDD 実装 → 受入テスト → リファクタリング → 進捗レポート |
-| 設計 → 実装（一括） | `/pm-auto-design2dev` | 設計レビュー → 作業計画 → TDD 実装 → 受入テスト → リファクタリング → 進捗レポート |
+### 1. 方法論を Skill として導入する
 
-詳細は CommandMate リポジトリの [Issues](https://github.com/Kewton/CommandMate/issues)、[開発レポート](../../dev-reports/issue/)、[ワークフロー例](../user-guide/workflow-examples.md) を参照してください。
+Skill は公式 Catalog（[Kewton/commandmate-skills](https://github.com/Kewton/commandmate-skills)）から
+取得し、選んだ worktree に導入します。Web UI（`/skills`、または worktree 詳細の Skills pane）からでも、
+CLI からでも実行できます。
+
+```bash
+commandmate skill list
+commandmate skill install cmate-task-contract --worktree <worktree-id> --version <version> --yes
+```
+
+| Skill | 扱う範囲 |
+|-------|---------|
+| `cmate-issue-authoring` | Feature 記述から実装可能な Issue 群を起案する |
+| `cmate-issue-refinement` | 曖昧な Issue を read-only で実装可能な仕様へ精緻化する |
+| `cmate-task-contract` | Issue から `.commandmate/tasks/<name>.yaml`（goal・scope・ゲート）を起案する |
+| `cmate-verify` | `.commandmate/verify.yaml` にゲートを宣言し、実 exit code で判定する |
+| `cmate-verify-advisor` | 検証の実行履歴から verify.yaml の改善案を出す |
+| `cmate-worker-development` | ワーカーが進める 6 段（読取・調査・計画・実装・検証・証拠） |
+| `cmate-acceptance-test` | Issue の受入条件を証跡付きで検証し Go / Conditional Go / No-Go を返す |
+| `cmate-orchestrate` | 複数 Issue を並列に計画し、契約付きで dispatch して exit code で裁定する |
+
+Catalog にはこのほか `cmate-repository-analysis` / `cmate-orchestrate-monitor` /
+`cmate-worktree-setup` / `cmate-worktree-cleanup` も公開されています。support matrix・install root・
+rollback の扱いは [Skills 配布ガイド](../user-guide/skills.md) を参照してください。
+
+### 2. 契約を宣言し、ゲートに裁定させる
+
+```bash
+# .commandmate/tasks/issue-123.yaml に goal・scope.allow / scope.deny・実行するゲートを宣言する
+commandmate send <worktree-id> --contract .commandmate/tasks/issue-123.yaml
+commandmate wait <worktree-id> --verify
+```
+
+`--contract` がメッセージを供給するため、メッセージ引数は渡しません。`wait --verify` は
+エージェントが停止した後にゲートを実行し、裁定を exit code で返します。**0** は全ゲート合格、
+**20** はいずれかのゲートが不合格、**21** は work-evidence ゲートが commit も未 commit の変更も
+見つけられなかった場合です。
+
+契約の書式は [実行契約 仕様](../design/task-contract.md)、ゲートの書式は
+[検証ゲート設定 仕様](../design/verification-config.md) が正準です。
+
+### 次に読むもの
+
+| ドキュメント | 得られるもの |
+|-------------|------------|
+| [コンセプト](../concept.md) | Vision・Mission と、各実装項目がどの機能に対応するか |
+| [チュートリアル](../user-guide/tutorial.md) | サンプルリポジトリを fork し、契約から検証までを 15 分ほどで一通り体験する |
+| [プロダクトの特徴](../features/product-highlights.md) | 機能ごとの紹介 |
+| [CLI 操作ガイド](../user-guide/cli-operations-guide.md) | エージェント操作系コマンドの詳細 |
+
+> **CommandMate 自体を開発する場合。** `.claude/commands` 配下の `/work-plan` `/pm-auto-dev` などの
+> スラッシュコマンドは**このリポジトリ専用**です。あなたのリポジトリには導入されません。可搬な
+> 代替は上の Catalog Skill です。詳細は [コマンド利用ガイド](../user-guide/commands-guide.md) を
+> 参照してください。
 
 ---
 
@@ -390,9 +460,12 @@ Issue 定義 → AI で補強 → 方向性レビュー → 計画生成 → エ
 | ドキュメント | 説明 |
 |-------------|------|
 | [CLI セットアップガイド](../user-guide/cli-setup-guide.md) | インストールと初期設定 |
+| [チュートリアル](../user-guide/tutorial.md) | サンプルリポジトリを fork し、契約から検証済みの成果物までを 15 分ほどで体験する |
 | [Webアプリ操作ガイド](../user-guide/webapp-guide.md) | Webアプリの基本操作 |
 | [クイックスタート](../user-guide/quick-start.md) | Claude Code コマンドの使い方 |
-| [コンセプト](../concept.md) | ビジョンと解決する課題 |
+| [コンセプト](../concept.md) | Vision・Mission・中核原則の正本と、各実装項目と機能の対応 |
+| [プロダクトの特徴](../features/product-highlights.md) | 機能ごとの紹介 |
+| [Skills 配布ガイド](../user-guide/skills.md) | 公式 Catalog の Skill を worktree へ導入する |
 | [アーキテクチャ](../architecture.md) | システム設計 |
 | [デプロイガイド](../DEPLOYMENT.md) | 本番環境構築手順 |
 | [UI/UXガイド](../UI_UX_GUIDE.md) | UI 実装の詳細 |

--- a/tests/unit/docs/public-messaging.test.ts
+++ b/tests/unit/docs/public-messaging.test.ts
@@ -24,6 +24,11 @@
  *    fails the doc instead of failing the render months later.
  * 6. **No table cell is left blank.** The brief was "every item filled in both
  *    ja and en"; a blank cell is how a later issue ends up inventing wording.
+ * 7. **The two READMEs are held to the same pins as the concept files**
+ *    (Issue #1814). They are the surface most likely to be edited by someone
+ *    who never opens public-messaging.md, so the hero, the definition and the
+ *    retired wording are asserted there directly — and the two languages are
+ *    kept structurally parallel for the same reason the concept files are.
  *
  * @vitest-environment node
  */
@@ -38,6 +43,8 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const MESSAGING_DOC = 'docs/design/public-messaging.md';
 const CONCEPT_JA = 'docs/concept.md';
 const CONCEPT_EN = 'docs/en/concept.md';
+const README_EN = 'README.md';
+const README_JA = 'docs/ja/README.md';
 const STORYBOARD = '.claude/skills/demo-video/scripts/storyboard.ts';
 
 /**
@@ -77,6 +84,11 @@ function tableCells(line: string): string[] | null {
   const trimmed = line.trim();
   if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) return null;
   return trimmed.slice(1, -1).split('|');
+}
+
+/** Top-level sections, the cheapest proxy for "both languages got the edit". */
+function sectionCount(content: string): number {
+  return content.split('\n').filter((line) => /^## /.test(line)).length;
 }
 
 function isSeparatorRow(cells: string[]): boolean {
@@ -175,9 +187,8 @@ describe('concept docs are the canonical Vision/Mission text', () => {
   });
 
   it('keeps the same number of ## sections in both languages', () => {
-    const count = (content: string) => content.split('\n').filter((l) => /^## /.test(l)).length;
-    expect(count(ja)).toBeGreaterThan(0);
-    expect(count(en)).toBe(count(ja));
+    expect(sectionCount(ja)).toBeGreaterThan(0);
+    expect(sectionCount(en)).toBe(sectionCount(ja));
   });
 
   it('draws the loop without an image', () => {
@@ -197,6 +208,42 @@ describe('concept docs are the canonical Vision/Mission text', () => {
       expect(ja, `${CONCEPT_JA} must list ${id}`).toContain(id);
       expect(en, `${CONCEPT_EN} must list ${id}`).toContain(id);
     }
+  });
+});
+
+describe('the READMEs carry the same axis as the concept docs', () => {
+  const en = readProse(README_EN);
+  const ja = readProse(README_JA);
+
+  it('opens with the hero and the definition, each in its own language', () => {
+    expect(en, `${README_EN} must open with the en hero verbatim`).toContain(HERO_H1_EN);
+    expect(en, `${README_EN} must carry the en definition verbatim`).toContain(DEFINITION_EN);
+    expect(ja, `${README_JA} must open with the ja hero verbatim`).toContain(HERO_H1_JA);
+    expect(ja, `${README_JA} must carry the ja definition verbatim`).toContain(DEFINITION_JA);
+  });
+
+  it.each([
+    [README_EN, en],
+    [README_JA, ja],
+  ])('%s uses none of the banned terms', (relative, prose) => {
+    const lowered = prose.toLowerCase();
+    const found = BANNED_TERMS.filter((term) => lowered.includes(term.toLowerCase()));
+    expect(found, `${relative} still uses retired wording`).toEqual([]);
+  });
+
+  it.each([
+    [README_EN, en],
+    [README_JA, ja],
+  ])('%s names the axis in the hero and again on the workflow section', (relative, prose) => {
+    // Two is the floor the issue set: the hero says it once, the workflow
+    // heading says it again. Fewer means one of the two was reverted.
+    const occurrences = prose.split('Vibe Engineering').length - 1;
+    expect(occurrences, `${relative} must name the axis at least twice`).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keeps the same number of ## sections in both languages', () => {
+    expect(sectionCount(ja)).toBeGreaterThan(0);
+    expect(sectionCount(en)).toBe(sectionCount(ja));
   });
 });
 


### PR DESCRIPTION
Closes #1814 （base=develop のため自動クローズされない。マージ後に手動クローズする）

Epic #1807 Step E。#1808 で確定した文言表 `docs/design/public-messaging.md` を README（EN/JA）へ適用する。

## 変更

- **hero** — 文言表の H1 ＋定義文 1 行に差替え。「orchestration と visibility を足す」の段落を「仕組み（契約・検証・Skills）を足す。tmux / worktree / ターミナル / エージェント CLI は置き換えない」に
- **Key Features** — 先頭に新軸 5 行（Task Contract / Verification Gates / Evidence & Metrics / Skills Catalog / Never miss a waiting agent）。Multi-Agent 行を **7 CLI** に更新
- **「Optional Workflow Layer」を中核節へ昇格** — `## Vibe Engineering workflow`。**"optional, not required" の段落を削除**（Mission と上下が逆だったため）。`.claude/commands` 表は「このリポジトリ限定」と明記して主導線から外した
- **競合比較表を撤去** — With / Without CommandMate 7 行に置換。他社製品名は README から消滅
- **JA README を同構成に**（見出し数一致）。GIF パスは未変更（#1815 の担当）

## 検証

`wait --verify` **exit 0**:

```
GATE work-evidence PASS (commits=1, uncommitted=0)
GATE scope PASS / lint PASS / typecheck PASS / unit PASS (499.6s)
RESULT passed
```

### オーケストレーターによる独立確認

| 受入条件 | 実測 |
|---|---|
| 禁止語（control plane / 競合 4 製品名 / "Orchestrate your agent CLIs"） | `README.md:0` `docs/ja/README.md:0` |
| `grep -c "Vibe Engineering" README.md` ≥ 2 | **4** |
| "optional, not required" | **0** |
| ja/en 見出し数一致 | **10 / 10** |
| 7 CLI の裏取り | `src/lib/cli-tools/types.ts` に antigravity/claude/codex/copilot/gemini/opencode/vibe-local の**7 件**。README の列挙と一致 |

**文言の単一ソース性（この Issue の肝）** — 定義文が `public-messaging.md` から**逐語コピー**されていることを en / ja 双方で照合し、空白・強調記号を除いて **byte-identical** を確認:

- en: `Vibe Engineering — the AI does the building; the system, not your expertise, guarantees the engineering.` → IDENTICAL
- ja: `Vibe Engineering — 作るのは AI。エンジニアリングを保証するのは、あなたの専門知識ではなく仕組み。` → IDENTICAL

**変異注入（非空振りの証明）** — ガードは 15 → **21 tests** に拡張され `README.md` / `docs/ja/README.md` を対象に含む。オーケストレーターが独立に再実行:

| | 結果 |
|---|---|
| baseline | 21 passed / exit 0 |
| `README.md` に `a local control plane for agent CLIs` を追記 | **exit 1** — `× README.md uses none of the banned terms` / `expected [ 'control plane' ] to deeply equal []` |
| revert 後 | クリーン |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Pd7DUZCktxPVhy1iy8rRK