### PR TITLE
docs(cli): capture --json のフィールド意味論を明記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **docs(cli): `capture --json` の各フィールドの意味論を明文化する** (#1840):
+  `docs/user-guide/cli-operations-guide.md`（および `docs/en/` の対応節）の capture 節に、
+  `content` / `realtimeSnippet` / `lineCount` / `isRunning` /
+  `sessionStatus`・`sessionStatusReason` / `structuredEvents`・`lastStopEventAt` の 6 行表を追加した。
+  監視スクリプトが実際に踏んでいた 2 つの誤読を名指しで潰している:
+  **`content` は `lastCapturedLine` 以降の差分**なのでポーラーが先に保存していれば正常時でも空
+  （`src/lib/session/current-output-builder.ts:535-556`）、
+  **`isRunning` は tmux セッションが存在して healthy という意味だけ**でターン進行中ではない
+  （`src/lib/session/claude-session.ts:543-556`）。画面が空かどうかは
+  `realtimeSnippet.trim() === ''` と `lineCount` で見る。あわせて wait 節に、完了判定が
+  `sessionStatus === 'ready'`（未分類フレームでない）またはセッション消滅であって
+  **ターンの成立は見ていない**ことを明記した（`src/cli/commands/wait.ts:356`）
+
 ## [0.25.0] - 2026-08-19
 
 > **Highlight**: 公開面（LP・README・チュートリアル・concept）を **Vibe Engineering** の軸へ据え替えた回（Epic #1807、子 Issue 10 件）。あわせて収録基盤 `demo-video` が worktree ID の path 由来化に追従できておらず**実収録が必ず失敗する**状態を復旧し、さらに `fake-agent.sh` が承認フレームを自動応答してしまい **`wait` が「起きていない作業」に `Completed` を返す**欠陥を修正した。これを直さないまま撮っていたら、全デモが「検証を通ったことになっている」だけの映像になっていた。製品側では実行契約と検証結果を Web UI に露出し（#1816）、codex 起動ダイアログへの Auto-Yes 誤応答（#1829）と CI のハング放置（#1830）を塞いだ。

--- a/docs/en/user-guide/cli-operations-guide.md
+++ b/docs/en/user-guide/cli-operations-guide.md
@@ -219,6 +219,10 @@ commandmate send "$WT" "Implement this"
 
 Block until the agent in the given worktree completes.
 
+> **Completion means `sessionStatus === 'ready'` on a frame that was classified, or the session
+> disappearing** (`src/cli/commands/wait.ts:356`). **It does not check that the turn actually
+> landed.** Use `--verify` / `--require-work` (below) to judge whether the work is really there.
+
 ### Usage
 
 ```bash
@@ -803,6 +807,21 @@ Everything the server sends except `fullOutput` is printed verbatim.
   "reasoningEffort": null
 }
 ```
+
+What each field actually means. The line numbers were measured on 2026-08-20; following the
+function names (`buildCurrentOutput` / `isClaudeRunning`) is the safer way to find them.
+
+| Field | Meaning |
+|---|---|
+| `content` | The delta since `lastCapturedLine` (`src/lib/session/current-output-builder.ts:535-556`). Empty even on a healthy session once the poller has already saved it |
+| `realtimeSnippet` | The last 100 rows of the pane — the screen itself (`src/lib/session/current-output-builder.ts:712`) |
+| `lineCount` | The row count of the whole capture, blank rows included. A TUI is drawn on a 1000-row pane, so even a blank pane can report 1001 |
+| `isRunning` | The tmux session exists and is healthy (`src/lib/session/claude-session.ts:543-556`). **It does not mean a turn is in progress** |
+| `sessionStatus` / `sessionStatusReason` | The state and what it rests on: a `hook_*` reason came from hooks, anything else from the scraper (`HOOK_STATUS_REASON` in `src/lib/session/status-mapping.ts`) |
+| `structuredEvents.*` / `lastStopEventAt` | The last hook event and the last `stop` timestamp. `null` when no hooks have arrived |
+
+To tell whether the screen is empty, read `realtimeSnippet.trim() === ''` together with `lineCount`.
+`content` is a delta, so it never answers that on its own.
 
 #### `model` / `reasoningEffort` (Issue #1785)
 

--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -300,6 +300,10 @@ commandmate send "$WT" "実装してください"
 
 指定worktreeのエージェントが完了するまでブロッキング待機します。
 
+> **完了判定は `sessionStatus === 'ready'`（かつ未分類フレームでない）またはセッション消滅。
+> ターンの成立は見ていない**（`src/cli/commands/wait.ts:356`）。エージェントが要求した作業を
+> 実際にやり遂げたかどうかは `--verify` / `--require-work`（下記）で確かめてください。
+
 ### 使用方法
 
 ```bash
@@ -824,6 +828,21 @@ commandmate capture <worktree-id> --instance codex-2 # 追加インスタンス�
   "reasoningEffort": null
 }
 ```
+
+各フィールドの意味論は次のとおりです。行番号は 2026-08-20 時点の実測で、
+関数名（`buildCurrentOutput` / `isClaudeRunning`）で追うほうが安全です。
+
+| フィールド | 意味 |
+|---|---|
+| `content` | lastCapturedLine 以降の差分（`src/lib/session/current-output-builder.ts:535-556`）。ポーラーが保存済みなら正常時でも空 |
+| `realtimeSnippet` | pane 末尾 100 行（画面そのもの。`src/lib/session/current-output-builder.ts:712`） |
+| `lineCount` | capture 全体の行数（空白行を含む。TUI は 1000 行のペインに描かれるため、空白 pane でも 1001 になりうる） |
+| `isRunning` | tmux セッションが存在して healthy（`src/lib/session/claude-session.ts:543-556`）。**ターン進行中の意味ではない** |
+| `sessionStatus` / `sessionStatusReason` | 状態と、その根拠（`hook_*` なら hooks 由来、それ以外はスクレイパー由来。`HOOK_STATUS_REASON` は `src/lib/session/status-mapping.ts`） |
+| `structuredEvents.*` / `lastStopEventAt` | hooks の最終イベントと最終 `stop` 時刻。hooks が来ていなければ `null` |
+
+画面が空かどうかは `realtimeSnippet.trim() === ''` と `lineCount` で見る。
+`content` は差分なので単独では判断しない。
 
 #### `model` / `reasoningEffort`（Issue #1785）
 


### PR DESCRIPTION
## 概要

`commandmate capture --json` の payload について、監視スクリプトが最も誤読しやすい 2 点を docs に明記する。コードは 1 バイトも変更していない。

Closes #1840

## 変更内容

`docs/user-guide/cli-operations-guide.md` の capture 節（例 JSON の直後）に 6 行の意味論表を追加。英語版 `docs/en/user-guide/cli-operations-guide.md` にも同内容。

| フィールド | 意味 | 裏取り |
|---|---|---|
| `content` | `lastCapturedLine` 以降の**差分**。ポーラー保存済みなら正常時でも空 | `src/lib/session/current-output-builder.ts:535-556` |
| `realtimeSnippet` | pane 末尾 100 行 | `current-output-builder.ts:712` |
| `lineCount` | capture 全体の行数（空白行含む。空白 pane でも 1001 になりうる） | `TUI_PANE_HEIGHT=1000` |
| `isRunning` | tmux セッションが存在して healthy。**ターン進行中の意味ではない** | `src/lib/session/claude-session.ts:543-556` |
| `sessionStatusReason` | `hook_*` は hooks 由来、それ以外はスクレイパー由来 | `status-mapping.ts` の `HOOK_STATUS_REASON` |
| `structuredEvents.*` / `lastStopEventAt` | hooks 未着なら `null` | `agent-event-state.ts` |

あわせて wait 節に完了判定の実体（`src/cli/commands/wait.ts:356`）を明記した。ターンが成立したかは見ていない。

## 検証

`commandmate wait --verify` の実 exit code で裁定済み（**exit 0 / RESULT passed**）。

| ゲート | 結果 |
|---|---|
| work-evidence | PASS (commits=1, uncommitted=0) |
| scope | PASS |
| lint | PASS (exit=0) |
| typecheck | PASS (exit=0) |
| unit | PASS (exit=0, 600.5s) |

## 受入条件

- [x] `grep -a 'lastCapturedLine 以降の差分'` が引ける
- [x] `grep -a 'ターン進行中の意味ではない'` が引ける
- [x] 表の 6 行すべてがある
- [x] 既存の例 JSON は不変
- [x] 英語版にも同内容（`##` 見出しを増やしていないので ja-en-heading-parity は不変）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ya52Env4iXYW8zWeWJ2CH