### PR TITLE
ci(e2e): Playwright インストールのハングを apt 側で塞ぎ、ブラウザを解決後バージョンでキャッシュする

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -370,16 +370,121 @@ jobs:
       # — same failure mode as the integration suite in #1102. Only chromium is
       # installed: playwright.config.ts declares a single chromium project (see
       # the comment there on why the Mobile Safari project was dropped).
+      # [Issue #1844] This used to be ONE step — `npx playwright install
+      # --with-deps chromium` — and it kept eating the whole job (88m, 3h55m and
+      # 3h48m on 2026-08-19 before #1830 capped it; then a hard 20-minute
+      # timeout failure in run 32248871561). #1844 proposed caching
+      # ~/.cache/ms-playwright as the primary fix. The measurement says the
+      # cache is not where the time is, so the split below follows the
+      # measurement and caches the browser anyway, because it is free.
+      #
+      # WHERE THE TIME ACTUALLY GOES. `--with-deps` does two unrelated things in
+      # one step: an apt transaction, then a browser download from
+      # cdn.playwright.dev. Cutting each job's step log at the
+      # `Downloading Chrome for Testing ...` line separates them exactly
+      # (`gh run view --repo Kewton/CommandMate --job <id> --log`, all six E2E
+      # jobs of 2026-08-19):
+      #
+      #   job            step total    apt phase   browser (CDN)
+      #   96068691996         0.31m        0.20m           0.11m
+      #   96109347270         3.26m        3.14m           0.11m
+      #   96118759977         7.71m        7.63m           0.09m
+      #   96062812368         9.34m        9.22m           0.11m
+      #   95947185874        10.54m       10.44m           0.10m
+      #   96055267143        20.21m    timed out     never began
+      #
+      # The browser download is 0.09-0.11m in EVERY sample. It is not bimodal
+      # and it has never hung; the entire spread, and the timeout, is apt. In
+      # run 96055267143 those 20 minutes went on font archives from
+      # azure.archive.ubuntu.com at 14-21 kB/s (fonts-ipafont-gothic 3513 kB in
+      # 169s, fonts-freefont-ttf 5641 kB in 397s, killed mid fonts-wqy-zenhei)
+      # and the browser download never started. So caching the browser buys
+      # ~6 seconds, not the fix — it is here because it costs nothing and takes
+      # the CDN out of the picture for good.
+      #
+      # WHAT apt IS ACTUALLY INSTALLING. Every real Chromium library on the
+      # ubuntu-24.04 image is already present: each run logs libnss3, libgbm1,
+      # libatk*, libcups2t64, xvfb, fonts-liberation and the rest as "already
+      # the newest version". The 9 packages it downloads (21.1 MB) are all
+      # fonts — fonts-freefont-ttf, fonts-ipafont-gothic, fonts-tlwg-loma-otf,
+      # fonts-unifont, fonts-wqy-zenhei, xfonts-{cyrillic,encodings,scalable,
+      # utils}. Nothing under tests/e2e asserts on pixels (no toHaveScreenshot
+      # and no toMatchSnapshot anywhere; playwright.config.ts takes screenshots
+      # `only-on-failure`, as debugging artifacts), so those fonts cannot turn a
+      # pass into a fail. That is what makes it safe for the dependency step to
+      # give up on a slow mirror instead of holding the job.
+      - name: Resolve the installed Playwright version
+        id: playwright
+        # The cache key has to bind to the RESOLVED version, never to the
+        # `^1.56.1` range in package.json: a range key keeps hitting after a
+        # minor bump and would hand the suite browsers built for the previous
+        # playwright-core. playwright-core is the package whose version pins the
+        # browser revisions, so it is the one to read.
+        run: |
+          VERSION=$(node -p "require('playwright-core/package.json').version")
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::could not resolve a Playwright version (got '$VERSION')"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Playwright (resolved): $VERSION"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          # Default PLAYWRIGHT_BROWSERS_PATH on Linux. Holds chromium-<rev>,
+          # chromium_headless_shell-<rev> and ffmpeg-<rev> — everything
+          # `playwright install chromium` writes.
+          path: ~/.cache/ms-playwright
+          # Deliberately no `restore-keys`: a partial-key fallback is precisely
+          # how a job ends up running last version's browser. Miss on a bump.
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright system dependencies
+        id: playwright-deps
+        # Bounded and non-fatal, which is the actual #1844 fix. On this image
+        # the step only ever fetches fonts nothing asserts on, so letting it run
+        # to a 20-minute cap — or to six hours before #1830 — buys nothing at
+        # all. 6 is ~30x the 0.20m median and still absorbs the 3.14m sample;
+        # the 7.6m / 9.2m / 10.4m samples are abandoned on purpose. A slow
+        # Ubuntu mirror now degrades a failure screenshot's CJK glyphs instead
+        # of failing the job. If a genuinely missing library ever reappears,
+        # `Run E2E tests` below fails with Playwright's own "Host system is
+        # missing dependencies" message, so this cannot go green while broken.
+        #
+        # No retry loop (considered, per #1844): the observed pathology is
+        # sustained low bandwidth over minutes rather than a stall, so a second
+        # attempt re-enters the same slow mirror — and killing the transaction
+        # mid-flight to retry leaves the dpkg lock held, which turns attempt 2
+        # into a different, more confusing failure.
+        timeout-minutes: 6
+        continue-on-error: true
+        run: npx playwright install-deps chromium
+
+      - name: Note degraded system dependencies
+        # `outcome` is the pre-continue-on-error result, so this fires on both a
+        # timeout and a real apt failure. Without it the give-up is a quiet
+        # orange tick nobody reads.
+        if: steps.playwright-deps.outcome != 'success'
+        run: |
+          echo "::warning title=Playwright system dependencies skipped::The system-dependency step did not finish inside its 6-minute budget (Issue #1844). On ubuntu-latest it only adds font packages, so the suite still runs; failure screenshots may render CJK glyphs as tofu."
+
       - name: Install Playwright browser
-        # THE STEP THAT HUNG FOR 88 MINUTES (run 32218070769). It is measurably
-        # bimodal — the browser download is at the CDN's mercy. Across the same
-        # 12 runs: 0.28 0.30 0.32 0.33 0.35 0.35 0.37 0.40 0.77 1.07 4.90 10.55
-        # minutes (median 0.36m, max 10.55m). 20 is ~2x that worst healthy run,
-        # and after a full 20-minute stall the job's 30m cap still has room for
-        # `npm ci` (0.4m) plus `Run E2E tests` (5.4m max) to finish, so this cap
-        # only ever fires on something genuinely stuck.
-        timeout-minutes: 20
-        run: npx playwright install --with-deps chromium
+        # Skipped outright on a cache hit, so a hit fetches nothing from
+        # cdn.playwright.dev. On a miss this is the same download as before the
+        # split — 0.09-0.11m across all six samples above — and `playwright
+        # install` is idempotent, so the miss path behaves exactly as it always
+        # did. 10 is ~90x the measured worst case and leaves the job's 30m cap
+        # room for `npm ci` (0.4m), the 6m dependency budget and `Run E2E tests`
+        # (5.4m max).
+        #
+        # `success()` is spelled out because a custom `if` replaces the implicit
+        # success check, and a browser download after a hard failure upstream is
+        # just wasted runner time.
+        if: success() && steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        run: npx playwright install chromium
 
       # playwright.config.ts owns the isolation: it boots its own dev server on
       # port 3177 with CM_DB_PATH/CM_ROOT_DIR pinned to a throwaway state dir, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **feat(polling): プロンプト dedup のスキップを `capture --json` に露出する** (#1695): 重複抑止で落としたプロンプトの累積回数と最終スキップ時刻を `promptDedup`（`skippedCount` / `lastSkippedAt`）として公開し、「プロンプトが出たはずなのに保存されていない」ときに dedup が原因か検出漏れ（#1676）かを CLI から判別できるようにした。あわせて response 側 dedup（`isDuplicateResponse`、#1268）に `duplicate-response-skipped` ログを追加（従来ログすら無かった）
 
-### Docs
+### Documentation
 
 - **docs(cli): `capture --json` の各フィールドの意味論を明文化する** (#1840):
   `docs/user-guide/cli-operations-guide.md`（および `docs/en/` の対応節）の capture 節に、
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `realtimeSnippet.trim() === ''` と `lineCount` で見る。あわせて wait 節に、完了判定が
   `sessionStatus === 'ready'`（未分類フレームでない）またはセッション消滅であって
   **ターンの成立は見ていない**ことを明記した（`src/cli/commands/wait.ts:356`）
+
+### Fixed
+
+- **ci(e2e): Playwright インストールのハングを実測に基づき apt 側で塞ぎ、ブラウザは解決後バージョンでキャッシュする** (#1844): `test-e2e` の `npx playwright install --with-deps chromium` が繰り返しハングしていた（2026-08-19 だけで 88 分 / 3h55m / 3h48m、その後 #1830 のステップ上限 20 分に当たって run `32248871561` が赤）。Issue は `~/.cache/ms-playwright` のキャッシュを最優先の主因対策として挙げていたが、当日の E2E ジョブ 6 本のステップログを `Downloading Chrome for Testing` 行で二分して実測すると、**ブラウザのダウンロードは全サンプルで 0.09〜0.11 分と一定**で、バラつきもタイムアウトも 100% apt 側だった（apt フェーズ 0.20m / 3.14m / 7.63m / 9.22m / 10.44m / タイムアウト）。ubuntu-24.04 ランナーでは Chromium の実ライブラリは全て導入済みで、`--with-deps` が実際に取得するのは**フォント 9 パッケージ 21.1 MB だけ**（azure.archive.ubuntu.com が 14〜21 kB/s に落ちるのが原因）。`tests/e2e` に画素比較（`toHaveScreenshot` / `toMatchSnapshot`）は 1 件も無く、スクリーンショットは失敗時の調査用のみなので、このフォントが合否を変えることはない。よって 1 ステップを分割し、(1) システム依存 `playwright install-deps` は 6 分予算の `continue-on-error`（超過時は `::warning` を出して続行、本当に必要なライブラリが欠ければ `Run E2E tests` が Playwright 自身のエラーで落ちる）、(2) ブラウザは `actions/cache` で `~/.cache/ms-playwright` をキャッシュし、キーは `package.json` の `^1.56.1` ではなく**解決後の実バージョン**（`playwright-core/package.json` の `version`）に紐付け、古いブラウザでのヒットを避けるため `restore-keys` は付けない。キャッシュヒット時はダウンロードステップ自体をスキップする
 
 ## [0.25.0] - 2026-08-19
 


### PR DESCRIPTION
## 概要

`test-e2e` の `npx playwright install --with-deps chromium` が繰り返しハングしていた（2026-08-19 だけで 88 分 / 3h55m / 3h48m、その後 #1830 の 20 分ステップ上限に当たって run `32248871561` が赤）。

Closes #1844

## 実測 — Issue 推奨 1 からの逸脱と、その根拠

Issue は「`~/.cache/ms-playwright` を `actions/cache` する」を**最優先の主因対策**とし、推奨 2 で「**apt 側が主因なら 1 は効かない**。切り分けの根拠を書け」と条件を付けていた。切り分けた結果 **主因は apt 側**だったので、そちらを主対策に据えた（キャッシュは受入条件でもあり、ほぼ無料なので併せて入れる）。

測定方法: 2026-08-19 の E2E ジョブ 6 本について `gh run view --repo Kewton/CommandMate --job <id> --log` を取り、ステップログを `Downloading Chrome for Testing …` 行で二分した（この行より前が apt、後が CDN）。

| job | step total | apt phase | browser (CDN) |
|---|---|---|---|
| 96068691996 | 0.31m | 0.20m | 0.11m |
| 96109347270 | 3.26m | 3.14m | 0.11m |
| 96118759977 | 7.71m | 7.63m | 0.09m |
| 96062812368 | 9.34m | 9.22m | 0.11m |
| 95947185874 | 10.54m | 10.44m | 0.10m |
| 96055267143 | 20.21m | **timed out** | never began |

**ブラウザのダウンロードは全サンプルで 0.09〜0.11 分と一定**で、バイモーダルではない。バラつきもタイムアウトも 100% apt 側。20 分で落ちた `96055267143` では `azure.archive.ubuntu.com` からのフォント取得が 14〜21 kB/s まで落ちており（`fonts-ipafont-gothic` 3513 kB / 169s、`fonts-freefont-ttf` 5641 kB / 397s、`fonts-wqy-zenhei` の途中で kill）、ブラウザのダウンロードは開始すらしていない。つまり**ブラウザキャッシュ単体で得られるのは約 6 秒**であって、ハングは 1 件も直らない。

さらに ubuntu-24.04 ランナーでは Chromium の実ライブラリ（`libnss3` / `libgbm1` / `libatk*` / `libcups2t64` / `xvfb` …）が全て "already the newest version" で、`--with-deps` が実際に取得するのは**フォント 9 パッケージ 21.1 MB のみ**。`tests/` に `toHaveScreenshot` / `toMatchSnapshot` は **0 件**（`playwright.config.ts:128` の screenshot は `only-on-failure` の調査用のみ）なので、このフォント群が合否を変えることはない。依存ステップに諦めさせてよい根拠がこれ。

## 変更

単一ステップを 5 つに分割:

1. **`Resolve the installed Playwright version`** — `playwright-core/package.json` の `version` を読む。`package.json` の `^1.56.1` ではなく**解決後の実バージョン（現在 1.58.2）**なので、版が上がれば必ず miss する。空・非 semver なら `::error::` を出して exit 1。
2. **`Cache Playwright browsers`** — `actions/cache@v4` で `~/.cache/ms-playwright`。キーは上で解決した実バージョン。**`restore-keys` は付けない**（部分キーで前版のブラウザにヒットするのが、まさに避けたい事故）。
3. **`Install Playwright system dependencies`** — `playwright install-deps chromium` を `timeout-minutes: 6` + `continue-on-error: true`。6 は median 0.20m の約 30 倍で 3.14m サンプルも吸収する。7.6m / 9.2m / 10.4m は意図的に捨てる（フォントのみ）。**リトライは入れない**（観測された病態は stall ではなく数分続く低帯域なので再試行は同じ遅いミラーに再入する。途中 kill は dpkg lock を残して 2 回目をより分かりにくい失敗に変える）。
4. **`Note degraded system dependencies`** — 3 が成功しなかった場合に `::warning`（`continue-on-error` の橙チェックは誰も読まないため）。実ライブラリが本当に欠けた場合は `Run E2E tests` が Playwright 自身の "Host system is missing dependencies" で落ちるので、**壊れたまま緑にはならない**。
5. **`Install Playwright browser`** — `playwright install chromium`（`--with-deps` を外した）。cache hit なら丸ごと skip、miss なら従来と同じダウンロード。`timeout-minutes: 10`。

## 検証

`commandmate wait --verify` の実 exit code で裁定済み（**exit 0 / RESULT passed**）: work-evidence / scope / lint / typecheck / unit すべて PASS（unit 485.3s）。

レビュア側で独立に再確認した load-bearing な主張:

- `grep -ra "toHaveScreenshot\|toMatchSnapshot" tests/` → **0 件**
- `node -p "require('playwright-core/package.json').version"` → **1.58.2**（宣言は `^1.56.1`。範囲キーでは版が上がっても hit してしまうことの実証）
- `yaml.safe_load('.github/workflows/ci-pr.yml')` → OK

導入後の実測（median / max）は本 PR 自身の CI run で取れる。

## 受入条件

- [x] cache hit 時にダウンロードを行わない（`if: steps.playwright-cache.outputs.cache-hit != 'true'` で step ごと skip）
- [x] cache miss 時も従来どおり成立する（`playwright install chromium` は冪等）
- [x] キャッシュキーが解決後の実バージョンに紐付いている（版が上がると miss）
- [x] #1830 の `timeout-minutes` と矛盾しない（step 上限を 6 + 10 に再配分し、job の 30m 上限内に収まることを算出）

## スコープ外

`timeout-minutes` の設定そのもの（#1830 で完了済み）、E2E テスト自体の内容・所要時間の改善。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ya52Env4iXYW8zWeWJ2CH