### PR TITLE
ci(publish): npm publish を self-hosted runner で走らせる

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,19 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    # [self-hosted] Same expression every job in ci-pr.yml uses. This workflow is
+    # only ever triggered by `release: [published]`, so the pull-request arm never
+    # fires here — it is kept identical so the two files cannot drift into
+    # different rules for "which runner".
+    #
+    # RISK, STATED. npm Trusted Publishers (OIDC) and `--provenance` were measured
+    # on GitHub-hosted runners only; whether npm accepts a token minted on a
+    # self-hosted runner has NOT been measured here. If it refuses, the job fails
+    # BEFORE `npm publish` writes anything — nothing reaches the registry and the
+    # published GitHub Release stays valid — and `gh run rerun --failed` retries
+    # after a one-line revert of this block. The preflight below makes the
+    # prerequisites fail by name instead of inside npm.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'self-hosted' || 'ubuntu-latest' }}
     environment: npm-publish  # Required: must match npm Trusted Publisher settings
     # [Issue #1830] This job publishes to npm, so a hang here leaves the release
     # state ambiguous — did the version go out or not? — on top of squatting a
@@ -38,6 +50,23 @@ jobs:
     # release. The measurement wins.
     timeout-minutes: 30
     steps:
+      # [self-hosted] Toolchain and OIDC preflight, deliberately the FIRST step of
+      # the only job that can publish. On a GitHub-hosted image node/npm/git are
+      # guaranteed and ACTIONS_ID_TOKEN_REQUEST_URL is present whenever
+      # `id-token: write` is set; on a self-hosted runner the image decides. Fail
+      # here, by name, rather than inside `npm publish --provenance`.
+      - name: Preflight the toolchain and the OIDC token endpoint
+        run: |
+          for tool in node npm git; do
+            command -v "$tool" >/dev/null || { echo "::error::missing required tool: $tool"; exit 1; }
+          done
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::ACTIONS_ID_TOKEN_REQUEST_URL is unset — OIDC is unavailable, so npm Trusted Publishers and --provenance cannot work"
+            exit 1
+          fi
+          node -v && npm -v
+          echo "runner: ${RUNNER_NAME:-unknown} (${RUNNER_OS:-?}/${RUNNER_ARCH:-?})"
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## 概要

`ci-pr.yml` の 10 ジョブ（#1863 / #1865）と skills の 4 ジョブ（[commandmate-skills#226](https://github.com/Kewton/commandmate-skills/pull/226)）に続き、残っていた `publish.yml` も self-hosted へ移す。

`runs-on` の式は `ci-pr.yml` と**同一**で、この workflow は `release: [published]` でしか起動しないため pull-request の腕は発火しない —— 2 つの file が「どの runner か」について別の規則へ分岐しないよう、あえて同じ式にしてある。

## 実測していないことを明記する

**npm Trusted Publishers（OIDC）と `--provenance` は GitHub ホストの runner でしか実測していない。** self-hosted で minted された token を npm が受けるかは未確認である。

拒否された場合の代償は限定的:

- **npm には何も書かれない**（preflight も npm 側の拒否も `npm publish` の前に起きる）
- 公開済みの GitHub Release はそのまま有効
- 本ブロックを 1 行戻して `gh run rerun --failed` で復旧できる

## preflight を足した

publish は**世界を変えられる唯一のジョブ**なので、その**最初のステップ**として検査する:

- `node` / `npm` / `git` の存在
- **`ACTIONS_ID_TOKEN_REQUEST_URL`**（OIDC が使えるか）—— GitHub ホストでは `id-token: write` があれば必ず在る変数で、self-hosted ではイメージ次第
- runner 名 / OS / ARCH をログに出す（どこで走ったかが後から分かる）

無いときに `npm publish --provenance` の中で落ちると原因が読めない。

## 適用範囲

これで CommandMate の workflow は次の状態になる。

| workflow | runner |
|---|---|
| `ci-pr.yml` | self-hosted 10 / 11（`legacy-tmux-readmode` は container ジョブで runner イメージに docker が無い） |
| `publish.yml` | **self-hosted**（本 PR） |
| `pages.yml` / `catalog-drift.yml` | `ubuntu-latest` のまま（website 変更時のみ / 週 1 回。CI 時間の得が無い） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ya52Env4iXYW8zWeWJ2CH