### PR TITLE
ci(publish): publish ジョブを GitHub ホストランナーへ戻す

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,19 +15,29 @@ permissions:
 
 jobs:
   publish:
-    # [self-hosted] Same expression every job in ci-pr.yml uses. This workflow is
-    # only ever triggered by `release: [published]`, so the pull-request arm never
-    # fires here — it is kept identical so the two files cannot drift into
-    # different rules for "which runner".
+    # GitHub-hosted, deliberately. #1867 moved this job to `self-hosted` and the
+    # v0.26.1 release is the first publish that actually ran there: it failed at
+    # the preflight with `missing required tool: npm`.
     #
-    # RISK, STATED. npm Trusted Publishers (OIDC) and `--provenance` were measured
-    # on GitHub-hosted runners only; whether npm accepts a token minted on a
-    # self-hosted runner has NOT been measured here. If it refuses, the job fails
-    # BEFORE `npm publish` writes anything — nothing reaches the registry and the
-    # published GitHub Release stays valid — and `gh run rerun --failed` retries
-    # after a one-line revert of this block. The preflight below makes the
-    # prerequisites fail by name instead of inside npm.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'self-hosted' || 'ubuntu-latest' }}
+    # The cause is step order, not the runner. The preflight is the FIRST step and
+    # `actions/setup-node@v4` is the second, so it checks for a tool the next step
+    # installs. A GitHub-hosted image ships node+npm, so the ordering never
+    # mattered there; the ephemeral self-hosted image ships node (via pnpm) but
+    # NOT npm (measured 2026-08-21: `command -v npm` is empty in
+    # `my-ephemeral-runner:latest`). ci-pr.yml survives on self-hosted because
+    # every one of its jobs runs setup-node before it needs a toolchain.
+    #
+    # This is the one-line revert the previous comment prescribed for exactly this
+    # situation. Reverting rather than reordering also sidesteps the risk that
+    # block stated and never measured: whether npm Trusted Publishers accepts an
+    # OIDC token minted on a self-hosted runner. Re-attempting self-hosted needs
+    # both fixes and a way to measure OIDC there — tracked separately, not folded
+    # into a release recovery.
+    #
+    # The preflight below stays first. It did its job: the run died by name before
+    # `npm publish` wrote anything, so nothing reached the registry and 0.26.1 was
+    # still publishable.
+    runs-on: ubuntu-latest
     environment: npm-publish  # Required: must match npm Trusted Publisher settings
     # [Issue #1830] This job publishes to npm, so a hang here leaves the release
     # state ambiguous — did the version go out or not? — on top of squatting a


### PR DESCRIPTION
## 何が起きたか

v0.26.1 のリリースで **npm publish が失敗**した（[run 32451947620](https://github.com/Kewton/CommandMate/actions/runs/32451947620)）。

```
##[error]missing required tool: npm
```

#1867 が publish ジョブを `self-hosted` に移し、**v0.26.1 がそこで実際に走った最初の publish** だった。

## 原因：ランナーではなくステップ順

```
publish.yml:58  Preflight（node/npm/git を検査）  ← ここで落ちた
publish.yml:72  actions/setup-node@v4            ← npm はここで入る
```

preflight が **次のステップが入れるツールを探している**。GitHub ホストのイメージは node+npm を同梱するので順序が問題にならなかっただけ。ephemeral な self-hosted イメージは **node はある（pnpm 経由）が npm が無い**（2026-08-21 実測）:

```
$ docker run --rm --entrypoint sh my-ephemeral-runner:latest -c 'command -v node; command -v npm'
/home/ubuntu/.local/share/pnpm/bin/node
（npm: 出力なし）
```

`ci-pr.yml` が self-hosted で通っているのは、**全ジョブが setup-node をツール使用前に実行している**から。

## 対処：1 行の revert

`runs-on` を `ubuntu-latest` に戻す。これは**元のコメント自身がこの状況向けに明記していた回避策**である。

順序を直すのではなく revert を選んだ理由: そのコメントが述べたまま未測定だったリスク — **npm Trusted Publishers が self-hosted で mint した OIDC トークンを受理するか** — を同時に回避できる。self-hosted への再挑戦には順序修正と OIDC の実測の両方が要り、**リリース復旧に混ぜるべきではない**。

## 被害なし

preflight は意図どおり機能し、`npm publish` が何かを書く**前に**名前で落ちた。

| 項目 | 状態 |
|---|---|
| npm の公開版 | 0.26.0（**0.26.1 は未公開＝版は焼けていない**） |
| タグ `v0.26.1` | 有効（`dbfacf93`） |
| GitHub Release | 公開済み・有効 |

修正が main に載り次第、Release を作り直して publish を再発火する。

## 残課題

self-hosted 化（#1867）のやり直しは別 Issue とする（preflight の順序修正 ＋ self-hosted での OIDC 実測）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xuV4GwtTrTh5BpSH2Z6CY