### PR TITLE
fix(api): capabilities route から SERVER_CAPABILITIES を出し、Next のビルドを直す (#1925)

### DIFF
--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -25,29 +25,14 @@
 
 import { NextResponse } from 'next/server';
 import { getServerVersion } from '@/lib/version-checker';
+import {
+  SERVER_CAPABILITIES,
+  type CapabilitiesResponse,
+} from '@/config/server-capabilities';
 
 // The version is read from the runtime package.json, so prerendering it at
 // build time would freeze the answer of a server that later gets upgraded.
 export const dynamic = 'force-dynamic';
-
-/**
- * Capability tokens this build declares.
- *
- * A token is a promise about a wire contract, not about an implementation, and
- * it is never removed once shipped — a client that keys off it must keep
- * working against every later server. Add one when a client needs to know
- * whether an endpoint exists before calling it.
- */
-export const SERVER_CAPABILITIES = [
-  /** GET /api/worktrees/:id/resolve-target answers with {cliToolId, instanceId, resolvedBy}. */
-  'resolve-session-target',
-] as const;
-
-/** Exact response shape. Pinned key-for-key by tests/unit/api/capabilities.test.ts. */
-export interface CapabilitiesResponse {
-  serverVersion: string;
-  capabilities: string[];
-}
 
 export async function GET(): Promise<NextResponse> {
   const body: CapabilitiesResponse = {

--- a/src/config/server-capabilities.ts
+++ b/src/config/server-capabilities.ts
@@ -1,0 +1,24 @@
+/**
+ * Capability tokens the running server declares (Issue #1925, design §10.6 / DR4-008).
+ *
+ * Lives outside `src/app/api/**` because an App Router `route.ts` may only export
+ * the fields Next.js knows about (`GET`, `dynamic`, `revalidate`, …). Exporting
+ * anything else — even a plain `const` the tests read — fails the build with
+ * `"X" is not a valid Route export field`, and neither `tsc --noEmit` nor the
+ * unit suite sees it because the check lives in Next's own build step (Issue #1943).
+ *
+ * A token is a promise about a wire contract, not about an implementation, and it
+ * is never removed once shipped — a client that keys off it must keep working
+ * against every later server. Add one when a client needs to know whether an
+ * endpoint exists before calling it.
+ */
+export const SERVER_CAPABILITIES = [
+  /** GET /api/worktrees/:id/resolve-target answers with {cliToolId, instanceId, resolvedBy}. */
+  'resolve-session-target',
+] as const;
+
+/** Exact response shape of GET /api/capabilities. Pinned key-for-key by tests. */
+export interface CapabilitiesResponse {
+  serverVersion: string;
+  capabilities: string[];
+}

--- a/tests/unit/api/capabilities.test.ts
+++ b/tests/unit/api/capabilities.test.ts
@@ -19,7 +19,8 @@ vi.mock('@/lib/version-checker', () => ({
   getServerVersion: vi.fn().mockReturnValue('9.9.9'),
 }));
 
-import { GET, SERVER_CAPABILITIES, dynamic } from '@/app/api/capabilities/route';
+import { GET, dynamic } from '@/app/api/capabilities/route';
+import { SERVER_CAPABILITIES } from '@/config/server-capabilities';
 import { AUTH_EXCLUDED_PATHS } from '@/config/auth-config';
 import { getServerVersion } from '@/lib/version-checker';
 


### PR DESCRIPTION
## 事象

PR #1943（#1925）のマージで develop の `npm run build` が壊れました。

```
Type error: Route "src/app/api/capabilities/route.ts" does not match the required types of a Next.js Route.
  "SERVER_CAPABILITIES" is not a valid Route export field.
```

App Router の `route.ts` は Next が知っている field（`GET` / `dynamic` / `revalidate` …）しか export できません。

## 修正

`SERVER_CAPABILITIES` と `CapabilitiesResponse` を **`src/config/server-capabilities.ts`** へ移し、route とテストはそこから import します。**API の応答は 1 バイトも変わりません。**

検証: `npx tsc --noEmit` exit 0 ／ `capabilities.test.ts` 8/8 緑 ／ **`npm run build` exit 0**（linked worktree で実行。稼働サーバの primary checkout では実行していません）。

## なぜ着地まで気づかなかったか

- `.commandmate/verify.yaml` に **`build` ゲートが無い**（#1882 が「稼働サーバの足元で build すると配信中の成果物を壊す」ため意図的に除外）。
- `npx tsc --noEmit` はこの制約を見ない。Next の route 型チェックは build ステップの中にある。
- **CI の Build ジョブは正しく落ちていた**（PR #1943 は 10 pass / 1 fail）。オーケストレーターが fail を確認せずマージしたのが直接原因です。

再発防止（`build` ゲートの追加可否と、追加した場合の CPU 競合トレードオフ）は #1946 で検討します。

Refs #1925, #1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rRBB2m6P8d1b4giKotyfS