### PR TITLE
docs(tasks): 2026-08-22〜23 のオーケストレーション実行契約 22 本を追跡に加える

### DIFF
--- a/.commandmate/tasks/issue-1927.yaml
+++ b/.commandmate/tasks/issue-1927.yaml
@@ -1,0 +1,139 @@
+version: 1
+title: "Issue #1927: 検出をツール別モジュールへ分割し no_recent_output の ready を廃止する（Phase 3 の土台）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1927 を実装してください。**Epic #1921 Phase 3 の土台**で、
+  #1928 / #1929 はこの上に乗ります。Epic 全体で 2 番目に重い変更です。
+
+  ## Issue 本文の「実装内容」節に誤りが 1 件あります（引き継ぎ節が正）
+
+  **`StatusVerdict { tool, verifiedAgainst, detect(frame): StatusVerdict, … }` の `StatusVerdict` という型は
+  実在しません。** develop `ccca5005` で実測（`grep -rn '\bStatusVerdict\b' src/` は 0 件）。実在するのは:
+
+  | 型 | 所在 |
+  |---|---|
+  | `StatusDetectionResult` | `src/lib/detection/status-detector.ts` |
+  | `ScraperVerdict` / `MergedStatusVerdict` | `src/lib/session/current-output-builder.ts` |
+  | `StructuredStatusVerdict` | `src/lib/session/agent-event-state.ts` |
+
+  `evidence` は `ScraperVerdict` に載っています（#1924 で着地済み）。`ToolStatusDetector` の戻り値型を
+  何にするかは**あなたが決めてください**。既存型を使うのか新設するのか、決めた理由を commit message に書くこと。
+
+  ## 順序制約（これを逆にするとガードが無音で外れます・DR2-003）
+
+  **必ずこの順で行ってください:**
+
+  1. **先に** `mergeStructuredStatus`（`src/lib/session/current-output-builder.ts`）の
+     「構造化 ready × scraper running」上書き分岐を **「scraper が `evidence:'positive'` のときだけ
+     `isUnclassifiedActive` を下ろす」**に改訂し、**#1708 ガードの pin を merged レベルに置く**。
+  2. **その後で** `no_recent_output` 由来の `ready` を廃止する（`running` ＋ `evidence:'none'`）。
+
+  逆順にすると、`no_recent_output` が `ready` を出さなくなった瞬間に上書き分岐が発火しなくなり、
+  **#1708 のガードが赤くならないまま無効化されます**。1 の完了を（変異注入で）確認してから 2 に進むこと。
+
+  ## 守ること
+
+  - **`input_prompt × evidence:'none'` の wire 値は `ready` のまま**（`running` に倒さない、DR3-002）。
+    `running` にすると `isProcessing` 経由で `ls` / sidebar / トースト / demo-video の probe が一斉に変わります。
+  - **公開関数のシグネチャは不変**（`detectSessionStatus` / `detectPrompt` / `getCliToolPatterns`）。
+  - **`STATUS_REASON.UNKNOWN_FRAME = 'unknown_frame'` の定義と使用の両方を本 Issue で入れる。**
+    `STATUS_REASON` の実体は `src/lib/detection/status-detector.ts:100`（実測）。#1924 の scope 外だったため未着地です。
+  - **ツール単位のキルスイッチ**（env か settings で、当該ツールの `input_prompt` evidence 判定を旧挙動へ戻す）と、
+    **観測条件**（倒す前後で `unclassified_frames` の記録件数が有意に増えない。倒す前に観測だけで走らせる）。
+    キルスイッチで旧挙動へ戻せることをテストで固定すること。
+  - fixture は**実 TUI キャプチャのみ**（claude / copilot は 200x1000、opencode は 80x200）。
+    各ツールに「**処理中語彙を 1 語変えたフレーム → evidence none**」の**変異ケースを必須**にすること
+    （緑の非空虚性はこれでしか証明できません）。
+
+  ## copilot の完了証拠について（#1979 で確定済み。方針書は更新済みです）
+
+  方針書の初版にあった「copilot は `●` 応答行の直後に空の composer」は **1.0.80 の実測と食い違い、
+  既に撤回されています**（#1979 / PR #1980 で方針書を訂正済み）。
+
+  - composer `❯` は 200x1000 ペインの **999 行目に固定**で、応答本文の**約 930〜970 行下**
+  - **composer は生成中も同じ形で描かれる**ので、「空の composer」は完了証拠になりません
+
+  copilot の肯定的完了証拠は**ペイン最下行のステータスバー**で、`readCopilotStatusBar()` /
+  `COPILOT_IDLE_STATUS_PATTERN` / `COPILOT_WORKING_STATUS_PATTERN` として **#1885 で着地済み**です
+  （fixture: `tests/unit/lib/detection/fixtures/copilot-live-1885/`）。**窓で照合してはいけません** —
+  `status-vocabulary-in-response.txt` は copilot 自身が ` ● Working esc interrupt` を本文として印字した
+  実フレームで、窓照合だと完了済みセッションが恒久的に `running` に貼りつきます。
+
+  ## この Issue で**やらないこと**
+
+  - **`docs/design/multi-agent-state-architecture.md` を編集しない。** Phase 2 の実測による訂正 3 件は
+    **#1979 で着地済み**（develop `561d6706`）。方針書は現在正しい状態です。scope 外です。
+  - **`getStatusCaptureLines` を `ICLITool.captureSpec()` へ寄せない。** Issue 本文は「P4-d と調整」と
+    書いていますが、`ICLITool` の拡張は **#1933（Phase 4）**の作業で、いま手を入れると衝突します。
+    寄せずに現状のままにし、#1933 への申し送りを commit message に書いてください。
+  - **`detectDialog` の中身と Auto-Yes の接続は #1928 の作業です。** `ToolStatusDetector` に
+    `detectDialog` の**口（インタフェース）**を用意するところまでが本 Issue で、ツール別の判定規則と
+    `response-checker.ts` への接続は入れないでください。入れると #1928 が空になります。
+
+  ## 受入条件
+
+  - `detectSessionStatus` / `detectPrompt` のシグネチャ不変、既存テスト緑
+    （期待値の更新は `no_recent_output` 関連に限ること。それ以外のテストを書き換えたら、
+    1 件ずつ「なぜ変える必要があったか」を commit message に書く）。
+  - **#1708 ガードの merged レベル pin が緑、かつ上書き分岐を元に戻すと赤**（変異注入）。
+  - キルスイッチで旧挙動に戻せることがテストで固定されている。
+  - 各ツールの fixture に肯定ケースと変異ケースが揃っている。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` / `npm run build` が exit 0。
+
+  ## 触ってよい範囲
+
+  `src/lib/detection/**`・`src/lib/session/current-output-builder.ts`・`src/lib/session/worktree-status-helper.ts`・
+  `src/config/**`・`tests/unit/detection/**`・`tests/unit/lib/**`・`tests/unit/session/**`・
+  `tests/unit/guards/**`・`tests/unit/skills/orchestrate-monitor/fixtures/**`・`tests/fixtures/**`。
+
+  **次の 5 ファイルは触らないでください**（別 PR #1986 が同時に編集中）:
+  `tests/unit/lib/tmux-capture-invalidation.test.ts` / `tests/unit/components/app-version-display.test.tsx` /
+  `tests/unit/api/hooks-claude-done-delegation.test.ts` /
+  `tests/unit/config/eslint-i18n-module-scope-literal.test.ts` / `tests/unit/ws-server-cleanup.test.ts`。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 代わりに
+    `dev-reports/changelog/issue-1927.md`（`## [Unreleased]` にそのまま貼れる 1 エントリ。1 行目に
+    どの節へ入るかをコメント）と `dev-reports/module-reference/issue-1927.md`（表に足す注記）を書くこと。
+    **既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で実在を確認してから**書くこと。
+  - **この契約の方針は「推奨」。** 別解が正しいと判断したら採ってよいが、**逸脱と理由を commit message に明記**すること。
+  - **Issue 本文をコードで裏取りすること。** 食い違ったら**実測を正**とし、commit message に書く。
+    この Issue は私が書いており、過去のランで自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 帰属の判断には `commandmate verify show <id>` で全文を見ること。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍かかる**（62s ↔ 560s）。
+    `gate-runner.ts:414` が `CI:'true'` を渡し `fileParallelism:false` になるためで、異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと**（vitest の遅延 transform で偽の赤が出る）。
+  - **別ワークツリーと同時にフル `npm run test:unit` を回さないこと**（#1985。30s サブプロセスガードが
+    その条件では小さく、無関係な 44 件が落ちます）。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+
+  ## 実 tmux を触る検証の追加ルール（厳守）
+
+  - **必ず `tmux -L <専用socket>` で行う。** `-L` / `-S` は `$TMUX` より優先されます。フラグ無しの `tmux` は
+    **ユーザーの本番サーバ**に届きます。
+  - **`kill-server` を `-L` 無しで書かない。** 後始末は `kill-session -t '=<name>:'`（完全一致）で。
+  - **`TMUX_TMPDIR` を隔離手段に使わない**（`$TMUX` があると無視される）。
+  - **`bind-key` / `unbind-key` / `set-option -g` を既定サーバへ撃たない**（サーバグローバル）。
+scope:
+  allow:
+    - "src/lib/detection/**"
+    - "src/lib/session/current-output-builder.ts"
+    - "src/lib/session/worktree-status-helper.ts"
+    - "src/config/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/lib/**"
+    - "tests/unit/session/**"
+    - "tests/unit/guards/**"
+    - "tests/unit/skills/orchestrate-monitor/fixtures/**"
+    - "tests/fixtures/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1927b.yaml
+++ b/.commandmate/tasks/issue-1927b.yaml
@@ -1,0 +1,60 @@
+version: 1
+title: "Issue #1927 再裁定: tests/unit 直下の detection-*.test.ts 3 本を scope に入れ直す（確認のみ）"
+goal: |
+  **追加の実装は不要です。** commit `9df208a9` の内容・判断・実測をすべて受領しました。
+
+  - `ToolStatusVerdict` を新設した判断を承認します。既存 3 型を却下した理由——特に
+    「`ScraperVerdict` の `thinking` は `GENERATING_REASONS` からの派生で `current-output-builder` の
+    関心。検出層に持たせると**同じ事実の 2 つ目の生産者ができる**」——は、このリポジトリが #1882 以来
+    守っている軸そのものです。
+  - `mergeStructuredStatus` の改訂を先、`no_recent_output` の `ready` 廃止を後、という順序も守られています。
+  - `detectDialog` を optional な口として用意し `run-detection.ts` で `?? (() => null)` に倒したのは、
+    #1928 の余地を正しく残した形です。
+
+  ## この送信の目的は scope の取り直しだけです
+
+  **私の `scope.allow` が 3 ファイル分足りませんでした。** 契約に `tests/unit/detection/**` と書きましたが、
+  次の 3 本は `tests/unit/` **直下**にあり（`detection/` ディレクトリの中ではない）、glob が一致しませんでした:
+
+      tests/unit/detection-copilot-generating-1885.test.ts
+      tests/unit/detection-help-overlay-1497.test.ts
+      tests/unit/detection-opencode-interrupt-1894.test.ts
+
+  いずれも本 Issue が当然触るべきファイルで、**あなたの落ち度ではありません**。今回 scope に追加しました。
+
+  ## やること
+
+  - `git status` を見て、`.commandmate/tasks/` 配下以外に未コミットの変更が無いことを確認する。
+  - **ファイルを 1 つも変更しない。** 新しい commit も作らない。
+  - 最終行に `VERIFY_ONLY_ACK` とだけ出力して終了する。
+
+  未コミットの変更が残っていた場合だけ `--amend` で畳んでから `VERIFY_ONLY_ACK` を出力してください。
+scope:
+  allow:
+    - "src/lib/detection/**"
+    - "src/lib/session/current-output-builder.ts"
+    - "src/lib/session/worktree-status-helper.ts"
+    - "src/config/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/detection-copilot-generating-1885.test.ts"
+    - "tests/unit/detection-help-overlay-1497.test.ts"
+    - "tests/unit/detection-opencode-interrupt-1894.test.ts"
+    - "tests/unit/lib/**"
+    - "tests/unit/session/**"
+    - "tests/unit/guards/**"
+    - "tests/unit/skills/orchestrate-monitor/fixtures/**"
+    - "tests/fixtures/**"
+  deny: []
+verify:
+  # [オーケストレーターの意図的な絞り込み] unit を外している。
+  # 直前の run 375 で unit は exit 0 / 557.1s で通っており、対象ツリーは 1 バイトも変わっていない。
+  # 落ちたのは scope ゲートのみ（私の glob 漏れ 3 ファイル）。もう一度 10 分回しても新しい情報が出ない。
+  # unit の最終裁定は PR の CI で行う。
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1927c.yaml
+++ b/.commandmate/tasks/issue-1927c.yaml
@@ -1,0 +1,85 @@
+version: 1
+title: "Issue #1927 追補: PR #1987 の Integration Tests 赤（current-output-structured-status-1723）を裁定して直す"
+goal: |
+  **PR #1987 の CI で Integration Tests が落ちました。** これを直してください。
+
+      FAIL tests/integration/current-output-structured-status-1723.test.ts
+        > Issue #1723: a posted Stop reaches current-output > is running before the event a…
+        AssertionError: expected true to be false
+        > Issue #1723: the benefit reaches `commandmate wait` unchanged > completes on the …
+      Test Files  1 failed | 81 passed (82)
+
+  ## これは想定内かもしれませんが、断定せずに裁定してください
+
+  あなたは commit `9df208a9` の message で、**unit 側**の
+  `tests/unit/session/current-output-structured-status-1723.test.ts` と
+  `status-evidence-1924.test.ts` の「構造化 stop が busy pane の証拠を上げる」ケースを
+  **DR2-003 の意図した変更**として更新したと書いています。
+
+  **`tests/integration/` に同名の双子があり、そちらは更新されていません。** まず次を裁定してください:
+
+  - (a) **unit 側と同じ「意図した変更」** — ならば integration 側も同じ理由で期待値を更新する。
+    ただし **integration 版が unit 版と何を違えて検証しているか**を読んでから決めること
+    （実 route と実 DB を通す層なので、unit では見えない前提を持っている可能性があります）。
+  - (b) **本物の回帰** — DR2-003 の改訂が意図しない場面まで発火している。ならば実装を直す。
+
+  **どちらだったかと根拠を commit message に書いてください。** 「unit を直したから integration も」
+  という理由だけで期待値を書き換えるのは不合格とみなします。
+
+  ## なぜ裁定をすり抜けたか（あなたの落ち度ではありません）
+
+  `wait --verify` の宣言ゲートに **integration が含まれていません**（#1946 で実測・記録済み。
+  `verify.yaml` が見ているのは CI 12 ジョブ中 7 本で、integration / build / e2e / Security Audit /
+  Legacy tmux は対象外）。あなたはフル `npm run test:unit` を回して緑を確認しており、
+  **見えるはずのない層**でした。
+
+  今回の scope に `tests/integration/**` を追加しました。
+
+  ## やること
+
+  - 上記を裁定して直す。
+  - **`npm run test:integration` を実際に回して 82 files 緑を確認**すること
+    （`wait --verify` は integration を見ないので、あなたが回さないと誰も見ません）。
+  - 変異注入: 直した箇所が空振りでないことを示す。(a) なら「DR2-003 の連言を外すと
+    integration 側も赤になる」ことを確認してください。
+  - フル `npm run test:unit` が引き続き exit 0 であること。
+  - 断片（`dev-reports/changelog/issue-1927.md` / `dev-reports/module-reference/issue-1927.md`）に
+    今回の裁定を**追記**してください。
+
+  commit は既存 commit への `--amend` でも 2 本目でも構いません（PR は squash マージします）。
+  PR は作らない・push しない（私が行います）。
+
+  ## 触ってよい範囲
+
+  前回の scope に加えて `tests/integration/**`。
+
+  **`src/lib/detection/tools/*/prompt.ts` と `tools/registry.ts` の `VERIFIED_AGAINST` は
+  触らないでください** — #1928 / #1929 のワーカーが**あなたのブランチの上**で同時に作業しています。
+
+  作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "src/lib/detection/**"
+    - "src/lib/session/current-output-builder.ts"
+    - "src/lib/session/worktree-status-helper.ts"
+    - "src/config/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/detection-copilot-generating-1885.test.ts"
+    - "tests/unit/detection-help-overlay-1497.test.ts"
+    - "tests/unit/detection-opencode-interrupt-1894.test.ts"
+    - "tests/unit/lib/**"
+    - "tests/unit/session/**"
+    - "tests/unit/guards/**"
+    - "tests/unit/skills/orchestrate-monitor/fixtures/**"
+    - "tests/fixtures/**"
+    - "tests/integration/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1928.yaml
+++ b/.commandmate/tasks/issue-1928.yaml
@@ -1,0 +1,147 @@
+version: 1
+title: "Issue #1928: ツール別の肯定確認 idle 規則と detectDialog、Auto-Yes をツール別判定に限定する"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1928 を実装してください。**#1927 が作った
+  `src/lib/detection/tools/<tool>/` の構造の上に載せる**作業です。
+
+  ## Issue 本文の「実装内容」節に誤りが 1 件あります（引き継ぎ節が正）
+
+  「例: copilot は `●` 応答行直後の空 composer かつステータスバーに `Working` 無し」は
+  **1.0.80 の実測と食い違い、既に撤回されています**（#1885 実測、#1979 / PR #1980 で方針書を訂正済み）。
+
+  - composer `❯` は 200x1000 ペインの **999 行目に固定**で、応答本文の**約 930〜970 行下**
+  - **composer は生成中も同じ形で描かれる**（両 running fixture が `COPILOT_PROMPT_PATTERN` に
+    当たり続けることを #1885 が assert 済み）
+
+  **copilot の完了証拠に composer は使えません。** 正解は **ペイン最下行のステータスバー**で、
+  `readCopilotStatusBar()` / `COPILOT_IDLE_STATUS_PATTERN` / `COPILOT_WORKING_STATUS_PATTERN` として
+  **#1885 で着地済み**です（実測で所在確認: `src/lib/detection/cli-patterns.ts` と
+  `src/lib/polling/response-checker.ts`）。**書き直さず再利用してください。**
+
+  fixture も既にあります: `tests/unit/lib/detection/fixtures/copilot-live-1885/`（実キャプチャ 4 件）。
+
+  **窓で照合してはいけません** — `status-vocabulary-in-response.txt` は copilot 自身が
+  ` ● Working esc interrupt` を**本文として印字した**実フレームで、窓照合だと完了済みセッションが
+  恒久的に `running` に貼りつきます。最下行から最初の非空行 1 行だけを読み、どちらでもなければ
+  `null`（＝証拠なし）を返す形です。
+
+  ## 既に存在するもの（新設しないこと）
+
+  - **`AutoYesSuppressionReason` の `'unclassified-frame'`** は #1924 で着地済み
+    （`src/cli/types/api-responses.ts:145`、`src/cli/commands/wait.ts:211` に説明文もある）。
+    本 Issue の仕事は**その値を実際に記録すること**であって、enum を足すことではありません。
+  - **`OPENCODE_RESPONSE_COMPLETE`**（唯一の実在する完了マーカー）は `src/lib/tui-accumulator.ts` /
+    `src/lib/response-cleaner.ts` にあります。
+
+  ## この Issue の中心（ここを外すと #1896 が再発します）
+
+  **Auto-Yes が撃ってよいのは、ツール別 `detectDialog` が肯定的に返したときだけ**です。
+  `detectPrompt` の汎用番号リスト推定だけでは撃たない。汎用推定が真で `detectDialog` が偽なら
+  `autoYes.lastSuppression.reason = 'unclassified-frame'` を記録して**撃たない**。
+
+  接続先は `src/lib/polling/response-checker.ts` の `detectPromptWithOptions` 経路です
+  （Auto-Yes は `sessionStatus` を経由しません。§4 D1 決定 4 / [[reference_autoyes_bypasses_status_detector]] の実測）。
+
+  **#1896 の実フレーム**（opencode の返答本文に番号リストが出る）で Auto-Yes が撃たないことを
+  pin してください。これが本 Issue の受入の要です。
+
+  ## ロールアウトはツール単位
+
+  規則と fixture（**肯定ケース＋変異ケース**）が揃ったツールから `input_prompt` 経路の evidence を
+  `'none'` に倒します。揃っていないツールは**現行どおり `evidence:'positive'` のまま**にしてください。
+  一斉に倒すと、通常の idle composer が `evidence:'none'` に落ちて `TerminalEscapeHatch` が常時開き、
+  `wait` の完了条件（`ready && !isUnclassifiedActive`）が成立しなくなります。
+
+  #1927 が入れた**ツール単位キルスイッチ**が効くことも確認してください。
+
+  ## この Issue で**やらないこと**
+
+  - **`docs/design/multi-agent-state-architecture.md` を編集しない。** Issue 本文は「方針書 §4 D1 の
+    copilot 例も本 Issue で更新すること」と書いていますが、**それは #1979 で完了済み**です
+    （develop `561d6706`）。二重に書き換えないでください。
+  - **`VERIFIED_AGAINST` / `DETECTOR_VERSION_PROBES` / `detector.staleness` は #1929 の作業**です。
+    `tools/<tool>/patterns.ts` には触らないでください。
+  - **#1927 が作った `index.ts` / `shared/` の構造を作り替えない。**
+
+  ## 受入条件
+
+  - ツールごとに**肯定 fixture ＋ 変異 fixture**（composer に 1 文字残す / 処理中語を 1 語足す → evidence none）。
+  - **返答本文の番号リスト（#1896 の実フレーム）で Auto-Yes が撃たない**ことを pin。
+  - 新たに `isUnclassifiedActive` が true になる fixture を**別表で明示列挙**して pin（等価性 pin はしない）。
+  - S19: `PromptPanel` / `ActivityPane` が新設フィールドを**テキストノードとしてのみ**描画。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` / `npm run build` が exit 0。
+
+  ## 触ってよい範囲（#1927 の実構成を確認して確定しました）
+
+  `src/lib/detection/tools/*/detect.ts`（**検出規則の本体のみ**）・`src/lib/detection/tools/*/prompt.ts`（新設）・
+  `src/lib/detection/tools/*/fixtures/**`・`src/lib/detection/tools/types.ts`・
+  `src/lib/polling/**`・`src/components/worktree/**`・
+  `tests/unit/detection/**`・`tests/unit/detection-*.test.ts`・`tests/unit/lib/**`・`tests/unit/polling/**`・
+  `tests/unit/components/**`・`tests/fixtures/**`。
+
+  **`src/lib/detection/tools/registry.ts` と、`detect.ts` 内の `VERIFIED_AGAINST` 定数ブロックは
+  触らないでください**（#1929 のワーカーが同時に編集しています。`tools/copilot/detect.ts:24` に実例）。
+  `detect.ts` は共有しますが、あなたは**検出規則の本体**、#1929 は **`VERIFIED_AGAINST` の宣言**と
+  役割が分かれています。マージは #1928 → refresh → #1929 の順に私が直列化します。
+
+  ## このブランチのベースについて（重要）
+
+  あなたのブランチは **#1927 の実装コミット `9df208a9` の上**に切ってあります（まだ develop には
+  マージされていません）。したがって:
+
+  - `src/lib/detection/tools/` の構造は**既に存在します**。読んで、その上に足してください。
+  - **#1927 が触ったファイルを書き換えないでください。** `git diff 9df208a9..HEAD` が
+    あなたの変更だけになる状態を保つこと。
+  - #1927 が develop へマージされたら、私（オーケストレーター）が `git merge origin/develop` で
+    取り込みます。あなたは何もしなくて構いません。
+  - **`wait --verify` はまだ走らせません**（scope ゲートが #1927 の 59 ファイルを「範囲外」と読むため）。
+    裁定は #1927 のマージ後に私が行います。あなたは自分で `npm run lint` / `npx tsc --noEmit` /
+    フル `npm run test:unit` を回して確認してください。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 代わりに
+    `dev-reports/changelog/issue-1928.md`（`## [Unreleased]` にそのまま貼れる 1 エントリ。1 行目に
+    どの節へ入るかをコメント）と `dev-reports/module-reference/issue-1928.md` を書くこと。
+    **既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で実在を確認してから**書くこと
+    （過去のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約の方針は「推奨」。** 別解が正しいと判断したら採ってよいが、**逸脱と理由を commit message に明記**すること。
+  - **Issue 本文をコードで裏取りすること。** 食い違ったら**実測を正**とし、commit message に書く。
+    この Issue は私が書いており、自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと**（vitest の遅延 transform で偽の赤が出る）。
+  - **別ワークツリーと同時にフル `npm run test:unit` を回さないこと**（#1985。30s サブプロセスガードが
+    その条件では小さく、無関係な 44 件が落ちます）。**この repo では今あなたを含め 3 本の worktree が
+    動いています。**
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+
+  ## 実 tmux を触る検証の追加ルール（厳守）
+
+  - **必ず `tmux -L <専用socket>` で行う。** `-L` / `-S` は `$TMUX` より優先されます。フラグ無しの `tmux` は
+    **ユーザーの本番サーバ**に届きます。
+  - **`kill-server` を `-L` 無しで書かない。** 後始末は `kill-session -t '=<name>:'`（完全一致）で。
+  - **`TMUX_TMPDIR` を隔離手段に使わない**（`$TMUX` があると無視される）。
+  - **`bind-key` / `unbind-key` / `set-option -g` を既定サーバへ撃たない**（サーバグローバル）。
+scope:
+  allow:
+    - "src/lib/detection/tools/**"
+    - "src/lib/polling/**"
+    - "src/components/worktree/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/detection-copilot-generating-1885.test.ts"
+    - "tests/unit/detection-help-overlay-1497.test.ts"
+    - "tests/unit/detection-opencode-interrupt-1894.test.ts"
+    - "tests/unit/lib/**"
+    - "tests/unit/polling/**"
+    - "tests/unit/components/**"
+    - "tests/fixtures/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1928b.yaml
+++ b/.commandmate/tasks/issue-1928b.yaml
@@ -1,0 +1,57 @@
+version: 1
+title: "Issue #1928 再裁定: src/lib/auto-yes-poller.ts を scope に入れ直す（確認のみ）"
+goal: |
+  **追加の実装は不要です。** commit `1a68f323`（21 files / +2488 / −30）の内容を受領しました。
+  `src/lib/auto-yes-poller.ts` の scope 逸脱も**承認します** — 私の `scope.allow` が
+  `src/lib/polling/**` までで、`src/lib/auto-yes-poller.ts`（`src/lib/` 直下）を含めていませんでした。
+  Auto-Yes の実経路がそこにある以上、触らずに本 Issue は達成できません。**あなたの落ち度ではありません。**
+
+  今回 scope に `src/lib/auto-yes-poller.ts` を追加しました。
+
+  ## 私（オーケストレーター）が行った作業の共有
+
+  #1927 が develop へ squash マージされたため、あなたのブランチ（`9df208a9` ベース）は
+  add/add 衝突を起こす状態でした。**`origin/develop` へリセットして `1a68f323` を
+  cherry-pick** し、衝突マーカー 0・diff はあなたの 21 ファイルのみ、という形に作り直しました。
+  内容は 1 バイトも変えていません。
+
+  また **#1929（`VERIFIED_AGAINST` / `detector.staleness`）が PR #1988 として先に出ています**。
+  `detect.ts` を共有するので、#1929 がマージされたら私が refresh します。
+
+  ## やること
+
+  - `git status` を見て、`.commandmate/tasks/` 配下以外に未コミットの変更が無いことを確認する。
+  - **ファイルを 1 つも変更しない。** 新しい commit も作らない。
+  - 最終行に `VERIFY_ONLY_ACK` とだけ出力して終了する。
+
+  未コミットの変更が残っていた場合だけ `--amend` で畳んでから `VERIFY_ONLY_ACK` を出力してください。
+
+  ## 申し送り（あなたの作業ではありません）
+
+  module-reference 断片で「`src/lib/detection/tools/**` の行はまだ存在しない（#1927 の断片が
+  未適用のため）」と報告されていましたが、**#1927 は develop `abfd6332` に着地済み**で、
+  `tools/*` の行は既に入っています。一本化は私が行うので、あなたは何もしなくて構いません。
+scope:
+  allow:
+    - "src/lib/detection/tools/**"
+    - "src/lib/polling/**"
+    - "src/lib/auto-yes-poller.ts"
+    - "src/components/worktree/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/detection-copilot-generating-1885.test.ts"
+    - "tests/unit/detection-help-overlay-1497.test.ts"
+    - "tests/unit/detection-opencode-interrupt-1894.test.ts"
+    - "tests/unit/lib/**"
+    - "tests/unit/polling/**"
+    - "tests/unit/components/**"
+    - "tests/fixtures/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1928c.yaml
+++ b/.commandmate/tasks/issue-1928c.yaml
@@ -1,0 +1,68 @@
+version: 1
+title: "Issue #1928 追補: tsc の TS2741（prompt-surface-text-nodes-1928.test.tsx:43）を直す"
+goal: |
+  **直前に送った「確認のみ」の契約を差し替えます。1 件だけ直してください。**
+
+  ## `npx tsc --noEmit` が exit 2 です
+
+      tests/unit/components/prompt-surface-text-nodes-1928.test.tsx(43,7):
+      error TS2741: Property 'status' is missing in type
+      '{ type: "multiple_choice"; question: string; options: (…)[] }'
+      but required in type 'MultipleChoicePromptData'.
+
+  `BasePromptData.status`（`src/types/models.ts:274`）は **required** です。
+
+  **あなたの報告では tsc は exit 0 でした。** おそらくこのテストファイルを足す前に測ったか、
+  `npm run test:unit`（vitest は esbuild で型検査をしない）の緑を tsc の緑と取り違えています。
+  **今後は「テストを足した後に」tsc を回してください。**
+
+  ## 直し方は自分で決めてください
+
+  `status` に何を入れるかは**意味のある選択**です。`src/types/models.ts:280-287` のコメントが
+  `'unclassified'`（#1708）と `'pending'` の違いを説明しており、この 2 値は
+  `markPendingPromptsAsAnswered()` の挙動を分けます。**このテストが何を主張しているのかを読んで**
+  適切な値を選び、理由を commit message に 1 行書いてください。
+
+  ## やること
+
+  - 上記 1 件を直す。
+  - `npx tsc --noEmit` が **exit 0** になることを確認する（必ず実際に回すこと）。
+  - `npm run lint` と、少なくとも `tests/unit/components/prompt-surface-text-nodes-1928.test.tsx` を
+    含むテストが緑であることを確認する。
+  - **既存 commit `1a68f323` へ `--amend` で畳む**（新しい commit を作らない）。
+  - 最終行に `IMPL_COMPLETED` とだけ出力する。
+
+  ## 私（オーケストレーター）が行った作業の共有
+
+  #1927 が develop へ squash マージされたため、あなたのブランチ（`9df208a9` ベース）は
+  add/add 衝突を起こす状態でした。**`origin/develop` へリセットして `1a68f323` を cherry-pick** し、
+  衝突マーカー 0・diff はあなたの 21 ファイルのみに作り直してあります（内容は 1 バイトも変えていません）。
+  **`src/lib/auto-yes-poller.ts` の scope 逸脱は承認済み**で、今回 `scope.allow` に入れました
+  （私の allow が `src/lib/polling/**` までで `src/lib/` 直下を含めていなかったのが原因です）。
+
+  module-reference 断片の「`src/lib/detection/tools/**` の行はまだ存在しない」という前提は、
+  **#1927 が develop `abfd6332` に着地したことで解消**しています。一本化は私が行います。
+scope:
+  allow:
+    - "src/lib/detection/tools/**"
+    - "src/lib/polling/**"
+    - "src/lib/auto-yes-poller.ts"
+    - "src/components/worktree/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/detection-copilot-generating-1885.test.ts"
+    - "tests/unit/detection-help-overlay-1497.test.ts"
+    - "tests/unit/detection-opencode-interrupt-1894.test.ts"
+    - "tests/unit/lib/**"
+    - "tests/unit/polling/**"
+    - "tests/unit/components/**"
+    - "tests/fixtures/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1929.yaml
+++ b/.commandmate/tasks/issue-1929.yaml
@@ -1,0 +1,147 @@
+version: 1
+title: "Issue #1929: VERIFIED_AGAINST と検出器の陳腐化警告（detector.staleness）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1929 を実装してください。**#1927 が作った
+  `src/lib/detection/tools/<tool>/patterns.ts` に `VERIFIED_AGAINST` を宣言する**作業です。
+
+  ## Issue 本文の「実装内容」節に誤りが 1 件あります（引き継ぎ節が正）
+
+  「copilot は **`gh copilot -- --version`**、裸の `copilot` は実行しない」は**採用できません**。
+  #1979（PR #1980）で方針書を訂正済みです。理由:
+
+  1. **`gh copilot -- --version` は copilot 未インストール時にダウンロードを起こす** — `gh copilot --help`
+     自身が「PATH に無ければ `~/.local/share/gh/copilot` へダウンロードする」と書いています。
+     version を知るための probe が環境を変更するのは、D2 の「ホットパスで副作用を持たない」前提と両立しません。
+  2. **`copilot` は gh の拡張ではありません**（gh 2.86.0 に組み込まれた preview コマンド）。
+     `gh extension list` は copilot を**一切列挙しません**（実測で出力 0 行）。
+
+  **採る解**: `resolveCopilotExecutable()`（`src/lib/cli-tools/copilot-executable.ts`、#1907 で着地）へ
+  **委譲**します。実測で所在を確認済みで、**`src/lib/slash-command-catalog.ts:109` に
+  `kind: 'delegated'` として既に接続されています**（#1913）。`DETECTOR_VERSION_PROBES` は
+  **この形をそのまま再利用**してください（`VERSION_PROBES` の型は `slash-command-catalog.ts:78` に
+  `| { kind: 'delegated'; probe: () => Promise<string | null> }` として実在）。
+
+  これは DR4-010 の例外ではなく、**規約 (1) をより強く満たします** — `CopilotTool.isInstalled()` /
+  `startSession()` が同じ関数の同じ戻り値で起動先を決めるため、probe と launch が原理的に食い違えません。
+
+  ## コスト規約（ここを外すとホットパスが詰まります）
+
+  - **プロセス内 1 回だけ実行、in-flight 共有、結果キャッシュ。**
+  - **ホットパス（`capture` / `current-output` の 5 秒ポーリング）では await しない。**
+    温まるまで `detector.staleness` は `undefined` のままでよい。
+    **「初回呼び出しが即返る」ことをテストで固定**すること（受入条件）。
+
+  ## 実行面の規約（§10.11 / S17）
+
+  - `which` で**絶対パスに解決してから** `execFile`。解決できなければ **probe をスキップ**し
+    `detector.staleness` は `undefined` のまま（子プロセスを 1 つも起動しないこと）。
+  - `sanitizeEnvForChildProcess()` の env で起動（実測で所在確認: `src/lib/slash-command-catalog.ts` ほか）。
+  - `timeout` に加えて **`maxBuffer` を明示**。
+  - **`detector.staleness` を `GET /api/capabilities` に載せない**（ソフトウェアインベントリの開示になる）。
+    露出先は認証必須の `capture --json` と `commandmate status` に限ること。
+
+  ## この Issue で**やらないこと**
+
+  - **`docs/design/multi-agent-state-architecture.md` を編集しない。** Issue 本文は「方針書 §4 D2 の表も
+    本 Issue で更新する」と書いていますが、**それは #1979 で完了済み**です（develop `561d6706`）。
+  - **ツール別の idle composer 規則 / `detectDialog` / Auto-Yes の接続は #1928 の作業**です。
+    `tools/<tool>/detect.ts` と `prompt.ts` には触らないでください。
+
+  ## 受入条件
+
+  - **S17 を pin**: 絶対パス解決を経ること、**copilot が `resolveCopilotExecutable()` へ委譲され
+    `gh copilot` を子プロセスとして起動しないこと**（`gh copilot -- --version` を綴った実装が赤になる
+    変異ケースを併設）、`copilot` も gh 管理コピーも無い環境で**子プロセスを 1 つも起動せず**
+    probe をスキップして `detector.staleness` が `undefined` のままになること。
+  - **ホットパスで probe を await していないことをテストで固定**（初回呼び出しが即返る）。
+  - gemini の probe コマンドは**実測で確定**すること（方針書は未確定としています）。
+  - CI 任意実行 `npm run check:detector-freshness` を用意。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` / `npm run build` が exit 0。
+
+  ## 検証時の注意（厳守）
+
+  probe の検証で**ユーザーの環境を変更しないこと**。使い捨ての `PATH` / `HOME` / `XDG_DATA_HOME` を
+  使い、`~/.config/gh` と `~/.local/share/gh` が**変化していないことを実測で確認**してください
+  （#1979 のワーカーが同じ方法で 3 シナリオを測っています）。
+
+  ## 触ってよい範囲（#1927 の実構成を確認して確定しました）
+
+  `src/lib/detection/tools/registry.ts`・`src/lib/detection/tools/*/detect.ts` の
+  **`VERIFIED_AGAINST` 定数ブロックのみ**・`src/lib/detection/version-probes*`（新設）・
+  `src/lib/slash-command-catalog.ts`・`src/lib/cli-tools/copilot-executable.ts`・
+  `src/app/api/worktrees/**`・`src/cli/commands/status.ts`・`src/cli/commands/capture.ts`・
+  `src/cli/types/**`・`package.json`・`scripts/**`・
+  `tests/unit/detection/**`・`tests/unit/cli/**`・`tests/unit/lib/**`。
+
+  **`detect.ts` の検出規則の本体と `prompt.ts` / `fixtures/**` は触らないでください**
+  （#1928 のワーカーが同時に編集しています）。`detect.ts` は共有しますが、あなたは
+  **`VERIFIED_AGAINST` の宣言だけ**です。
+
+  **#1927 の実測**: `VERIFIED_AGAINST` は `tools/registry.ts:31` に未計測ツールの既定
+  （`version:'unmeasured'` / `capturedAt:'never'` / `paneGeometry:'unmeasured'`）があり、
+  **copilot だけ `tools/copilot/detect.ts:24` に実測値**が入っています（#1885 の実キャプチャがあるため）。
+  型は `tools/types.ts:114` の `DetectorProvenance`。この形をそのまま拡張してください。
+
+  ## このブランチのベースについて（重要）
+
+  あなたのブランチは **#1927 の実装コミット `9df208a9` の上**に切ってあります（まだ develop には
+  マージされていません）。したがって:
+
+  - `src/lib/detection/tools/` の構造は**既に存在します**。読んで、その上に足してください。
+  - **#1927 が触ったファイルを書き換えないでください。** `git diff 9df208a9..HEAD` が
+    あなたの変更だけになる状態を保つこと。
+  - #1927 が develop へマージされたら、私（オーケストレーター）が `git merge origin/develop` で
+    取り込みます。あなたは何もしなくて構いません。
+  - **`wait --verify` はまだ走らせません**（scope ゲートが #1927 の 59 ファイルを「範囲外」と読むため）。
+    裁定は #1927 のマージ後に私が行います。あなたは自分で `npm run lint` / `npx tsc --noEmit` /
+    フル `npm run test:unit` を回して確認してください。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 代わりに
+    `dev-reports/changelog/issue-1929.md`（`## [Unreleased]` にそのまま貼れる 1 エントリ。1 行目に
+    どの節へ入るかをコメント）と `dev-reports/module-reference/issue-1929.md` を書くこと。
+    **既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で実在を確認してから**書くこと
+    （過去のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約の方針は「推奨」。** 別解が正しいと判断したら採ってよいが、**逸脱と理由を commit message に明記**すること。
+  - **Issue 本文をコードで裏取りすること。** 食い違ったら**実測を正**とし、commit message に書く。
+    この Issue は私が書いており、自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと**（vitest の遅延 transform で偽の赤が出る）。
+  - **別ワークツリーと同時にフル `npm run test:unit` を回さないこと**（#1985。30s サブプロセスガードが
+    その条件では小さく、無関係な 44 件が落ちます）。**この repo では今あなたを含め 3 本の worktree が
+    動いています。**
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+
+  ## 実 tmux を触る検証の追加ルール（厳守）
+
+  - **必ず `tmux -L <専用socket>` で行う。** `-L` / `-S` は `$TMUX` より優先されます。フラグ無しの `tmux` は
+    **ユーザーの本番サーバ**に届きます。
+  - **`kill-server` を `-L` 無しで書かない。** 後始末は `kill-session -t '=<name>:'`（完全一致）で。
+  - **`TMUX_TMPDIR` を隔離手段に使わない**（`$TMUX` があると無視される）。
+  - **`bind-key` / `unbind-key` / `set-option -g` を既定サーバへ撃たない**（サーバグローバル）。
+scope:
+  allow:
+    - "src/lib/detection/tools/**"
+    - "src/lib/detection/version-probes.ts"
+    - "src/lib/slash-command-catalog.ts"
+    - "src/lib/cli-tools/copilot-executable.ts"
+    - "src/app/api/worktrees/**"
+    - "src/cli/commands/status.ts"
+    - "src/cli/commands/capture.ts"
+    - "src/cli/types/**"
+    - "package.json"
+    - "scripts/**"
+    - "tests/unit/detection/**"
+    - "tests/unit/cli/**"
+    - "tests/unit/lib/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1931.yaml
+++ b/.commandmate/tasks/issue-1931.yaml
@@ -1,0 +1,86 @@
+version: 1
+title: "Issue #1931: opencode SSE の信頼境界の残差（redirect manual / replay 上限）を実測して埋める"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1931 を実装してください。
+
+  ## 最初にやること: **残差の再スコープ**（この Issue の本文は #1900 より前に書かれています）
+
+  Issue が求める項目の**大半は #1900（Epic #1891）で既に着地しています。** 私が develop `a5934d49` で
+  実測した結果:
+
+  | 項目 | 状態 |
+  |---|---|
+  | `verifyServerIdentity`（health + version 一致の確認） | **着地済み**（`subscription.ts`） |
+  | `port_identity_changed` | **着地済み**（`subscription.ts`） |
+  | `resync_idle` | **着地済み**（`subscription.ts`） |
+  | `probeOpencodeHealth` | **着地済み**（`runtime.ts` / `client.ts` / `subscription.ts`） |
+  | **`redirect: 'manual'`** | **未着地** — `client.ts:81` の `requestJson()` は `signal` しか渡していません（実測） |
+  | **replay 上限** | 要確認 — `MAX_OPENCODE_SESSION_STATUSES = 128` は `/session/status` の上限で、**permission replay の上限は別物**。#1900 の commit message は「50 件上限」と書いていますが、名前つき定数があるか実測してください |
+
+  **まず `git log --oneline -- src/lib/hooks/sources/opencode/` と実コードを読み、
+  「Issue のどの項目が本当に残っているか」を表にして commit message の冒頭に書いてください。**
+  既に着地している項目を作り直さないこと。**残差がほぼ無いなら、それを実測で示すこと自体が成果**です。
+
+  ## 確実に残っている 1 件（S13 / §10.4）
+
+  **`requestJson()` に `redirect: 'manual'` が無い。** opencode の port は使い捨てで、
+  先に port を奪ったプロセスが 3xx を返すと fetch が**別ホストへ追随**しかねません。
+  loopback 固定の前提が崩れる経路なので、ここは確実に塞いでください。
+  `fetch` を使う他の箇所（`client.ts` 内の別関数、`runtime.ts`）も同様に確認すること。
+
+  ## 露出（§7 の発見可能性）
+
+  `port_identity_changed` / `resync_idle` が**運用者が読む層に出ているか**を確認してください。
+  サーバーログにしか出ていないなら `capture --json` の `structuredEvents` に載せる価値があります。
+  ただし **`src/cli/types/api-responses.ts` は #1930 のワーカーが同時に編集中**なので、
+  そこへの追加が必要と判断したら**変更せずに commit message で報告**してください（私が裁きます）。
+
+  ## 受入条件
+
+  - 残差の表（Issue の各項目 × 着地済み / 未着地 / 本 Issue で実装）が commit message にある。
+  - `redirect: 'manual'` が全 fetch 経路に入り、**変異注入**（外すと赤）で pin されている。
+  - replay 上限が名前つき定数で、超過件数がログに出ることを pin。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` / `npm run test:integration` が exit 0。
+
+  ## 触ってよい範囲
+
+  `src/lib/hooks/sources/opencode/**`・`tests/unit/hooks/sources/**`・`tests/unit/hooks/**`。
+
+  **`src/cli/types/api-responses.ts`・`src/lib/session/**`・`src/lib/hooks/ingest.ts`・
+  `src/lib/hooks/structured-decision-response.ts` は触らないでください**（#1930 が同時に編集中）。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 代わりに
+    `dev-reports/changelog/issue-1931.md`（`## [Unreleased]` にそのまま貼れる 1 エントリ。1 行目に
+    どの節へ入るかをコメント）と `dev-reports/module-reference/issue-1931.md` を書くこと。
+    **既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で実在を確認してから**書くこと。
+  - **`docs/design/multi-agent-state-architecture.md` を編集しない**（#1979 で訂正済み・develop `561d6706`）。
+  - **この契約の方針は「推奨」。** 別解が正しいと判断したら採ってよいが、**逸脱と理由を commit message に明記**すること。
+  - **Issue 本文をコードで裏取りすること。** 食い違ったら**実測を正**とし、commit message に書く。
+    この Issue は私が書いており、自作 Issue の記述が実測と食い違った実績が多数あります。
+  - **テストを足した「後」に `npx tsc --noEmit` を回すこと。** `npm run test:unit`（vitest は esbuild で
+    型検査をしない）の緑を tsc の緑と取り違えた事例が直前のランで出ています。
+  - **`npm run test:integration` も自分で回すこと。** `wait --verify` の宣言ゲートに integration は
+    **含まれていません**（#1946）。#1927 はこれで CI を 1 回落としました。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍かかる**（62s ↔ 560s）。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと**（vitest の遅延 transform で偽の赤が出る）。
+  - **別ワークツリーと同時にフル `npm run test:unit` を回さないこと**（#1985）。
+    **この repo では今あなたを含め 4 本の worktree が動いています。**
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "src/lib/hooks/sources/opencode/**"
+    - "tests/unit/hooks/sources/**"
+    - "tests/unit/hooks/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1932.yaml
+++ b/.commandmate/tasks/issue-1932.yaml
@@ -1,0 +1,97 @@
+version: 1
+title: "Issue #1932: respond を decisionId で応答可能にする（Web 応答面を CLI と同じ土俵へ）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1932 を実装してください。
+
+  ## 実測（私が develop `a5934d49` で確認済み。Issue 本文より新しい状態です）
+
+  **`decisionId` の機構は既に動いています** — #1898 が着地させました:
+
+  - `src/app/api/worktrees/[id]/prompt-response/route.ts:167,183` が `structuredDecision` から
+    `{ option, decisionId, delivered }` を取り出して返している
+  - `src/cli/commands/respond.ts:125` が `Answered approval ${resolved.decisionId} with …` を出している
+  - `answerStructuredDecision()` / `resolveStructuredDecisionOption()` は
+    `src/lib/hooks/structured-decision-response.ts` にある
+
+  **残っているのは Web 側です:**
+
+  - `src/app/api/worktrees/[id]/respond/route.ts` は **`messageId` を必須にしています**
+    （`:44` で分解、`:47` で「messageId and answer are required」、`:57` で `getMessageById`）。
+    ここを **optional 化し、`decisionId` でも応答できるように**する。
+  - `src/components/worktree/PromptPanel.tsx:50` の `PromptPanelProps` に **`decisionId` が無い**。
+
+  したがって本 Issue は**「機構を作る」ではなく「Web の応答面を CLI と同じ土俵に乗せる」**作業です。
+  この認識が正しいか**自分で裏取りしてから**着手し、食い違ったら実測を正としてください。
+
+  ## 守ること
+
+  - **解決スコープは resolve 済みの (worktree, tool, instance) 内に閉じる**（方針書 §10.3 / D3 決定 3）。
+    **見つからなければ 404 `decision_not_found`。** 他インスタンスの decision に答えられてはいけません。
+  - **所属照合を必ず行う**こと。`decisionId` を受け取ったら、それが**この worktree のこの instance の
+    pending decision か**を確認してから適用する。照合なしに `answerStructuredDecision` を呼ばないこと。
+  - `messageId` を optional にしても、**既存の `messageId` 経路の挙動は 1 バイトも変えない**こと
+    （Web UI の既存フローが乗っています）。
+  - **`decisionId` は外部由来の id** です。#1930 の契約と同じく、`MAX_SESSION_ID_LENGTH`(256) と
+    `^[A-Za-z0-9._:-]+$` で検証し、**違反は破棄（切り詰め禁止）**。
+
+  ## 受入条件
+
+  - `respond/route.ts` が `messageId` / `decisionId` のどちらでも応答でき、両方欠けたら 400。
+  - **他インスタンスの `decisionId` を渡すと 404 `decision_not_found`** になることを pin
+    （変異注入: 所属照合を外すと赤）。
+  - `PromptPanelProps.decisionId` が入り、UI から decision で応答できる。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` / `npm run test:integration` が exit 0。
+
+  ## 触ってよい範囲
+
+  `src/app/api/worktrees/[id]/respond/**`・`src/app/api/worktrees/[id]/prompt-response/**`・
+  `src/cli/commands/respond.ts`・`src/components/worktree/PromptPanel.tsx`・
+  `src/components/worktree/**`・`src/hooks/**`・
+  `tests/unit/api/**`・`tests/unit/cli/**`・`tests/unit/components/**`・`tests/integration/**`。
+
+  **`src/lib/hooks/structured-decision-response.ts`・`src/lib/session/**`・
+  `src/cli/types/api-responses.ts` は触らないでください**（#1930 のワーカーが同時に編集中）。
+  そこを変えないと実装できないと判断したら、**変更せずに理由と必要な変更内容を commit message に書いて
+  報告**してください。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 代わりに
+    `dev-reports/changelog/issue-1932.md`（`## [Unreleased]` にそのまま貼れる 1 エントリ。1 行目に
+    どの節へ入るかをコメント）と `dev-reports/module-reference/issue-1932.md` を書くこと。
+    **既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で実在を確認してから**書くこと。
+  - **`docs/design/multi-agent-state-architecture.md` を編集しない**（#1979 で訂正済み・develop `561d6706`）。
+  - **この契約の方針は「推奨」。** 別解が正しいと判断したら採ってよいが、**逸脱と理由を commit message に明記**すること。
+  - **Issue 本文をコードで裏取りすること。** 食い違ったら**実測を正**とし、commit message に書く。
+    この Issue は私が書いており、自作 Issue の記述が実測と食い違った実績が多数あります。
+  - **テストを足した「後」に `npx tsc --noEmit` を回すこと。** `npm run test:unit`（vitest は esbuild で
+    型検査をしない）の緑を tsc の緑と取り違えた事例が直前のランで出ています。
+  - **`npm run test:integration` も自分で回すこと。** `wait --verify` の宣言ゲートに integration は
+    **含まれていません**（#1946）。#1927 はこれで CI を 1 回落としました。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍かかる**（62s ↔ 560s）。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと**（vitest の遅延 transform で偽の赤が出る）。
+  - **別ワークツリーと同時にフル `npm run test:unit` を回さないこと**（#1985）。
+    **この repo では今あなたを含め 4 本の worktree が動いています。**
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "src/app/api/worktrees/[id]/respond/**"
+    - "src/app/api/worktrees/[id]/prompt-response/**"
+    - "src/cli/commands/respond.ts"
+    - "src/components/worktree/**"
+    - "src/hooks/**"
+    - "tests/unit/api/**"
+    - "tests/unit/cli/**"
+    - "tests/unit/components/**"
+    - "tests/integration/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1933.yaml
+++ b/.commandmate/tasks/issue-1933.yaml
@@ -1,0 +1,105 @@
+version: 1
+title: "Issue #1933: ICLITool に describeComposer / gracefulExitSequence / captureSpec を追加し KeySequence を判別 union にする"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1933 を実装してください。ツール固有の挙動を
+  ツールクラスに閉じるための**型と契約**です（方針書 §4 D4 / §6.3 / §10.12 / §13.2）。
+
+  ## 着手前の実測（私が develop `b982fb88` で確認済み）
+
+  - **`describeComposer` / `gracefulExitSequence` / `captureSpec` / `ComposerSpec` / `CaptureSpec` /
+    `KeySequence` は src に 1 件も存在しません**（すべて新設）。
+  - **`sendKeys` は `-l` を一度も渡していません** — `grep -n "'-l'" src/lib/tmux/*.ts` が **0 件**。
+    Issue 本文（DR4-011）の「本文が `Escape` / `C-c` / `Enter` だとキーとして着弾する」という
+    前提は**実測で裏が取れました**。
+  - `TUI_EXIT_WAIT_MS` は **既に `src/config/cli-tool-timing-config.ts` にあります**
+    （Issue 本文は「ツール定数へ」と書いていますが、config への集約は済んでいます）。
+    **注意**: このモジュールは **#1977 が `tests/unit/lib/tmux-capture-invalidation.test.ts` で
+    `*_MS` だけ 0 にする部分 mock** に使っています。値の置き場を変えるならその mock も追随が要ります。
+  - `getStatusCaptureLines` は `src/lib/session/worktree-status-helper.ts` にあります。
+    **#1927 は「`captureSpec()` への集約は #1933 の作業」として意図的に手を付けずに残しました。**
+
+  ## 受入の要（S9・実測で裏が取れている唯一の実害）
+
+  `KeySequence` を `{kind:'key', name}` | `{kind:'literal', text}` の**判別 union** にし、
+  **literal は必ず `send-keys -l`** を通ること。**本文が `Escape` / `C-c` / `Enter` である
+  メッセージがキーとして着弾しないこと**を transport スタブで pin してください。
+  これは型の飾りではなく、`-l` が 0 件という実測が示す**現に踏みうるバグ**です。
+
+  ## その他の受入条件
+
+  - **S10**: graceful exit の**後置条件**を pin — `/exit` 後に `hasSession` が false、かつ
+    **opencode は割当 port の `/global/health` が無応答になるまで port を forget しない**。
+    満たせなければ `graceful_exit_timeout` / `port_orphaned` を出して force kill。
+  - **S18**: `AgentLaunchPlan.env` に `CM_AUTH_TOKEN` 等の秘密が入らないことを pin。
+    **#1942 が `sanitizeEnvForChildProcess()` に `CM_HOOK_` 名前空間の prefix 除去を入れた**ので、
+    その仕組みと矛盾しない形にすること。
+  - `BaseCLITool` に claude 相当の既定実装を置き、**既存 7 ツールの挙動を変えないこと**
+    （本 Issue は型と契約であり、挙動変更は #1894 / #1905 / #1906 / #1910 が既に着地させています）。
+
+  ## この Issue で**やらないこと**
+
+  - `OpenCodeTool.interrupt()` の実装（Escape ×2、300ms 間隔）は **#1894 で着地済み**です。
+    本 Issue はそれが乗るインタフェースを整えるだけ。**挙動を書き換えないこと。**
+  - **`src/lib/session/agent-event-state.ts` / `provisional-turn.ts` / `src/cli/commands/wait.ts` に
+    触らないこと**（#1930 のワーカーが同時に編集しています）。
+  - **`src/lib/detection/**` に触らないこと**（Phase 3 が着地したばかり）。
+
+  ## 触ってよい範囲
+
+  `src/lib/cli-tools/**`・`src/lib/tmux/**`・`src/lib/session-key-sender.ts`・
+  `src/config/cli-tool-timing-config.ts`・`src/lib/session/worktree-status-helper.ts`・
+  `src/types/**`・
+  `tests/unit/cli-tools/**`・`tests/unit/lib/**`・`tests/unit/config/**`・`tests/unit/session/**`。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 代わりに
+    `dev-reports/changelog/issue-1933.md`（`## [Unreleased]` にそのまま貼れる 1 エントリ。1 行目に
+    どの節へ入るかをコメント）と `dev-reports/module-reference/issue-1933.md` を書くこと。
+    **既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で実在を確認してから**書くこと。
+  - **`docs/design/multi-agent-state-architecture.md` を編集しない。** Phase 2 の実測による訂正は
+    #1979 で着地済み（develop `561d6706`）。方針書は現在正しい状態です。
+  - **この契約の方針は「推奨」。** 別解が正しいと判断したら採ってよいが、**逸脱と理由を commit message に明記**すること。
+  - **Issue 本文をコードで裏取りすること。** 食い違ったら**実測を正**とし、commit message に書く。
+    この Issue は私が書いており、自作 Issue の記述が実測と食い違った実績が多数あります。
+  - **テストを足した「後」に `npx tsc --noEmit` を回すこと。** `npm run test:unit`（vitest は esbuild で
+    型検査をしない）の緑を tsc の緑と取り違えた事例が直前のランで出ています。
+  - **`npm run test:integration` も自分で回すこと。** `wait --verify` の宣言ゲートに integration は
+    **含まれていません**（#1946）。#1927 はこれで CI を 1 回落としました。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍かかる**（62s ↔ 560s）。
+    `gate-runner.ts:414` が `CI:'true'` を渡し `fileParallelism:false` になるためで、異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと**（vitest の遅延 transform で偽の赤が出る）。
+  - **別ワークツリーと同時にフル `npm run test:unit` を回さないこと**（#1985。30s サブプロセスガードが
+    その条件では小さく、無関係な 44 件が落ちます）。**この repo では今あなたを含め複数の worktree が動いています。**
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+
+  ## 実 tmux を触る検証の追加ルール（厳守）
+
+  - **必ず `tmux -L <専用socket>` で行う。** `-L` / `-S` は `$TMUX` より優先されます。フラグ無しの `tmux` は
+    **ユーザーの本番サーバ**に届きます。
+  - **`kill-server` を `-L` 無しで書かない。** 後始末は `kill-session -t '=<name>:'`（完全一致）で。
+  - **`TMUX_TMPDIR` を隔離手段に使わない**（`$TMUX` があると無視される）。
+  - **`bind-key` / `unbind-key` / `set-option -g` を既定サーバへ撃たない**（サーバグローバル）。
+scope:
+  allow:
+    - "src/lib/cli-tools/**"
+    - "src/lib/tmux/**"
+    - "src/lib/session-key-sender.ts"
+    - "src/config/cli-tool-timing-config.ts"
+    - "src/lib/session/worktree-status-helper.ts"
+    - "src/types/**"
+    - "tests/unit/cli-tools/**"
+    - "tests/unit/lib/**"
+    - "tests/unit/config/**"
+    - "tests/unit/session/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1933b.yaml
+++ b/.commandmate/tasks/issue-1933b.yaml
@@ -1,0 +1,73 @@
+version: 1
+title: "Issue #1933 追補: build:cli の TS2307（tsconfig.cli.json は paths を持たない）を直す"
+goal: |
+  **PR #1991 の CI で Build が落ちました。** 1 件だけ直してください。
+
+      src/lib/cli-tools/types.ts(9,8): error TS2307:
+      Cannot find module '@/types/cli-tool-contracts' or its corresponding type declarations.
+
+  ## 原因（私が実測しました）
+
+  **`tsconfig.cli.json` は `"paths": {}` です**（`@/` エイリアスを持たない）。CI の Build ジョブは
+  `npm run build` / `npm run build:cli` / `npm run build:server` の 3 本を順に走らせ、
+  `build:cli`（`tsc --project tsconfig.cli.json`）が `src/lib/cli-tools/types.ts` を引くため、
+  **`@/types/cli-tool-contracts` が解決できません**。手元で `npm run build:cli` を回して **exit 2** を再現済みです。
+
+  **これは #1929 の実装者が同じ罠を踏んで記録しています** —
+  「`tsconfig.cli.json` が `"paths": {}` で、`commandmate status` から到達するモジュールが
+  `@/` エイリアスを使えない（`copilot-executable.ts` の env-sanitizer import も同じ理由で相対に変えた）」。
+
+  ## やること
+
+  1. **CLI ビルドから到達する経路の `@/` import を相対パスへ変える。** `src/lib/cli-tools/types.ts` の
+     1 件だけとは限りません — **あなたが新設した 5 モジュール**（`src/types/cli-tool-contracts.ts` /
+     `src/lib/tmux/key-sequence.ts` / `src/lib/cli-tools/{composer,capture}-spec.ts` /
+     `src/lib/cli-tools/graceful-exit.ts`）と、それらを引く既存ファイルを**すべて確認**してください。
+  2. **`npm run build:cli` と `npm run build:server` と `npm run build` の 3 本すべてを実際に回して
+     exit 0 を確認する**こと。`npx tsc --noEmit`（ルート tsconfig）は `paths` を持つので**通ってしまいます** —
+     それが今回すり抜けた理由です。
+  3. 既存 commit へ `--amend` で畳む（新しい commit を作らない）。
+  4. 最終行に `IMPL_COMPLETED` とだけ出力する。
+
+  ## なぜ裁定をすり抜けたか（あなたの落ち度ではありません）
+
+  `.commandmate/verify.yaml` に **build ゲートがありません**（#1946 で実測・記録済み。verify が見ているのは
+  CI 12 ジョブ中 7 本）。あなたはフル `test:unit` と `tsc --noEmit` の緑を確認しており、
+  **見えるはずのない層**でした。この穴が刺さったのは本ランで **3 回目**です
+  （#1943 → PR #1945、#1927 の integration、今回）。
+
+  ## 私（オーケストレーター）が行った作業の共有
+
+  ブランチは develop `7b7a998a`（#1931 込み）へ refresh 済みで、CHANGELOG の衝突は両側保持で解決、
+  断片の一本化（CHANGELOG 1 件・module-reference 新規 5 行＋既存 5 行）も済んでいます。
+  **それらのファイルは触らないでください。**
+
+  ## 触ってよい範囲
+
+  前回と同じ（`src/lib/cli-tools/**`・`src/lib/tmux/**`・`src/lib/session-key-sender.ts`・
+  `src/config/cli-tool-timing-config.ts`・`src/lib/session/worktree-status-helper.ts`・`src/types/**`・
+  `tests/unit/cli-tools/**`・`tests/unit/lib/**`・`tests/unit/config/**`・`tests/unit/session/**`）。
+  加えて、CLI ビルド経路上の `@/` import を持つファイルがこの範囲の外にあった場合は、
+  **変更せずに commit message で報告**してください。
+scope:
+  allow:
+    - "src/lib/cli-tools/**"
+    - "src/lib/tmux/**"
+    - "src/lib/session-key-sender.ts"
+    - "src/config/cli-tool-timing-config.ts"
+    - "src/lib/session/worktree-status-helper.ts"
+    - "src/types/**"
+    - "tests/unit/cli-tools/**"
+    - "tests/unit/lib/**"
+    - "tests/unit/config/**"
+    - "tests/unit/session/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1939.yaml
+++ b/.commandmate/tasks/issue-1939.yaml
@@ -1,0 +1,122 @@
+version: 1
+title: "Issue #1939: src/**/__tests__ の 267 テストをゲートに載せ 19 件の赤を裁く"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1939 を修正してください。
+
+  `src/` に同居配置された unit テストが **13 ファイル / 267 テスト**あり、**CI でも `wait --verify` でも
+  一度も実行されません**。develop `a175767a` で実測すると **5 ファイル / 19 テストが赤**です:
+
+      src/components/worktree/__tests__/HistoryPane.integration.test.tsx  10 failed
+      src/components/worktree/__tests__/ConversationPairCard.test.tsx      5 failed
+      src/lib/__tests__/db-migrations-v10.test.ts                          2 failed
+      src/lib/__tests__/status-detector.test.ts                            1 failed
+      src/lib/__tests__/clipboard-utils.test.ts                            1 failed
+
+  #1946（route export ガード）と同じ穴です — **裁定が見ていない領域**があると、そこは永久に直りません。
+
+  ## 方針（推奨は B。ただし実測して判断すること）
+
+  Issue 本文の A / B / C のうち **B（`tests/unit` へ移設し、同居配置を禁止するガードを入れる）を
+  推奨**します。理由: テストの置き場が 2 つあること自体が「同じ規約の実装が 2 箇所」であり、
+  #1882 が静的ガードで潰したのと同じ形の欠陥だからです。CLAUDE.md のファイル構成も
+  `tests/unit/` / `tests/integration/` を正としています。
+
+  ただし移設には判断が要ります:
+  - `HistoryPane.integration.test.tsx` は名前が integration ですが testing-library のコンポーネント
+    テストです。`tests/unit/` と `tests/integration/` のどちらへ置くかを**中身を読んで**決めること。
+  - 相対 import が壊れないこと（`@/` エイリアスへ寄せるのが素直）。
+  - `tests/unit` 側に**後継が既にある重複**が無いか調べること（あれば移設ではなく削除）。
+
+  A（`test:unit` を `vitest run tests/unit src` にする）を採ってもよいですが、その場合は
+  **同居配置が今後も増えることを受け入れる**判断になるので、理由を commit message に書いてください。
+
+  ## 19 件の赤は 1 件ずつ裁定すること（ここが本体）
+
+  A/B のどちらでも**赤を先に裁く**必要があります。**「テストが陳腐化している」のか「実装のバグ」なのかは
+  ファイルごとに違います。** 一律にテストを書き換えて緑にするのは不合格とみなします。各件について
+  「どちらだったか」と根拠を commit message の表に書いてください。
+
+  分かっている手がかり:
+  - `clipboard-utils`: `document is not defined` ＝ environment が node のまま。`@vitest-environment jsdom`
+    の docblock 漏れの可能性が高い（**テスト側の欠陥**）。
+  - `db-migrations-v10`: `SqliteError: table worktrees has no column named memo` ＝ スキーマ変更に
+    テストが追随できていない疑い。**ただし migration の実装バグの可能性も潰すこと。**
+  - `status-detector` の gemini `expected 'running' to be 'ready'`: **Epic #1891 で検出層の挙動が
+    意図的に変わった可能性がある**。変わったのなら、テストを更新したうえで「どの Issue の
+    どの変更で変わったか」を書くこと。実装の回帰なら実装を直すこと。**ここは Phase 3（#1927）の
+    主戦場なので、判断を書き残すこと自体に価値があります。**
+  - `ConversationPairCard` / `HistoryPane`: `Unable to find an element with the text: …`。
+    React 19 移行（`act()` 外の更新は遅延する）で壊れた可能性を疑うこと。
+
+  ## ゲートに載せる
+
+  `.commandmate/verify.yaml` の `unit` ゲートと CI の Unit Tests が**この 267 テストを実際に走らせる**
+  ようにしてください。#1882 の単一実装規律（verify と CI が同じものを呼ぶ）を守ること。
+
+  ## 受入条件
+
+  - 267 テストが `npm run test:unit` と CI の Unit Tests の両方で走り、**全件緑**。
+  - **変異注入**: 移設・ゲート追加が空振りでないことを示す。移設したテストの 1 つにわざと欠陥を入れて
+    `npm run test:unit` が赤になることを確認し、変異と結果を commit message に書く。
+  - `npm run lint` / `npx tsc --noEmit` / 静的ガード 4 本が exit 0。
+
+  ## 触ってよい範囲
+
+  `src/**/__tests__/**`・`tests/unit/**`・`tests/integration/**`・`package.json`・`vitest.config.ts`・
+  `.commandmate/verify.yaml`・`.github/workflows/ci-pr.yml`、および**赤の原因が実装側だった場合の
+  該当ソース**（`src/lib/db/**`・`src/lib/clipboard-utils.ts`・`src/components/worktree/**`）。
+
+  **`tests/setup.ts` は触らないでください**（scope 外・#1942 のワーカーが同時に編集しています）。
+  **`tests/unit/components/app-version-display.test.tsx`・`tests/unit/lib/ws-server-cleanup.test.ts`・
+  `tests/unit/api/hooks-claude-done-delegation.test.ts`・`tests/unit/lib/tmux-capture-invalidation.test.ts`・
+  `tests/unit/config/eslint-i18n-module-scope-literal.test.ts` の 5 本も触らないでください**
+  （#1977 のワーカーが同時に編集しています）。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1939.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1939): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1939.md` — `docs/module-reference.md` の表に足す注記。
+      **既存行への追記を指示する場合は、その行が実在することを `grep -n '^| `<path>`' docs/module-reference.md`
+      で必ず確認してから書くこと**（前回のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍の時間がかかる**
+    （62s ↔ 560s）。`src/lib/verification/gate-runner.ts:414` が `CI: 'true'` を渡し、
+    `vitest.config.ts` が `CI==='true'` で `fileParallelism:false` にするため。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」が走り、実在しない赤が出ます。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "src/**/__tests__/**"
+    - "tests/unit/**"
+    - "tests/integration/**"
+    - "package.json"
+    - "vitest.config.ts"
+    - ".commandmate/verify.yaml"
+    - ".github/workflows/ci-pr.yml"
+    - "src/lib/db/**"
+    - "src/lib/clipboard-utils.ts"
+    - "src/components/worktree/**"
+    - "src/hooks/**"
+    - "src/lib/detection/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1942.yaml
+++ b/.commandmate/tasks/issue-1942.yaml
@@ -1,0 +1,96 @@
+version: 1
+title: "Issue #1942: CM_HOOK_* の子プロセス env 除去（S8 後半）と COPILOT_HOME 既定"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1942 を修正してください。
+
+  #1904（PR #1941）が scope 外だったため積み残した 2 件です。どちらも「既定値こそが危険」という同じ形。
+
+  ## 1. S8 後半 — `CM_HOOK_*` を子プロセス環境から除去する
+
+  方針書 §13.2 の S8 は「hook 設定に必要な値だけを env で渡し、**エージェントが起動する子プロセスへは
+  漏らさない**」を要求しています。#1904 は前半（`CM_HOOK_PORT` を launch line に載せ、生成コマンド側で
+  数値検証する）を実装しましたが、**後半（sanitizer 側での除去）が未実装**です。
+
+  - 対象: `src/lib/security/env-sanitizer.ts` の `SENSITIVE_ENV_KEYS`
+  - #1904 が `COMMANDMATE_HOOK_ENV_VARS`（`src/lib/hooks/sources/launch-command.ts`）を置いたので、
+    **sanitizer 側はこれを import すれば足ります**（綴りを 2 箇所に持たない ＝ #1882 の単一実装規律）。
+  - **import の向きが循環を作らないか確認すること。** `security` → `hooks` の依存が新設されるので、
+    逆向きの依存が既にあるなら型だけの共有モジュールへ切り出す等の判断が要ります。
+
+  ## 2. `tests/setup.ts` に `COPILOT_HOME` の既定が無い
+
+  `CODEX_HOME` / `CM_VERIFY_WORKTREE_INDEX_ROOT` には隔離用の既定がありますが、`COPILOT_HOME` には
+  ありません。`~/.copilot/` は**マシン共通の 1 本**（`configScope: 'global-singleton'`）なので、
+  既定が無いテストが 1 本でも実ファイルに到達すると**ユーザーの本番設定を書き換えます**。
+
+  現状は事故になっていません（#1904 の実装者が実測で確認済み: copilot の launch を実行するテストは
+  全て自前で `COPILOT_HOME` か `HOME` を stub しており、`terminal-route` / `api-send-cli-tool` は
+  `CopilotTool` 自体を mock していて実ファイルに到達しない）。**この実測が今も成り立つか裏を取り**、
+  そのうえで `CODEX_HOME` と同じ形で既定を置いてください。
+
+  ## 受入条件
+
+  - **変異注入 1**: `SENSITIVE_ENV_KEYS` から `CM_HOOK_*` の除去を外すと、子プロセス env に
+    `CM_HOOK_*` が現れることを assert するテストが**赤になる**こと。
+  - **変異注入 2**: `tests/setup.ts` の `COPILOT_HOME` 既定を外すと、`~/.copilot/` の実パスへ
+    到達しうることを検出するテストが**赤になる**こと。「既定を置いた」だけでは受入としません。
+  - `COMMANDMATE_HOOK_ENV_VARS` の綴りが**リポジトリ内で 1 箇所**であること（`grep` で確認し、
+    件数を commit message に書く）。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` が exit 0。
+
+  ## 実ファイルに触れない（厳守）
+
+  `~/.copilot/settings.json` と `~/.copilot/config.json` は**マシン共通**です。検証で触る場合は
+  **事前に sha256 を採り、終了後に必ず復元**してください。テストは `COPILOT_HOME` を使い捨てディレクトリへ
+  向けること。
+
+  ## 触ってよい範囲
+
+  `src/lib/security/**`・`src/lib/hooks/sources/launch-command.ts`・`tests/setup.ts`・
+  `tests/unit/security/**`・`tests/unit/hooks/**`・`tests/unit/config/**`。
+
+  **`vitest.config.ts`・`src/cli/**`・`src/**/__tests__/**` は触らないでください**
+  （#1939 / #1975 のワーカーが同時に編集しています）。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1942.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1942): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1942.md` — `docs/module-reference.md` の表に足す注記。
+      **既存行への追記を指示する場合は、その行が実在することを `grep -n '^| `<path>`' docs/module-reference.md`
+      で必ず確認してから書くこと**（前回のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍の時間がかかる**
+    （62s ↔ 560s）。`src/lib/verification/gate-runner.ts:414` が `CI: 'true'` を渡し、
+    `vitest.config.ts` が `CI==='true'` で `fileParallelism:false` にするため。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」が走り、実在しない赤が出ます。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "src/lib/security/**"
+    - "src/lib/hooks/sources/launch-command.ts"
+    - "tests/setup.ts"
+    - "tests/unit/security/**"
+    - "tests/unit/hooks/**"
+    - "tests/unit/config/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1946.yaml
+++ b/.commandmate/tasks/issue-1946.yaml
@@ -1,0 +1,126 @@
+version: 1
+title: "Issue #1946: route.ts の export 形状を静的ガードで裁定に載せる（build/integration ゲートは対象外）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1946 を修正してください。
+
+  ## 事象
+
+  PR #1943（#1925）が `src/app/api/capabilities/route.ts` に `SERVER_CAPABILITIES` を export し、
+  **develop の `npm run build` を壊した**（修正は PR #1945）。
+
+      Type error: Route "src/app/api/capabilities/route.ts" does not match the required types of a Next.js Route.
+        "SERVER_CAPABILITIES" is not a valid Route export field.
+
+  この欠陥は `lint` でも `tsc --noEmit` でも `test:unit` でも捕まらない（Next の route 型チェックは
+  build ステップの中にある）。`.commandmate/verify.yaml` に **build ゲートが存在しない**ため、
+  `/orchestrate` の裁定（`wait --verify` の exit code）を素通りして develop まで届いた。
+
+  ## この Issue でやること（推奨案 = Issue 本文の「検討事項 2」）
+
+  **静的ガードを 1 本足す。** `src/app/api/**/route.ts` が Next の許す field 以外を export して
+  いないことを検査する `scripts/check-route-exports.mjs` を新設し、**verify と CI の両方から
+  同じスクリプトを呼ぶ**。0.1 秒で決定的に判定でき、CPU 競合がゼロなのが選定理由。
+
+  実装の型は既存の静的ガード 3 本（`scripts/check-token-discipline.mjs` /
+  `check-control-chars.mjs` / `check-claudemd-size.mjs`）にそろえること:
+
+  - `.commandmate/verify.yaml` の `gates` に追加する。**`mutex` は付けない**
+    （`tests/unit/guards/verify-heavy-gate-mutex.test.ts` が「静的ガードに mutex を付けない」を
+    固定している。0.1s のガードを他 worktree の 500s の unit の後ろに並ばせると、秒で失敗を返すという
+    #1882 の設計意図が消える）。重いゲートより**前**に置くこと。
+  - `.github/workflows/ci-pr.yml` に同じスクリプトを呼ぶジョブを足す（`claudemd-size` /
+    `control-chars` / `token-discipline` ジョブの形にそろえる。self-hosted ランナーのラベル指定と
+    コメント規約も既存にならう）。
+  - `tests/unit/guards/static-guard-single-source.test.ts` は「検査本体の実装が 1 箇所しかない」
+    ことを固定している（#1882）。**新しいガードもこの不変条件の対象に含めること。**
+    検査ロジックを `verify.yaml` や `ci-pr.yml` にコピーしてはいけない。
+
+  ## 許可リストの決め方（ここを間違えると偽陽性になる）
+
+  許可する export 名は Next のバージョンに従う。`package.json` の Next 実バージョンを確認し、
+  **そのバージョンが実際に受け付ける field を根拠に**リストを決めること。私の推定は次だが、
+  **裏取りして違えば実測を正**とする:
+
+      GET POST PUT PATCH DELETE HEAD OPTIONS
+      dynamic revalidate runtime fetchCache dynamicParams preferredRegion maxDuration
+      generateStaticParams
+
+  型 export（`export type` / `export interface`）は実行時 export ではないので**落としてはいけない**。
+  `export default` の扱いも決めて commit message に書くこと。判定は文字列 grep ではなく
+  **構文を見る形**（AST もしくはそれに準ずる確実な方法）にすること — 過去に grep ベースの判定が
+  コメント内や文字列内を拾って誤判定した実績がある。
+
+  ## この PR で**やらないこと**（重要）
+
+  - **`build` ゲートを `verify.yaml` に足さない。**
+  - **`integration` ゲートを `verify.yaml` に足さない。**
+
+  どちらも CPU 競合の実測（#1917 と同型の検討）が要り、かつ **#1950（実シェル系テストが負荷で
+  落ちる問題）が未解決の今、裁定を重くする変更を入れると #1950 を悪化させる**。この 2 件は
+  #1950 の着地後に別 Issue で判断します。
+
+  ただし**判断材料は残してください**。`dev-reports/module-reference/issue-1946.md` とは別に
+  `dev-reports/issue-1946-gate-coverage.md` を書き、次を記録すること:
+
+  - CI 11 ジョブのうち verify が見ているもの / 見ていないものの一覧（現状と、この PR 適用後）
+  - `npm run build` と `npm run test:integration` の**実測所要**（linked worktree で 1 回ずつ計測）
+  - それぞれを裁定に足す場合の mutex の要否についてのあなたの見解
+
+  ## 受入条件
+
+  - `src/app/api/**/route.ts` が許可されていない値を export したときに、**`wait --verify` の
+    exit code が非 0 になる**こと。
+  - **変異注入**: `export const SERVER_CAPABILITIES = [...]` を実際に route.ts へ戻して
+    ガードが赤になることを確認し、**元に戻す**。変異と結果を commit message に書くこと。
+  - ガードを入れた時点の develop で `npm run lint` と全ゲートが緑のままであること
+    （＝ 既存の route.ts に偽陽性を出さないこと）。もし既存 route が引っかかったら、
+    **その route を直すのではなく**、ビルドが通る事実を根拠に許可リスト側を直すこと
+    （develop の build は現在 exit 0 なので、真の違反は存在しないはずです）。
+
+  ## 触ってよい範囲
+
+  `scripts/**`・`.commandmate/verify.yaml`・`.github/workflows/ci-pr.yml`・`tests/unit/guards/**`・
+  `docs/design/verification-config.md`。
+
+  **`vitest.config.ts`・`package.json`・`tests/unit` の guards 以外は触らないでください**
+  （scope 外・別 Issue #1950 のワーカーが同時に編集しています）。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1946.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1946): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1946.md` — `docs/module-reference.md` の表に足す注記を
+      **行キー（`| \`path\` |`）ごと**に列挙する。既存行への追記なら「どの行に何を足すか」を書く。
+    断片が無いとリリースノートと module-reference に載らない。**実装と同じ commit の時点で書くこと。**
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数ある。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。切られた範囲に別ファイルの FAIL が隠れる。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」の組み合わせが走り、実在しない赤が出る（2026-08-22 に実例あり）。
+    待ち時間に手を動かすならリポジトリ外のファイルに限る。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "scripts/**"
+    - ".commandmate/verify.yaml"
+    - ".github/workflows/ci-pr.yml"
+    - "tests/unit/guards/**"
+    - "docs/design/verification-config.md"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1946b.yaml
+++ b/.commandmate/tasks/issue-1946b.yaml
@@ -1,0 +1,52 @@
+version: 1
+title: "Issue #1946: scope 取り直し＋全ゲート（route-exports 含む）での再裁定"
+goal: |
+  **追加の実装は不要です。** この worktree の作業は commit `3b02ed6f` で完了しており、
+  あなたの報告（scope 逸脱 1 件・スコープを `src/app/**` へ拡大・build/integration の実測）は
+  受領しました。逸脱の判断は**正しい**と裁定します。`tests/unit/verification/verify-config.test.ts`
+  は私（オーケストレーター）が契約の `scope.allow` に入れ忘れたもので、あなたの落ち度ではありません。
+
+  この送信は次の 2 つだけを目的にしています。
+
+  1. **scope の取り直し** — scope は send 時のスナップショットで裁定されるため、契約ファイルを
+     直すだけでは判定が変わりません。今回 allow に
+     `tests/unit/verification/verify-config.test.ts` を追加しました。
+  2. **新設した `route-exports` ゲート自身を裁定に含める** — 前回の契約は `verify.gates` を
+     明示列挙しており、あなたが足したゲートが走っていませんでした（あなたの指摘どおりです）。
+     今回は `verify.gates` を省略して全ゲートを走らせます。
+
+  ## やること
+
+  - `git status` を見て、`.commandmate/tasks/` 配下以外に未コミットの変更が無いことを確認する。
+  - **ファイルを 1 つも変更しない。** 新しい commit も作らない。
+  - 最終行に `VERIFY_ONLY_ACK` とだけ出力して終了する。
+
+  もし未コミットの変更が残っていた場合だけ、それを既存 commit に `--amend` で畳んでから
+  `VERIFY_ONLY_ACK` を出力してください（新しい commit は作らないこと）。
+scope:
+  allow:
+    - "scripts/**"
+    - ".commandmate/verify.yaml"
+    - ".github/workflows/ci-pr.yml"
+    - "tests/unit/guards/**"
+    - "tests/unit/verification/verify-config.test.ts"
+    - "docs/design/verification-config.md"
+  deny: []
+verify:
+  # [オーケストレーターの意図的な絞り込み]
+  # unit を外している。理由は 2 つ:
+  #  1. 直前の run 365 で unit は 974/975 files・18195/18196 tests まで通っており、唯一の赤
+  #     tests/unit/skills/orchestrate-monitor/hooks-git-resolution.test.ts は #1946 の diff に
+  #     含まれず、単独実行 3/3 緑（13 tests）を実測済み ＝ #1950 のファミリの環境起因。
+  #     もう一度回しても新しい情報が出ない。
+  #  2. #1950 のワーカーがいま「フル test:unit 連続 5 回」という**負荷に敏感な計測**を
+  #     実行中で、ここで 10 分のフル unit を重ねるとその計測を汚す。
+  # unit の最終裁定は PR の CI（self-hosted、このファミリの赤の実績なし）で行う。
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1950.yaml
+++ b/.commandmate/tasks/issue-1950.yaml
@@ -1,0 +1,128 @@
+version: 1
+title: "Issue #1950: 実シェルを起動する unit テスト 69 ファイルがフル test:unit で断続的に落ちる"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1950 を修正してください。
+
+  ## 事象（要約。詳細は Issue 本文と 4 つの追記を必ず読むこと）
+
+  `tests/unit` のうち **テスト本文で実シェル / 実サブプロセスを起動するテスト**（`execFileSync` /
+  `spawnSync` / `execSync` / `/bin/sh` を使うもの、実測 69 ファイル）が、**開発機のフル
+  `npm run test:unit` でだけ**断続的に落ちる。症状は 2 種類:
+
+  - `Test timed out in 5000ms`（vitest 既定のテスト予算。子プロセス生成待ちがそのまま予算を食う）
+  - `expected { status: 141 }` — `141 = 128 + 13` ＝ **SIGPIPE**（パイプの読み手が早く閉じた）
+
+  2026-08-22 の並列オーケストレーション中に**独立に 5 回**観測し、毎回**別のテスト**が落ちた。
+  いずれも:
+
+  - 落ちたテストは **diff に含まれていない**（無関係の PR の裁定が exit 20 になる）。
+  - **単独実行は緑**（3 連続で 3/3 exit 0 を確認済み）。
+  - **CI（self-hosted ランナー）では 1 度も落ちていない**（同じセッションで 11 本の PR が通過）。
+  - #1898 の実装者が独立に `git archive HEAD` で対照 checkout を作り、**同じ赤が対照でも出る**ことを
+    確認している（＝ diff 起因ではない）。
+
+  ## なぜ重要か
+
+  `/orchestrate` はワーカーの完了を `wait --verify` の exit code で裁定する。その unit ゲートが
+  フル `test:unit` なので、**このファミリが不安定だと裁定そのものが信用できない**。本ランでは
+  再検証に 4 回・約 40 分を失い、さらに「exit 20 は負荷かもしれない」という学習が生まれた
+  ＝ 本物の不合格まで疑われてゲートが形骸化する。**CI が緑だからよい、ではない。裁定が開発機で
+  行われる以上、開発機で安定していなければ裁定に使えない。**
+
+  ## 最初にやること（実測での裏取り）
+
+  1. `grep -rln "execFileSync\|spawnSync\|/bin/sh\|execSync" tests/unit --include='*.test.ts'` で
+     ファミリの実数を数え、Issue 本文の 65（私の計測値）と食い違うなら**実測を正**とする。
+  2. `git archive HEAD` で対照 checkout を作り、**負荷をかけた状態で同じ赤が出ること**を確認する
+     （帰属の証明。この手法は #1898 の実装者が実証済み）。
+  3. **SIGPIPE 141 と 5000ms timeout が同じ原因かどうかを切り分ける。** 別原因なら別々に直す。
+     `set -o pipefail` の下では上流の 141 がそのまま最終 exit code になる点に注意。
+
+  ## 対処の候補（推奨順。実測して選ぶこと）
+
+  - (a) 子プロセスの起動を `it()` 本文から `beforeAll` へ移し、5 秒のテスト予算から外す
+  - (b) このファミリだけ vitest の `poolOptions` / `projects` で直列化する
+  - (c) SIGPIPE を出さないパイプラインに直す（`head` や早期 `exit` の後ろで書き込みを続けている箇所）
+  - (d) このファミリにだけ専用の `testTimeout` を与える（**最後の手段**。予算を伸ばすだけで
+     根本は残るうえ、本物の hang を隠す）
+
+  **(b) を採る場合は `npm run test:unit` 全体の所要への影響を必ず測って commit message に書くこと。**
+  直列化で裁定が 2 倍遅くなるなら、それは別の形の裁定破壊になる。
+
+  ## 横断で洗ってほしいもの
+
+  Issue 追記 2 のとおり、**時間や実測値を固定閾値と比較する assert** も同じ性質の脆さを持つ。
+  `tests/unit/verification/gate-runner-timestamps.test.ts` は CI 側で
+  `expected 1104 to be less than 800` で落ちた実績がある。次で候補を洗い、直せるものは直すこと:
+
+      grep -rn "toBeLessThan\|toBeGreaterThan" tests/unit | grep -iE "ms|duration|elapsed|window"
+
+  ## 受入条件
+
+  - フル `npm run test:unit` を **連続 5 回**回し、**このファミリの全ファイルが 5/5 緑**であること。
+    5 回の所要（秒）を commit message に列挙すること。
+  - **変異注入**で、入れた安定化が「テストを無効化しただけ」ではないことを示すこと。
+    監視・検証ロジック側に欠陥を注入して**赤になること**を確認し、変異と結果を表にして
+    commit message に書く。テストを skip / timeout 延長だけで通した場合は不合格とみなす。
+  - `npm run lint` / `npx tsc --noEmit` が exit 0 のままであること。
+
+  ## 触ってよい範囲
+
+  `tests/**`・`vitest.config.ts`・`package.json`（`test:unit` スクリプトを変える場合のみ）。
+
+  **`.commandmate/verify.yaml` と `.github/workflows/ci-pr.yml` は触らないでください**（scope 外・
+  別 Issue #1946 のワーカーが同時に編集しています）。そこを変えないと直せないと判断した場合は、
+  変更せずに理由と必要な変更内容を commit message に書いて報告してください。
+
+  `src/**` も scope 外です。プロダクトコードの欠陥がこの flake の原因だと判明した場合も、
+  変更せずに commit message で報告してください。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1950.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1950): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1950.md` — `docs/module-reference.md` の表に足す注記を
+      **行キー（`| \`path\` |`）ごと**に列挙する。既存行への追記なら「どの行に何を足すか」を書く。
+    断片が無いとリリースノートと module-reference に載らない。**実装と同じ commit の時点で書くこと。**
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数ある。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。切られた範囲に別ファイルの FAIL が隠れる。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」の組み合わせが走り、実在しない赤が出る（2026-08-22 に実例あり）。
+    待ち時間に手を動かすならリポジトリ外のファイルに限る。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+
+  ## 実 tmux を触る検証の追加ルール（厳守）
+
+  対象ファミリには `tests/unit/lib/tmux/**` が含まれる。実 tmux に触る検証を行う場合:
+
+  - **必ず `tmux -L <専用socket>` で行う。** `-L` / `-S` は `$TMUX` より優先される。
+    あなたは tmux ペインの中で動いていて `$TMUX` が既定サーバを指しているため、フラグ無しの
+    `tmux` 呼び出しは全て**ユーザーの本番サーバ**に届く。
+  - **`kill-server` を `-L` 無しで書かない。** 後始末は `kill-session -t '=<name>:'`（完全一致）で行う。
+  - **`TMUX_TMPDIR` を隔離手段に使わない。** `$TMUX` が設定されていると完全に無視される。
+  - **`bind-key` / `unbind-key` / `set-option -g` を既定サーバへ撃たない。** サーバグローバルなので
+    他の全セッションに波及する（2026-08-02 に稼働中の全 `mcbd-*` セッションを消した実害がある）。
+scope:
+  allow:
+    - "tests/**"
+    - "vitest.config.ts"
+    - "package.json"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1950b.yaml
+++ b/.commandmate/tasks/issue-1950b.yaml
@@ -1,0 +1,81 @@
+version: 1
+title: "Issue #1950 追補: cmate-verify の waited=0s 固定 assert を dual placement で直す"
+goal: |
+  **前回の作業（commit `1a2f1912`）は裁定に合格する見込みで、方針・実測・変異注入いずれも受領しました。**
+  グローバル予算を上げずにクラス予算＋ガードで解いた判断、対照 checkout での帰属証明、
+  無効になった 1 回目のキャンペーンを自分で破棄して取り直した点、いずれも正しい進め方です。
+
+  この送信は**あなたが「scope 外なので変更していない。必要な修正はこれ」と報告した 1 件を、
+  scope を広げて実際に直してもらう**ためのものです。
+
+  ## やること
+
+  ### 1. `waited=0s` の固定値 assert を直す（必須）
+
+  `.claude/skills/cmate-verify/scripts/tests/run-tests.sh` の 2 箇所:
+
+  - `:797` `assert_eq "mutex: the first run declares a wait of zero rather than nothing" "0" "$holder_waited"`
+  - `:871` `assert_has "mutex-flaky: the wait keeps its own field beside a two-valued duration" "$OUT" "waited=0s"`
+
+  あなたの報告どおり「**フィールドが存在すること**」の assert へ変えてください。元の assert が
+  何を守ろうとしていたのか（`:790` 付近のコメント）を読み、**その意図は保ったまま**、
+  負荷で 0 秒にならないケースを赤にしないようにすること。値そのものを捨てるのではなく、
+  「`waited=` フィールドが出ていること」「2 値の duration とは別フィールドであること」を
+  見る形が本来の意図に見えますが、コメントを読んだうえであなたが正しいと判断した形にしてください。
+
+  **`.claude/` と `.agents/` の両方を byte-identical に保つこと。** 現在どちらも
+  sha256 `180d7656c29e…` で一致しています。片方だけ直すと dual placement が壊れます。
+
+  ### 2. `monitor.sh` の PIPE trap（任意・安いと判断したときだけ）
+
+  `.claude/skills/orchestrate-monitor/scripts/monitor.sh` の `trap ... PIPE` があるため、
+  外から殺されると 141 を返す — あなたの報告どおり動作は正しいのですが、#1950 の調査を
+  丸一日ミスリードした表示です。trap 内の `echo ... >&2` を `2>/dev/null` で保護し、
+  TERM の 143 が保たれるようにする案を挙げていました。**安く安全に入るなら入れてください。
+  副作用が読み切れないなら入れず、理由を commit message に書いてください。** これも
+  `.claude/` と `.agents/` の両方が対象です。
+
+  ### 3. やらないこと
+
+  - **非ファミリで負荷に脆い 5 ファイル**（`app-version-display.test.tsx` 28.2s ほか）は
+    **触らないでください**。あなたの「クラスの予算は妥当であり、この 5 件は個別に
+    『なぜ jsdom のモーダル 1 枚に 28 秒かかるのか』を見るべき別 Issue」という判断を採用します。
+    別 Issue として私が起票します。
+  - `.commandmate/verify.yaml` / `.github/workflows/ci-pr.yml` — **#1946 は既に develop へ
+    マージ済み**（`417b9435`、静的ガード `route-exports` が 4 本目として増えています）。
+    あなたのブランチは私が `git merge origin/develop` で取り込み済みで、衝突はありませんでした。
+    これらのファイルは引き続き触らないでください。
+
+  ## 検証
+
+  - `tests/unit/skills/cmate-verify/verify-run.test.ts` を**負荷をかけた状態で 3 回**回して
+    3/3 緑であること（前回 run 1 と 4 で落ちた 2 件が出ないこと）。
+  - 直した assert が**空振りでないこと**を変異注入で示すこと — 元の assert が守っていた欠陥
+    （`waited` フィールドを落とす、2 値 duration に混ぜる 等）を注入して**赤になること**を確認し、
+    変異と結果を commit message に書く。「assert を緩めただけ」になっていないことの証明です。
+  - `npm run lint` / `npx tsc --noEmit` / 静的ガード 4 本（`route-exports` を含む）が exit 0。
+
+  commit は既存 `1a2f1912` への amend でも 2 本目でも構いません（PR は squash マージします）。
+  断片（`dev-reports/changelog/issue-1950.md` / `dev-reports/module-reference/issue-1950.md`）は
+  今回の修正を含む内容に**更新**してください。
+
+  作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "tests/**"
+    - "vitest.config.ts"
+    - "package.json"
+    - ".claude/skills/cmate-verify/**"
+    - ".agents/skills/cmate-verify/**"
+    - ".claude/skills/orchestrate-monitor/**"
+    - ".agents/skills/orchestrate-monitor/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1950c.yaml
+++ b/.commandmate/tasks/issue-1950c.yaml
@@ -1,0 +1,54 @@
+version: 1
+title: "Issue #1950 最終: sync-map.json を含む union scope での再裁定（確認のみ）"
+goal: |
+  **追加の実装は不要です。** commit `cf438066` の内容・判断・変異注入をすべて受領しました。
+
+  - `waited=0s` の固定値 assert を「フィールドの存在」＋「holder の待ちが後続より厳密に短い」＋
+    「GATE 行を行頭行末で固定」へ変えた形は**両方向に厳密に強く**なっており、MB の変異が
+    その証明になっています。元の assert の意図を `:785` のコメントから読み取り、
+    **同じ欠陥の片割れ（`duration=3s` の literal）が既に直っていて wait 側だけ残っていた**ことまで
+    突き止めた点も含めて、期待以上です。
+  - `monitor.sh` の `fatal_reported`（first signal wins）で 141 → 143 になり、かつ単独 SIGPIPE は
+    今も 141 を報告するという陽性対照も確認済みであること、了解しました。
+  - **契約の前提 2 件の訂正を受け入れます**（実測が正）: `.agents/skills/` に orchestrate-monitor は
+    存在しない（dual placement は cmate-verify / demo-video / video-to-gif の 3 つだけ）。
+    私が挙げた sha256 `180d7656c29e…` は `run-tests.sh` のもので monitor.sh のものではない。
+  - **`.claude/skills/sync-map.json` の re-pin を承認します。** 「re-pin すると scope が落ち、
+    re-pin しないと unit が落ちる」という相互排他で unit 側を選んだ判断は正しい —
+    unit を赤のまま置くことは #1950 が直そうとしている失敗そのものを再生産します。
+    今回の送信で scope.allow に `.claude/skills/sync-map.json` を追加しました。
+
+  ## やること
+
+  - `git status` を見て、`.commandmate/tasks/` 配下以外に未コミットの変更が無いことを確認する。
+  - **ファイルを 1 つも変更しない。** 新しい commit も作らない。
+  - 最終行に `VERIFY_ONLY_ACK` とだけ出力して終了する。
+
+  未コミットの変更が残っていた場合だけ、それを `cf438066` に `--amend` で畳んでから
+  `VERIFY_ONLY_ACK` を出力してください（新しい commit は作らないこと）。
+
+  ## 申し送り（あなたの作業ではありません）
+
+  commit message の「残っている宿題」— `Kewton/commandmate-skills` への移植 2 件
+  （`run-tests.sh` は byte-identical コピー、`monitor.sh` は port-required なので `fatal_reported` の
+  挙動を再表現）— は**私が別 Issue に切り出します**。`lastSyncedRef` を `9604e8f` のままにして
+  「移植済み」を主張しなかったのは正しい判断です。
+scope:
+  allow:
+    - "tests/**"
+    - "vitest.config.ts"
+    - "package.json"
+    - ".claude/skills/cmate-verify/**"
+    - ".agents/skills/cmate-verify/**"
+    - ".claude/skills/orchestrate-monitor/**"
+    - ".claude/skills/sync-map.json"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1975.yaml
+++ b/.commandmate/tasks/issue-1975.yaml
@@ -1,0 +1,118 @@
+version: 1
+title: "Issue #1975: send 直後の wait が 0 秒で偽完了する（STARTED ガード）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1975 を修正してください。
+
+  `send` の直後に `wait` を実行すると、エージェントが 1 バイトも仕事をしていないのに 0〜1 秒で
+  `Completed`（exit 0）を返します。隔離サーバでの実機受入で **copilot 3/3 再現**しました。
+
+      Completed: uatcp (basis=scraper_ready)
+      wait_exit=0  elapsed=0s
+      file at wait-return: NO          ← 仕事は始まってすらいない
+
+  根本原因は `src/cli/commands/wait.ts` の `turnSettled()` が **`turnStartedAt === null` を
+  「決着済み」と読む**こと。`send` 直後の最新イベントは「直前ターンの `stop`」なので
+  `adoptTurnStart()` は何も採用せず、スクレイパは（まだ生成が始まっていないので）idle composer を
+  見て `ready` を返し、**初回ポーリングで完了**します。
+
+  ## 方針（推奨は案 1。ただし実測して判断すること）
+
+  Issue 本文は案 3（`AgentSourceCapabilities` で「hook を出さないツール」を宣言し、
+  「まだ最初のイベントが来ていない」は待つ）を本筋としています。**その分析は正しい**のですが、
+  この Issue では **案 1（`wait` に STARTED ガードを入れる）を推奨**します。理由:
+
+  - 案 3 は `AgentSourceCapabilities` に項目を足すことになり、**6 ソース全部＋ capability 表の pin**
+    に波及します。それは Phase 4（#1930、構造化層を TurnRecord へ置換）の作業範囲で、
+    いま別ブランチが同じ `src/lib/hooks/` を触っています。
+  - `wait.ts` の turn 処理は **#1930 が置換対象にしている**ので、いま重い設計変更を入れると二重作業に
+    なります。最小で正しいガードを入れ、#1930 へ申し送るのが順序として正しい。
+
+  **案 1 が不健全だと判断したら案 3 を採ってよい**ですが、その場合は `src/lib/hooks/` に触れる
+  ファイルを commit message に列挙してください（私が #1942 との衝突を裁きます）。
+
+  ## 設計上の注意（ここを外すと別の壊し方になる）
+
+  `.claude/skills/orchestrate-monitor/scripts/verify-completion.sh` の **STARTED ガード**が同型の
+  実装です。まずこれを読んでください。特に:
+
+  - **何も始まらないときに無限に待ってはいけない。** 既存の `--timeout` / `--stall-timeout` 経路へ
+    ちゃんと落ちること。ガードが「永久に完了しない `wait`」を作ったら、それは別の裁定破壊です。
+  - **hook を出さないツールの挙動は不変であること**（Issue の受入条件）。既存の `sawRunning`
+    （#1628 の「セッションが一度も生きていなかった」ガード）と同じ位置に置けるはずです。
+  - すでに生成が終わってアイドルのセッションに対して `wait` を撃つ正当な使い方
+    （オーケストレーターは実際にこれをやります）を壊さないこと。**「今回の `wait` が始まる前から
+    アイドル」と「`send` 直後でまだ始まっていない」を区別できるか**を設計の中心に置いてください。
+
+  ## 受入条件
+
+  - **アイドル状態から `send` → `wait` を 5 回連続**で実行し、いずれもエージェントの成果物が存在する
+    時点でのみ `Completed` を返すこと（**copilot / opencode 両方**）。
+  - hook を出さないツールの挙動が不変であること。
+  - **変異注入**: STARTED ガードを外すと上記の 5 回試行が赤になること。変異と結果を commit message に。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` が exit 0。
+
+  ## 実機検証の隔離（厳守）
+
+  実機で `send` / `wait` を試すときは**必ず隔離環境**で行うこと。ユーザーの本番サーバ（port 3000）と
+  本番 DB、稼働中の `mcbd-*` セッションに触れてはいけません。
+
+  - 別ポート（例 3012）＋ 隔離 DB（`CM_DB_PATH` を `$HOME` 配下の使い捨てへ）で dev サーバを上げる。
+    このシェルは `NODE_ENV=production` を export しているので **`NODE_ENV=development` を明示**すること。
+  - 終了時は**自分が起動した PID を特定して**停止する（`lsof -iTCP:<port> -sTCP:LISTEN -t` で確認し、
+    そのプロセスが自分の worktree のものだと確かめてから kill）。`pkill -f` のような広いパターンは使わない。
+  - `~/.copilot/settings.json` は**マシン共通の 1 本**です。触る場合は sha256 を採って**必ず復元**すること。
+
+  ## 触ってよい範囲
+
+  `src/cli/**`・`tests/unit/cli/**`・`tests/unit/skills/**`。
+
+  **`src/lib/hooks/**` と `src/lib/security/**` は触らないでください**（#1942 のワーカーが同時に編集）。
+  **`tests/setup.ts` も触らないでください**（同上）。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1975.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1975): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1975.md` — `docs/module-reference.md` の表に足す注記。
+      **既存行への追記を指示する場合は、その行が実在することを `grep -n '^| `<path>`' docs/module-reference.md`
+      で必ず確認してから書くこと**（前回のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍の時間がかかる**
+    （62s ↔ 560s）。`src/lib/verification/gate-runner.ts:414` が `CI: 'true'` を渡し、
+    `vitest.config.ts` が `CI==='true'` で `fileParallelism:false` にするため。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」が走り、実在しない赤が出ます。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+
+  ## 実 tmux を触る検証の追加ルール（厳守）
+
+  - **必ず `tmux -L <専用socket>` で行う。** `-L` / `-S` は `$TMUX` より優先される。あなたは tmux ペインの
+    中で動いていて `$TMUX` が既定サーバを指しているため、フラグ無しの `tmux` は**ユーザーの本番サーバ**に届く。
+  - **`kill-server` を `-L` 無しで書かない。** 後始末は `kill-session -t '=<name>:'`（完全一致）で行う。
+  - **`TMUX_TMPDIR` を隔離手段に使わない**（`$TMUX` があると無視される）。
+  - **`bind-key` / `unbind-key` / `set-option -g` を既定サーバへ撃たない**（サーバグローバル）。
+scope:
+  allow:
+    - "src/cli/**"
+    - "tests/unit/cli/**"
+    - "tests/unit/skills/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1977.yaml
+++ b/.commandmate/tasks/issue-1977.yaml
@@ -1,0 +1,98 @@
+version: 1
+title: "Issue #1977: 非ファミリの遅い 5 テストを個別に直す（予算で覆わない）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1977 を修正してください。
+
+  #1950 で「実シェルを起動するテスト 69 ファイル」の負荷起因の赤は解消しました。**その外側に、
+  負荷で 9〜28 秒かかるテストが 5 本残っています。**
+
+  | ファイル | 所要（負荷下・60s 予算での実測） |
+  |---|---|
+  | `tests/unit/components/app-version-display.test.tsx` | **28.2s** |
+  | `tests/unit/lib/ws-server-cleanup.test.ts` | 20.5s |
+  | `tests/unit/api/hooks-claude-done-delegation.test.ts` | 11.2s |
+  | `tests/unit/lib/tmux-capture-invalidation.test.ts` | 9.4s |
+  | `tests/unit/config/eslint-i18n-module-scope-literal.test.ts` | （5000ms 超） |
+
+  **非ファミリ全体の所要分布は p99.9 = 4253ms** なので、vitest 既定の 5000ms は**このクラスに対して
+  正しいサイズ**です。上の 5 本は分布の外れ値であり、予算の問題ではなく**テスト（あるいは対象コードの）
+  問題**です。
+
+  ## やること
+
+  1. **5 本それぞれについて、何にその時間を使っているのかを実測する。** 原因はファイルごとに違うはずです
+     （jsdom のレイアウト、fake timer と実 timer の混在、`waitFor` のポーリング間隔、実ソケット待ち、
+     ESLint の実行、など）。**推測で直さないこと。**
+     `app-version-display.test.tsx` が jsdom のモーダル 1 枚に 28 秒かかるのは、それ自体が異常です。
+  2. 原因に応じて直す。
+  3. 直したものが空振りでないことを**変異注入**で示す。
+
+  ## やらないこと（重要）
+
+  - **グローバル `testTimeout` を上げない。** 非ファミリの p99.9 は 4253ms なので 5000ms は妥当で、
+    60s のグローバル予算は p99.9 の 14 倍＝「数字を大きくするだけ」のアンチパターンです。
+  - **`vitest.config.ts` と `tests/setup.ts` を触らない**（scope 外・#1939 / #1942 のワーカーが
+    同時に編集しています）。
+  - **#1950 が入れたファミリ側の仕組み**（`tests/helpers/real-shell-budget.ts`）を変更しない。
+    5 本のうち `tmux-capture-invalidation.test.ts` などがファミリ判定に入っているなら、
+    **予算を広げるのではなく個別の遅さを直す**こと。
+  - 個別の `testTimeout` を上げるのは**最後の手段**。採る場合は「なぜこのテストだけ本質的に遅いのか」を
+    根拠つきで commit message に書くこと。
+
+  ## 受入条件
+
+  - 負荷下（並列で shell を回すなどで load avg を上げた状態）でフル `npm run test:unit` を
+    **連続 3 回**回して、上記 5 ファイルが 3/3 緑。5 回の所要（秒）と load avg を commit message に。
+  - 各ファイルについて「遅さの原因」と「直した内容」が commit message の表に書かれている。
+  - グローバル `testTimeout` を上げていないこと。
+  - `npm run lint` / `npx tsc --noEmit` が exit 0。
+
+  ## 触ってよい範囲
+
+  上記 5 テストファイルと、遅さの原因が実装側だった場合の該当ソース
+  （`src/components/**`・`src/lib/**`・`src/app/api/**`）。
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1977.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1977): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1977.md` — `docs/module-reference.md` の表に足す注記。
+      **既存行への追記を指示する場合は、その行が実在することを `grep -n '^| `<path>`' docs/module-reference.md`
+      で必ず確認してから書くこと**（前回のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍の時間がかかる**
+    （62s ↔ 560s）。`src/lib/verification/gate-runner.ts:414` が `CI: 'true'` を渡し、
+    `vitest.config.ts` が `CI==='true'` で `fileParallelism:false` にするため。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」が走り、実在しない赤が出ます。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "tests/unit/components/app-version-display.test.tsx"
+    - "tests/unit/lib/ws-server-cleanup.test.ts"
+    - "tests/unit/api/hooks-claude-done-delegation.test.ts"
+    - "tests/unit/lib/tmux-capture-invalidation.test.ts"
+    - "tests/unit/config/eslint-i18n-module-scope-literal.test.ts"
+    - "src/components/**"
+    - "src/lib/tmux/**"
+    - "src/app/api/hooks/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1977b.yaml
+++ b/.commandmate/tasks/issue-1977b.yaml
@@ -1,0 +1,101 @@
+version: 1
+title: "Issue #1977 追補: ws-server-cleanup を scope に入れ直して直す"
+goal: |
+  **追加の実装は不要な部分が大半です。** commit `7f39b315` の 4 ファイル分の修正・実測・変異注入は
+  受領しました。「予算ではなく遅さの原因から直す」という契約の核心を守り、**本文が挙げた 5 ファイルが
+  実はフル実行の赤の主因ではなかった**ことまで対照で示した点も含めて、良い仕事です。
+
+  この送信は**あなたが「scope 外なので触っていない」と報告した 1 件を、scope を広げて直す**ためのものです。
+
+  ## 1. `ws-server-cleanup` を直す（必須）
+
+  **私の scope.allow が間違っていました。** 契約に `tests/unit/lib/ws-server-cleanup.test.ts` と
+  書きましたが、実際のパスは **`tests/unit/ws-server-cleanup.test.ts`** です。あなたの指摘どおり
+  glob が一度も一致していませんでした。あなたの落ち度ではありません。
+
+  今回 scope に次を追加しました:
+
+      tests/unit/ws-server-cleanup.test.ts
+      src/lib/ws-server.ts
+      src/lib/cli-tools/manager.ts
+
+  あなたの実測（`import('@/lib/ws-server')` 1160ms、うち **1046ms が `@/lib/cli-tools/manager`**）を
+  出発点にしてください。**負荷下フル実行で 2.67-3.33s と 5 ファイル中で最も予算を食う**という
+  あなた自身の計測どおり、ここが残った最大の一本です。
+
+  **判断してほしいこと**: `manager` の 1046ms が
+
+  - (a) **テスト側の問題**（テストが本番の import グラフ全体を引く必要が無いのに引いている）なら、
+    テストだけを直す。`vi.mock` / 遅延 import / 必要な部分だけの import へ。**これが第一選択**。
+  - (b) **本番の import グラフの問題**（`manager` が起動時に不要なものまで静的 import している）なら、
+    プロダクションコードを直す価値がある。ただし `manager.ts` は多くの経路が通る中核なので、
+    **import の向きを変える変更は影響が広い**。直す場合は何が動かなくなりうるかを commit message に
+    書き、フル `npm run test:unit` で確かめること。
+  - (c) 1046ms が本質的（本当にその依存が要る）なら、**直さずに理由を書く**のも正解です。
+    その場合は「なぜこのテストだけ本質的に遅いのか」を根拠つきで書き、個別 `testTimeout` の
+    是非も併せて述べてください。
+
+  **どれを採ってもよいので、実測してから決めてください。**
+
+  ## 2. Issue #1977 の前提が外れていた件を記録する（必須）
+
+  あなたの報告 4:
+
+  > 本文が挙げた 5 ファイルは、そのフル実行での赤の主因ではなかった。ベースライン実行で赤だった
+  > 48 テストはすべて #1950 のファミリで、別ワークツリーのフル test:unit を同時に走らせたことによる
+  > 30s サブプロセスガード超過だった。単独で回せば同じ負荷でも緑（受入 3 回とも 0 failed）。
+
+  **これは重要な訂正**なので、commit message に残したうえで `dev-reports/issue-1977-findings.md` にも
+  書いてください。特に次を明確に:
+
+  - **#1950 が入れた 30s サブプロセスガードが、複数 worktree の同時フル実行では超過しうる**のか。
+    そうならそれは #1950 の残課題であり、私が別 Issue に切り出します。**あなたが直す必要はありません。**
+    「ガードが超過した」のか「ガードが正しく発火して報告した」のかを区別して書いてください。
+  - 「5 ファイルが赤の主因ではない」ことと「5 ファイルが遅い」ことは両立します。あなたが直した
+    4 ファイルの改善は有効です。**それを取り下げる必要はありません。**
+
+  ## 受入条件
+
+  - `ws-server-cleanup` について (a)(b)(c) のいずれかの結論が実測つきで出ていること。
+    (a)(b) を採った場合は、負荷下でフル `npm run test:unit` を**連続 3 回**回して当該ファイルが 3/3 緑、
+    かつ所要（秒）と load avg を commit message に。
+  - 変異注入で、直したものが空振りでないことを示すこと（(c) を採った場合は不要）。
+  - `npm run lint` / `npx tsc --noEmit` / フル `npm run test:unit` が exit 0。
+  - **グローバル `testTimeout` を上げていないこと**（前回と同じ）。
+
+  commit は既存 `7f39b315` への amend でも 2 本目でも構いません（PR は squash マージします）。
+  断片（`dev-reports/changelog/issue-1977.md` / `dev-reports/module-reference/issue-1977.md`）は
+  今回の内容を含めて**更新**してください。
+
+  ## 作業ルール（厳守）
+
+  - PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しない。** 断片は `dev-reports/` 配下へ。
+    既存行への追記を指示する場合は `grep -n '^| `<path>`' docs/module-reference.md` で**実在を確認**してから書くこと。
+  - **この契約の方針は「推奨」。** 逸脱するなら理由を commit message に明記すること。
+  - **`wait --verify` の unit ゲートは素の実行の約 9 倍かかる**（62s ↔ 560s）。`gate-runner.ts:414` が
+    `CI:'true'` を渡し `fileParallelism:false` になるため。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しない**（vitest の遅延 transform で偽の赤が出る）。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "tests/unit/components/app-version-display.test.tsx"
+    - "tests/unit/ws-server-cleanup.test.ts"
+    - "tests/unit/api/hooks-claude-done-delegation.test.ts"
+    - "tests/unit/lib/tmux-capture-invalidation.test.ts"
+    - "tests/unit/config/eslint-i18n-module-scope-literal.test.ts"
+    - "src/lib/ws-server.ts"
+    - "src/lib/cli-tools/manager.ts"
+    - "src/components/**"
+    - "src/lib/tmux/**"
+    - "src/app/api/hooks/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck, unit]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true

--- a/.commandmate/tasks/issue-1979.yaml
+++ b/.commandmate/tasks/issue-1979.yaml
@@ -1,0 +1,83 @@
+version: 1
+title: "Issue #1979: 方針書を Phase 2 の実測で訂正する（copilot probe / idle composer 例 / UNKNOWN_FRAME）"
+goal: |
+  https://github.com/Kewton/CommandMate/issues/1979 を実施してください。
+
+  **方針書 `docs/design/multi-agent-state-architecture.md` の訂正のみ。ソースコードは変更しません。**
+
+  Epic #1891 の実装 26 件と実機受入で、方針書の記述が実測と食い違う箇所が 3 件見つかりました。
+  いずれも Phase 3（#1927 / #1928 / #1929）が直接の実装対象なので、直さずに着手すると
+  「方針書どおりに実装して間違える」ことになります。Issue 本文に 3 件の詳細があります。
+
+  ## 最も重要な作業は訂正 1（copilot probe の代替を決めること）
+
+  「`gh copilot -- --version` は使えない」と書くだけでは #1929 が着手できません。**非破壊な代替を
+  実測で探し、選んだ案を根拠つきで書いてください。** 候補と、確認すべきこと:
+
+  - `gh extension list` の出力から `github/gh-copilot` の版を読む（**出力形式を実測すること**）
+  - `~/.local/share/gh/extensions/` などインストール実体のパスを読む（**実在するか実測**）
+  - **copilot だけ probe 対象から外し `detector.staleness` を `undefined` のままにする** —
+    §4 D2 が既に「解決できなければ probe をスキップ」を既定にしているので、規約と矛盾しません
+  - どの案でも「**`gh copilot` 拡張が未インストールの環境で何も起こさない**」ことを確認してください
+    （`gh` 自体が無い場合も含む）。あなたの環境で拡張がインストール済みなら、未インストール環境の
+    挙動は `PATH` や `GH_CONFIG_DIR` を差し替えた使い捨て環境で確かめること。**ユーザーの
+    `~/.config/gh` を書き換えないこと。**
+
+  DR4-010 の規約文（probe 対象と launch 対象を別物にしない）は**維持したまま**、copilot だけ
+  例外扱いする理由を書いてください。
+
+  ## 訂正 2 は実フレームで裏を取ること
+
+  `:129` の copilot の例（`●` 応答行の直後に空の composer）は実測と食い違います。差し替える記述は
+  **実 TUI キャプチャ（200x1000 ペイン）に基づく**こと。`tests/fixtures/` に既存の copilot キャプチャが
+  あればそれを根拠に使ってください（無ければ「実測が必要」と明記し、推測で書かない）。
+
+  ## 訂正 3
+
+  `:555` の `STATUS_REASON.UNKNOWN_FRAME` は `grep -rn 'UNKNOWN_FRAME' src/` が 0 件（develop
+  `a175767a` で実測済み）。§8 の Phase 3 行に「#1927 の作業に含まれる」ことを明記してください。
+
+  ## 受入条件
+
+  - 3 箇所が実測に基づく記述へ差し替わっている。
+  - §15.5 に「Phase 2 の実装・実機受入で覆った実測」として 3 件を追記し、影響を受ける Issue
+    （#1927 / #1928 / #1929）を併記している。
+  - **ソースコードを 1 行も変更していない。**
+
+  ## 作業ルール（厳守）
+
+  - **commit は 1 本にまとめる。** PR は作らない・push しない（オーケストレーターが行う）。
+  - **`CHANGELOG.md` と `docs/module-reference.md` を編集しないでください**（scope 外です）。
+    代わりに次の 2 ファイルを書いてください。どちらも `dev-reports/` 配下なので commit には入りません。
+    - `dev-reports/changelog/issue-1979.md` — `CHANGELOG.md` の `## [Unreleased]` にそのまま貼れる
+      **1 エントリ**（先頭は `- **<type>(<scope>): …** (#1979): …`）。1 行目にどの節
+      （`### Added` / `### Changed` / `### Fixed`）へ入るかをコメントで書く。
+    - `dev-reports/module-reference/issue-1979.md` — `docs/module-reference.md` の表に足す注記。
+      **既存行への追記を指示する場合は、その行が実在することを `grep -n '^| `<path>`' docs/module-reference.md`
+      で必ず確認してから書くこと**（前回のランで、存在しない行への追記を 4 件指示した実績があります）。
+  - **この契約に書いた方針は「推奨」であって命令ではない。** コードを読んで別の解のほうが正しいと
+    判断したら、そちらを採ってよい。ただし**逸脱した箇所と理由を commit message に明記すること**。
+  - **Issue 本文をコードで裏取りすること。** 本文と実測が食い違ったら**実測を正**とし、
+    どこがどう違ったかを commit message に書く。この Issue はオーケストレーター（私）が書いており、
+    過去のランでは自作 Issue の記述が実測と食い違った実績が複数あります。
+  - **`wait --verify` / `verify` の出力は 344 行で切られる。** 失敗の帰属を判断するときは必ず
+    `commandmate verify show <id>` で全文を見ること。
+  - **`wait --verify` の unit ゲートは素の `npm run test:unit` の約 9 倍の時間がかかる**
+    （62s ↔ 560s）。`src/lib/verification/gate-runner.ts:414` が `CI: 'true'` を渡し、
+    `vitest.config.ts` が `CI==='true'` で `fileParallelism:false` にするため。異常ではありません。
+  - **フル `npm run test:unit` の実行中にソースやテストを編集しないこと。** vitest の遅延 transform に
+    より「新しいテスト × 古いソース」が走り、実在しない赤が出ます。
+  - 作業が終わったら最終行に `IMPL_COMPLETED` とだけ出力すること。
+scope:
+  allow:
+    - "docs/design/**"
+  deny: []
+verify:
+  gates: [token-discipline, control-chars, claudemd-size, route-exports, lint, typecheck]
+autoYes:
+  mode: allow-listed
+  allowPromptTypes: [yes_no, multiple_choice]
+  denyPatterns: []
+success:
+  requireWorkEvidence: true
+  requireScopeClean: true


### PR DESCRIPTION
## 概要

2026-08-22〜23 のオーケストレーション（17 Issue・4 波）で使った**実行契約 22 本**を追跡に加えます。**ソースコードの変更はありません。**

## なぜ

`.gitignore:83-86` が `.commandmate/tasks/*.yaml` を**意図的に追跡対象**にしています:

```
# 実行契約（Issue #1545 / Phase 2-1）。「誰がどんな制約で作業させたか」の記録なので
# レビュー可能な形で追跡する。.yaml 以外（ログ等の副産物）は除外したままにする。
!/.commandmate/tasks/
/.commandmate/tasks/*
!/.commandmate/tasks/*.yaml
```

既に **69 本**が追跡されています（`issue-1621-phase0.yaml` / `issue-1723.yaml` など）。しかし今回のランの契約は worktree 側にしか置いておらず、**worktree を掃除した時点で記録が失われていました**。既に追跡済みの `issue-1930.yaml` を除く 22 本を復元します。

## 内訳

| 波 | 契約 |
|---|---|
| 裁定基盤 | `issue-1939` / `1942` / `1946`(+b) / `1950`(+b,+c) / `1975` / `1977`(+b) |
| 方針書訂正 | `issue-1979` |
| Phase 3 | `issue-1927`(+b,+c) / `1928`(+b,+c) / `1929` |
| Phase 4 | `issue-1931` / `1932` / `1933`(+b) |

**`b` / `c` の接尾辞は同じ Issue に対する再送**で、scope の取り直しや追補の指示を含みます。**裁定がどこで割れて何を根拠に承認したかが本文に残っている**ため、初回の契約だけでは記録として不完全です。例:

- `issue-1927b.yaml` — `tests/unit` 直下の `detection-*.test.ts` 3 本が私の glob 漏れで scope 外になった件の取り直し
- `issue-1928c.yaml` — `prompt-surface-text-nodes-1928.test.tsx` の TS2741 を差し戻した際の指示（`status` に何を入れるかを worker に委ねた理由つき）
- `issue-1933b.yaml` — `tsconfig.cli.json` が `"paths": {}` である件の差し戻し
- `issue-1950b.yaml` / `1977b.yaml` — scope 外として報告された残件を scope を広げて処理した記録

## 検証

| 検査 | 結果 |
|---|---|
| `scripts/check-commandmate-tracking.sh` | **OK: all expectations hold** |
| 静的ガード 4 本（token-discipline / control-chars / claudemd-size / route-exports） | exit 0 |
| YAML 妥当性 | 22 本すべて `yaml.safe_load` 可能 |
| 影響テスト（verification / guards / config） | **68 files / 1391 tests PASS** |
| 秘密の混入 | なし（`CM_AUTH_TOKEN` の 1 件は「秘密が入らないことを pin せよ」という要件文の中の識別子） |

`CHANGELOG.md` / `docs/module-reference.md` は変更していません（コードの挙動が変わらないため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rRBB2m6P8d1b4giKotyfS
