### PR TITLE
fix(remote): cloudflared の fd 2 をファイルに向け remote 終了後もトンネルを生かす (#2146)

### DIFF
--- a/src/lib/remote/cloudflare.ts
+++ b/src/lib/remote/cloudflare.ts
@@ -32,6 +32,33 @@
  *    keeps the first candidate actually first: for that long, only the metrics
  *    route is consulted.
  *
+ * 4. **The tunnel outlives the CLI that started it.** `commandmate remote up`
+ *    exits as soon as it has a URL — measured at about 6.5 seconds, taken from
+ *    the metrics API. cloudflared has to still be there afterwards, because the
+ *    whole point is a QR code someone reads with a phone a minute later. Two
+ *    things make that true, and Issue #2146 is what happens without them:
+ *    cloudflared's stderr goes to a **file descriptor, never a pipe**, and the
+ *    child is spawned `detached` and `unref`ed.
+ *
+ *    Measured (Issue #2146, `docs/qa/1937-remote-uat-record.md` D-1): with
+ *    `stdio: ['ignore', 'ignore', 'pipe']` the child was dead within two
+ *    seconds of the parent exiting, and the public URL answered HTTP 530 before
+ *    the QR code could be read. The parent's exit closes the read end of that
+ *    pipe; cloudflared is Go, does not ignore SIGPIPE, and dies on its next
+ *    write to fd 2 — which, at t+6.5s, is still mid log-burst. The same argv
+ *    with a parent kept alive for 70 seconds gave a child that lived 70
+ *    seconds, so this is the plumbing and not cloudflared giving up.
+ *
+ *    `'ignore'` would also have fixed it and is the wrong fix: it takes fd 2
+ *    away entirely, and fd 2 is where both the **second URL candidate**
+ *    (`parseBannerUrl`) and every failure diagnostic (`stderrTail`) come from.
+ *    A file keeps both — nothing closes when the CLI exits, and the parser and
+ *    the diagnostic read it back by path. `--logfile` was the other candidate:
+ *    it covers cloudflared's own log lines but not anything the Go runtime or
+ *    the loader writes straight to fd 2, so fd 2 would still have been a pipe.
+ *    `'ignore'` for fd 2 is what this falls back to only when the log file
+ *    cannot be opened at all: a diagnostic is worth less than a working tunnel.
+ *
  * Deliberately absent: the approval prompt. Creating a public URL is an
  * irreversible, user-facing decision, and §6.2 puts it in the orchestrator that
  * owns `src/cli/commands/remote.ts` — the same code that knows whether the
@@ -48,7 +75,7 @@ import {
   type SpawnSyncOptionsWithStringEncoding,
   type SpawnSyncReturns,
 } from 'child_process';
-import { mkdirSync } from 'fs';
+import { closeSync, fstatSync, mkdirSync, openSync, readSync } from 'fs';
 import { createServer } from 'net';
 import { get as httpGet } from 'http';
 import { homedir } from 'os';
@@ -83,6 +110,15 @@ export const QUICK_TUNNEL_SUFFIX = 'trycloudflare.com';
 /** Written next to the rest of CommandMate's state, for humans and for `ps`. */
 export const CLOUDFLARED_PIDFILE_NAME = 'cloudflared.pid';
 
+/**
+ * Where cloudflared's stderr goes. Beside the pidfile, and for the same reason:
+ * a human who wants to know what the tunnel is doing should be able to find it.
+ *
+ * A fixed name, like the pidfile, so one `remote` session at a time is the
+ * assumption in both places rather than in one of them.
+ */
+export const CLOUDFLARED_LOG_NAME = 'cloudflared.log';
+
 /** Same 5s budget `PreflightChecker` gives every other dependency probe. */
 export const DETECT_TIMEOUT_MS = 5_000;
 
@@ -111,18 +147,32 @@ export const DEFAULT_QUICK_TUNNEL_TIMING: QuickTunnelTiming = {
 /** Per-request budget for the loopback metrics call. */
 export const METRICS_REQUEST_TIMEOUT_MS = 1_000;
 
-/** Cap on retained stderr, so a chatty reconnect loop cannot grow unbounded. */
+/**
+ * How much of the stderr log is read back, so a chatty reconnect loop cannot
+ * make either consumer grow unbounded.
+ *
+ * The **tail**, not the head: `parseBannerUrl` takes the last match on purpose
+ * (a reconnect banner should win), and `stderrTail` wants the last few lines.
+ */
 export const STDERR_CAPTURE_LIMIT = 64 * 1024;
 
-/** The part of a spawned cloudflared this module uses, and nothing more. */
+/**
+ * The part of a spawned cloudflared this module uses, and nothing more.
+ *
+ * No `stderr`: as of Issue #2146 fd 2 is a file, so there is no stream to read
+ * and nothing here that could be tempted to hold one open. `unref` is required
+ * rather than optional because forgetting it is exactly the class of mistake
+ * this interface exists to make impossible.
+ */
 export interface QuickTunnelProcess {
   readonly pid?: number | undefined;
-  readonly stderr: NodeJS.ReadableStream | null;
   once(
     event: 'exit',
     listener: (code: number | null, signal: NodeJS.Signals | null) => void,
   ): unknown;
   kill(signal?: NodeJS.Signals): boolean;
+  /** Releases the parent's event-loop reference to this child. */
+  unref(): unknown;
 }
 
 export type SpawnQuickTunnel = (
@@ -180,6 +230,124 @@ export function buildQuickTunnelArgs(opts: {
     '--pidfile',
     opts.pidfile,
   ];
+}
+
+/**
+ * The spawn options for one Quick Tunnel. Issue #2146 is entirely about these.
+ *
+ * `stderr` is a **file descriptor**, or `'ignore'` when the log file could not
+ * be opened. It is never `'pipe'`: a pipe's read end belongs to `commandmate
+ * remote`, which exits as soon as it has the URL, and cloudflared then dies of
+ * SIGPIPE on its next write to fd 2. See the file header for the measurement.
+ *
+ * `detached: true` puts the child in its own session. Without it, a Ctrl-C in
+ * the terminal that launched the CLI reaches cloudflared too — the tunnel is
+ * supposed to outlive the command, so it must not share its process group.
+ * `stop()` is unaffected: it signals a **positive** pid, which is one process,
+ * not a group, so detaching changes nothing about teardown.
+ */
+export function buildQuickTunnelSpawnOptions(stderr: number | 'ignore'): SpawnOptions {
+  const stdio: ('ignore' | number)[] = ['ignore', 'ignore', stderr];
+  return { detached: true, stdio };
+}
+
+/**
+ * cloudflared's stderr, as this module hands it out and reads it back.
+ *
+ * Two consumers depend on it and both survive the change from a pipe to a file,
+ * because a file can be re-read by path at any time: `parseBannerUrl()` (the
+ * second URL candidate) and `stderrTail()` (the failure diagnostic).
+ */
+export interface StderrLog {
+  /** Goes in slot 2 of `stdio`. A descriptor, or `'ignore'`. Never `'pipe'`. */
+  readonly stdio: number | 'ignore';
+  /** The file being written to, or `null` when there is none. */
+  readonly path: string | null;
+  /** The tail of what cloudflared has written so far. Never throws. */
+  read(): string;
+  /** Closes this process's copy of the descriptor. The child keeps its own. */
+  close(): void;
+}
+
+/** What `openStderrLog()` falls back to: no log, and still a working tunnel. */
+const SILENT_STDERR_LOG: StderrLog = {
+  stdio: 'ignore',
+  path: null,
+  read: () => '',
+  close: () => {
+    // Nothing was opened, so there is nothing to close.
+  },
+};
+
+/**
+ * Reads the last `limit` bytes of a log file.
+ *
+ * The tail rather than the head, because both consumers want the end: the
+ * banner parser takes the last match so a reconnect wins, and the diagnostic
+ * wants the last few lines. Never throws — a log that cannot be read is a
+ * missing diagnostic, not a failed tunnel.
+ */
+function readLogTail(logPath: string, limit: number): string {
+  let fd: number | null = null;
+  try {
+    fd = openSync(logPath, 'r');
+    const { size } = fstatSync(fd);
+    const start = size > limit ? size - limit : 0;
+    const length = size - start;
+    if (length <= 0) return '';
+    const buffer = Buffer.alloc(length);
+    const bytes = readSync(fd, buffer, 0, length, start);
+    // A tail can start mid-codepoint. cloudflared logs ASCII, and at worst one
+    // leading character is mangled; neither consumer anchors on the first byte.
+    return buffer.subarray(0, bytes).toString('utf-8');
+  } catch {
+    return '';
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Already closed.
+      }
+    }
+  }
+}
+
+/**
+ * Opens the file cloudflared's stderr is redirected into.
+ *
+ * Truncating (`'w'`) rather than appending, because `parseBannerUrl()` takes the
+ * last URL in the buffer and a previous session's banner names a tunnel that no
+ * longer exists. Starting from empty means the only banner that can be read is
+ * this session's.
+ *
+ * Returns `SILENT_STDERR_LOG` rather than throwing when the file cannot be
+ * opened: `start()` still has `/quicktunnel` — the *first* URL candidate — and
+ * a tunnel with no diagnostics beats no tunnel.
+ */
+export function openStderrLog(logPath: string): StderrLog {
+  let fd: number;
+  try {
+    fd = openSync(logPath, 'w', 0o600);
+  } catch {
+    return SILENT_STDERR_LOG;
+  }
+
+  let open = true;
+  return {
+    stdio: fd,
+    path: logPath,
+    read: () => readLogTail(logPath, STDERR_CAPTURE_LIMIT),
+    close: () => {
+      if (!open) return;
+      open = false;
+      try {
+        closeSync(fd);
+      } catch {
+        // The child holds its own duplicate either way.
+      }
+    },
+  };
 }
 
 /** `QUICK_TUNNEL_SUFFIX` as a regex fragment, so the suffix has one definition. */
@@ -449,22 +617,27 @@ export function createCloudflareProvider(
       }
 
       const args = buildQuickTunnelArgs({ port, metricsPort, pidfile });
-      const child = deps.spawn(CLOUDFLARED_BIN, args, {
-        stdio: ['ignore', 'ignore', 'pipe'],
-      });
+      const stderrLog = openStderrLog(join(stateDir, CLOUDFLARED_LOG_NAME));
 
-      const state: { exit: ExitInfo | null; stderr: string } = { exit: null, stderr: '' };
+      let child: QuickTunnelProcess;
+      try {
+        child = deps.spawn(CLOUDFLARED_BIN, args, buildQuickTunnelSpawnOptions(stderrLog.stdio));
+      } finally {
+        // `spawn` duplicates the descriptor into the child before it returns, so
+        // this copy has no remaining job. Keeping it would tie fd 2's lifetime
+        // to the CLI's, which is the mistake Issue #2146 is about.
+        stderrLog.close();
+      }
+
+      // The tunnel has to outlive `commandmate remote`, which exits as soon as
+      // it has a URL. `unref()` means the CLI's event loop is not held open by a
+      // child it never intends to wait for.
+      child.unref();
+
+      const state: { exit: ExitInfo | null } = { exit: null };
       child.once('exit', (code, exitSignal) => {
         state.exit = { code, signal: exitSignal };
       });
-      const stream = child.stderr;
-      if (stream !== null) {
-        stream.setEncoding('utf-8');
-        stream.on('data', (chunk: string | Buffer) => {
-          if (state.stderr.length >= STDERR_CAPTURE_LIMIT) return;
-          state.stderr += typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
-        });
-      }
 
       const pid = child.pid;
       if (pid === undefined) {
@@ -479,7 +652,7 @@ export function createCloudflareProvider(
           signal,
           timing: deps.timing,
           fetchHostname: deps.fetchHostname,
-          readStderr: () => state.stderr,
+          readStderr: () => stderrLog.read(),
           readExit: () => state.exit,
         });
       } catch (error) {

--- a/src/lib/remote/index.ts
+++ b/src/lib/remote/index.ts
@@ -29,7 +29,9 @@ export {
 } from './provider-registry';
 export {
   buildQuickTunnelArgs,
+  buildQuickTunnelSpawnOptions,
   CLOUDFLARED_BIN,
+  CLOUDFLARED_LOG_NAME,
   CLOUDFLARED_PIDFILE_NAME,
   CLOUDFLARED_VERSION_ARG,
   cloudflareProvider,
@@ -40,13 +42,16 @@ export {
   findFreeLoopbackPort,
   isQuickTunnelHostname,
   LOOPBACK_HOST,
+  openStderrLog,
   parseBannerUrl,
   parseQuickTunnelHostname,
   QUICK_TUNNEL_SUFFIX,
   resolveCloudflareStateDir,
+  STDERR_CAPTURE_LIMIT,
   type CloudflareProviderDeps,
   type QuickTunnelProcess,
   type QuickTunnelTiming,
+  type StderrLog,
 } from './cloudflare';
 export {
   BACKEND_STATE_RUNNING,

--- a/tests/fixtures/remote/short-lived-parent.cjs
+++ b/tests/fixtures/remote/short-lived-parent.cjs
@@ -1,0 +1,55 @@
+'use strict';
+/**
+ * A parent that spawns the stand-in and then exits immediately (Issue #2146).
+ *
+ * This is `commandmate remote up` reduced to the one thing that makes the bug
+ * fire: it starts a long-running child and then calls `process.exit()` while
+ * that child is still writing to fd 2. Everything else about `up` — the metrics
+ * poll, the pairing code, the QR — is irrelevant to whether the child survives.
+ *
+ * The stdio shape is passed in rather than hard-coded, so the regression test
+ * can drive this with the shape the *production* Provider actually builds. If
+ * the Provider goes back to `stdio: [..., 'pipe']`, this parent reproduces that
+ * and the child dies, which is the point.
+ *
+ * argv[2] is JSON:
+ *   { standin: string, stderr: 'pipe'|'ignore'|'inherit'|'file',
+ *     logPath: string, detached: boolean, unref: boolean }
+ *
+ * Writes `{"pid":<child pid>}` to fd 1 and exits 0.
+ */
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+const spec = JSON.parse(process.argv[2]);
+
+// 'file' stands for "a file descriptor". The production Provider opens its own
+// log file and puts the descriptor in slot 2; this does the same thing to the
+// path it was given, because a descriptor number cannot cross a process
+// boundary.
+let ownFd = null;
+let stderrSlot = spec.stderr;
+if (spec.stderr === 'file') {
+  ownFd = fs.openSync(spec.logPath, 'w', 0o600);
+  stderrSlot = ownFd;
+}
+
+const child = spawn(process.execPath, [spec.standin], {
+  detached: spec.detached === true,
+  stdio: ['ignore', 'ignore', stderrSlot],
+});
+
+if (ownFd !== null) fs.closeSync(ownFd);
+
+// The Provider reads the pipe when there is one, so read it here too: the two
+// shapes must differ only in what fd 2 is, not in whether anyone drains it.
+if (child.stderr) child.stderr.on('data', () => {});
+
+if (spec.unref === true) child.unref();
+
+// writeSync, not process.stdout.write: a write to a pipe is asynchronous and
+// process.exit() would truncate it.
+fs.writeSync(1, `${JSON.stringify({ pid: child.pid })}\n`);
+
+// Exactly what the CLI does once it has the URL, and the moment the bug fires.
+process.exit(0);

--- a/tests/fixtures/remote/stderr-writer.cjs
+++ b/tests/fixtures/remote/stderr-writer.cjs
@@ -1,0 +1,36 @@
+'use strict';
+/**
+ * Stand-in for cloudflared (Issue #2146).
+ *
+ * cloudflared is not needed to reproduce the bug, and using it would make the
+ * regression test depend on a binary, an account-less Cloudflare service and a
+ * network. What actually matters is one property of the real process: it keeps
+ * writing to fd 2 for several seconds after it starts, and it dies if that
+ * write fails. This script has exactly that property and nothing else.
+ *
+ * The write is deliberately NOT wrapped in try/catch. When fd 2 is a pipe whose
+ * read end has closed, `fs.writeSync` throws EPIPE, the throw is uncaught, and
+ * the process ends — the same fate SIGPIPE gives cloudflared, which is Go and
+ * does not ignore that signal. Catching it here would turn the failure this
+ * test exists to detect into a green.
+ *
+ * Prints nothing to stdout: the parent reports the pid, not the child.
+ */
+const fs = require('fs');
+
+/** Long enough for any assertion here, short enough that a leak self-clears. */
+const LIFETIME_MS = 10_000;
+
+/** Small enough never to fill a pipe buffer, frequent enough to fail fast. */
+const WRITE_INTERVAL_MS = 10;
+
+const deadline = Date.now() + LIFETIME_MS;
+
+const timer = setInterval(() => {
+  if (Date.now() >= deadline) {
+    clearInterval(timer);
+    process.exit(0);
+    return;
+  }
+  fs.writeSync(2, `standin ${String(Date.now())} still here\n`);
+}, WRITE_INTERVAL_MS);

--- a/tests/unit/lib/remote/cloudflare-child-survival.test.ts
+++ b/tests/unit/lib/remote/cloudflare-child-survival.test.ts
@@ -1,0 +1,295 @@
+/**
+ * The Quick Tunnel must outlive `commandmate remote` (Issue #2146).
+ *
+ * ## Why this file exists at all
+ *
+ * R2's suite was 12/12 green while shipping a tunnel that died a second or two
+ * after the command returned, and the reason is structural rather than an
+ * oversight: `deps.spawn` is a test double, so no real process is ever created,
+ * no real pipe is ever opened, and the parent never exits. The failure mode is
+ * made entirely of those three things. **Another mocked test would have been
+ * green too**, so this file uses real processes.
+ *
+ * ## The mechanism, measured in `docs/qa/1937-remote-uat-record.md` D-1
+ *
+ * `commandmate remote up` takes the URL from the metrics API at about t+6.5s
+ * and calls `process.exit()`. If fd 2 of the child is a **pipe**, the parent
+ * owns the read end; exiting closes it, and cloudflared — Go, which does not
+ * ignore SIGPIPE — dies on its next write to fd 2. At t+6.5s it is still mid
+ * log-burst, so the next write is milliseconds away. The public URL then answers
+ * HTTP 530 before anyone can point a phone at the QR code.
+ *
+ * ## How this reproduces it without cloudflared
+ *
+ * Nothing about the bug is specific to cloudflared, to Cloudflare, or to the
+ * network. Two throwaway scripts are enough:
+ *
+ * - `tests/fixtures/remote/stderr-writer.cjs` — writes to fd 2 every 10ms and
+ *   does not catch the error, so a broken pipe ends it. That is the one
+ *   property of cloudflared that matters here.
+ * - `tests/fixtures/remote/short-lived-parent.cjs` — spawns it with a stdio
+ *   shape given on the command line, prints the pid, and exits immediately.
+ *   That is `remote up` with everything else removed.
+ *
+ * The test is the grandparent: it runs the parent to completion, then asks
+ * whether the grandchild is still there.
+ *
+ * ## What makes it bite rather than merely pass
+ *
+ * 1. The shape the parent is driven with is **read out of the production
+ *    Provider** by running `start()` against a spawn double and capturing the
+ *    options. Putting `stdio: ['ignore', 'ignore', 'pipe']` back into
+ *    `cloudflare.ts` therefore changes what this test runs, and it goes red.
+ *    (Verified by doing exactly that before the fix was written.)
+ * 2. The pipe form is run too, as a **positive control**, and is asserted to
+ *    kill the grandchild. Without it, "the grandchild survived" would be equally
+ *    consistent with a harness that cannot observe death at all.
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { spawnSync, type SpawnOptions } from 'child_process';
+import { existsSync, fstatSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+import {
+  CLOUDFLARED_LOG_NAME,
+  createCloudflareProvider,
+  type QuickTunnelProcess,
+} from '@/lib/remote/cloudflare';
+
+const STANDIN_SCRIPT = resolve(__dirname, '../../../fixtures/remote/stderr-writer.cjs');
+const PARENT_SCRIPT = resolve(__dirname, '../../../fixtures/remote/short-lived-parent.cjs');
+
+/**
+ * A private state directory per test process.
+ *
+ * Not a fixed path under /tmp: sibling git worktrees run this suite at the same
+ * time on this machine, and a shared file name is how those runs poison each
+ * other's log.
+ */
+const STATE_DIR = mkdtempSync(join(tmpdir(), 'cm-remote-2146-'));
+
+afterAll(() => {
+  rmSync(STATE_DIR, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Reading the shape out of the production Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * What slot 2 of `stdio` is, in a form that survives being handed to another
+ * process. A descriptor number is meaningless outside the process that opened
+ * it, so a descriptor is reported as `'file'` and the parent script opens the
+ * same path itself.
+ */
+type StderrKind = 'pipe' | 'ignore' | 'inherit' | 'file';
+
+interface SpawnShape {
+  stderr: StderrKind;
+  detached: boolean;
+  unref: boolean;
+  /** True when slot 2 was a descriptor and it pointed at a regular file. */
+  stderrIsRegularFile: boolean;
+}
+
+/**
+ * Runs the real `start()` against a spawn double and reports the shape it built.
+ *
+ * This is the coupling between the mechanism proven below and the code that
+ * ships. Everything the parent script is told comes from here.
+ */
+async function productionSpawnShape(): Promise<SpawnShape> {
+  let captured: SpawnOptions | undefined;
+  let stderrIsRegularFile = false;
+  let unrefCalls = 0;
+
+  const child: QuickTunnelProcess = {
+    pid: 424242,
+    once: () => child,
+    kill: () => true,
+    unref: () => {
+      unrefCalls += 1;
+      return child;
+    },
+  };
+
+  const provider = createCloudflareProvider({
+    spawn: (_command, _args, options) => {
+      captured = options;
+      const slot = (options.stdio as unknown[])[2];
+      // Checked here rather than after `start()` returns: the Provider closes
+      // its own copy of the descriptor the moment `spawn` comes back.
+      if (typeof slot === 'number') stderrIsRegularFile = fstatSync(slot).isFile();
+      return child;
+    },
+    findFreePort: async () => 45678,
+    fetchHostname: async () => 'shape-probe.trycloudflare.com',
+    resolveStateDir: () => STATE_DIR,
+    timing: { urlWaitMs: 2000, metricsPreferenceMs: 0, pollIntervalMs: 1 },
+  });
+
+  await provider.start({ port: 3000, signal: new AbortController().signal });
+
+  if (captured === undefined) throw new Error('start() did not spawn anything');
+  const slot = (captured.stdio as unknown[])[2];
+
+  return {
+    stderr: typeof slot === 'number' ? 'file' : (slot as StderrKind),
+    detached: captured.detached === true,
+    unref: unrefCalls > 0,
+    stderrIsRegularFile,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Driving real processes
+// ---------------------------------------------------------------------------
+
+interface ParentSpec {
+  standin: string;
+  stderr: StderrKind;
+  logPath: string;
+  detached: boolean;
+  unref: boolean;
+}
+
+/** Runs the short-lived parent to completion and returns the grandchild's pid. */
+function runShortLivedParent(spec: Omit<ParentSpec, 'standin' | 'logPath'>): number {
+  const payload: ParentSpec = {
+    standin: STANDIN_SCRIPT,
+    logPath: join(STATE_DIR, 'standin-stderr.log'),
+    ...spec,
+  };
+  const result = spawnSync(process.execPath, [PARENT_SCRIPT, JSON.stringify(payload)], {
+    encoding: 'utf-8',
+    timeout: 20_000,
+  });
+
+  expect(result.error).toBeUndefined();
+  // `spawnSync` returns only after the parent has exited, so by the time this
+  // assertion runs the read end of any pipe is already closed.
+  expect(result.status, result.stderr).toBe(0);
+
+  const pid = (JSON.parse(result.stdout.trim()) as { pid: number }).pid;
+  expect(Number.isInteger(pid)).toBe(true);
+  return pid;
+}
+
+/** EPERM means the process exists and belongs to somebody else — still alive. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => {
+    setTimeout(r, ms);
+  });
+}
+
+async function diedWithin(pid: number, budgetMs: number): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await delay(10);
+  }
+  return !isAlive(pid);
+}
+
+async function stayedAliveFor(pid: number, ms: number): Promise<boolean> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return false;
+    await delay(10);
+  }
+  return isAlive(pid);
+}
+
+function reap(pid: number): void {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Already gone, which is the state this wanted anyway.
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+describe('a Quick Tunnel survives the CLI that started it (Issue #2146)', () => {
+  it(
+    'positive control: with fd 2 on a pipe, the child dies when the parent exits',
+    async () => {
+      // This is mutation A from the UAT record, run every time so that the
+      // survival assertion below cannot be vacuously green. If this ever stops
+      // being red-making, the harness has stopped modelling the bug and the
+      // test underneath it means nothing.
+      const pid = runShortLivedParent({ stderr: 'pipe', detached: false, unref: false });
+      try {
+        await expect(diedWithin(pid, 5000)).resolves.toBe(true);
+      } finally {
+        reap(pid);
+      }
+    },
+    20_000,
+  );
+
+  it(
+    'the shape start() actually builds leaves the child running',
+    async () => {
+      // The shape is not written down here on purpose — it is read out of the
+      // Provider. Reverting cloudflare.ts to `['ignore', 'ignore', 'pipe']`
+      // turns this into the positive control above, and it fails.
+      const shape = await productionSpawnShape();
+
+      const pid = runShortLivedParent({
+        stderr: shape.stderr,
+        detached: shape.detached,
+        unref: shape.unref,
+      });
+      try {
+        await expect(stayedAliveFor(pid, 750)).resolves.toBe(true);
+      } finally {
+        reap(pid);
+      }
+    },
+    20_000,
+  );
+
+  it('puts a real file on fd 2, and never a pipe', async () => {
+    const shape = await productionSpawnShape();
+
+    expect(shape.stderr).toBe('file');
+    expect(shape.stderrIsRegularFile).toBe(true);
+    // Named separately from the check above so the failure message says which
+    // of the two mistakes was made.
+    expect(shape.stderr).not.toBe('pipe');
+  });
+
+  it('detaches the child and drops the event-loop reference to it', async () => {
+    // `detached` is what keeps a Ctrl-C in the launching terminal from reaching
+    // the tunnel; `unref` is what stops the CLI's event loop being held open by
+    // a child it never waits for. Neither fixes the pipe, and neither is
+    // sufficient on its own — they are the other half of "outlives the CLI".
+    const shape = await productionSpawnShape();
+
+    expect(shape.detached).toBe(true);
+    expect(shape.unref).toBe(true);
+  });
+
+  it('creates the log file where a human can find it', async () => {
+    await productionSpawnShape();
+
+    const logPath = join(STATE_DIR, CLOUDFLARED_LOG_NAME);
+    expect(existsSync(logPath)).toBe(true);
+    // Opened with 'w', so a previous session's banner cannot be read back as
+    // this session's URL.
+    expect(readFileSync(logPath, 'utf-8')).toBe('');
+  });
+});

--- a/tests/unit/lib/remote/cloudflare-provider.test.ts
+++ b/tests/unit/lib/remote/cloudflare-provider.test.ts
@@ -30,6 +30,14 @@
  *    and the pair of tests at the bottom shows the window is load-bearing: same
  *    inputs, different window, different source wins.
  *
+ * 4. **fd 2 is a file, and both of its readers still work.** Issue #2146: a
+ *    pipe on fd 2 dies with the parent and takes cloudflared with it. The
+ *    stderr fixtures below are therefore written to the **real log file** the
+ *    Provider opens, not into a `PassThrough`, so the second URL candidate and
+ *    the failure diagnostic are exercised through the code that actually reads
+ *    them back. Whether the child survives the parent is a different question
+ *    and needs real processes: `cloudflare-child-survival.test.ts`.
+ *
  * Every fixture in this file is copied from that live capture. The stderr
  * fixture keeps the two unrelated `https://…cloudflare.com` URLs cloudflared
  * really prints, so the banner parser is tested against the distractors it will
@@ -37,17 +45,27 @@
  *
  * @vitest-environment node
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 import { spawn as realSpawn } from 'child_process';
 import type {
   SpawnOptions,
   SpawnSyncOptionsWithStringEncoding,
   SpawnSyncReturns,
 } from 'child_process';
-import { PassThrough } from 'stream';
+import {
+  appendFileSync,
+  fstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import {
   buildQuickTunnelArgs,
+  CLOUDFLARED_LOG_NAME,
   CLOUDFLARED_PIDFILE_NAME,
   cloudflareProvider,
   createCloudflareProvider,
@@ -112,18 +130,19 @@ function spawnSyncResult(
 interface FakeCloudflared {
   child: QuickTunnelProcess;
   killed: NodeJS.Signals[];
+  /** How many times `start()` called `unref()` on this child. */
+  unrefCount: () => number;
   emitExit: (code: number | null, signal?: NodeJS.Signals | null) => void;
   writeStderr: (text: string) => void;
 }
 
 function fakeCloudflared(options: { pid?: number | undefined } = {}): FakeCloudflared {
-  const stderr = new PassThrough();
   const exitListeners: ((code: number | null, signal: NodeJS.Signals | null) => void)[] = [];
   const killed: NodeJS.Signals[] = [];
+  let unrefs = 0;
 
   const child: QuickTunnelProcess = {
     pid: 'pid' in options ? options.pid : 4242,
-    stderr: stderr as unknown as NodeJS.ReadableStream,
     once(_event: 'exit', listener) {
       exitListeners.push(listener);
       return child;
@@ -132,16 +151,24 @@ function fakeCloudflared(options: { pid?: number | undefined } = {}): FakeCloudf
       killed.push(signal);
       return true;
     },
+    unref() {
+      unrefs += 1;
+      return child;
+    },
   };
 
   return {
     child,
     killed,
+    unrefCount: () => unrefs,
     emitExit: (code, signal = null) => {
       for (const listener of exitListeners) listener(code, signal);
     },
+    // Appends to the log file the Provider opened, because that is where the
+    // real cloudflared's fd 2 now points. Writing into a stream instead would
+    // test a path the shipped code no longer has.
     writeStderr: (text) => {
-      stderr.write(text);
+      appendFileSync(TEST_LOG_PATH, text);
     },
   };
 }
@@ -165,11 +192,25 @@ function spawnDouble(
 
 const FAST_TIMING = { urlWaitMs: 200, metricsPreferenceMs: 0, pollIntervalMs: 1 };
 
+/**
+ * A private state directory per test process.
+ *
+ * `start()` now writes a real file here, so the fixed `/tmp/commandmate-remote-test`
+ * this used to name would be shared with every sibling git worktree running the
+ * same suite on this machine. That is how one run poisons another's log.
+ */
+const TEST_STATE_DIR = mkdtempSync(join(tmpdir(), 'cm-remote-cf-'));
+const TEST_LOG_PATH = join(TEST_STATE_DIR, CLOUDFLARED_LOG_NAME);
+
+afterAll(() => {
+  rmSync(TEST_STATE_DIR, { recursive: true, force: true });
+});
+
 function testDeps(overrides: Partial<CloudflareProviderDeps> = {}): Partial<CloudflareProviderDeps> {
   return {
     findFreePort: async () => 45678,
     fetchHostname: async () => null,
-    resolveStateDir: () => '/tmp/commandmate-remote-test',
+    resolveStateDir: () => TEST_STATE_DIR,
     timing: FAST_TIMING,
     ...overrides,
   };
@@ -480,10 +521,74 @@ describe('start() (design §6.4, §9.2)', () => {
     expect(loopbackViolations(args)).toEqual([]);
 
     expect(args[args.indexOf('--pidfile') + 1]).toBe(
-      `/tmp/commandmate-remote-test/${CLOUDFLARED_PIDFILE_NAME}`,
+      join(TEST_STATE_DIR, CLOUDFLARED_PIDFILE_NAME),
     );
-    // stderr must be piped or the second URL candidate has nothing to read.
-    expect(options.stdio).toEqual(['ignore', 'ignore', 'pipe']);
+
+    // Issue #2146. fd 2 is a descriptor on a file, never a pipe: a pipe's read
+    // end belongs to `commandmate remote`, which exits as soon as it has the
+    // URL, and cloudflared then dies of SIGPIPE on its next log line. What the
+    // shape does to a real process is measured in
+    // `cloudflare-child-survival.test.ts`; what is pinned here is that this is
+    // the shape.
+    const stdio = options.stdio as unknown[];
+    expect(stdio.slice(0, 2)).toEqual(['ignore', 'ignore']);
+    expect(typeof stdio[2]).toBe('number');
+    expect(stdio[2]).not.toBe('pipe');
+    expect(options.detached).toBe(true);
+    expect(fake.unrefCount()).toBe(1);
+  });
+
+  it('points fd 2 at the log file beside the pidfile, freshly truncated', async () => {
+    // Truncated rather than appended: `parseBannerUrl` takes the LAST URL in the
+    // buffer, so a previous session's banner would otherwise be readable as this
+    // session's URL — a QR code for a tunnel that no longer exists.
+    writeFileSync(TEST_LOG_PATH, `stale https://from-a-dead-session.trycloudflare.com\n`);
+
+    const fake = fakeCloudflared();
+    let stderrWasARegularFile = false;
+    const spawn = vi.fn((_c: string, _a: readonly string[], options: SpawnOptions) => {
+      // Checked inside `spawn`: the Provider closes its own copy of the
+      // descriptor as soon as this returns.
+      const slot = (options.stdio as unknown[])[2];
+      if (typeof slot === 'number') stderrWasARegularFile = fstatSync(slot).isFile();
+      return fake.child;
+    });
+
+    const provider = createCloudflareProvider(
+      testDeps({ spawn, fetchHostname: async () => MEASURED_HOSTNAME }),
+    );
+    const handle = await provider.start({ port: 3000, signal: liveSignal() });
+
+    expect(stderrWasARegularFile).toBe(true);
+    expect(handle.url).toBe(`https://${MEASURED_HOSTNAME}`);
+    expect(readFileSync(TEST_LOG_PATH, 'utf-8')).toBe('');
+  });
+
+  it('still starts when the log file cannot be opened at all', async () => {
+    // A state directory that cannot be created (its parent is a file, so
+    // mkdir fails with ENOTDIR). A missing diagnostic must not cost the user a
+    // working tunnel — fd 2 falls back to 'ignore' and `/quicktunnel`, the
+    // FIRST URL candidate, is untouched.
+    const blocker = join(TEST_STATE_DIR, 'not-a-directory');
+    writeFileSync(blocker, 'this is a file');
+
+    const fake = fakeCloudflared();
+    const spawn = spawnDouble(fake);
+    const provider = createCloudflareProvider(
+      testDeps({
+        spawn,
+        resolveStateDir: () => join(blocker, 'state'),
+        fetchHostname: async () => MEASURED_HOSTNAME,
+      }),
+    );
+
+    const handle = await provider.start({ port: 3000, signal: liveSignal() });
+
+    expect(handle.url).toBe(`https://${MEASURED_HOSTNAME}`);
+    expect((spawn.mock.calls[0][2].stdio as unknown[])[2]).toBe('ignore');
+    // Still never a pipe. 'ignore' loses the banner and the diagnostic; a pipe
+    // would lose the tunnel.
+    expect((spawn.mock.calls[0][2].stdio as unknown[])[2]).not.toBe('pipe');
   });
 
   it('returns a handle with owned.pid and preexisting null', async () => {
@@ -580,6 +685,56 @@ describe('start() (design §6.4, §9.2)', () => {
     await expect(provider.start({ port: 3000, signal: liveSignal() })).rejects.toThrow(
       /exit code 1 before a public URL appeared/,
     );
+  });
+
+  it('quotes what cloudflared printed, read back out of the log file', async () => {
+    // `stderrTail()` is the other consumer of fd 2, and the one a user actually
+    // sees. Issue #2146 moved fd 2 from a pipe to a file; this asserts the
+    // diagnostic survived the move rather than quietly becoming an empty tail.
+    const fake = fakeCloudflared();
+    const spawn = vi.fn((_c: string, _a: readonly string[], _o: SpawnOptions) => {
+      queueMicrotask(() => {
+        fake.writeStderr(
+          '2026-08-29T01:59:11Z ERR failed to request quick Tunnel: 503 Service Unavailable\n',
+        );
+        queueMicrotask(() => fake.emitExit(1));
+      });
+      return fake.child;
+    });
+    const provider = createCloudflareProvider(
+      testDeps({ spawn, timing: { urlWaitMs: 2000, metricsPreferenceMs: 0, pollIntervalMs: 1 } }),
+    );
+
+    const error = await provider
+      .start({ port: 3000, signal: liveSignal() })
+      .then(() => null)
+      .catch((caught: unknown) => caught as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toContain('last output:');
+    expect(error?.message).toContain('failed to request quick Tunnel: 503 Service Unavailable');
+  });
+
+  it('says so plainly when the URL never came, and still quotes the log', async () => {
+    const fake = fakeCloudflared();
+    const provider = createCloudflareProvider(
+      testDeps({
+        spawn: spawnDouble(fake, MEASURED_STDERR_WITHOUT_BANNER),
+        timing: { urlWaitMs: 60, metricsPreferenceMs: 0, pollIntervalMs: 1 },
+      }),
+    );
+
+    const error = await provider
+      .start({ port: 3000, signal: liveSignal() })
+      .then(() => null)
+      .catch((caught: unknown) => caught as Error);
+
+    expect(error?.message).toContain('no public URL after 60ms');
+    // `stderrTail()` keeps the last five lines and caps the join at 400 chars,
+    // so the assertion is on a line that is inside that budget rather than on
+    // the very last one.
+    expect(error?.message).toContain('last output:');
+    expect(error?.message).toContain('Requesting new quick Tunnel on trycloudflare.com');
   });
 
   describe('a URL is never returned for a process that has already exited', () => {
@@ -833,13 +988,20 @@ describe('stop() (design §6.3, §6.4)', () => {
     expect(kill).toHaveBeenCalledWith(50850, 'SIGTERM');
   });
 
-  it('really does signal a real process (default wiring)', async () => {
+  it('really does signal a real process, detached, in its own group', async () => {
     // Everything above goes through the `kill` seam. This one uses the shipped
     // Provider and a live child, so "the default is wired to process.kill" is
     // measured rather than assumed.
+    //
+    // Spawned `detached` because Issue #2146 made the real child detached, and
+    // detaching moves a process into its own group. `stop()` signals a POSITIVE
+    // pid, which is one process rather than a group, so teardown is unaffected —
+    // but that is the sort of claim that should be measured, not reasoned about.
     const child = realSpawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+      detached: true,
       stdio: 'ignore',
     });
+    child.unref();
     const exitSignal = new Promise<NodeJS.Signals | null>((resolve) => {
       child.once('exit', (_code, signal) => resolve(signal));
     });


### PR DESCRIPTION
## 概要

Closes #2146

`commandmate remote --provider cloudflare` が払い出した公開 URL が、**コマンドが返った直後には
もう HTTP 530** になる問題を修正します。**QR を読む時間が無い**状態でした。

## 原因

親（`commandmate remote`）が `process.exit()` すると **stderr パイプの読み口が閉じ**、
cloudflared（Go — SIGPIPE を無視しない）が次に fd 2 へ書いた時点で死んでいました。

`up` は URL を metrics API から**約 6.5 秒**で取って終了しますが、その時点の cloudflared は
まだログ噴出中なので、**次の書き込みは数ミリ秒後**に来ます。

## 修正

**fd 2 をファイル記述子に向け、`detached: true` ＋ `unref()` を併用します。**

`stdio` を単に `'ignore'` にする案は採りませんでした。stderr は **2 つの用途**で使われているためです:

1. **第 2 候補の URL 取得**（`parseBannerUrl`）— `/quicktunnel` が失敗したときのフォールバック
2. **失敗時の診断**（`stderrTail`）

ファイルなら親の終了で読み口が閉じず、**両方ともパスから読み戻せます**。`--logfile` も候補でしたが、
（採用理由と却下理由はソースの doc コメントに記載）。

`detached: true` は子を独自セッションに置きます。これが無いと、端末での Ctrl-C が
プロセスグループ全体に届いてトンネルも巻き添えになります。

## 【最重要】モックでは再現しない不具合なので、実プロセスの回帰テストを追加しました

**R2 が着地したとき CI は 12/12 緑でしたが、この不具合は素通りしました。** 構造的な理由があります —
`deps.spawn` はテストダブルなので、**実プロセスも実パイプも作られず、親も終了しません**。
この失敗モードはその 3 つだけでできています。**もう一本モックのテストを足しても緑のまま**でした。

そこで `tests/unit/lib/remote/cloudflare-child-survival.test.ts` は実プロセスを使います。
cloudflared もネットワークも要りません:

- `tests/fixtures/remote/stderr-writer.cjs` — 10ms ごとに fd 2 へ書き、**エラーを catch しない**
  （壊れたパイプで死ぬ）。cloudflared のうち**この件に効く唯一の性質**
- `tests/fixtures/remote/short-lived-parent.cjs` — 上記を spawn して**即座に終了**する。
  `remote up` から他を全部削ったもの

テスト本体は祖父の位置に立ち、親の終了後に**孫が生きているか**を尋ねます。

### 空振りでないことの確認

**stdio の形をハードコードせず、本番 Provider の `start()` が実際に組み立てた形を読み出して**
fixture を駆動します。したがって `'pipe'` に戻せば自動的に赤くなります。

**オーケストレーター側で変異注入して確認済みです**:

```
変異: stdio -> ['ignore','ignore','pipe'] / detached 削除（#2146 修正前の形）
→ 3 テストが FAIL
   × the shape start() actually builds leaves the child running   ← 実プロセスの孫が死んだ
   × puts a real file on fd 2, and never a pipe
   × detaches the child and drops the event-loop reference to it
復元後: 95 tests 全緑（survival / provider / destructive-command-guard）
```

## 壊していないもの

- **R2 の argv assert** — アップストリームと `--metrics` が常に `127.0.0.1`（`0.0.0.0` / `localhost` は禁止）
- **第 2 候補のフォールバック**と陰性対照（`cloudflare.com/website-terms/` を拾わない）
- **`METRICS_PREFERENCE_WINDOW`（既定 5 秒）の優先窓** — バナーが metrics より約 1 秒早く出るため、
  これが無いと第 1 候補がデッドコードになる
- **R4 の全消し禁止ガード 8 ルール**
- `stop()` は `owned.pid` への SIGTERM のみ

## 実機確認について

**公開 Tunnel を作る実機確認は行っていません**（承認を得ていないため）。
実プロセスの回帰テストで「親の終了後も子が生きる」ことを示しています。
実機での最終確認は改めて承認を得たうえで `docs/qa/1937-remote-uat-record.md` に追記します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hiod6zbSTaDnwfJUPoaG8
