### PR TITLE
docs(en): commandmate remote の英語ミラーを追加し Provider 記述を実測に合わせて訂正 (#1937)

### DIFF
--- a/docs/en/TRUST_AND_SAFETY.md
+++ b/docs/en/TRUST_AND_SAFETY.md
@@ -12,6 +12,8 @@ CommandMate runs on your local machine.
 
 - The application, SQLite database, and tmux sessions all operate entirely locally
 - External communication is limited to API calls made by the CLI tools themselves (Claude Code / Codex CLI)
+  (for the exception when you publish the server with `commandmate remote`, see
+  "External Access Dependencies (Optional)" below)
 - No user data is sent to external servers
 
 ### Dependency on CLI Tools
@@ -29,6 +31,55 @@ If you want to access CommandMate from outside your home, you can use Cloudflare
 - Cloudflare Tunnel is **optional** and not needed for local-only use
 - For LAN access, `CM_BIND=0.0.0.0` configuration is required. Reverse proxy authentication is recommended
 
+#### Provider dependencies of `commandmate remote`
+
+`commandmate remote` depends on an external tool — **`cloudflared`** (the Cloudflare Tunnel
+client) or **`tailscale`** — depending on which provider it selects.
+
+- Both are **optional dependencies**. If neither is installed, `remote` stops with
+  `DEPENDENCY_ERROR` and nothing about ordinary local use of CommandMate changes
+- CommandMate never installs either of them for you
+- `remote` runs `cloudflared` as a child process. Tunnel traffic passes through Cloudflare,
+  so use it **only if you are willing to trust Cloudflare as a transit path**
+- The `tailscale-serve` provider does not spawn a long-lived process. It writes a Serve
+  handler into configuration owned by `tailscaled` — configuration you may already be using
+  for your own services, and which has no undo. Everything under "Cleanup removes only what
+  CommandMate created" below exists because of that
+
+#### What is exposed
+
+- What goes outside is **the CommandMate server itself**. The server listening on
+  127.0.0.1 becomes reachable through a provider URL — a random public address
+  (`https://<random>.trycloudflare.com`) with Cloudflare, or a tailnet-only address with
+  Tailscale Serve
+- **The bind address does not change.** `remote` neither reads nor writes `CM_BIND`; it
+  stays at the default `127.0.0.1`. No new port opens on your LAN
+- Only this one CommandMate server is published. Nothing else on the machine is
+- Because anyone who learns the URL can reach it, **CommandMate's own token authentication
+  is mandatory**. `remote` always starts the server with authentication enabled, and only a
+  device that redeems the pairing code (single-use, 10 minutes by default) can sign in
+- **Creating a public tunnel always requires your explicit approval.** Interactively you
+  are shown a warning and asked; non-interactively the run stops with `CONFIG_ERROR` unless
+  you passed `--yes`. Nothing is ever published silently
+- A Quick Tunnel URL changes on every start and carries no access policy and no audit log
+  you control. **Do not use a Quick Tunnel for long-lived or production access**
+  (details: `docs/security-guide.md`)
+
+#### Cleanup removes only what CommandMate created
+
+- `commandmate remote stop` reverts **only what CommandMate recorded creating**
+- When the state file cannot be read, it **does not guess which provider to tear down.** It
+  reports that it does not know what to clean up and exits successfully. Guessing could
+  destroy provider configuration you set up yourself — a Tailscale Serve mapping you added
+  by hand, say — which CommandMate has no way to restore
+- For the same reason, do not follow the teardown hint Tailscale prints after a successful
+  `serve`: re-running `serve` with only the port and "off", with no path, removes **every**
+  handler on that port, yours included. `commandmate remote stop` always names the specific
+  path it created
+- When `--expires` (8 hours by default) elapses, **only the outward door closes — the
+  server is not stopped**, because stopping it would take your local session on the machine
+  down with it
+
 ## Least Privilege Guide
 
 ### Recommended Settings
@@ -36,12 +87,19 @@ If you want to access CommandMate from outside your home, you can use Cloudflare
 - Set `CM_ROOT_DIR` to only **specific, git-managed directories**
 - Use Claude Code's permission settings to limit operations to the target repository
 - When exposing externally, set up reverse proxy authentication (details: `docs/security-guide.md`)
+- For temporary access while you are away from your machine, use `commandmate remote`:
+  publish for as long as you actually need and close it with `commandmate remote stop`
+  (set `--expires` to the shortest value that does the job)
 
 ### Not Recommended
 
 - Setting `CM_ROOT_DIR` to your entire home directory (`~`)
 - Exposing the server with `CM_BIND=0.0.0.0` without reverse proxy authentication
 - Enabling Auto Yes mode while Claude Code has broad file operation permissions
+- Keeping a Cloudflare Quick Tunnel (`commandmate remote`) up as a permanent public
+  entrance, for long-lived or production use
+- Forwarding, screenshotting into a chat, or reusing the pairing QR code / URL — it is a
+  single-use credential
 
 ## Preventing Dangerous Operations
 

--- a/docs/en/security-guide.md
+++ b/docs/en/security-guide.md
@@ -31,6 +31,29 @@ When `CM_BIND=0.0.0.0` is set, the server becomes accessible from external netwo
 
 **You MUST configure reverse proxy authentication before exposing CommandMate externally.**
 
+### Provider Tunnel (`commandmate remote`)
+
+`commandmate remote` is a third shape, and neither of the two modes above describes it.
+
+The server keeps its `127.0.0.1` bind — `remote` neither reads nor writes `CM_BIND`, so a
+host on the default binding stays on the default binding. What `remote` adds is an
+*outward door*: a provider process (or, for Tailscale, a provider *configuration*) that
+accepts connections from outside and forwards them to the loopback listener.
+
+| Property | Value under `commandmate remote` |
+|----------|----------------------------------|
+| Listening socket | Still `127.0.0.1` only — nothing new listens on your LAN interface |
+| Reachability | The provider URL is reachable by anyone who learns it (a Cloudflare Quick Tunnel URL is public; a Tailscale Serve URL is reachable only from your tailnet) |
+| Authentication | Always on. `remote` starts the server with token authentication enabled |
+| Blast radius | The CommandMate server only, not other services on this machine |
+
+So the exposure is "one authenticated HTTP surface, reachable by anyone who learns the
+URL". It is neither the localhost case ("no authentication required") nor the
+`CM_BIND=0.0.0.0` case ("every client on the network reaches this port"). The risks in the
+table above still apply to anyone who *does* get past authentication.
+
+See *Option 4: `commandmate remote`* under Recommended Authentication Methods below.
+
 ---
 
 ## Quick Start: Built-in Token Authentication + HTTPS
@@ -211,6 +234,165 @@ Benefits:
 - Encrypted end-to-end
 - Works across NAT and firewalls
 
+### Option 4: `commandmate remote` (CommandMate performs the setup)
+
+Options 1-3 above are configurations **you build and own**: you install Nginx, you create
+the Cloudflare Tunnel, you join the Tailscale network. CommandMate is unaware of any of
+them and never touches them.
+
+`commandmate remote` is the opposite arrangement. **CommandMate performs the setup on your
+behalf** — it starts a server with authentication enabled, mints a session token, asks a
+provider to publish that server, and prints a QR code to pair a phone with. It records
+what it created so that it can later undo exactly that, and nothing else.
+
+```bash
+commandmate remote          # up (default): start the server, publish it, print a pairing QR code
+commandmate remote status   # provider, URL, expiry, pairing state
+commandmate remote stop     # close the outside door; the server keeps running
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--provider <tailscale\|cloudflare>` | Override provider auto-selection |
+| `--expires <duration>` | Remote session TTL (default `8h`, range `1h`-`30d`) |
+| `--pairing-expires <duration>` | Pairing code TTL (default `10m`, range `1m`-`24h`) |
+| `-p, --port <number>` | Port of the server to expose |
+| `--yes` | Approve creating a public tunnel without prompting (required when non-interactive) |
+| `--json` | JSON output |
+
+There is deliberately **no `--token` flag**: `remote` is the side that mints the token, so
+one supplied from outside would have no matching hash on the server. There is **no
+`--auto-yes` flag in any form** either. Auto-Yes state is an in-memory map that is empty at
+server start, so a server `remote` has just started has Auto-Yes off for every worktree —
+not offering a flag to turn it on is the structural guarantee that it stays off.
+
+Exit codes: `0` success, `1` `DEPENDENCY_ERROR` (no usable provider), `2` `CONFIG_ERROR`
+(non-interactive without approval, an invalid `--expires`, or a server already running with
+authentication enabled that this session cannot pair with), `3` `START_FAILED`,
+`4` `STOP_FAILED`, `99` `UNEXPECTED_ERROR`.
+
+#### Provider availability
+
+| Provider | State |
+|----------|-------|
+| `tailscale-serve` (`--provider tailscale`) | **Implemented.** Ready when `tailscale` is installed, the node is logged in, and Serve/HTTPS is available on the tailnet. Tried first by auto-selection, because it publishes only to your own tailnet |
+| `cloudflare-quick` (`--provider cloudflare`) | **Implemented.** Selectable whenever `cloudflared` is installed. Publishes to the public internet, so it always asks for approval first. **See the known issue below before relying on it** |
+
+> **The `tailscale-serve` provider is not Option 3, even though both work.** Option 3 above
+> is *you* using Tailscale yourself: you join the tailnet and browse to the node's Tailscale
+> IP, and CommandMate is not involved at all. The `tailscale-serve` **provider** is
+> CommandMate driving `tailscale serve` for you as part of `remote`, and it therefore writes
+> to configuration that belongs to `tailscaled` and that you may already be using. Because
+> that configuration has no undo, `remote` snapshots it before touching it, refuses to start
+> when the path it wants is already served, and on `stop` removes only the one handler it
+> created (see *Expiry and cleanup* below).
+
+> **Do not follow Tailscale's own teardown hint.** After a successful `tailscale serve`,
+> Tailscale prints a suggestion to disable the proxy by re-running `serve` with only the
+> port and the word "off" — with no path. That untargeted form removes **every** handler on
+> that port, including ones you set up yourself, with exit status 0 and no warning. Use
+> `commandmate remote stop`, which always passes the specific path it created.
+
+If no provider is ready, `remote` stops with `DEPENDENCY_ERROR` (exit code `1`). It does
+**not** fall through to a public tunnel on its own when Tailscale is unavailable: putting
+this machine on the public internet always requires your explicit approval.
+
+> **Known issue (as of 2026-08-29): the Cloudflare Quick Tunnel does not outlive the
+> command.** In the live acceptance run, `cloudflared` exited at the same moment
+> `commandmate remote` returned, and the URL it had just printed began answering HTTP 530
+> within seconds — before there was time to scan the QR code. The cause is the provider's
+> spawn shape (the child's stderr stays attached to a pipe the exiting parent closes), and
+> it is a defect, not a configuration problem on your side. Until it is fixed, prefer
+> `--provider tailscale`. The measured record is in
+> [`docs/qa/1937-remote-uat-record.md`](../qa/1937-remote-uat-record.md) (defect D-1).
+
+#### Cloudflare Quick Tunnel: what you are approving
+
+A Quick Tunnel is convenient *and* disposable. Both halves matter:
+
+- **A random, publicly reachable URL is created on the internet.** `cloudflared` allocates
+  a `https://<random>.trycloudflare.com` address. Anyone who learns that address can reach
+  your CommandMate server, and the traffic passes through Cloudflare.
+- **The URL changes on every start.** It is not stable, so it cannot be bookmarked, put
+  behind a DNS record, or added to any allow-list.
+- **Do not use it for long-lived or production access.** A Quick Tunnel carries no access
+  policy of its own, no audit trail you control, and no availability guarantee. For
+  anything beyond an ad-hoc "reach my machine from my phone right now", use Option 2
+  (Cloudflare Access) or Option 3 (Tailscale) instead.
+- **CommandMate's own authentication is not optional here.** `remote` always starts the
+  server with token authentication enabled; a visitor who does not redeem the pairing code
+  is refused. The tunnel publishes an authenticated surface, never an open one.
+- **CommandMate never creates a public tunnel without explicit approval.** Interactively
+  you are shown a warning and must confirm. Non-interactively — CI, a script, a message
+  sent by an agent — there is nobody to ask, so the run fails with `CONFIG_ERROR`
+  (exit code `2`) unless you passed `--yes`. `--yes` *is* the approval; do not add it to a
+  wrapper script by reflex.
+
+Only the public-tunnel provider asks this question. `tailscale-serve` publishes to your own
+tailnet rather than to the internet, so it does not require `--yes`.
+
+#### Pairing code
+
+- **Single-use**, and expires after 10 minutes by default (`--pairing-expires`)
+- 26 Crockford Base32 characters, i.e. 128 bits of entropy
+- **The plaintext is never persisted.** It is handed to the server through
+  `~/.commandmate/remote-pairing.json`, mode `0600`, and that file is deleted the instant
+  the code is redeemed. "Already used" is represented by the file's *absence*, not by a
+  flag written inside it
+- `remote` contributes exactly three environment variables to the server it starts:
+  `CM_AUTH_TOKEN_HASH`, `CM_AUTH_EXPIRE`, and `CM_REMOTE_PAIRING_FILE`. The third is a
+  **path, not a secret**. No plaintext long-lived token is placed in the environment,
+  because a tmux pane CommandMate spawns inherits the server's environment wholesale —
+  anything left there would be readable by the very agents CommandMate is driving
+
+#### The session cookie carries no `Secure` attribute over a tunnel (expected)
+
+CommandMate issues its authentication cookie with `HttpOnly` and `SameSite=Strict` always,
+and with `Secure` **only when the server itself is serving HTTPS** — that is, when
+`CM_HTTPS_CERT` is set. A provider tunnel terminates TLS at the provider and forwards plain
+HTTP to the loopback origin, so `CM_HTTPS_CERT` is unset and the cookie is issued
+**without** `Secure`.
+
+**This is correct behaviour, not a defect**, for three reasons:
+
+1. **`Secure` describes the origin, and the origin really is plain HTTP.** Setting it
+   unconditionally would make browsers refuse the cookie over `http://localhost:3000`,
+   breaking ordinary local use — the primary way CommandMate is run — in order to annotate
+   a connection that is already encrypted.
+2. **The exposed leg is already HTTPS.** Between the browser and the provider the traffic
+   is encrypted, so the on-the-wire eavesdropping that `Secure` exists to prevent is
+   already addressed. What is left in the clear is the loopback hop inside your own
+   machine.
+3. **The other cookie protections do not depend on transport.** `HttpOnly` (no JavaScript
+   access) and `SameSite=Strict` (no cross-site submission) are set in every configuration.
+
+If you want `Secure` set, terminate TLS at the CommandMate server itself
+(`commandmate start --auth --cert ... --key ...`, see the Quick Start above) rather than
+relying on a tunnel for it.
+
+#### Expiry and cleanup
+
+- When `--expires` elapses, **only the outside door closes — the server keeps running.**
+  Shutting it down would take your local session with it, so an expiring remote session
+  never costs you your work on the machine itself.
+- `commandmate remote stop` closes the provider session and reverts **only what CommandMate
+  recorded creating.**
+- If the recorded state is missing or unreadable, `stop` does **not** guess which provider
+  to tear down. It reports that it has nothing it knows how to clean up and exits
+  successfully. Guessing would mean deleting provider configuration that belongs to you —
+  a Tailscale Serve mapping you set up by hand, say — which CommandMate has no way to
+  restore.
+
+#### Deprecated: long-lived tokens in the URL fragment
+
+The earlier QR sign-in flow put a long-lived token into the URL fragment
+(`.../login#token=...`). The generator for those links has been **removed** from
+CommandMate — nothing in the product produces such a URL any more. The receiving side still
+accepts `#token=` for one more release and logs a deprecation warning when it does; it will
+be removed after that. Use the pairing URL that `commandmate remote` prints instead, and
+treat any surviving `#token=` link as a live credential — it is a long-lived token
+sitting in a URL — rather than as a convenient bookmark.
+
 ---
 
 ## Migration from CM_AUTH_TOKEN
@@ -264,6 +446,18 @@ Before exposing CommandMate to external networks:
 - [ ] `CM_ROOT_DIR` points only to intended repositories
 - [ ] `CM_BROWSE_ROOTS` lists only directories whose folder names may be exposed to authenticated clients (unset is safest)
 
+When using `commandmate remote`:
+
+- [ ] You understand that a Cloudflare Quick Tunnel URL is reachable from the public internet
+- [ ] The tunnel is for ad-hoc access, not long-lived or production access
+- [ ] `--yes` is used only where you have consciously pre-approved creating a public tunnel, never as a default in a wrapper script
+- [ ] `--expires` is set to the shortest TTL the task needs (default `8h`, range `1h`-`30d`)
+- [ ] `--pairing-expires` is short and the QR code is scanned promptly (default `10m`)
+- [ ] The pairing QR code / URL is not forwarded, screenshotted into a chat, or reused — it is single-use
+- [ ] `commandmate remote stop` is run when remote access is no longer needed (expiry closes the door, but only after the TTL elapses)
+- [ ] Teardown goes through `commandmate remote stop`, never through Tailscale's own untargeted `serve ... off` hint, which clears the whole port
+- [ ] You accept that over a tunnel the session cookie has no `Secure` attribute (see Option 4) — use built-in TLS if you need it
+
 ---
 
 ## Additional Security Measures
@@ -304,4 +498,4 @@ rather than a public issue.
 
 ---
 
-*Last updated: 2026-02-21 (Issue #331: mkcert certificate generation, built-in token auth + HTTPS quick start)*
+*Last updated: 2026-08-29 (Issue #1937: `commandmate remote`, Quick Tunnel risks, cookie `Secure` over a tunnel)*

--- a/docs/en/user-guide/cli-operations-guide.md
+++ b/docs/en/user-guide/cli-operations-guide.md
@@ -69,6 +69,7 @@ node bin/commandmate.js ls
 | [`commandmate report`](#commandmate-report) | Generate, show, and list daily reports; aggregate Eval metrics |
 | [`commandmate skill`](#commandmate-skill) | Browse the Skill catalog; plan, install, update, uninstall, and inspect Skills |
 | [`commandmate update`](#commandmate-update) | Update CommandMate itself (stop, update, restart) |
+| [`commandmate remote`](#commandmate-remote) | Use CommandMate from your phone (publish over a provider tunnel and pair with a QR code) |
 
 ---
 
@@ -1580,6 +1581,139 @@ Each of these prints a message and exits 0 without changing anything.
 
 ---
 
+### commandmate remote
+
+Make this server reachable from outside and pair a phone with it over a QR code. Unlike the other commands here, **what it acts on is not a worktree — it is this machine's server and a provider (tunnel)**.
+
+> **All `remote` adds is an outward door.** It neither reads nor writes `CM_BIND`, so the default `127.0.0.1` bind does not change. There is no flag to enable Auto-Yes either, so on a server started by `remote` Auto-Yes stays off for every worktree.
+
+#### Usage
+
+```bash
+commandmate remote          # up (default): start the server, publish it, print the QR code
+commandmate remote status   # provider, URL, expiry, pairing state
+commandmate remote stop     # close the provider session (the server keeps running)
+
+commandmate remote --provider cloudflare        # force a provider
+commandmate remote --expires 24h                # remote session TTL
+commandmate remote --pairing-expires 3m         # pairing code TTL
+commandmate remote --yes                        # approve a public tunnel (required when non-interactive)
+commandmate remote status --json                # machine-readable output
+```
+
+#### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--provider <name>` | Force a provider (`tailscale` / `cloudflare`). If the named provider is unusable this exits 1; it never falls back to another one | Auto-selects the first ready provider in preference order |
+| `--expires <duration>` | Remote session TTL (`1h`-`30d`) | `8h` |
+| `--pairing-expires <duration>` | Pairing code TTL (`1m`-`24h`) | `10m` |
+| `-p, --port <number>` | Port of the server to expose | Same resolution order as `commandmate start` |
+| `--yes` | Approve creating a public tunnel. Required without a TTY | Off (asks interactively) |
+| `--json` | JSON output | Off |
+
+> **There is no `--token` flag and no `--auto-yes` flag in any form.** `remote` is the side that mints the token, so one supplied from outside would have no matching hash on the server. For Auto-Yes, see the note above.
+
+#### Exit Codes
+
+| Code | Name | Meaning |
+|:----:|------|---------|
+| 0 | SUCCESS | Published, reported, or stopped successfully (including a `stop` that found nothing recorded to clean up) |
+| 1 | DEPENDENCY_ERROR | No provider is usable / the provider named by `--provider` is unusable on this machine |
+| 2 | CONFIG_ERROR | No TTY and no `--yes` for a public tunnel / an invalid `--expires`, `--pairing-expires` or `--provider` value / a server with authentication is already running / restarting the running server was not approved |
+| 3 | START_FAILED | The server or the provider failed to start (anything already opened is rolled back) |
+| 4 | STOP_FAILED | The provider session could not be closed (the state file is kept, so you can retry) |
+| 99 | UNEXPECTED_ERROR | Unexpected error |
+
+`remote` adds no new exit codes. The values mean the same as in [Exit Codes](#exit-codes).
+
+#### Provider status
+
+| Provider ID | `--provider` value | State |
+|-------------|--------------------|-------|
+| `tailscale-serve` | `tailscale` | **Implemented** (Issue #1937 R3). Ready when `tailscale` is installed, the node is logged in, and Serve/HTTPS is available. Publishes to your tailnet only, so it needs no public-tunnel approval |
+| `cloudflare-quick` | `cloudflare` | **Implemented.** Ready whenever `cloudflared` is installed (measured: `available: true` / `version: 2025.4.0` / `ready: true`). Publishes to the public internet. **See the known issue below** |
+
+Auto-selection walks the preference order (tailscale, then cloudflare) and takes the first provider that reports ready. If no provider is ready it stops with `DEPENDENCY_ERROR` (exit 1).
+
+> **Known issue (measured 2026-08-29): the Cloudflare Quick Tunnel does not outlive the command.** `cloudflared` exits at the moment `commandmate remote` returns, and the URL it just printed starts answering HTTP 530 within seconds — before there is time to scan the QR code. The cause is the provider's spawn shape (the child's stderr stays attached to a pipe that the exiting parent closes), so it is a defect rather than something to configure around. Until it is fixed, prefer `--provider tailscale`, whose provider holds configuration rather than a process and is unaffected. The measured record is in [`docs/qa/1937-remote-uat-record.md`](../../qa/1937-remote-uat-record.md) (defect D-1).
+
+#### A public tunnel needs explicit approval
+
+A Cloudflare Quick Tunnel creates `https://<random>.trycloudflare.com` — an address **on the public internet**. So approval is taken before it is created.
+
+- **Interactive**: a warning describing what is about to be published, then a yes/no question (the default is **no**)
+- **Non-interactive (no TTY)**: **refused** unless `--yes` was passed, exiting 2. This is what stops "it got published because nobody was watching"
+- **Tailscale being unavailable is not a reason to switch to a public tunnel.** Choosing a provider and approving publication are separate decisions, and nothing is published without the approval
+
+Only the CommandMate server running on 127.0.0.1 is published; nothing else on this machine is. CommandMate answers with token authentication enabled, so a visitor without the pairing code is refused — but **the listener itself is public**. See the [Security Guide](../security-guide.md) as well.
+
+#### Pairing code
+
+- **Single-use**, and expires after 10 minutes by default (`--pairing-expires`)
+- 26 Crockford Base32 characters (128 bits). **The plaintext is never stored anywhere**
+- The QR code is shown **once**, during `up`. Only when the terminal is too narrow to draw a scannable QR code is the URL printed as text instead (that URL contains the code, so it stays in your scrollback)
+- The handoff file `~/.commandmate/remote-pairing.json` is mode 0600. **"Already used" is the file's absence**, not a flag inside it — it is deleted the instant pairing succeeds
+
+#### remote status output
+
+```
+Provider:        cloudflare-quick
+URL:             https://<random>.trycloudflare.com
+Remote expires:  2026-08-29T21:00:00.000Z (in 6h 12m)
+Pairing:         unused
+Server:          running (pid 12345, http://localhost:3000, auth: on)
+```
+
+`Pairing:` is one of `unused` / `consumed` / `expired`. With no remote session recorded it looks like this:
+
+```
+Provider:        (none - no remote session recorded)
+Server:          stopped
+```
+
+**Neither the pairing code nor the session token ever appears in this output.** The URL does, because it is not a secret.
+
+> `status` reports what was recorded, not what is still alive: it does not probe the provider. If the URL stops answering while `status` still shows the session as valid, see the known issue above.
+
+#### Expiry closes the outward door only
+
+Running `commandmate remote status` after `--expires` (`8h` by default) has elapsed closes the provider session there and then. **The CommandMate server is not stopped** — stopping it would take your local use of the machine down with it. `up` starts the server as a daemon and returns, so no long-running process is left behind and the expiry is evaluated when `status` runs.
+
+#### remote stop does not guess
+
+- If the state file (`~/.commandmate/remote.json`, mode 0600) cannot be read, `remote stop` **does not guess which provider to tear down**. It says it does not know what to clean up and exits 0. Some providers — Tailscale Serve above all — hold configuration of yours that cannot be restored once deleted
+- CommandMate reverts **only what it created**. Anything the provider reports as having existed before this session is listed under `Left alone (existed before this session):` and is **reported, not removed**
+- If it cannot finish closing, it exits 4 (STOP_FAILED) and keeps the state file, so `commandmate remote stop` can be retried
+- On success the **CommandMate server is still running**
+
+> **With Tailscale, tear down through `commandmate remote stop`.** After a successful `tailscale serve`, Tailscale itself suggests disabling the proxy by re-running `serve` with only the port and the word "off" and no path. That untargeted form removes **every** handler on that port — including your own — with exit status 0 and no warning. `remote stop` always passes the specific path it created.
+
+#### When the server is already running
+
+- **Running without authentication**: it has to be restarted with authentication enabled, so you are asked to confirm a stop and restart. Without a TTY this is refused with exit 2 unless `--yes` was passed
+- **Running with authentication**: that server's token hash was fixed at start and the plaintext is not retained, so **this session cannot pair with it**. It stops with exit 2 — run `commandmate stop` first, then `commandmate remote`
+
+#### remote passes exactly three environment variables to the server
+
+`CM_AUTH_TOKEN_HASH`, `CM_AUTH_EXPIRE` and `CM_REMOTE_PAIRING_FILE`, and the third is a **path, not a secret**. No plaintext long-lived token goes into the environment, because a tmux pane inherits the server's environment wholesale — anything left there would be readable by the very agents CommandMate is driving. `CM_BIND` is neither read nor written, so your existing bind setting is untouched.
+
+#### Reading `--json`
+
+`status` and `stop` print JSON only, so they pipe directly. `up` mixes server start-up progress lines into stdout, so **the JSON is the last line of stdout**.
+
+```bash
+commandmate remote status --json | jq -r '.remote.url'
+```
+
+> **`up --json` puts the pairing code in `pairingUrl`.** Do not leave it in a log or a file. `status` does not emit that field — only `up` ever shows the code.
+
+#### No `Secure` attribute on the cookie over a tunnel
+
+The `Secure` attribute of the authentication cookie is decided by whether `CM_HTTPS_CERT` is set. A tunnel setup is **HTTPS on the outside and plain HTTP at the origin**, so `Secure` is not set. **This is correct behaviour**: setting it would make the browser refuse the cookie over HTTP to `127.0.0.1`, breaking local use. The outside of the tunnel is HTTPS, so the on-the-wire eavesdropping risk is already addressed.
+
+---
+
 ## Typical Workflows
 
 ### Basic: send, wait, capture
@@ -1736,10 +1870,10 @@ commandmate ls --token your-token
 | Code | Name | Meaning |
 |:----:|------|---------|
 | 0 | SUCCESS | Completed successfully |
-| 1 | DEPENDENCY_ERROR | Server not running |
+| 1 | DEPENDENCY_ERROR | Server not running / no usable remote provider (`remote`) |
 | 2 | CONFIG_ERROR | Validation error (invalid agent, duration, etc.) |
-| 3 | START_FAILED | Failed to start or verify the server (`start` / `update`) |
-| 4 | STOP_FAILED | Failed to stop the server (`stop` / `update`) |
+| 3 | START_FAILED | Failed to start or verify the server (`start` / `update` / `remote`) |
+| 4 | STOP_FAILED | Failed to stop the server (`stop` / `update`) / the provider session could not be closed (`remote stop`) |
 | 5 | UPDATE_FAILED | Update failed (`update`: registry query / `npm install -g` / version verification) |
 | 10 | PROMPT_DETECTED | Prompt detected during wait |
 | 99 | UNEXPECTED_ERROR | Unexpected error / resource not found |

--- a/docs/en/user-guide/webapp-guide.md
+++ b/docs/en/user-guide/webapp-guide.md
@@ -385,7 +385,151 @@ run is already going, the pane says so and names it.
 
 How to access CommandMate from your smartphone.
 
-### Same LAN Access
+There are two routes. **Try `commandmate remote` first.** Use
+[Method 2: connect directly on the same LAN](#method-2-connect-directly-on-the-same-lan-without-cloudflared)
+only if you would rather not install a provider tool, or you want to stay inside the LAN.
+
+| | Method 1: `commandmate remote` | Method 2: direct on the same LAN |
+|---|---|---|
+| **Authentication** | Yes (only the paired phone) | **None** |
+| **Encryption** | Yes (HTTPS on the outside) | **None** (plain HTTP) |
+| **Reach** | Also from away (over the internet or your tailnet) | Only inside the same Wi-Fi |
+| **Requires** | `tailscale` or `cloudflared` | Nothing |
+| **Server bind** | Stays `127.0.0.1` | `0.0.0.0` (every interface) |
+
+### Method 1 (recommended): `commandmate remote` with QR pairing
+
+`commandmate remote` **starts the server, publishes it, and pairs your phone** in one
+command. A QR code is printed in the terminal; point your phone's camera at it.
+
+```bash
+commandmate remote
+```
+
+It does four things:
+
+1. Detects the providers (the ways out) and picks one
+2. **Asks you before creating a public tunnel** (see "Approval before publishing" below)
+3. Starts a CommandMate server with authentication enabled
+4. Prints a QR code for `https://<published URL>/login#code=<code>`, carrying a one-time
+   pairing code
+
+Scanning that QR code on the phone completes the sign-in. **The pairing code is single-use
+and expires after 10 minutes by default.** That is the only time the code is shown —
+`commandmate remote status` shows the URL but never shows the code again.
+
+#### Approval before publishing
+
+`commandmate remote` can publish through either of two providers:
+
+| Provider | `--provider` | What it publishes to |
+|---|---|---|
+| Tailscale Serve | `tailscale` | Your own tailnet — not the public internet. Tried first |
+| Cloudflare Quick Tunnel | `cloudflare` | A temporary **public internet** address, `https://<random>.trycloudflare.com` |
+
+Because the Cloudflare route puts this machine on the public internet, `commandmate remote`
+prints a warning and asks y/n before creating that tunnel. In a non-interactive environment
+(a script, CI) **there is no way to ask, so it refuses by default** and stops with
+`CONFIG_ERROR` (exit 2). Pass `--yes` only when you mean to publish.
+
+```bash
+commandmate remote --yes    # skip the confirmation and create the public tunnel
+```
+
+> **If no provider is ready, `remote` stops with `DEPENDENCY_ERROR` (exit 1).**
+> It never switches to a public tunnel on its own because Tailscale was unavailable.
+
+> **Known issue (measured 2026-08-29): the Cloudflare route does not currently survive the
+> command.** `cloudflared` exits at the moment `commandmate remote` returns, and the URL it
+> just printed starts answering HTTP 530 within seconds — there is no time to scan the QR
+> code. This is a defect in how the provider spawns the process, not something you can
+> configure around. **Until it is fixed, use `--provider tailscale`**, which is unaffected
+> because it writes configuration rather than running a process. The measured record is in
+> [`docs/qa/1937-remote-uat-record.md`](../../qa/1937-remote-uat-record.md) (defect D-1).
+
+#### Checking the state, and packing up
+
+```bash
+commandmate remote status   # provider, URL, expiry, pairing state
+commandmate remote stop     # close the outward door
+```
+
+`remote stop` reverts **only the settings CommandMate itself created**. When the state file
+cannot be read it does not guess which provider to tear down — it says it does not know
+what to clean up and exits successfully.
+
+**When the session expires, only the outward door closes; the server is not stopped.**
+Stopping it would take your local use of the machine down with it.
+
+> **With Tailscale, always pack up with `commandmate remote stop`.** After a successful
+> `tailscale serve`, Tailscale itself suggests disabling the proxy by re-running `serve`
+> with only the port and the word "off" and no path. That form removes **every** handler on
+> that port, including mappings you set up yourself, silently and with exit status 0.
+
+#### Main options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--provider <tailscale\|cloudflare>` | Auto | Force a provider |
+| `--expires <duration>` | `8h` | Remote session TTL (`1h`-`30d`) |
+| `--pairing-expires <duration>` | `10m` | Pairing code TTL (`1m`-`24h`) |
+| `-p, --port <number>` | Auto | Port of the server to expose |
+| `--yes` | — | Approve a public tunnel (required when non-interactive) |
+| `--json` | — | JSON output |
+
+Exit codes: `0` success / `1` DEPENDENCY_ERROR / `2` CONFIG_ERROR / `3` START_FAILED /
+`4` STOP_FAILED / `99` UNEXPECTED_ERROR.
+For the CLI in full, see the [CLI Operations Guide](./cli-operations-guide.md#commandmate-remote).
+
+#### Worth knowing
+
+- **`CM_BIND` does not change.** `remote` neither reads nor writes it; the server stays
+  bound to `127.0.0.1`. All it adds is one door out.
+- **Auto-Yes stays off by default.** `remote` has no flag that enables Auto-Yes.
+- **No plaintext long-lived token is stored anywhere.** The server is handed only
+  `CM_AUTH_TOKEN_HASH`, `CM_AUTH_EXPIRE` and `CM_REMOTE_PAIRING_FILE`, and the third is a
+  file path rather than a secret. The pairing handoff file
+  `~/.commandmate/remote-pairing.json` is mode 0600 and is **deleted the instant pairing
+  succeeds**.
+- **The login cookie carries no `Secure` attribute over a tunnel, and that is correct.**
+  Setting `Secure` would make the browser refuse the cookie during local use over
+  `http://127.0.0.1:3000`, breaking access from the PC. The outside of the tunnel is HTTPS,
+  so the eavesdropping risk on the wire is already addressed. See the
+  [Security Guide](../security-guide.md) for details.
+
+#### OS support status
+
+Measured as of 2026-08-29. **Read "measured" and "unverified" as the different things they
+are.** The procedure and raw logs are under `dev-reports/issue/1937/u8-os-matrix.md`, and
+the live acceptance run is in
+[`docs/qa/1937-remote-uat-record.md`](../../qa/1937-remote-uat-record.md).
+
+| OS | Provider detection | Approval flow | Reaching the published tunnel | Notes |
+|----|--------------------|---------------|-------------------------------|-------|
+| **macOS** (Darwin arm64) | ✅ Measured<br>`ready` once the provider tool is installed | ✅ Measured<br>non-interactive stops with exit 2 | ⚠️ Measured, mixed<br>Tailscale Serve ✅ passed; Cloudflare Quick Tunnel ❌ failed (D-1) | cloudflared 2025.4.0, Tailscale 1.102.3 |
+| **Linux** (Debian 12 / aarch64) | ✅ Measured<br>`DEPENDENCY_ERROR` (exit 1) before install, `ready` after | ✅ Measured<br>identical to macOS | ⏭️ Not attempted | ⚠️ **Measured in a docker container, whose network setup can differ from bare-metal Linux** |
+| **WSL2** | ❌ **Unverified** | ❌ **Unverified** | ❌ **Unverified** | **No test environment was available.** WSL2 varies widely in how `localhost` is forwarded, so **whether the tunnel's `127.0.0.1` upstream points inside WSL2 or at the Windows side is configuration-dependent** |
+
+- ✅ **Measured** / ⏭️ **Not attempted** (deliberately skipped, to avoid creating a new
+  public tunnel) / ❌ **Unverified** (no environment to test in)
+- The "measured" entries in the detection and approval columns are the part that can be
+  checked **without creating a public tunnel** (provider detection, the approval gate,
+  `status` and `stop`).
+- **End-to-end use from a real phone (scanning the QR code, the PWA, push notifications) is
+  still outstanding on every OS.** The acceptance run covered the server side only.
+
+### Method 2: Connect directly on the same LAN (without `cloudflared`)
+
+Use this if you would rather not install a provider tool, or you want nothing to leave the
+LAN at all.
+
+> ⚠️ **This method opens the server to the LAN with no authentication.**
+> `CM_BIND=0.0.0.0` makes CommandMate listen on every network interface of your PC.
+> **Anyone** on the same Wi-Fi who opens `http://<your PC's IP address>:3000` in a browser
+> can operate your repositories, terminals and agents **without being asked to authenticate**.
+> Do not use it on shared Wi-Fi (a cafe, a coworking space, a corporate guest network).
+> If you need authentication and encryption, use
+> [Method 1](#method-1-recommended-commandmate-remote-with-qr-pairing).
 
 1. Connect your PC and smartphone to the same Wi-Fi
 2. Edit the `.env` file:
@@ -395,9 +539,9 @@ How to access CommandMate from your smartphone.
 3. Restart the server
 4. Open `http://<your PC's IP address>:3000` in your smartphone's browser
 
-> **Note**: We recommend authentication via a reverse proxy for external network access. See the [Security Guide](../../security-guide.md) for details.
+When you are done, set `CM_BIND` back to `127.0.0.1` (the default) and restart the server.
 
-### Finding Your PC's IP Address
+#### Finding Your PC's IP Address
 
 ```bash
 # macOS
@@ -407,10 +551,11 @@ ifconfig | grep "inet " | grep -v 127.0.0.1
 ip addr | grep "inet " | grep -v 127.0.0.1
 ```
 
-### Remote Access
+#### Exposing to an external network
 
-Use tunneling services like Cloudflare Tunnel to access from outside your home.
-See the [Deployment Guide](../../DEPLOYMENT.md) for details.
+If you publish the server yourself rather than through `commandmate remote`, always pair it
+with authentication at a reverse proxy. See the [Security Guide](../security-guide.md) and
+the [Deployment Guide](../../DEPLOYMENT.md) for details.
 
 ### Mobile UI
 
@@ -446,10 +591,13 @@ has no VAPID keys, and without them the whole push feature is off.
 | **iOS / iPadOS: add to Home Screen** | Web Push is unavailable in a Safari tab. You can only subscribe from an **installed** app, launched from the Home Screen icon | If you see "add this app to your Home Screen" instead of the subscribe button, this is why |
 | **Android Chrome works in a normal tab** | No Home Screen install needed | — |
 
-Two ways to get HTTPS:
+Three ways to get HTTPS:
 
-- **A tunnel** (also works away from home; recommended): Cloudflare Tunnel and friends —
-  see the [Deployment Guide](../../DEPLOYMENT.md)
+- **`commandmate remote`** (simplest; recommended): the provider terminates TLS, so the
+  phone reaches the app over HTTPS and the secure-context requirement is met as-is. See
+  [Mobile Access](#method-1-recommended-commandmate-remote-with-qr-pairing)
+- **A tunnel you set up yourself** (also works away from home): Cloudflare Tunnel and
+  friends — see the [Deployment Guide](../../DEPLOYMENT.md)
 - **A self-signed certificate** (same LAN only):
   ```bash
   brew install mkcert && mkcert -install && mkcert <your PC's IP address>


### PR DESCRIPTION
## 概要

Issue #1937（`commandmate remote`）の記述を **`docs/en/` の英語ミラー**へ反映します。

**コードは 1 行も変更していません。**

## 背景

`docs/en/` は 33 ファイルあり、通常の feature PR で**日本語と同時に更新されている**運用です
（直近 8 コミットが該当）。R11（#2141-2143）は日本語だけを更新したため、
**`docs/en/` で `commandmate remote` に言及しているファイルが 0 件**の状態でした。

日本語だけ更新された状態は、英語読者にとって「機能が存在しない」のと同じです。

## 対象（4 ファイル、+547 行）

| ファイル | 行数 |
|---|---|
| `docs/en/security-guide.md` | +195 |
| `docs/en/user-guide/webapp-guide.md` | +157 |
| `docs/en/user-guide/cli-operations-guide.md` | +137 |
| `docs/en/TRUST_AND_SAFETY.md` | +58 |

### 対象外にしたもの

- **`docs/en/module-reference.md`** — **意図的にミラーしない設計**です。ファイル冒頭に
  「詳細は日本語のみが正。完全な英訳ミラーは即座に陳腐化し、変更のたび保守コストが倍になる」と
  明記されています（ja 836 KB / en 5 KB の入口ページ）
- **`README.md`** — 元から英語で、R11 で更新済み

## 既存記述の訂正も含みます

`docs/en/user-guide/cli-operations-guide.md` の exit code 表に、`remote` 導入前の古い記述が
残っていました（`1 | DEPENDENCY_ERROR | Server not running` など）。実測値に合わせて訂正しています。

## Tailscale の罠も英語で警告

R3 の U-2 実測で判明した「**Tailscale 自身が `serve` 成功時に案内する `off` の形が全消しコマンド**」を、
英語版でも警告しています:

> do not follow the teardown hint Tailscale prints after a successful …

`tailscale-serve` provider が未実装のスタブであることと、
`Option 3: Tailscale`（**利用者自身が Tailscale を使う話。今日も有効**）との混同を防ぐ注記も入れました。

## U-8 の OS 表は D-1 を反映済み

日本語版の U-8 表は R11-B が R12 より先に着地したため D-1 を反映していませんが、
**英語版は R12 の結果を織り込んでいます**:

| OS | 公開 Tunnel の疎通 |
|---|---|
| macOS | ⚠️ Measured, mixed — Tailscale Serve ✅ passed; Cloudflare Quick Tunnel ❌ failed (D-1) |
| Linux | ⏭️ Not attempted（docker コンテナでの実測である旨を注記） |
| WSL2 | ❌ Not verified |

> **Read "measured" and "unverified" as the different things they [are]**

D-1 は #2148 で修正され PR #2149 の実機再確認で解消していますが、
**この PR の時点の記述は R12 実施時の実測**です。日本語版とあわせた追随は別途行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hiod6zbSTaDnwfJUPoaG8
