### PR TITLE
docs(remote): Tailscale Provider を「未実装」と書いている日本語 docs 5 ファイルを実態に直す (#1937)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,10 +275,11 @@ commandmate update --yes      # 確認スキップ（非対話環境では必須
 commandmate remote                         # 既定 = up。サーバ起動 + 公開 + QR 表示
 commandmate remote status                  # Provider / URL / 期限 / ペアリング状態
 commandmate remote stop                    # 外への口を閉じる（サーバは止めない）
-commandmate remote --provider cloudflare   # Provider 指定（tailscale は未実装）
+commandmate remote --provider tailscale    # Provider 指定（tailnet 内に閉じる。承認不要）
+commandmate remote --provider cloudflare   # Provider 指定（公開 Tunnel。承認が要る）
 commandmate remote --expires 24h           # remote セッションTTL（既定 8h、1h〜30d）
 commandmate remote --pairing-expires 3m    # ペアリングコードTTL（既定 10m、1m〜24h）
-commandmate remote --yes                   # 公開Tunnelの明示承認（非対話環境では必須）
+commandmate remote --yes                   # 公開Tunnel（cloudflare）の明示承認（非対話環境では必須）
 
 # Worktree並列開発（Issue #136）
 commandmate start --issue 135 --auto-port  # Issue #135用サーバー起動（自動ポート割当）

--- a/docs/TRUST_AND_SAFETY.md
+++ b/docs/TRUST_AND_SAFETY.md
@@ -30,31 +30,39 @@ CommandMate はローカルマシン上で動作します。
 - Cloudflare Tunnel は**任意**であり、ローカル利用のみであれば不要です
 - LAN 内アクセスの場合は `CM_BIND=0.0.0.0` の設定が必要です。リバースプロキシでの認証を推奨します
 
-#### `cloudflared` への依存（`commandmate remote`）
+#### Provider ツールへの依存（`commandmate remote`）
 
-`commandmate remote` は、外部ツール **`cloudflared`**（Cloudflare Tunnel クライアント）に依存します。
+`commandmate remote` は、選んだ Provider に応じて外部ツール **`cloudflared`**（Cloudflare Tunnel
+クライアント）または **`tailscale`** に依存します。
 
-- `cloudflared` は**任意の依存**です。インストールされていなければ `remote` は `DEPENDENCY_ERROR`
+- どちらも**任意の依存**です。どちらもインストールされていなければ `remote` は `DEPENDENCY_ERROR`
   で停止するだけで、CommandMate 本体のローカル利用には一切影響しません
-- CommandMate が `cloudflared` を自動でインストールすることはありません
+- CommandMate がこれらを自動でインストールすることはありません
 - `remote` は `cloudflared` を子プロセスとして起動します。トンネルの通信は Cloudflare を経由するため、
   **Cloudflare を経路として信頼できる場合にのみ**利用してください
-- Tailscale を CommandMate が代行して設定する Provider（`tailscale-serve`）は**未実装**です。
-  現時点で `remote` が実際に使える Provider は Cloudflare Quick Tunnel だけです
-  （利用者自身が Tailscale を導入して使う方法は従来どおり有効で、そちらは CommandMate に依存しません）
+- `tailscale-serve` Provider は常駐プロセスを起こしません。`tailscaled` が持つ設定に Serve ハンドラを
+  書き込みます。これは**利用者自身が既に使っているかもしれない設定**で、しかも undo がありません。
+  下の「片付けるのは『CommandMate が作ったものだけ』」は、そのために存在します
+- **`tailscale-serve` の公開先は自分の tailnet の中だけで、インターネットには出ません。**
+  そのため公開トンネルの明示承認（`--yes`）は要らず、`--provider` 無しの自動選択でも先に試されます
+  （利用者自身が Tailscale を導入して使う方法も従来どおり有効で、そちらは CommandMate に依存しません）
 
 #### 何が外部に出るのか
 
 - 外部に出るのは **CommandMate サーバーそのもの**です。127.0.0.1 で待ち受けているサーバーが、
-  ランダムな公開 URL（`https://<ランダム>.trycloudflare.com`）経由でインターネットから到達可能になります
+  Provider の URL 経由で到達可能になります。Cloudflare ならランダムな公開 URL
+  （`https://<ランダム>.trycloudflare.com`）でインターネットから、Tailscale Serve なら
+  **自分の tailnet の中からのみ**到達できるアドレスです
 - **待ち受けアドレスは変わりません。** `remote` は `CM_BIND` を読みも書きもせず、既定の `127.0.0.1`
   のままです。LAN 側に新しいポートが開くわけではありません
 - 公開対象はこの CommandMate サーバー 1 つだけで、同じマシン上の他のサービスは含まれません
-- 公開 URL は誰でも到達できるため、**CommandMate 側のトークン認証が必須**です。`remote` は常に認証を
+- URL を知った相手は到達できるため、**CommandMate 側のトークン認証が必須**です。`remote` は常に認証を
   有効にしてサーバーを起動し、ペアリングコード（一度限り・既定 10 分で失効）を使った端末だけが
   ログインできます
 - **公開トンネルの作成には利用者の明示承認が必要です。** 対話環境では警告を表示して確認を求め、
-  非対話環境では `--yes` が無ければ `CONFIG_ERROR` で停止します。黙って公開されることはありません
+  非対話環境では `--yes` が無ければ `CONFIG_ERROR` で停止します。黙って公開されることはありません。
+  この承認を求めるのは公開トンネルの Provider（Cloudflare）だけで、tailnet の中に閉じる
+  `tailscale-serve` には要りません
 - 公開 URL は起動のたびに変わり、アクセスポリシーも監査ログもありません。
   **長期利用・本番利用には Quick Tunnel を使わないでください**（詳細: `docs/security-guide.md`）
 
@@ -65,6 +73,10 @@ CommandMate はローカルマシン上で動作します。
   「片付けるべきものが分からない」と報告して正常終了します。推測で消すと、利用者が自分で設定した
   Provider 側の構成（例: 手動で設定した Tailscale Serve）まで壊す可能性があり、CommandMate には
   それを復元する手段が無いためです
+- 同じ理由で、`tailscale serve` の成功時に Tailscale 自身が案内する撤収方法には**従わないでください**。
+  パスを付けずにポートと `off` だけを指定して `serve` を再実行する形は、そのポートの**すべて**の
+  ハンドラ（あなた自身のものを含む）を消します。`commandmate remote stop` は必ず自分が作ったパスを
+  指定して撃ちます
 - `--expires`（既定 8 時間）が切れたときに閉じるのは**外部への口だけ**で、**サーバーは停止しません**。
   停止すると PC 上のローカル利用まで巻き添えになるためです
 

--- a/docs/security-guide.md
+++ b/docs/security-guide.md
@@ -37,13 +37,13 @@ When `CM_BIND=0.0.0.0` is set, the server becomes accessible from external netwo
 
 The server keeps its `127.0.0.1` bind — `remote` neither reads nor writes `CM_BIND`, so a
 host on the default binding stays on the default binding. What `remote` adds is an
-*outward door*: a provider process that accepts connections from outside and forwards them
-to the loopback listener.
+*outward door*: a provider process (or, for Tailscale, a provider *configuration*) that
+accepts connections from outside and forwards them to the loopback listener.
 
 | Property | Value under `commandmate remote` |
 |----------|----------------------------------|
 | Listening socket | Still `127.0.0.1` only — nothing new listens on your LAN interface |
-| Reachability | The provider URL is reachable by anyone who learns it |
+| Reachability | The provider URL is reachable by anyone who learns it (a Cloudflare Quick Tunnel URL is public; a Tailscale Serve URL is reachable only from your tailnet) |
 | Authentication | Always on. `remote` starts the server with token authentication enabled |
 | Blast radius | The CommandMate server only, not other services on this machine |
 
@@ -257,7 +257,7 @@ commandmate remote stop     # close the outside door; the server keeps running
 | `--expires <duration>` | Remote session TTL (default `8h`, range `1h`-`30d`) |
 | `--pairing-expires <duration>` | Pairing code TTL (default `10m`, range `1m`-`24h`) |
 | `-p, --port <number>` | Port of the server to expose |
-| `--yes` | Approve creating a public tunnel without prompting (required when non-interactive) |
+| `--yes` | Approve creating a public tunnel without prompting (required when non-interactive). Not needed for `tailscale`, which stays inside your tailnet |
 | `--json` | JSON output |
 
 There is deliberately **no `--token` flag**: `remote` is the side that mints the token, so
@@ -275,14 +275,23 @@ authentication enabled that this session cannot pair with), `3` `START_FAILED`,
 
 | Provider | State |
 |----------|-------|
-| `cloudflare-quick` (Cloudflare Quick Tunnel) | **Implemented.** Selectable whenever `cloudflared` is installed |
-| `tailscale-serve` | **Not implemented.** A stub that always reports itself unavailable, so `remote` can never select it |
+| `tailscale-serve` (`--provider tailscale`) | **Implemented.** Ready when `tailscale` is installed, the node is logged in, and Serve/HTTPS is available on the tailnet. Tried first by auto-selection, because it publishes only to your own tailnet |
+| `cloudflare-quick` (`--provider cloudflare`) | **Implemented.** Selectable whenever `cloudflared` is installed. Publishes to the public internet, so it always asks for approval first |
 
-> **The `tailscale-serve` provider is not Option 3.** Option 3 above is *you* using
-> Tailscale yourself: it works today, it is a good choice, and it needs nothing from
-> CommandMate. The `tailscale-serve` **provider** — CommandMate driving `tailscale serve`
-> for you as part of `remote` — does not exist yet. Do not read Option 3's recommendation
-> as saying that `commandmate remote --provider tailscale` will work.
+> **The `tailscale-serve` provider is not Option 3, even though both work.** Option 3 above
+> is *you* using Tailscale yourself: you join the tailnet and browse to the node's Tailscale
+> IP, and CommandMate is not involved at all. The `tailscale-serve` **provider** is
+> CommandMate driving `tailscale serve` for you as part of `remote`, and it therefore writes
+> to configuration that belongs to `tailscaled` and that you may already be using. Because
+> that configuration has no undo, `remote` snapshots it before touching it, refuses to start
+> when the path it wants is already served, and on `stop` removes only the one handler it
+> created.
+
+> **Do not follow Tailscale's own teardown hint.** After a successful `tailscale serve`,
+> Tailscale prints a suggestion to disable the proxy by re-running `serve` with only the
+> port and the word "off" — with no path. That untargeted form removes **every** handler on
+> that port, including ones you set up yourself, with exit status 0 and no warning. Use
+> `commandmate remote stop`, which always passes the specific path it created.
 
 If no provider is ready, `remote` stops with `DEPENDENCY_ERROR` (exit code `1`). It does
 **not** fall through to a public tunnel on its own when Tailscale is unavailable: putting
@@ -309,6 +318,9 @@ A Quick Tunnel is convenient *and* disposable. Both halves matter:
   sent by an agent — there is nobody to ask, so the run fails with `CONFIG_ERROR`
   (exit code `2`) unless you passed `--yes`. `--yes` *is* the approval; do not add it to a
   wrapper script by reflex.
+
+Only the public-tunnel provider asks this question. `tailscale-serve` publishes to your own
+tailnet rather than to the internet, so it does not require `--yes`.
 
 #### Pairing code
 
@@ -434,6 +446,7 @@ When using `commandmate remote`:
 - [ ] `--pairing-expires` is short and the QR code is scanned promptly (default `10m`)
 - [ ] The pairing QR code / URL is not forwarded, screenshotted into a chat, or reused — it is single-use
 - [ ] `commandmate remote stop` is run when remote access is no longer needed (expiry closes the door, but only after the TTL elapses)
+- [ ] Teardown goes through `commandmate remote stop`, never through Tailscale's own untargeted `serve ... off` hint, which clears the whole port
 - [ ] You accept that over a tunnel the session cookie has no `Secure` attribute (see Option 4) — use built-in TLS if you need it
 
 ---

--- a/docs/user-guide/cli-operations-guide.md
+++ b/docs/user-guide/cli-operations-guide.md
@@ -2455,7 +2455,8 @@ commandmate remote          # 既定 = up。サーバを起動し、公開し、
 commandmate remote status   # Provider / URL / 期限 / ペアリング状態
 commandmate remote stop     # Provider を閉じる（サーバは止めない）
 
-commandmate remote --provider cloudflare        # Provider を明示指定
+commandmate remote --provider tailscale         # Provider を明示指定（tailnet 内に閉じる）
+commandmate remote --provider cloudflare        # Provider を明示指定（公開 Tunnel）
 commandmate remote --expires 24h                # remote セッションのTTL
 commandmate remote --pairing-expires 3m         # ペアリングコードのTTL
 commandmate remote --yes                        # 公開Tunnelを明示承認（非対話環境では必須）
@@ -2470,7 +2471,7 @@ commandmate remote status --json                # 機械可読出力
 | `--expires <duration>` | remote セッションのTTL（`1h`〜`30d`） | `8h` |
 | `--pairing-expires <duration>` | ペアリングコードのTTL（`1m`〜`24h`） | `10m` |
 | `-p, --port <number>` | 公開するサーバのポート | 未指定なら `commandmate start` と同じ解決順 |
-| `--yes` | 公開Tunnelの作成を明示承認する。非対話環境（TTYなし）では必須 | 無効（対話で確認する） |
+| `--yes` | 公開Tunnel（`cloudflare`）の作成を明示承認する。非対話環境（TTYなし）では必須。`tailscale` は tailnet 内に閉じるため不要 | 無効（対話で確認する） |
 | `--json` | JSON出力 | 無効 |
 
 > **`--token` と `--auto-yes` 系のフラグはありません。** トークンを鋳造するのは `remote` 自身の側なので、外から渡されたトークンには照合するハッシュがサーバに存在しません。Auto-Yes については上の注記のとおりです。
@@ -2492,10 +2493,10 @@ commandmate remote status --json                # 機械可読出力
 
 | Provider ID | `--provider` の値 | 状態 |
 |-------------|------------------|------|
-| `cloudflare-quick` | `cloudflare` | **実装済み**。`cloudflared` がインストールされていれば使えます（実測: `available: true` / `version: 2025.4.0` / `ready: true`） |
-| `tailscale-serve` | `tailscale` | **未実装のスタブ**。`detect()` は常に `available: false` を返し、`--provider tailscale` は exit 1 になります |
+| `tailscale-serve` | `tailscale` | **実装済み**（Issue #1937 R3）。`tailscale` がインストールされ、ノードがログイン済みで、Serve/HTTPS が使える状態なら `ready` になります。公開先は**自分の tailnet の中だけ**でインターネットには出ないため、公開Tunnel の承認（`--yes`）は要りません |
+| `cloudflare-quick` | `cloudflare` | **実装済み**。`cloudflared` がインストールされていれば使えます（実測: `available: true` / `version: 2025.4.0` / `ready: true`）。公開先は**インターネット**なので、承認が要ります |
 
-自動選択は優先順（tailscale → cloudflare）で最初に ready な Provider を選びます。現時点で ready になり得るのは `cloudflare-quick` だけです。ready な Provider が1つも無ければ `DEPENDENCY_ERROR`（exit 1）で停止します。
+自動選択は優先順（tailscale → cloudflare）で最初に ready な Provider を選びます。tailnet の中に閉じる `tailscale-serve` が先に試されるのはこのためです。ready な Provider が1つも無ければ `DEPENDENCY_ERROR`（exit 1）で停止します。
 
 #### 公開Tunnel には明示承認が必要
 
@@ -2504,6 +2505,7 @@ Cloudflare Quick Tunnel は `https://<ランダム>.trycloudflare.com` という
 - **対話環境**: 何が公開されるかを示す警告を表示し、yes/no を尋ねます（既定は **no**）
 - **非対話環境（TTYなし）**: `--yes` が無い限り**拒否**し、exit 2 で終了します。「誰も見ていなかったので公開された」が起きないようにするためです
 - **Tailscale が使えないことは、公開Tunnel へ切り替える理由になりません。** Provider の選択と公開の承認は別々の判断で、承認が無ければ公開されません
+- **この確認を求めるのは公開Tunnel の Provider だけです。** `tailscale-serve` の公開先は自分の tailnet の中に閉じていてインターネットには出ないため、`--yes` は要りません
 
 公開されるのは 127.0.0.1 で動く CommandMate サーバだけで、この PC の他のものは公開されません。CommandMate はトークン認証を有効にした状態で応答するため、ペアリングコードを持たない訪問者は拒否されますが、**リスナー自体は公開**です。あわせて[セキュリティガイド](../security-guide.md)も参照してください。
 
@@ -2543,6 +2545,8 @@ Server:          stopped
 - CommandMate は**自分が作ったものだけ**を取り消します。Provider が「このセッションより前から存在していた」と報告した設定は `Left alone (existed before this session):` として**報告されるだけで、削除されません**
 - 閉じきれなかった場合は exit 4（STOP_FAILED）で終了し、状態ファイルは残るので `commandmate remote stop` を再実行できます
 - 成功した場合も **CommandMate サーバは動いたまま**です
+
+> **Tailscale の撤収は `commandmate remote stop` で行ってください。** `tailscale serve` に成功すると、Tailscale 自身が「パスを付けずにポートと `off` だけを指定して `serve` を再実行する」撤収方法を案内します。このパス無しの形は、そのポートの**すべて**のハンドラ（あなた自身が設定したものを含む）を、警告も無く exit 0 で消します。`remote stop` は必ず自分が作ったパスを指定して撃ちます。
 
 #### サーバがすでに起動している場合
 

--- a/docs/user-guide/webapp-guide.md
+++ b/docs/user-guide/webapp-guide.md
@@ -384,15 +384,15 @@ Vibe-Localを選択した場合、使用するOllamaモデルを指定できま�
 スマートフォンから CommandMate にアクセスする方法です。
 
 経路は 2 つあります。**まず `commandmate remote` を試してください。**
-`cloudflared` を入れたくない、あるいは LAN 内で完結させたい場合に限り、
+Provider のツール（`tailscale` / `cloudflared`）を入れたくない、あるいは LAN 内で完結させたい場合に限り、
 [方法2: 同一 LAN 内から直接つなぐ](#方法2-同一-lan-内から直接つなぐcloudflared-を使わない場合) を使います。
 
 | | 方法1: `commandmate remote` | 方法2: 同一 LAN 内から直接つなぐ |
 |---|---|---|
 | **認証** | あり（ペアリングしたスマホだけ） | **なし** |
 | **暗号化** | あり（外側が HTTPS） | **なし**（平文 HTTP） |
-| **届く範囲** | 外出先からも（インターネット経由） | 同じ Wi-Fi の中だけ |
-| **必要なもの** | `cloudflared` | なし |
+| **届く範囲** | 外出先からも（tailnet またはインターネット経由） | 同じ Wi-Fi の中だけ |
+| **必要なもの** | `tailscale` または `cloudflared` | なし |
 | **サーバの bind** | `127.0.0.1` のまま | `0.0.0.0`（全インターフェース） |
 
 ### 方法1（推奨）: `commandmate remote` で QR ペアリング
@@ -418,21 +418,27 @@ commandmate remote
 
 #### 公開前の確認
 
-CommandMate が使う Provider は現在 **Cloudflare Quick Tunnel のみ**です。これは
-`https://<ランダム>.trycloudflare.com` という **インターネット上のアドレス**を一時的に作ります。
-そのため `commandmate remote` は、Tunnel を作る前に警告を出して y/n を尋ねます。
+`commandmate remote` は 2 つの Provider のどちらかで公開できます。
 
-非対話環境（スクリプトや CI）では**プロンプトを出せないので既定で拒否**し、
-`CONFIG_ERROR`（exit 2）で止まります。意図して公開する場合だけ `--yes` を付けてください。
+| Provider | `--provider` | 公開先 |
+|---|---|---|
+| Tailscale Serve | `tailscale` | **自分の tailnet の中だけ**。インターネットには出ません。先に試されます |
+| Cloudflare Quick Tunnel | `cloudflare` | `https://<ランダム>.trycloudflare.com` という一時的な**インターネット上のアドレス** |
+
+Cloudflare 経路はこの PC をインターネット上に出すため、`commandmate remote` は
+Tunnel を作る前に警告を出して y/n を尋ねます。非対話環境（スクリプトや CI）では
+**プロンプトを出せないので既定で拒否**し、`CONFIG_ERROR`（exit 2）で止まります。
+意図して公開する場合だけ `--yes` を付けてください。
 
 ```bash
 commandmate remote --yes    # 確認をスキップして公開 Tunnel を作る
 ```
 
-> **Tailscale はまだ使えません。** `--provider tailscale` は用意されていますが、
-> 中身は未実装のスタブで、実行すると `DEPENDENCY_ERROR`（exit 1）になります。
-> **使える Provider が 1 つも無いときも `DEPENDENCY_ERROR` で止まり、
-> 勝手に公開 Tunnel へ切り替わることはありません。**
+> **この確認を求めるのは Cloudflare 経路だけです。** Tailscale Serve は自分の tailnet の
+> 中に閉じていてインターネットには出ないため、`--provider tailscale` に `--yes` は要りません。
+
+> **使える Provider が 1 つも無いときは `DEPENDENCY_ERROR`（exit 1）で止まります。**
+> Tailscale が使えなかったからといって、勝手に公開 Tunnel へ切り替わることはありません。
 
 > **修正済み — Cloudflare 経路が `commandmate remote` の終了と同時に死ぬ不具合
 > （[#2146](https://github.com/Kewton/CommandMate/issues/2146)、CLOSED）。**
@@ -461,6 +467,11 @@ commandmate remote stop     # 外への口を閉じる
 **期限が切れたときに閉じるのは外への口だけで、サーバは落としません。**
 PC でのローカル利用まで巻き添えにしないためです。
 
+> **Tailscale の撤収は必ず `commandmate remote stop` で行ってください。**
+> `tailscale serve` に成功すると Tailscale 自身が、パスを付けずにポートと `off` だけを
+> 指定して `serve` を再実行する撤収方法を案内します。この形はそのポートの**すべて**の
+> ハンドラ（あなた自身が設定したものを含む）を、警告も無く exit 0 で消します。
+
 #### 主なオプション
 
 | オプション | 既定 | 説明 |
@@ -469,7 +480,7 @@ PC でのローカル利用まで巻き添えにしないためです。
 | `--expires <duration>` | `8h` | remote セッションの TTL（`1h`〜`30d`） |
 | `--pairing-expires <duration>` | `10m` | ペアリングコードの TTL（`1m`〜`24h`） |
 | `-p, --port <number>` | 自動 | 公開するサーバのポート |
-| `--yes` | — | 公開 Tunnel の明示承認（非対話環境では必須） |
+| `--yes` | — | 公開 Tunnel（`cloudflare`）の明示承認（非対話環境では必須）。`tailscale` には不要 |
 | `--json` | — | JSON 出力 |
 
 終了コード: `0` 成功 / `1` DEPENDENCY_ERROR / `2` CONFIG_ERROR / `3` START_FAILED /
@@ -496,9 +507,9 @@ CLI としての詳細は [CLI 運用ガイド](./cli-operations-guide.md) を�
 実測の手順と生ログは `dev-reports/issue/1937/u8-os-matrix.md` に、実機受入テストの記録は
 [`docs/qa/1937-remote-uat-record.md`](../qa/1937-remote-uat-record.md) にあります。
 
-| OS | Provider 検出 | 承認フロー | 公開 Tunnel の疎通 | 備考 |
-|----|--------------|-----------|------------------|------|
-| **macOS** (Darwin arm64) | ✅ 実測済み<br>`cloudflared` 導入済みなら `ready` | ✅ 実測済み<br>非対話は exit 2 で停止 | ✅ 実測済み<br>Cloudflare Quick Tunnel は当初 **D-1** で不合格。[#2148](https://github.com/Kewton/CommandMate/pull/2148) の修正後は合格で、[#2149](https://github.com/Kewton/CommandMate/pull/2149) が実物の `cloudflared` で再確認 | cloudflared 2025.4.0 で確認 |
+| OS | Provider 検出 | 承認フロー | 公開経路の疎通 | 備考 |
+|----|--------------|-----------|--------------|------|
+| **macOS** (Darwin arm64) | ✅ 実測済み<br>Provider のツール導入済みなら `ready` | ✅ 実測済み<br>非対話は exit 2 で停止（Cloudflare のみ） | ✅ 実測済み<br>**Tailscale Serve は全項目合格**。Cloudflare Quick Tunnel は当初 **D-1** で不合格で、[#2148](https://github.com/Kewton/CommandMate/pull/2148) の修正後は合格。[#2149](https://github.com/Kewton/CommandMate/pull/2149) が実物の `cloudflared` で再確認 | cloudflared 2025.4.0 / Tailscale 1.102.3 で確認 |
 | **Linux** (Debian 12 / aarch64) | ✅ 実測済み<br>未導入時は `DEPENDENCY_ERROR` (exit 1)、導入後 `ready` | ✅ 実測済み<br>macOS と同一の挙動 | ⏭️ 未実施 | ⚠️ **docker コンテナでの実測であり、ベアメタル Linux とはネットワーク構成が異なりうる** |
 | **WSL2** | ❌ **未検証** | ❌ **未検証** | ❌ **未検証** | **検証環境が用意できなかったため未実施。** WSL2 は `localhost` 転送の構成差が大きく、**Tunnel のアップストリーム `127.0.0.1` が WSL2 内部を指すか Windows 側を指すかが構成依存**です |
 
@@ -509,7 +520,10 @@ CLI としての詳細は [CLI 運用ガイド](./cli-operations-guide.md) を�
 - **スマホ実機での通し（QR 読取 → ペアリング → PWA → Push）は、どの OS でもまだ未実施です。**
   実機受入テストが確認したのはサーバ側までで、スマホでの確認は
   [#2152](https://github.com/Kewton/CommandMate/issues/2152) で追跡しています。
-- `--provider tailscale` はすべての OS で使えません（未実装のスタブのため）。OS 差ではありません。
+- **`--provider tailscale` は実装済みで、macOS では実機受入テストの全項目に合格しています**
+  （[`docs/qa/1937-remote-uat-record.md`](../qa/1937-remote-uat-record.md) §3.4）。
+  Linux / WSL2 の行が「未実施 / 未検証」なのは **OS 対応の可否ではなく、その OS の検証環境を
+  用意できなかったため**です。上の 3 区分は、この違いを読み分けるためにあります。
 
 ### 方法2: 同一 LAN 内から直接つなぐ（`cloudflared` を使わない場合）
 


### PR DESCRIPTION
## 概要

**日本語 docs 5 ファイルが Tailscale Provider を「未実装」と書いていました。** 実態は実装済みです。

**v0.29.0 のリリース前に直す必要がある事実誤り**として発見しました。
**コードは 1 行も変更していません。**

## なぜずれたか（着地順のずれ）

R11（docs、PR #2141-2143）を書いた時点では **Tailscale Provider は本当に未実装**でした。
その後 **R3（PR #2144）が着地して実装され**ましたが、日本語 docs が追随していませんでした。

**英語版は R3 の後に書かれたので既に正しく**、全数点検で **0 件**です:

```
docs/en/user-guide/cli-operations-guide.md:1634
| `tailscale-serve` | **Implemented** (Issue #1937 R3). … Publishes to your tailnet only,
  so it needs no public-tunnel approval |
```

英語版を正として日本語を揃えました。

## 実害

`--provider tailscale` は**今なら動きます**。しかも R12 の実機 UAT で **Tailscale 経路は全項目合格**
（非破壊確認・占有パスへの `up` 拒否・tailnet 内に閉じること）で、
**公開 Tunnel の承認すら要りません** — Cloudflare より露出が小さい経路です。

docs が「`exit 1` になります」「すべての OS で使えません」と書いたまま v0.29.0 を出すと、
**一番安全な経路を使えないと利用者に伝える**ことになっていました。

## 直した箇所

| ファイル | 変更前 |
|---|---|
| `CLAUDE.md:278` | `--provider cloudflare  # Provider 指定（tailscale は未実装）` |
| `docs/user-guide/cli-operations-guide.md:2496` | `**未実装のスタブ**。detect() は常に available: false` |
| `docs/user-guide/webapp-guide.md:432` | `> **Tailscale はまだ使えません。**` |
| `docs/user-guide/webapp-guide.md:512` | `--provider tailscale はすべての OS で使えません（未実装のスタブのため）` |
| `docs/security-guide.md:279` | `**Not implemented.** A stub that always reports itself unavailable` |
| `docs/TRUST_AND_SAFETY.md:42` | `Provider（tailscale-serve）は**未実装**です` |

`CLAUDE.md` は 2 行に分けて違いが 1 行ずつ読めるようにしました:

```
commandmate remote --provider tailscale    # Provider 指定（tailnet 内に閉じる。承認不要）
commandmate remote --provider cloudflare   # Provider 指定（公開 Tunnel。承認が要る）
```

サイズは **20,101 bytes**（CI hard-fail の上限 35,000 に対し余裕あり）。

## 消さずに残したもの

**U-8 表の 3 区分**（実測済み / 未実施 / 未検証）は維持しています。512 行目は丸ごと削除せず
書き換えました — 元の役目は「Tailscale が使えないのは OS の違いのせいではない」と伝えることで、
実態は「実装済みで macOS では実機合格。Linux / WSL2 未検証は**検証環境の問題**」だからです。
承認ゲートの列には「**（Cloudflare のみ）**」の補足が入り、表からも承認不要が読めます。

**`security-guide.md` の「Provider は Option 3 ではない」注記**も残しました。むしろ
「**even though both work**」と補強されています — 両方動く今のほうが混同しやすいためです。

## 検証

`lint` / `typecheck` / `build` はローカルで実行済み（全 pass）。
`docs/en/` は変更していません（既に正しいため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hiod6zbSTaDnwfJUPoaG8
